### PR TITLE
VZ-8748: Check for Config Changes in compStateInstallEnd State

### DIFF
--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -284,10 +284,6 @@ pipeline {
                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-install-verify-infra"
             }
             steps {
-                // Verrazzano may continue reconciling even after the `vz install` command exits, so
-                // wait a bit before running the verify-install tests.
-                sleep time: 5, unit: 'MINUTES'
-
                 runGinkgoRandomize('verify-install')
             }
             post {

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package reconcile
@@ -191,8 +191,8 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, install
 
 	// The component previously finished installing, but check for any mid-installation updates
 	// which may require restarting the component's installation from the beginning
-	if restartComponentInstallFromEndState(compContext, comp, componentStatus, compTracker) {
-		compTracker.installState = compStateInstallInitDetermineComponentState
+	if restartComponentInstallFromEndState(compContext, comp, componentStatus) {
+		installContext.state = compStateInstallInitDetermineComponentState
 		if err := r.updateComponentStatus(compContext, "PreInstall started", vzapi.CondPreInstall); err != nil {
 			compLog.ErrorfThrottled("Error writing component PreInstall state to the status: %v", err)
 		}
@@ -265,8 +265,7 @@ func chooseCompState(componentStatus *vzapi.ComponentStatusDetails) componentIns
 }
 
 // restartComponentInstallFromEndState contains the logic about whether to restart this component's installation from compStateInstallEnd
-func restartComponentInstallFromEndState(compContext spi.ComponentContext, comp spi.Component, componentStatus *vzapi.ComponentStatusDetails,
-	compTracker *componentTrackerContext) bool {
+func restartComponentInstallFromEndState(compContext spi.ComponentContext, comp spi.Component, componentStatus *vzapi.ComponentStatusDetails) bool {
 	// Do not interrupt the upgrade flow
 	if compContext.ActualCR().Status.State == vzapi.VzStateUpgrading || compContext.ActualCR().Status.State == vzapi.VzStatePaused {
 		return false

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -187,8 +187,18 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, install
 
 			installContext.state = compStateInstallEnd
 		}
-
 	}
+
+	// The component previously finished installing, but check for any mid-installation updates
+	// which may require restarting the component's installation from the beginning
+	if restartComponentInstallFromEndState(compContext, comp, componentStatus, compTracker) {
+		compTracker.installState = compStateInstallInitDetermineComponentState
+		if err := r.updateComponentStatus(compContext, "PreInstall started", vzapi.CondPreInstall); err != nil {
+			compLog.ErrorfThrottled("Error writing component PreInstall state to the status: %v", err)
+		}
+		return ctrl.Result{Requeue: true}
+	}
+
 	// Component has been installed
 	return ctrl.Result{}
 }
@@ -252,6 +262,25 @@ func chooseCompState(componentStatus *vzapi.ComponentStatusDetails) componentIns
 	default:
 		return compStateInstallInitReady
 	}
+}
+
+// restartComponentInstallFromEndState contains the logic about whether to restart this component's installation from compStateInstallEnd
+func restartComponentInstallFromEndState(compContext spi.ComponentContext, comp spi.Component, componentStatus *vzapi.ComponentStatusDetails,
+	compTracker *componentTrackerContext) bool {
+	// Do not interrupt the upgrade flow
+	if compContext.ActualCR().Status.State == vzapi.VzStateUpgrading || compContext.ActualCR().Status.State == vzapi.VzStatePaused {
+		return false
+	}
+	// Only restart the component install if the config has been updated and the component is enabled
+	if !checkConfigUpdated(compContext, componentStatus) || !comp.IsEnabled(compContext.EffectiveCR()) {
+		return false
+	}
+	// if monitoring overrides is disabled, updates are prevented for override changes and the install process should be bypassed
+	if !comp.MonitorOverrides(compContext) {
+		compContext.Log().Oncef("Skipping update for component %s, monitorChanges set to false", comp.Name())
+		return false
+	}
+	return true
 }
 
 // skipComponentFromDetermineComponentState contains the logic about whether to go straight to the component terminal state from compStateInstallInitDetermineComponentState

--- a/platform-operator/controllers/verrazzano/reconcile/install_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_test.go
@@ -344,7 +344,6 @@ func TestUpdateBeforeInstallComplete(t *testing.T) {
 	vz := vzapi.Verrazzano{}
 	err = ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &vz)
 	asserts.NoError(err)
-	fmt.Println(vz.Status.Components[fakeCompReleaseName].Conditions)
 
 	asserts.Equal(vzapi.VzStateReconciling, vz.Status.State)
 	asserts.False(*fakeCompUpdated)

--- a/platform-operator/controllers/verrazzano/reconcile/install_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_test.go
@@ -58,7 +58,7 @@ var (
 )
 
 // TestStartUpdate tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
+// GIVEN a request to reconcile a verrazzano resource after install is completed
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure a Reconciling State
 func TestStartUpdate(t *testing.T) {
@@ -94,7 +94,7 @@ func TestStartUpdate(t *testing.T) {
 }
 
 // TestCompleteUpdateReadyComponent tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install has been started
+// GIVEN a request to reconcile a verrazzano resource after install has been started
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure a Ready State
 func TestCompleteUpdateReadyComponent(t *testing.T) {
@@ -134,7 +134,7 @@ func TestCompleteUpdateReadyComponent(t *testing.T) {
 }
 
 // TestCompleteUpdateDisabledComponent tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install has been started
+// GIVEN a request to reconcile a verrazzano resource after install has been started
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure a Ready State
 func TestCompleteUpdateDisabledComponent(t *testing.T) {
@@ -174,7 +174,7 @@ func TestCompleteUpdateDisabledComponent(t *testing.T) {
 }
 
 // TestNoUpdateSameGeneration tests the reconcile func with same generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
+// GIVEN a request to reconcile a verrazzano resource after install is completed
 // WHEN all components have the same LastReconciledGeneration as verrazzano CR
 // THEN ensure a Ready State
 func TestNoUpdateSameGeneration(t *testing.T) {
@@ -207,7 +207,7 @@ func TestNoUpdateSameGeneration(t *testing.T) {
 }
 
 // TestUpdateWithUpgrade tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
+// GIVEN a request to reconcile a verrazzano resource after install is completed
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure an Upgrading State
 func TestUpdateWithUpgrade(t *testing.T) {
@@ -241,7 +241,7 @@ func TestUpdateWithUpgrade(t *testing.T) {
 }
 
 // TestUpdateOnUpdate tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
+// GIVEN a request to reconcile a verrazzano resource after install is completed
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure a Reconciling State
 func TestUpdateOnUpdate(t *testing.T) {
@@ -279,7 +279,7 @@ func TestUpdateOnUpdate(t *testing.T) {
 }
 
 // TestUpdateFalseMonitorChanges tests the reconcile func with updated generation
-// GIVEN a request to reconcile an verrazzano resource after install is completed
+// GIVEN a request to reconcile a verrazzano resource after install is completed
 // WHEN all components have the smaller LastReconciledGeneration but MonitorOverrides returns false
 // THEN ensure a Ready State
 func TestUpdateFalseMonitorChanges(t *testing.T) {
@@ -314,6 +314,44 @@ func TestUpdateFalseMonitorChanges(t *testing.T) {
 	asserts.False(result.Requeue)
 	assertKeycloakAuthConfig(asserts, ctx)
 	assertArgoCDConfig(asserts, ctx)
+}
+
+// TestUpdateBeforeInstallComplete tests the reconcile func with updated generation
+// GIVEN a request to reconcile an installing verrazzano resource before it completes
+// WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
+// THEN ensure a Reconciling State
+func TestUpdateBeforeInstallComplete(t *testing.T) {
+	initUnitTesing()
+
+	status := vzapi.VerrazzanoStatus{
+		State:   vzapi.VzStateReconciling,
+		Version: statusVer,
+		Conditions: []vzapi.Condition{
+			{
+				Type: vzapi.CondInstallStarted,
+			},
+		},
+		Components: makeVerrazzanoComponentStatusMap(),
+	}
+
+	ctx, asserts, result, fakeCompUpdated, err := testUpdate(t,
+		lastReconciledGeneration+1, int64(0), lastReconciledGeneration,
+		"1.3.0", status, namespace, name, "true")
+	asserts.NoError(err)
+
+	defer reset()
+
+	vz := vzapi.Verrazzano{}
+	err = ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &vz)
+	asserts.NoError(err)
+	fmt.Println(vz.Status.Components[fakeCompReleaseName].Conditions)
+
+	asserts.Equal(vzapi.VzStateReconciling, vz.Status.State)
+	asserts.False(*fakeCompUpdated)
+	asserts.Equal(vz.Generation, vz.Status.Components[fakeCompReleaseName].ReconcilingGeneration)
+	asserts.Equal(vzapi.CondInstallComplete, vz.Status.Components[fakeCompReleaseName].Conditions[0].Type)
+	asserts.Equal(vzapi.CondPreInstall, vz.Status.Components[fakeCompReleaseName].Conditions[1].Type)
+	asserts.True(result.Requeue)
 }
 
 func reset() {


### PR DESCRIPTION
Backport of https://github.com/verrazzano/verrazzano/pull/5514 and https://github.com/verrazzano/verrazzano/pull/5529.

Changes:
- Removes the `sleep` command in the "Verify Install" stage of ci/dynamic-updates/JenkinsfileUpdateDuringInstall
- `installSingleComponent` checks for config changes when in `compStateInstallEnd` State
- adds `TestUpdateBeforeInstallComplete` unit test