### PR TITLE
VZ-8357 handle Rancher unistall update conflict 

### DIFF
--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -276,7 +276,7 @@ pipeline {
                     yq -i eval '.spec.components.prometheusPushgateway.enabled = true'  ${INSTALL_CONFIG_FILE}
 
                     echo "Installing Verrazzano on OKE"
-                    ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/acceptance-test-operator.yaml --timeout 30m
+                    ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/acceptance-test-operator.yaml --timeout 45m
 
                     ${TEST_SCRIPTS_DIR}/common-test-setup-script.sh "${GO_REPO_PATH}" "${TEST_CONFIG_FILE}" "${env.DOCKER_REPO}" "${KUBECONFIG}" "${OCR_CREDS_USR}" "${OCR_CREDS_PSW}" "default" "${env.OCR_REPO}"
                     ${TEST_SCRIPTS_DIR}/get_ingress_ip.sh ${TEST_CONFIG_FILE}
@@ -413,7 +413,7 @@ pipeline {
                     ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "verrazzano-install"
 
 
-                    ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/acceptance-test-operator.yaml --timeout 30m
+                    ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/acceptance-test-operator.yaml --timeout 45m
 
                     ${TEST_SCRIPTS_DIR}/common-test-setup-script.sh "${GO_REPO_PATH}" "${TEST_CONFIG_FILE}" "${env.DOCKER_REPO}" "${KUBECONFIG}" "${OCR_CREDS_USR}" "${OCR_CREDS_PSW}" "default"
                     ${TEST_SCRIPTS_DIR}/get_ingress_ip.sh ${TEST_CONFIG_FILE}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -101,7 +101,7 @@ func postUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMo
 		// Check the result
 		succeeded, err := monitor.CheckResult()
 		if err != nil {
-			// Not finished yet, requeue
+			// Background goroutine is not finished yet, requeue
 			ctx.Log().Progress("Component Rancher waiting to finish post-uninstall in the background")
 			return err
 		}
@@ -114,8 +114,6 @@ func postUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMo
 			monitor.SetCompleted()
 			return nil
 		}
-		// if we were unsuccessful, reset and drop through to try again
-		ctx.Log().Debug("Error during Rancher post-uninstall, retrying")
 	}
 
 	return forkPostUninstallFunc(ctx, monitor)
@@ -123,8 +121,6 @@ func postUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMo
 
 // forkPostUninstall - fork uninstall install of Rancher
 func forkPostUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMonitor) error {
-	ctx.Log().Debug("Creating background post-uninstall goroutine for Rancher")
-
 	monitor.Run(
 		func() error {
 			return postUninstallFunc(ctx)
@@ -138,6 +134,12 @@ func forkPostUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProce
 // This calls the rancher-cleanup tool.
 func invokeRancherSystemToolAndCleanup(ctx spi.ComponentContext) error {
 	var err error
+	ctx.Log().Progress("Component Rancher background post-uninstall goroutine is running")
+
+	// Delete Rancher finalizers before running the rancher-cleanup job (to speed up the uninstall)
+	if err := deleteRancherFinalizers(ctx); err != nil {
+		return err
+	}
 
 	// Run the rancher-cleanup job
 	if err := runCleanupJob(ctx); err != nil {
@@ -204,7 +206,7 @@ func runCleanupJob(ctx spi.ComponentContext) error {
 	err := ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: rancherCleanupJobNamespace, Name: rancherCleanupJobName}, job)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			ctx.Log().Infof("Component %s created job %s/%s", ComponentName, rancherCleanupJobNamespace, rancherCleanupJobName)
+			ctx.Log().Infof("Component %s created cleanup job %s/%s", ComponentName, rancherCleanupJobNamespace, rancherCleanupJobName)
 			return createCleanupJob(ctx)
 		}
 		return err
@@ -220,7 +222,8 @@ func runCleanupJob(ctx spi.ComponentContext) error {
 	}
 
 	if !jobComplete {
-		return fmt.Errorf("Component %s waiting for job to complete: %s/%s", ComponentName, job.Namespace, job.Name)
+		ctx.Log().Progressf("Component %s waiting for cleanup job to complete: %s/%s", ComponentName, job.Namespace, job.Name)
+		return ctrlerrors.RetryableError{}
 	}
 	ctx.Log().Progressf("Component %s job successfully completed: %s/%s", ComponentName, job.Namespace, job.Name)
 
@@ -232,13 +235,14 @@ func createCleanupJob(ctx spi.ComponentContext) error {
 	// Prepare the Yaml to create the rancher-cleanup job
 	jobYaml, err := parseCleanupJobTemplate()
 	if err != nil {
-		ctx.Log().ErrorfThrottled("Failed to create yaml for %s job: %v", rancherCleanupJobName, err)
+		ctx.Log().ErrorfThrottled("Failed to create yaml for %s cleanup job: %v", rancherCleanupJobName, err)
 		return err
 	}
 
 	// Write to a temporary file
 	file, err := os.CreateTempFile("vz", jobYaml)
 	if err != nil {
+		ctx.Log().ErrorfThrottled("Failed to create Rancher cleanup temporary file for %s job: %v", rancherCleanupJobName, err)
 		return err
 	}
 	defer file.Close()
@@ -247,7 +251,8 @@ func createCleanupJob(ctx spi.ComponentContext) error {
 	if err = k8sutil.NewYAMLApplier(ctx.Client(), "").ApplyF(file.Name()); err != nil {
 		return ctx.Log().ErrorfNewErr("Failed applying Yaml to create job %s/%s for component %s: %v", rancherCleanupJobNamespace, rancherCleanupJobName, ComponentName, err)
 	}
-	return ctx.Log().ErrorfNewErr("Component %s waiting for job %s/%s to start", ComponentName, rancherCleanupJobNamespace, rancherCleanupJobName)
+	ctx.Log().Progressf("Component %s waiting for cleanup job %s/%s to start", ComponentName, rancherCleanupJobNamespace, rancherCleanupJobName)
+	return ctrlerrors.RetryableError{}
 }
 
 // deleteCleanupJob - delete the rancher-cleanup job. Do not return any errors,
@@ -256,20 +261,21 @@ func deleteCleanupJob(ctx spi.ComponentContext) {
 	// Prepare the Yaml to delete the rancher-cleanup job
 	jobYaml, err := parseCleanupJobTemplate()
 	if err != nil {
-		ctx.Log().ErrorfThrottled("Failed to create yaml for %s job: %v", rancherCleanupJobName, err)
+		ctx.Log().ErrorfThrottled("Failed to create yaml for %s cleanup job: %v", rancherCleanupJobName, err)
 		return
 	}
 
 	// Write to a temporary file
 	file, err := os.CreateTempFile("vz", jobYaml)
 	if err != nil {
+		ctx.Log().ErrorfThrottled("Failed to create Rancher cleanup temporary file for %s job: %v", rancherCleanupJobName, err)
 		return
 	}
 	defer file.Close()
 
 	// Delete the rancher-cleanup job
 	if err = k8sutil.NewYAMLApplier(ctx.Client(), "").DeleteF(file.Name()); err != nil {
-		ctx.Log().Errorf("Failed applying Yaml to delete job %s/%s for component %s: %v", rancherCleanupJobNamespace, rancherCleanupJobName, ComponentName, err)
+		ctx.Log().Errorf("Failed applying Yaml to delete cleanup job %s/%s for component %s: %v", rancherCleanupJobNamespace, rancherCleanupJobName, ComponentName, err)
 	}
 }
 
@@ -364,7 +370,7 @@ func getCRDList(ctx spi.ComponentContext) *v1.CustomResourceDefinitionList {
 
 // removeCRs deletes any remaining Rancher cattle.io custom resources
 func removeCRs(ctx spi.ComponentContext, crds *v1.CustomResourceDefinitionList) {
-	ctx.Log().Oncef("Removing Rancher custom resources")
+	ctx.Log().Progress("Removing Rancher custom resources")
 	for _, crd := range crds.Items {
 		if strings.HasSuffix(crd.Name, finalizerSubString) {
 			for _, version := range crd.Spec.Versions {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall_test.go
@@ -683,7 +683,6 @@ func TestCleanupJob(t *testing.T) {
 	// Expect the job to get created
 	err := runCleanupJob(ctx)
 	a.Error(err)
-	a.Contains(err.Error(), "waiting for job")
 	job := batchv1.Job{}
 	err = ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: rancherCleanupJobNamespace, Name: rancherCleanupJobName}, &job)
 	a.NoError(err)

--- a/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
+++ b/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
+++ b/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
@@ -14,7 +14,7 @@ i=0
 resName=$(kubectl get vz -o jsonpath='{.items[*].metadata.name}')
 echo "waiting for install of resource ${resName} to complete"
 
-while [[ $retval_success -ne 0 ]] && [[ $retval_failed -ne 0 ]]  && [[ $i -lt 30 ]]  ; do
+while [[ $retval_success -ne 0 ]] && [[ $retval_failed -ne 0 ]]  && [[ $i -lt 45 ]]  ; do
   sleep 60
   output=$(kubectl wait --for=condition=InstallFailed verrazzano/${resName} --timeout=0 2>&1)
   retval_failed=$?
@@ -23,7 +23,7 @@ while [[ $retval_success -ne 0 ]] && [[ $retval_failed -ne 0 ]]  && [[ $i -lt 30
   i=$((i+1))
 done
 
-if [[ $retval_failed -eq 0 ]] || [[ $i -eq 30 ]] ; then
+if [[ $retval_failed -eq 0 ]] || [[ $i -eq 45 ]] ; then
     echo "Installation Failed"
     kubectl get vz ${resName} -o yaml
     exit 1


### PR DESCRIPTION
This is a cherry-pick of https://github.com/verrazzano/verrazzano/commit/a02ed14dcbc6d741f1af5085ce32765c9214632e

Rancher uninstall was getting conflict errors when removing finalizers from clusterroles, but the errors were being ignored so the clusterroles were not getting deleted. Change the code to bubble the error up the stack so reconcile is called again. Also add more logging/

Change the install timeout to 45 min for OCI DNS.  The install was taking 33-34 min because of Let's Encrypt being slow and the tests failed.  Do the same for the install phase of uninstall pipeline.

