### PR TITLE
log message fix to include none keyword

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/validate.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/validate.go
@@ -20,7 +20,7 @@ func ValidateProfile(requestedProfile ProfileType) error {
 		case Prod, Dev, ManagedCluster, None:
 			return nil
 		default:
-			return fmt.Errorf("Requested profile %s is invalid, valid options are dev, prod, or managed-cluster",
+			return fmt.Errorf("Requested profile %s is invalid, valid options are dev, prod, managed-cluster, or none",
 				requestedProfile)
 		}
 	}

--- a/platform-operator/apis/verrazzano/v1beta1/validate.go
+++ b/platform-operator/apis/verrazzano/v1beta1/validate.go
@@ -18,7 +18,7 @@ func ValidateProfile(requestedProfile ProfileType) error {
 		case Prod, Dev, ManagedCluster, None:
 			return nil
 		default:
-			return fmt.Errorf("Requested profile %s is invalid, valid options are dev, prod, managed-cluster or none",
+			return fmt.Errorf("Requested profile %s is invalid, valid options are dev, prod, managed-cluster, or none",
 				requestedProfile)
 		}
 	}

--- a/platform-operator/apis/verrazzano/v1beta1/validate.go
+++ b/platform-operator/apis/verrazzano/v1beta1/validate.go
@@ -18,7 +18,7 @@ func ValidateProfile(requestedProfile ProfileType) error {
 		case Prod, Dev, ManagedCluster, None:
 			return nil
 		default:
-			return fmt.Errorf("Requested profile %s is invalid, valid options are dev, prod, or managed-cluster",
+			return fmt.Errorf("Requested profile %s is invalid, valid options are dev, prod, managed-cluster or none",
 				requestedProfile)
 		}
 	}


### PR DESCRIPTION
Changes to update the log message to include none keyword when user provides invalid entry for profile name
> Changes to v1alpha/validate.go
> Changes to v1beta1/validate.go