### PR TITLE
VZ-8764: Use URL trigger to control the periodic and backend pipeline triggers

### DIFF
--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -281,13 +281,12 @@ def preliminaryChecks() {
     if (backendTestsUpToDate) {
         currentBuild.displayName = "${currentBuild.displayName} : UP-TO-DATE"
     }
-    if (backendTestsUpToDateFailed) {
-        currentBuild.displayName = "${currentBuild.displayName} : UP-TO-DATE-FAILED"
-        currentBuild.result = 'FAILURE'
-        error('Failing the build since the current commit matches the commit of previously failing backend build')
-    }
     if (params.FORCE) {
         currentBuild.displayName = "${currentBuild.displayName} : FORCE"
+    } else if (backendTestsUpToDateFailed) {
+       currentBuild.displayName = "${currentBuild.displayName} : UP-TO-DATE-FAILED"
+       currentBuild.result = 'FAILURE'
+       error('Failing the build since the current commit matches the commit of previously failing backend build')
     }
 
     if (runTests()) {

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -679,13 +679,13 @@ def preliminaryChecks() {
     if (periodicsUpToDate) {
         currentBuild.displayName = "${currentBuild.displayName} : UP-TO-DATE"
     }
-    if (periodicsUpToDateFailed) {
-        currentBuild.displayName = "${currentBuild.displayName} : UP-TO-DATE-FAILED"
-        currentBuild.result = 'FAILURE'
-        error('Failing the build since the current commit matches the commit of previously failing periodic build')
-    }
+
     if (params.FORCE) {
         currentBuild.displayName = "${currentBuild.displayName} : FORCE"
+    } else if (periodicsUpToDateFailed) {
+       currentBuild.displayName = "${currentBuild.displayName} : UP-TO-DATE-FAILED"
+       currentBuild.result = 'FAILURE'
+       error('Failing the build since the current commit matches the commit of previously failing periodic build')
     }
 
     if (runTests()) {


### PR DESCRIPTION
When FORCE parameter is enabled, do not mark the build as failed when the up-to-date failed condition is true.

Backporting #5530 