### PR TITLE
Move a network policy to the Helm chart

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -27,13 +27,11 @@ import (
 	istiov1beta1 "istio.io/api/type/v1beta1"
 	istioclisec "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -132,9 +130,6 @@ func postInstallUpgrade(ctx spi.ComponentContext) error {
 		return err
 	}
 	if err := createOrUpdatePrometheusAuthPolicy(ctx); err != nil {
-		return err
-	}
-	if err := createOrUpdateNetworkPolicies(ctx); err != nil {
 		return err
 	}
 	if err := createOrUpdateServiceMonitors(ctx); err != nil {
@@ -714,18 +709,6 @@ func createOrUpdateServiceMonitors(ctx spi.ComponentContext) error {
 	return nil
 }
 
-// createOrUpdateNetworkPolicies creates or updates network policies for this component
-func createOrUpdateNetworkPolicies(ctx spi.ComponentContext) error {
-	netPolicy := &netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: networkPolicyName, Namespace: ComponentNamespace}}
-
-	_, err := controllerutil.CreateOrUpdate(context.TODO(), ctx.Client(), netPolicy, func() error {
-		netPolicy.Spec = newNetworkPolicySpec()
-		return nil
-	})
-
-	return err
-}
-
 // create or update ingresses creates ingresses for each of the Prometheus endpoints
 func createOrUpdateIngresses(ctx spi.ComponentContext) error {
 	// If NGINX is not enabled, skip the ingress creation
@@ -779,111 +762,4 @@ func isThanosEnabled(ctx spi.ComponentContext) (bool, error) {
 		}
 	}
 	return false, nil
-}
-
-// newNetworkPolicy returns a populated NetworkPolicySpec with ingress rules for Prometheus
-func newNetworkPolicySpec() netv1.NetworkPolicySpec {
-	tcpProtocol := corev1.ProtocolTCP
-	promPort := intstr.FromInt(9090)
-	sidecarPort := intstr.FromInt(10901)
-
-	return netv1.NetworkPolicySpec{
-		PodSelector: metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"app.kubernetes.io/name": prometheusName,
-			},
-		},
-		PolicyTypes: []netv1.PolicyType{
-			netv1.PolicyTypeIngress,
-		},
-		Ingress: []netv1.NetworkPolicyIngressRule{
-			{
-				// allow ingress to port 9090 and 10901 from Auth Proxy, Grafana, and Kiali
-				From: []netv1.NetworkPolicyPeer{
-					{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								vzconst.LabelVerrazzanoNamespace: constants.VerrazzanoSystemNamespace,
-							},
-						},
-						PodSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{
-									Key:      "app",
-									Operator: metav1.LabelSelectorOpIn,
-									Values: []string{
-										"verrazzano-authproxy",
-										"system-grafana",
-										"kiali",
-									},
-								},
-							},
-						},
-					},
-				},
-				Ports: []netv1.NetworkPolicyPort{
-					{
-						Protocol: &tcpProtocol,
-						Port:     &promPort,
-					},
-					{
-						Protocol: &tcpProtocol,
-						Port:     &sidecarPort,
-					},
-				},
-			},
-			{
-				// allow ingress to port 9090 from Jaeger
-				From: []netv1.NetworkPolicyPeer{
-					{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								vzconst.LabelVerrazzanoNamespace: constants.VerrazzanoMonitoringNamespace,
-							},
-						},
-						PodSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{
-									Key:      "app",
-									Operator: metav1.LabelSelectorOpIn,
-									Values: []string{
-										"jaeger",
-									},
-								},
-							},
-						},
-					},
-				},
-				Ports: []netv1.NetworkPolicyPort{
-					{
-						Protocol: &tcpProtocol,
-						Port:     &promPort,
-					},
-				},
-			},
-			{
-				// allow ingress to Thanos sidecar on port 10901 from Thanos Query
-				From: []netv1.NetworkPolicyPeer{
-					{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								vzconst.LabelVerrazzanoNamespace: constants.VerrazzanoMonitoringNamespace,
-							},
-						},
-						PodSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app.kubernetes.io/component": "query",
-							},
-						},
-					},
-				},
-				Ports: []netv1.NetworkPolicyPort{
-					{
-						Protocol: &tcpProtocol,
-						Port:     &sidecarPort,
-					},
-				},
-			},
-		},
-	}
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -901,33 +901,6 @@ func TestCreateOrUpdatePrometheusAuthPolicy(t *testing.T) {
 	assertions.ErrorContains(err, "not found")
 }
 
-// TestCreateOrUpdateNetworkPolicies tests the createOrUpdateNetworkPolicies function
-func TestCreateOrUpdateNetworkPolicies(t *testing.T) {
-	// GIVEN a Prometheus Operator component
-	// WHEN  the createOrUpdateNetworkPolicies function is called
-	// THEN  no error is returned and the expected network policies have been created
-	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
-	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false)
-
-	err := createOrUpdateNetworkPolicies(ctx)
-	assert.NoError(t, err)
-
-	netPolicy := &netv1.NetworkPolicy{}
-	err = client.Get(context.TODO(), types.NamespacedName{Name: networkPolicyName, Namespace: ComponentNamespace}, netPolicy)
-	assert.NoError(t, err)
-	assert.Len(t, netPolicy.Spec.Ingress, 3)
-	assert.Equal(t, []netv1.PolicyType{netv1.PolicyTypeIngress}, netPolicy.Spec.PolicyTypes)
-	assert.Equal(t, int32(9090), netPolicy.Spec.Ingress[0].Ports[0].Port.IntVal)
-	assert.Equal(t, int32(10901), netPolicy.Spec.Ingress[0].Ports[1].Port.IntVal)
-	assert.Equal(t, int32(9090), netPolicy.Spec.Ingress[1].Ports[0].Port.IntVal)
-	assert.Equal(t, int32(10901), netPolicy.Spec.Ingress[2].Ports[0].Port.IntVal)
-	assert.Contains(t, netPolicy.Spec.Ingress[0].From[0].PodSelector.MatchExpressions[0].Values, "verrazzano-authproxy")
-	assert.Contains(t, netPolicy.Spec.Ingress[0].From[0].PodSelector.MatchExpressions[0].Values, "system-grafana")
-	assert.Contains(t, netPolicy.Spec.Ingress[0].From[0].PodSelector.MatchExpressions[0].Values, "kiali")
-	assert.Contains(t, netPolicy.Spec.Ingress[1].From[0].PodSelector.MatchExpressions[0].Values, "jaeger")
-	assert.Equal(t, netPolicy.Spec.Ingress[2].From[0].PodSelector.MatchLabels["app.kubernetes.io/component"], "query")
-}
-
 // erroringFakeClient wraps a k8s client and returns an error when Update is called
 type erroringFakeClient struct {
 	client.Client

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/networkpolicy.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/networkpolicy.yaml
@@ -1,0 +1,52 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vmi-system-prometheus
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          verrazzano.io/namespace: verrazzano-system
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - verrazzano-authproxy
+          - system-grafana
+          - kiali
+    ports:
+    - port: 9090
+      protocol: TCP
+    - port: 10901
+      protocol: TCP
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          verrazzano.io/namespace: {{ template "kube-prometheus-stack.namespace" . }}
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - jaeger
+    ports:
+    - port: 9090
+      protocol: TCP
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          verrazzano.io/namespace: {{ template "kube-prometheus-stack.namespace" . }}
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/component: query
+    ports:
+    - port: 10901
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+  - Ingress

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
 {{ if .Capabilities.APIVersions.Has "security.istio.io/v1beta1" -}}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
@@ -1,5 +1,3 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
-# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 {{ if .Capabilities.APIVersions.Has "security.istio.io/v1beta1" -}}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
@@ -1,5 +1,3 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
-# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
This PR moves a network policy out of the VPO Prometheus Operator installation code into the kube-prometheus-stack Helm chart. Also fixes up the copyright header on two templates we have added to the Thanos Helm chart.

To test this locally, I saved the network policy from an older cluster and compared it with a new install and confirmed the network policies were the same.