### PR TITLE
Backport VZ-7460 Move to Flexible Load Balancer Usages

### DIFF
--- a/pkg/yaml/expand.go
+++ b/pkg/yaml/expand.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package yaml

--- a/pkg/yaml/expand.go
+++ b/pkg/yaml/expand.go
@@ -13,29 +13,32 @@ import (
 // a: b
 //
 // Nested values are expanded as follows:
-//   a.b.c : v1
-//     expands to
-//   a:
-//     b:
-//       c: v1
+//
+//	a.b.c : v1
+//	  expands to
+//	a:
+//	  b:
+//	    c: v1
 //
 // If there is more than one value then
-//   a.b : {v1,v2}
-//     expands to
-//   a:
-//     b:
-//       - v1
-//       - v2
+//
+//	a.b : {v1,v2}
+//	  expands to
+//	a:
+//	  b:
+//	    - v1
+//	    - v2
 //
 // The last segment of the name might be a quoted string, for example:
 //
-//   controller.service.annotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape" : 10Mbps
+//	controller.service.annotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape" : flexible
 //
 // which translates to
-//   controller:
-//     service:
-//       annotations:
-//         service.beta.kubernetes.io/oci-load-balancer-shape: 10Mbps
+//
+//	controller:
+//	  service:
+//	    annotations:
+//	      service.beta.kubernetes.io/oci-load-balancer-shape: flexible
 //
 // If forcelist is true then always use the list format.
 func Expand(leftMargin int, forceList bool, name string, vals ...string) (string, error) {

--- a/pkg/yaml/replace_merge_test.go
+++ b/pkg/yaml/replace_merge_test.go
@@ -19,7 +19,7 @@ platform:
   vendor: company1
   os:
     name: linux
-    patches: 
+    patches:
     - version: 0.5.0
       date: 01/01/2020
 `
@@ -45,7 +45,7 @@ platform:
   vendor: company1
   os:
     name: linux
-    patches: 
+    patches:
     - version: 0.6.0
       date: 02/02/2022
 `
@@ -78,7 +78,7 @@ spec:
       gateways:
         istio-ingressgateway:
           serviceAnnotations:
-            service.beta.kubernetes.io/oci-load-balancer-shape: 10Mbps
+            service.beta.kubernetes.io/oci-load-balancer-shape: flexible
 `
 
 // istiOverlay is the overlay of an IstioOperator YAML
@@ -122,7 +122,7 @@ spec:
       gateways:
         istio-ingressgateway:
           serviceAnnotations:
-            service.beta.kubernetes.io/oci-load-balancer-shape: 10Mbps
+            service.beta.kubernetes.io/oci-load-balancer-shape: flexible
 `
 
 const jaegerBase = `

--- a/pkg/yaml/replace_merge_test.go
+++ b/pkg/yaml/replace_merge_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package yaml

--- a/platform-operator/apis/verrazzano/testdata/fromistioaffinityargs/v1alpha1.yaml
+++ b/platform-operator/apis/verrazzano/testdata/fromistioaffinityargs/v1alpha1.yaml
@@ -49,11 +49,10 @@ spec:
         type: NodePort
       istioInstallArgs:
         - name: gateways.istio-ingressgateway.serviceAnnotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape"
-          value: 10Mbps
+          value: flexible
         - name: global.defaultPodDisruptionBudget.enabled
           value: "false"
         - name: pilot.resources.requests.memory
           value: 128Mi
         - name: gateways.istio-ingressgateway.externalIPs
           value: 1.2.3.4
-

--- a/platform-operator/apis/verrazzano/testdata/fromistioaffinityargs/v1alpha1.yaml
+++ b/platform-operator/apis/verrazzano/testdata/fromistioaffinityargs/v1alpha1.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: install.verrazzano.io/v1alpha1
 kind: Verrazzano

--- a/platform-operator/apis/verrazzano/testdata/fromistioaffinityargs/v1beta1.yaml
+++ b/platform-operator/apis/verrazzano/testdata/fromistioaffinityargs/v1beta1.yaml
@@ -64,7 +64,7 @@ spec:
                 gateways:
                   istio-ingressgateway:
                     serviceAnnotations:
-                      service.beta.kubernetes.io/oci-load-balancer-shape: 10Mbps
+                      service.beta.kubernetes.io/oci-load-balancer-shape: flexible
                 global:
                   defaultPodDisruptionBudget:
                     enabled: false

--- a/platform-operator/apis/verrazzano/testdata/fromistioaffinityargs/v1beta1.yaml
+++ b/platform-operator/apis/verrazzano/testdata/fromistioaffinityargs/v1beta1.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: install.verrazzano.io/v1beta1
 kind: Verrazzano

--- a/platform-operator/controllers/verrazzano/component/spi/component_context_permutations_test.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context_permutations_test.go
@@ -356,7 +356,7 @@ var prodIngressIstioOverrides = v1alpha1.Verrazzano{
 		Components: v1alpha1.ComponentSpec{
 			Ingress: &v1alpha1.IngressNginxComponent{
 				NGINXInstallArgs: []v1alpha1.InstallArgs{
-					{Name: "controller.service.annotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-shape\"", Value: "10Mbps"},
+					{Name: "controller.service.annotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-shape\"", Value: "flexible"},
 					{Name: "controller.service.externalTrafficPolicy", Value: "Local"},
 					{Name: "controller.service.externalIPs", ValueList: []string{"11.22.33.44"}},
 				},
@@ -367,7 +367,7 @@ var prodIngressIstioOverrides = v1alpha1.Verrazzano{
 			},
 			Istio: &v1alpha1.IstioComponent{
 				IstioInstallArgs: []v1alpha1.InstallArgs{
-					{Name: "gateways.istio-ingressgateway.serviceAnnotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-shape\"", Value: "10Mbps"},
+					{Name: "gateways.istio-ingressgateway.serviceAnnotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-shape\"", Value: "flexible"},
 					{Name: "gateways.istio-ingressgateway.replicaCount", Value: "3"},
 					{Name: "gateways.istio-ingressgateway.externalIPs", ValueList: []string{"11.22.33.44"}},
 				},

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
@@ -122,7 +122,7 @@ spec:
       type: LoadBalancer
       nginxInstallArgs:
         - name: controller.service.annotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape"
-          value: "10Mbps"
+          value: "flexible"
         - name: controller.service.externalTrafficPolicy
           value: Local
         - name: controller.service.externalIPs
@@ -188,7 +188,7 @@ spec:
                             weight: 100
       istioInstallArgs:
         - name: gateways.istio-ingressgateway.serviceAnnotations."service\.beta\.kubernetes\.io/oci-load-balancer-shape"
-          value: "10Mbps"
+          value: "flexible"
         - name: gateways.istio-ingressgateway.replicaCount
           value: "3"
         - name: gateways.istio-ingressgateway.externalIPs

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -61,7 +61,7 @@ oci ce cluster list --compartment-id=${TF_VAR_compartment_id} --region=${TF_VAR_
 
 # check available resources
 check_for_resources VCN vcn vcn-count 1
-check_for_resources LB load-balancer lb-100mbps-count 2
+check_for_resources LB load-balancer lb-flexible-count 2
 
 echo 'Install OKE...'
 echo 'Create cluster...'

--- a/tests/e2e/config/scripts/create_oke_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/tests/e2e/config/scripts/create_oke_multi_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_multi_cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/tests/e2e/config/scripts/create_oke_multi_cluster.sh
+++ b/tests/e2e/config/scripts/create_oke_multi_cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 
@@ -68,7 +68,7 @@ rm -rf ${KUBECONFIG_DIR}/*
 
 # check available resources
 check_for_resources VCN vcn vcn-count $REQUIRED_VNC_COUNT
-check_for_resources LB load-balancer lb-100mbps-count $REQUIRED_LB_COUNT
+check_for_resources LB load-balancer lb-flexible-count $REQUIRED_LB_COUNT
 
 cd ${SCRIPT_DIR}/terraform/cluster
 

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -50,7 +50,7 @@ const (
 	istioTestAnnotationValue = "value-i"
 	newReplicas              = 3
 	nginxLBShapeValue        = "flexible"
-	istioLBShapeValue        = "10Mbps"
+	istioLBShapeValue        = "flexible"
 )
 
 var testNginxIngressPorts = []corev1.ServicePort{

--- a/tests/e2e/update/nginxistio/nginxistio_test.go
+++ b/tests/e2e/update/nginxistio/nginxistio_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nginxistio

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -254,7 +254,7 @@ func TestInstallCmdFilenamesAndSets(t *testing.T) {
 	cmd.PersistentFlags().Set(constants.SetFlag, "profile=prod")
 	cmd.PersistentFlags().Set(constants.SetFlag, "environmentName=test")
 	cmd.PersistentFlags().Set(constants.SetFlag, "components.ingress.overrides[0].values.controller.podLabels.override=\"true\"")
-	cmd.PersistentFlags().Set(constants.SetFlag, "components.ingress.overrides[1].values.controller.service.annotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-shape\"=10Mbps")
+	cmd.PersistentFlags().Set(constants.SetFlag, "components.ingress.overrides[1].values.controller.service.annotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-shape\"=flexible")
 	cmd.PersistentFlags().Set(constants.SetFlag, "components.ingress.enabled=true")
 	cmd.PersistentFlags().Set(constants.WaitFlag, "false")
 	cmdHelpers.SetDeleteFunc(cmdHelpers.FakeDeleteFunc)
@@ -281,7 +281,7 @@ func TestInstallCmdFilenamesAndSets(t *testing.T) {
 	assert.NoError(t, err)
 	outyaml, err = yaml.JSONToYAML(json)
 	assert.NoError(t, err)
-	assert.Equal(t, "controller:\n  service:\n    annotations:\n      service.beta.kubernetes.io/oci-load-balancer-shape: 10Mbps\n", string(outyaml))
+	assert.Equal(t, "controller:\n  service:\n    annotations:\n      service.beta.kubernetes.io/oci-load-balancer-shape: flexible\n", string(outyaml))
 }
 
 // TestInstallCmdOperatorFile

--- a/tools/vz/pkg/analysis/test/cluster/ingress-lb-limit/cluster-snapshot/ingress-nginx/services.json
+++ b/tools/vz/pkg/analysis/test/cluster/ingress-lb-limit/cluster-snapshot/ingress-nginx/services.json
@@ -23,7 +23,7 @@
                 "annotations": {
                     "meta.helm.sh/release-name": "ingress-controller",
                     "meta.helm.sh/release-namespace": "ingress-nginx",
-                    "service.beta.kubernetes.io/oci-load-balancer-shape": "8000Mbps"
+                    "service.beta.kubernetes.io/oci-load-balancer-shape": "flexible"
                 },
                 "finalizers": [
                     "service.kubernetes.io/load-balancer-cleanup"

--- a/tools/vz/pkg/analysis/test/cluster/problem-pods-install/cluster-snapshot/ingress-nginx/services.json
+++ b/tools/vz/pkg/analysis/test/cluster/problem-pods-install/cluster-snapshot/ingress-nginx/services.json
@@ -26,7 +26,7 @@
                     "meta.helm.sh/release-name": "ingress-controller",
                     "meta.helm.sh/release-namespace": "ingress-nginx",
                     "service.beta.kubernetes.io/oci-load-balancer-security-list-management-mode": "None",
-                    "service.beta.kubernetes.io/oci-load-balancer-shape": "8000Mbps"
+                    "service.beta.kubernetes.io/oci-load-balancer-shape": "flexible"
                 },
                 "finalizers": [
                     "service.kubernetes.io/load-balancer-cleanup"

--- a/tools/vz/pkg/analysis/test/cluster/problem-pods-install/cluster-snapshot/verrazzano-resources.json
+++ b/tools/vz/pkg/analysis/test/cluster/problem-pods-install/cluster-snapshot/verrazzano-resources.json
@@ -6,7 +6,7 @@
             "kind": "Verrazzano",
             "metadata": {
                 "annotations": {
-                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"install.verrazzano.io/v1alpha1\",\"kind\":\"Verrazzano\",\"metadata\":{\"annotations\":{},\"name\":\"my-verrazzano\",\"namespace\":\"default\"},\"spec\":{\"components\":{\"dns\":{\"oci\":{\"dnsScope\":\"GLOBAL\",\"dnsZoneCompartmentOCID\":\"ocid1.compartment.oc1..aaaaaaaahyfirmf5si5nwycvdiqql77beqfbrd6tiielgutgfw65qnlnugja\",\"dnsZoneName\":\"z69d20a.v8o.io\",\"dnsZoneOCID\":\"ocid1.dns-zone.oc1..2201e62e428548e294c446d3142fe9fa\\n\",\"ociConfigSecret\":\"oci\"}},\"fluentd\":{\"extraVolumeMounts\":[{\"source\":\"/u01/data\"}]},\"ingress\":{\"nginxInstallArgs\":[{\"name\":\"controller.service.annotations.\\\"service\\\\.beta\\\\.kubernetes\\\\.io/oci-load-balancer-shape\\\"\",\"value\":\"8000Mbps\"},{\"name\":\"controller.service.annotations.\\\"service\\\\.beta\\\\.kubernetes\\\\.io/oci-load-balancer-security-list-management-mode\\\"\",\"value\":\"None\"}],\"type\":\"LoadBalancer\"},\"istio\":{\"istioInstallArgs\":[{\"name\":\"gateways.istio-ingressgateway.serviceAnnotations.\\\"service\\\\.beta\\\\.kubernetes\\\\.io/oci-load-balancer-shape\\\"\",\"value\":\"8000Mbps\"},{\"name\":\"gateways.istio-ingressgateway.serviceAnnotations.\\\"service\\\\.beta\\\\.kubernetes\\\\.io/oci-load-balancer-security-list-management-mode\\\"\",\"value\":\"None\"}]},\"keycloak\":{\"mysql\":{\"mysqlInstallArgs\":[{\"name\":\"persistence.enabled\",\"value\":\"false\"}]}},\"kubeStateMetrics\":{\"enabled\":true},\"prometheusAdapter\":{\"enabled\":true},\"prometheusNodeExporter\":{\"enabled\":true},\"prometheusOperator\":{\"enabled\":true},\"prometheusPushgateway\":{\"enabled\":true}},\"environmentName\":\"b2\",\"profile\":\"dev\"}}\n"
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"install.verrazzano.io/v1alpha1\",\"kind\":\"Verrazzano\",\"metadata\":{\"annotations\":{},\"name\":\"my-verrazzano\",\"namespace\":\"default\"},\"spec\":{\"components\":{\"dns\":{\"oci\":{\"dnsScope\":\"GLOBAL\",\"dnsZoneCompartmentOCID\":\"ocid1.compartment.oc1..aaaaaaaahyfirmf5si5nwycvdiqql77beqfbrd6tiielgutgfw65qnlnugja\",\"dnsZoneName\":\"z69d20a.v8o.io\",\"dnsZoneOCID\":\"ocid1.dns-zone.oc1..2201e62e428548e294c446d3142fe9fa\\n\",\"ociConfigSecret\":\"oci\"}},\"fluentd\":{\"extraVolumeMounts\":[{\"source\":\"/u01/data\"}]},\"ingress\":{\"nginxInstallArgs\":[{\"name\":\"controller.service.annotations.\\\"service\\\\.beta\\\\.kubernetes\\\\.io/oci-load-balancer-shape\\\"\",\"value\":\"flexible\"},{\"name\":\"controller.service.annotations.\\\"service\\\\.beta\\\\.kubernetes\\\\.io/oci-load-balancer-security-list-management-mode\\\"\",\"value\":\"None\"}],\"type\":\"LoadBalancer\"},\"istio\":{\"istioInstallArgs\":[{\"name\":\"gateways.istio-ingressgateway.serviceAnnotations.\\\"service\\\\.beta\\\\.kubernetes\\\\.io/oci-load-balancer-shape\\\"\",\"value\":\"flexible\"},{\"name\":\"gateways.istio-ingressgateway.serviceAnnotations.\\\"service\\\\.beta\\\\.kubernetes\\\\.io/oci-load-balancer-security-list-management-mode\\\"\",\"value\":\"None\"}]},\"keycloak\":{\"mysql\":{\"mysqlInstallArgs\":[{\"name\":\"persistence.enabled\",\"value\":\"false\"}]}},\"kubeStateMetrics\":{\"enabled\":true},\"prometheusAdapter\":{\"enabled\":true},\"prometheusNodeExporter\":{\"enabled\":true},\"prometheusOperator\":{\"enabled\":true},\"prometheusPushgateway\":{\"enabled\":true}},\"environmentName\":\"b2\",\"profile\":\"dev\"}}\n"
                 },
                 "creationTimestamp": "2022-06-16T10:18:45Z",
                 "finalizers": [
@@ -40,7 +40,7 @@
                         "nginxInstallArgs": [
                             {
                                 "name": "controller.service.annotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-shape\"",
-                                "value": "8000Mbps"
+                                "value": "flexible"
                             },
                             {
                                 "name": "controller.service.annotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-security-list-management-mode\"",
@@ -53,7 +53,7 @@
                         "istioInstallArgs": [
                             {
                                 "name": "gateways.istio-ingressgateway.serviceAnnotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-shape\"",
-                                "value": "8000Mbps"
+                                "value": "flexible"
                             },
                             {
                                 "name": "gateways.istio-ingressgateway.serviceAnnotations.\"service\\.beta\\.kubernetes\\.io/oci-load-balancer-security-list-management-mode\"",


### PR DESCRIPTION
This PR changes the annotations on all Verrazzano services currently using fixed-shape LBs to use the flexible shape instead. This is due to OCI deprecating fixed-shape LBs in May 2023.