### PR TITLE
VZ-8764: Use URL trigger to control the periodic and backend pipeline…

### DIFF
--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -35,6 +35,11 @@ def branchSpecificSchedule = getCronSchedule()
 @Field
 def verrazzanoDistributionsFile = "verrazzano_distributions.html"
 
+def ociOsRegion = "us-phoenix-1"
+def ociOsBucket = "verrazzano-builds"
+def urlTriggerBranchName = env.BRANCH_NAME.replace('/', '%2F')
+def lastStableCommitFile = "last-stable-commit.txt"
+
 pipeline {
     options {
         timeout(time: 12, unit: 'HOURS')
@@ -54,7 +59,25 @@ pipeline {
     }
 
     triggers {
-        cron(branchSpecificSchedule)
+        URLTrigger(
+            cronTabSpec: branchSpecificSchedule,
+            entries: [
+                URLTriggerEntry(
+                    url: "https://objectstorage.${ociOsRegion}.oraclecloud.com/n/${OS_NAMESPACE_URL_TRIGGER}/b/${ociOsBucket}/o/${urlTriggerBranchName}/${lastStableCommitFile}",
+                    checkETag: false,
+                    checkStatus: true,
+                    statusCode: 403,
+                    checkLastModificationDate: true,
+                    timeout: 200,
+                    requestHeaders: [
+                        RequestHeader( headerName: "Accept" , headerValue: "application/json" )
+                    ],
+                    contentTypes: [
+                        MD5Sum()
+                    ]
+                )
+            ]
+        )
     }
 
     parameters {
@@ -243,6 +266,8 @@ def preliminaryChecks() {
     }
     if (backendTestsUpToDateFailed) {
         currentBuild.displayName = "${currentBuild.displayName} : UP-TO-DATE-FAILED"
+        currentBuild.result = 'FAILURE'
+        error('Failing the build since the current commit matches the commit of previously failing backend build')
     }
     if (params.FORCE) {
         currentBuild.displayName = "${currentBuild.displayName} : FORCE"

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -49,6 +49,11 @@ def branchSpecificSchedule = getCronSchedule()
 @Field
 def verrazzanoDistributionsFile = "verrazzano_distributions.html"
 
+def ociOsRegion = "us-phoenix-1"
+def ociOsBucket = "verrazzano-builds"
+def urlTriggerBranchName = env.BRANCH_NAME.replace('/', '%2F')
+def lastStableCommitFile = "last-stable-commit.txt"
+
 pipeline {
     options {
         timeout(time: 12, unit: 'HOURS')
@@ -68,7 +73,25 @@ pipeline {
     }
 
     triggers {
-        cron(branchSpecificSchedule)
+        URLTrigger(
+            cronTabSpec: branchSpecificSchedule,
+            entries: [
+                URLTriggerEntry(
+                    url: "https://objectstorage.${ociOsRegion}.oraclecloud.com/n/${OS_NAMESPACE_URL_TRIGGER}/b/${ociOsBucket}/o/${urlTriggerBranchName}/${lastStableCommitFile}",
+                    checkETag: false,
+                    checkStatus: true,
+                    statusCode: 403,
+                    checkLastModificationDate: true,
+                    timeout: 200,
+                    requestHeaders: [
+                        RequestHeader( headerName: "Accept" , headerValue: "application/json" )
+                    ],
+                    contentTypes: [
+                        MD5Sum()
+                    ]
+                )
+            ]
+        )
     }
 
     parameters {
@@ -746,6 +769,8 @@ def preliminaryChecks() {
     }
     if (periodicsUpToDateFailed) {
         currentBuild.displayName = "${currentBuild.displayName} : UP-TO-DATE-FAILED"
+        currentBuild.result = 'FAILURE'
+        error('Failing the build since the current commit matches the commit of previously failing periodic build')
     }
     if (params.FORCE) {
         currentBuild.displayName = "${currentBuild.displayName} : FORCE"


### PR DESCRIPTION
… triggers (#5513)

* VZ-8764: Use URL trigger to control the periodic and backend pipeline triggers

* Mark build as failed when up-to-date failed condition is reached

* temporarily switching cron to 2 mins

* Revert "temporarily switching cron to 2 mins"

This reverts commit 4f4def1356b9d789b4e83e7df43b1dc94060df03.

Cherry-picking #5513 
