### PR TITLE
VZ-8748: Cleanup code for config change checks in compStateInstallEnd state

### DIFF
--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -213,7 +213,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 
 	// The component previously finished installing, but check for any mid-installation updates
 	// which may require restarting the component's installation from the beginning
-	if restartComponentInstallFromEndState(compContext, comp, componentStatus, compTracker) {
+	if restartComponentInstallFromEndState(compContext, comp, componentStatus) {
 		compTracker.installState = compStateInstallInitDetermineComponentState
 		if err := r.updateComponentStatus(compContext, "PreInstall started", vzapi.CondPreInstall); err != nil {
 			compLog.ErrorfThrottled("Error writing component PreInstall state to the status: %v", err)
@@ -288,8 +288,7 @@ func chooseCompState(componentStatus *vzapi.ComponentStatusDetails) componentIns
 }
 
 // restartComponentInstallFromEndState contains the logic about whether to restart this component's installation from compStateInstallEnd
-func restartComponentInstallFromEndState(compContext spi.ComponentContext, comp spi.Component, componentStatus *vzapi.ComponentStatusDetails,
-	compTracker *componentTrackerContext) bool {
+func restartComponentInstallFromEndState(compContext spi.ComponentContext, comp spi.Component, componentStatus *vzapi.ComponentStatusDetails) bool {
 	// Do not interrupt the upgrade flow
 	if compContext.ActualCR().Status.State == vzapi.VzStateUpgrading || compContext.ActualCR().Status.State == vzapi.VzStatePaused {
 		return false

--- a/platform-operator/controllers/verrazzano/reconcile/install_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_test.go
@@ -344,7 +344,6 @@ func TestUpdateBeforeInstallComplete(t *testing.T) {
 	vz := vzapi.Verrazzano{}
 	err = ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &vz)
 	asserts.NoError(err)
-	fmt.Println(vz.Status.Components[fakeCompReleaseName].Conditions)
 
 	asserts.Equal(vzapi.VzStateReconciling, vz.Status.State)
 	asserts.False(*fakeCompUpdated)


### PR DESCRIPTION
https://github.com/verrazzano/verrazzano/pull/5514 had a few uncaught things related to code cleanliness that could be fixed.

There is a debugging print statement in a unit test that should not be there, and an unused parameter in the `restartComponentInstallFromEndState` function.