### PR TITLE
VZ-8357 handle Rancher unistall update conflict

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -149,7 +149,9 @@ func invokeRancherSystemToolAndCleanup(ctx spi.ComponentContext) error {
 
 	// Delete Rancher finalizers before running the rancher-cleanup job (to speed up the uninstall)
 	if !rancherFinalizersDeleted {
-		deleteRancherFinalizers(ctx)
+		if err := deleteRancherFinalizers(ctx); err != nil {
+			return err
+		}
 		rancherFinalizersDeleted = true
 	}
 
@@ -533,7 +535,7 @@ func isRancherNamespace(ns *corev1.Namespace) bool {
 
 // deleteRancherFinalizers - delete Rancher finalizers on resources that the cleanup job
 // didn't catch
-func deleteRancherFinalizers(ctx spi.ComponentContext) {
+func deleteRancherFinalizers(ctx spi.ComponentContext) error {
 
 	// Check the finalizers of all ClusterRoles
 	crList := rbacv1.ClusterRoleList{}
@@ -570,7 +572,7 @@ func deleteRancherFinalizers(ctx spi.ComponentContext) {
 		// Check the finalizers of all RoleBindings
 		rbList := rbacv1.RoleBindingList{}
 		if err := ctx.Client().List(context.TODO(), &rbList, &listOptions); err != nil {
-			return
+			return err
 		}
 		for i, roleBinding := range rbList.Items {
 			removeFinalizer(ctx, &rbList.Items[i], roleBinding.Finalizers)
@@ -582,13 +584,16 @@ func deleteRancherFinalizers(ctx spi.ComponentContext) {
 			ctx.Log().Errorf("Component %s failed to list Roles: %v", ComponentName, err)
 		}
 		for i, role := range roleList.Items {
-			removeFinalizer(ctx, &roleList.Items[i], role.Finalizers)
+			if err := removeFinalizer(ctx, &roleList.Items[i], role.Finalizers); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 // removeFinalizer - remove finalizers from an object if one is owned by Rancher
-func removeFinalizer(ctx spi.ComponentContext, object client.Object, finalizers []string) {
+func removeFinalizer(ctx spi.ComponentContext, object client.Object, finalizers []string) error {
 	// If any of the finalizers contains a rancher one, remove them all
 	for _, finalizer := range finalizers {
 		if strings.Contains(finalizer, finalizerSubString) {
@@ -600,9 +605,9 @@ func removeFinalizer(ctx spi.ComponentContext, object client.Object, finalizers 
 				Log:       ctx.Log(),
 			}.RemoveFinalizers()
 			if err != nil {
-				ctx.Log().Errorf("Component %s failed to remove finalizers from %s/%s: %v", ComponentName, object.GetNamespace(), object.GetName(), err)
+				return ctx.Log().ErrorfNewErr("Component %s failed to remove finalizers from %s/%s: %v", ComponentName, object.GetNamespace(), object.GetName(), err)
 			}
-			return
 		}
 	}
+	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -543,7 +543,9 @@ func deleteRancherFinalizers(ctx spi.ComponentContext) error {
 		ctx.Log().Errorf("Component %s failed to list ClusterRoles: %v", ComponentName, err)
 	}
 	for i, clusterRole := range crList.Items {
-		removeFinalizer(ctx, &crList.Items[i], clusterRole.Finalizers)
+		if err := removeFinalizer(ctx, &crList.Items[i], clusterRole.Finalizers); err != nil {
+			return err
+		}
 	}
 
 	// Check the finalizers of all ClusterRoleBindings
@@ -552,7 +554,9 @@ func deleteRancherFinalizers(ctx spi.ComponentContext) error {
 		ctx.Log().Errorf("Component %s failed to list ClusterRoleBindings: %v", ComponentName, err)
 	}
 	for i, clusterRoleBinding := range crbList.Items {
-		removeFinalizer(ctx, &crbList.Items[i], clusterRoleBinding.Finalizers)
+		if err := removeFinalizer(ctx, &crbList.Items[i], clusterRoleBinding.Finalizers); err != nil {
+			return err
+		}
 	}
 
 	// Check the finalizers of Roles and RoleBindings of all namespaces.  Rancher adds a finalizer
@@ -575,7 +579,9 @@ func deleteRancherFinalizers(ctx spi.ComponentContext) error {
 			return err
 		}
 		for i, roleBinding := range rbList.Items {
-			removeFinalizer(ctx, &rbList.Items[i], roleBinding.Finalizers)
+			if err := removeFinalizer(ctx, &rbList.Items[i], roleBinding.Finalizers); err != nil {
+				return err
+			}
 		}
 
 		// Check the finalizers of all Roles

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -109,7 +109,7 @@ func postUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMo
 		// Check the result
 		succeeded, err := monitor.CheckResult()
 		if err != nil {
-			// Not finished yet, requeue
+			// Background goroutine is not finished yet, requeue
 			ctx.Log().Progress("Component Rancher waiting to finish post-uninstall in the background")
 			return err
 		}
@@ -122,8 +122,6 @@ func postUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMo
 			monitor.SetCompleted()
 			return nil
 		}
-		// if we were unsuccessful, reset and drop through to try again
-		ctx.Log().Debug("Error during Rancher post-uninstall, retrying")
 	}
 
 	return forkPostUninstallFunc(ctx, monitor)
@@ -131,8 +129,6 @@ func postUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMo
 
 // forkPostUninstall - fork uninstall install of Rancher
 func forkPostUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMonitor) error {
-	ctx.Log().Debug("Creating background post-uninstall goroutine for Rancher")
-
 	monitor.Run(
 		func() error {
 			return postUninstallFunc(ctx)
@@ -146,6 +142,7 @@ func forkPostUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProce
 // This calls the rancher-cleanup tool.
 func invokeRancherSystemToolAndCleanup(ctx spi.ComponentContext) error {
 	var err error
+	ctx.Log().Progress("Component Rancher background post-uninstall goroutine is running")
 
 	// Delete Rancher finalizers before running the rancher-cleanup job (to speed up the uninstall)
 	if !rancherFinalizersDeleted {
@@ -215,7 +212,7 @@ func runCleanupJob(ctx spi.ComponentContext) error {
 	err := ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: rancherCleanupJobNamespace, Name: rancherCleanupJobName}, job)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			ctx.Log().Infof("Component %s created job %s/%s", ComponentName, rancherCleanupJobNamespace, rancherCleanupJobName)
+			ctx.Log().Infof("Component %s created cleanup job %s/%s", ComponentName, rancherCleanupJobNamespace, rancherCleanupJobName)
 			return createCleanupJob(ctx)
 		}
 		return err
@@ -231,7 +228,8 @@ func runCleanupJob(ctx spi.ComponentContext) error {
 	}
 
 	if !jobComplete {
-		return fmt.Errorf("Component %s waiting for job to complete: %s/%s", ComponentName, job.Namespace, job.Name)
+		ctx.Log().Progressf("Component %s waiting for cleanup job to complete: %s/%s", ComponentName, job.Namespace, job.Name)
+		return ctrlerrors.RetryableError{}
 	}
 	ctx.Log().Progressf("Component %s job successfully completed: %s/%s", ComponentName, job.Namespace, job.Name)
 
@@ -243,13 +241,14 @@ func createCleanupJob(ctx spi.ComponentContext) error {
 	// Prepare the Yaml to create the rancher-cleanup job
 	jobYaml, err := parseCleanupJobTemplate()
 	if err != nil {
-		ctx.Log().ErrorfThrottled("Failed to create yaml for %s job: %v", rancherCleanupJobName, err)
+		ctx.Log().ErrorfThrottled("Failed to create yaml for %s cleanup job: %v", rancherCleanupJobName, err)
 		return err
 	}
 
 	// Write to a temporary file
 	file, err := os.CreateTempFile("vz", jobYaml)
 	if err != nil {
+		ctx.Log().ErrorfThrottled("Failed to create Rancher cleanup temporary file for %s job: %v", rancherCleanupJobName, err)
 		return err
 	}
 	defer file.Close()
@@ -258,7 +257,8 @@ func createCleanupJob(ctx spi.ComponentContext) error {
 	if err = k8sutil.NewYAMLApplier(ctx.Client(), "").ApplyF(file.Name()); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed applying Yaml to create job %s/%s for component %s: %v", rancherCleanupJobNamespace, rancherCleanupJobName, ComponentName, err)
 	}
-	return ctx.Log().ErrorfNewErr("Component %s waiting for job %s/%s to start", ComponentName, rancherCleanupJobNamespace, rancherCleanupJobName)
+	ctx.Log().Progressf("Component %s waiting for cleanup job %s/%s to start", ComponentName, rancherCleanupJobNamespace, rancherCleanupJobName)
+	return ctrlerrors.RetryableError{}
 }
 
 // deleteCleanupJob - delete the rancher-cleanup job. Do not return any errors,
@@ -267,20 +267,21 @@ func deleteCleanupJob(ctx spi.ComponentContext) {
 	// Prepare the Yaml to delete the rancher-cleanup job
 	jobYaml, err := parseCleanupJobTemplate()
 	if err != nil {
-		ctx.Log().ErrorfThrottled("Failed to create yaml for %s job: %v", rancherCleanupJobName, err)
+		ctx.Log().ErrorfThrottled("Failed to create yaml for %s cleanup job: %v", rancherCleanupJobName, err)
 		return
 	}
 
 	// Write to a temporary file
 	file, err := os.CreateTempFile("vz", jobYaml)
 	if err != nil {
+		ctx.Log().ErrorfThrottled("Failed to create Rancher cleanup temporary file for %s job: %v", rancherCleanupJobName, err)
 		return
 	}
 	defer file.Close()
 
 	// Delete the rancher-cleanup job
 	if err = k8sutil.NewYAMLApplier(ctx.Client(), "").DeleteF(file.Name()); err != nil {
-		ctx.Log().Errorf("Failed applying Yaml to delete job %s/%s for component %s: %v", rancherCleanupJobNamespace, rancherCleanupJobName, ComponentName, err)
+		ctx.Log().Errorf("Failed applying Yaml to delete cleanup job %s/%s for component %s: %v", rancherCleanupJobNamespace, rancherCleanupJobName, ComponentName, err)
 	}
 }
 
@@ -375,7 +376,7 @@ func getCRDList(ctx spi.ComponentContext) *v1.CustomResourceDefinitionList {
 
 // removeCRs deletes any remaining Rancher cattle.io custom resources
 func removeCRs(ctx spi.ComponentContext, crds *v1.CustomResourceDefinitionList) {
-	ctx.Log().Oncef("Removing Rancher custom resources")
+	ctx.Log().Progress("Removing Rancher custom resources")
 	for _, crd := range crds.Items {
 		if strings.HasSuffix(crd.Name, finalizerSubString) {
 			for _, version := range crd.Spec.Versions {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -683,7 +683,6 @@ func TestCleanupJob(t *testing.T) {
 	// Expect the job to get created
 	err := runCleanupJob(ctx)
 	a.Error(err)
-	a.Contains(err.Error(), "waiting for job")
 	job := batchv1.Job{}
 	err = ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: rancherCleanupJobNamespace, Name: rancherCleanupJobName}, &job)
 	a.NoError(err)

--- a/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
+++ b/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
+++ b/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
@@ -14,7 +14,7 @@ i=0
 resName=$(kubectl get vz -o jsonpath='{.items[*].metadata.name}')
 echo "waiting for install of resource ${resName} to complete"
 
-while [[ $retval_success -ne 0 ]] && [[ $retval_failed -ne 0 ]]  && [[ $i -lt 30 ]]  ; do
+while [[ $retval_success -ne 0 ]] && [[ $retval_failed -ne 0 ]]  && [[ $i -lt 45 ]]  ; do
   sleep 60
   output=$(kubectl wait --for=condition=InstallFailed verrazzano/${resName} --timeout=0 2>&1)
   retval_failed=$?
@@ -23,7 +23,7 @@ while [[ $retval_success -ne 0 ]] && [[ $retval_failed -ne 0 ]]  && [[ $i -lt 30
   i=$((i+1))
 done
 
-if [[ $retval_failed -eq 0 ]] || [[ $i -eq 30 ]] ; then
+if [[ $retval_failed -eq 0 ]] || [[ $i -eq 45 ]] ; then
     echo "Installation Failed"
     kubectl get vz ${resName} -o yaml
     exit 1


### PR DESCRIPTION
Rancher uninstall was getting conflict errors when removing finalizers from clusterroles, but the errors were being ignored so the clusterroles were not getting deleted.  Change the code to bubble the error up the stack so reconcile is called again.  Also add more logging/

Change the install timeout to 45 min for OCI DNS.  The install was taking 33-34 min because of Let's Encrypt being slow and the tests failed.