### PR TITLE
VZ-8748: Remove sleep from dynamic-config-install tests

### DIFF
--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -272,10 +272,6 @@ pipeline {
                 DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-install-verify-infra"
             }
             steps {
-                // Verrazzano may continue reconciling even after the `vz install` command exits, so
-                // wait a bit before running the verify-install tests.
-                sleep time: 5, unit: 'MINUTES'
-
                 runGinkgoRandomize('verify-install')
             }
             post {


### PR DESCRIPTION
(Partial) backport of https://github.com/verrazzano/verrazzano/pull/5514.

Removes the `sleep` command in the "Verify Install" stage of ci/dynamic-updates/JenkinsfileUpdateDuringInstall.