### PR TITLE
NO JIRA - Extend install timeout to 45 from 30 in tests/e2e/config/sc…

### DIFF
--- a/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
+++ b/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
@@ -21,7 +21,7 @@ while [[ $retval_success -ne 0 ]] && [[ $retval_failed -ne 0 ]]  && [[ $i -lt 30
   i=$((i+1))
 done
 
-if [[ $retval_failed -eq 0 ]] || [[ $i -eq 30 ]] ; then
+if [[ $retval_failed -eq 0 ]] || [[ $i -eq 45 ]] ; then
     echo "Installation Failed"
     kubectl get vz my-verrazzano -o yaml
     exit 1


### PR DESCRIPTION
…ripts/wait-for-verrazzano-install.sh

Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
