### PR TITLE
Additional pod and container security context settings for Thanos components

### DIFF
--- a/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -45,9 +45,6 @@ prometheus:
       - name: config-reloader
         securityContext:
           privileged: false
-      - name: thanos-sidecar
-        securityContext:
-          privileged: false
     initContainers:
       - name: init-config-reloader
         securityContext:

--- a/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -45,6 +45,9 @@ prometheus:
       - name: config-reloader
         securityContext:
           privileged: false
+      - name: thanos-sidecar
+        securityContext:
+          privileged: false
     initContainers:
       - name: init-config-reloader
         securityContext:

--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -2,6 +2,65 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 query:
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    privileged: false
+    capabilities:
+      drop:
+        - ALL
+
   # Adds the Prometheus Thanos sidecar as a Store API endpoint to Query
   stores:
     - prometheus-operator-kube-p-prometheus:10901
+
+queryFrontend:
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    privileged: false
+    capabilities:
+      drop:
+        - ALL
+
+compactor:
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    privileged: false
+    capabilities:
+      drop:
+        - ALL
+
+storegateway:
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    privileged: false
+    capabilities:
+      drop:
+        - ALL
+
+ruler:
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    privileged: false
+    capabilities:
+      drop:
+        - ALL
+
+receive:
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    privileged: false
+    capabilities:
+      drop:
+        - ALL

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/prometheus.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/prometheus.yaml
@@ -301,6 +301,11 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.containers }}
   containers:
 {{ toYaml .Values.prometheus.prometheusSpec.containers | indent 4 }}
+{{- if and (.Values.prometheus.prometheusSpec.thanos) (eq .Values.prometheus.thanos.integration "sidecar") }}
+    - name: thanos-sidecar
+      securityContext:
+        privileged: false
+{{- end }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.initContainers }}
   initContainers:


### PR DESCRIPTION
Out of the box, the Thanos components include some pod and container security context settings. This PR adds more settings to make the pods and containers more secure, and makes the security configuration consistent with other Verrazzano components.

To verify the changes, I ran the pod security e2e test which reports missing security context on pods and containers on a cluster with Thanos installed (including the Prometheus sidecar). After these changes, the test passes. I also ran an internal diagnostic tool against the verrazzano-monitoring namespace, and it reported no issues.

I ran one additional validation by labeling the verrazzano-monitoring namespace with `"pod-security.kubernetes.io/enforce"=restricted`. That also reported no issues.