### PR TITLE
Follow up PR for revert PR to update copyright year

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1

--- a/platform-operator/apis/verrazzano/v1beta1/validate.go
+++ b/platform-operator/apis/verrazzano/v1beta1/validate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1beta1


### PR DESCRIPTION
Changes to validate.go files for v1alpha and v1beta1 because, the copyright checker detects changes to this files which is causing the failure