### PR TITLE
VZ-8999 correctly configure Gateway and VirtuaService for multiple IngressTraits and multiple hosts

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -252,7 +252,7 @@ func (r *Reconciler) createOrUpdateChildResources(ctx context.Context, trait *vz
 		if err != nil {
 			status.Errors = append(status.Errors, err)
 		} else {
-			// The Gateway is shared across all ingress traits, update it with all known hosts for the trait
+			// The Gateway is shared across all ingress traits for the app, update it with all known hosts for the trait
 			// - Must create GW before service so that external DNS sees the GW once the service is created
 			gateway, err := r.createOrUpdateGateway(ctx, trait, allHostsForTrait, gwName, secretName, &status, log)
 			if err != nil {

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -2348,9 +2348,7 @@ func TestIngressTraitHostsForVirtualServiceAndGateway(t *testing.T) {
 func getHostsInTrait(trait *vzapi.IngressTrait) []string {
 	hosts := []string{}
 	for _, rule := range trait.Spec.Rules {
-		for _, host := range rule.Hosts {
-			hosts = append(hosts, host)
-		}
+		hosts = append(hosts, rule.Hosts...)
 	}
 	return hosts
 }

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -2180,7 +2180,6 @@ func TestCreateHostsFromIngressTraitRuleWildcards(t *testing.T) {
 func TestVirtualServerHostsPerIngressTrait(t *testing.T) {
 	assert := asserts.New(t)
 	const appName = "hello"
-	appFakes := setupAppFakes(appName)
 
 	tests := []struct {
 		name   string
@@ -2244,6 +2243,8 @@ func TestVirtualServerHostsPerIngressTrait(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			appFakes := setupAppFakes(appName)
+
 			// Create the fake reconciler up front with all traits
 			cli := fake.NewClientBuilder().WithScheme(newScheme())
 			cli = cli.WithObjects(getAppFakeResources(appFakes)...)

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -2173,12 +2173,13 @@ func TestCreateHostsFromIngressTraitRuleWildcards(t *testing.T) {
 	assert.Equal("myapp.myns.my.host.com", hosts[0])
 }
 
-// TestIngressTraitHostsForVirtualServerAndGateway tests the host in a Gateways and VirtualServers
+// TestIngressTraitHostsForVirtualServiceAndGateway tests the host in a Gateways and VirtualServices
 // GIVEN a list of IngressTraits
 // WHEN createOrUpdateChildResources is called
-// THEN verify that the correct Gateways and VirtualServers are created
-//   AND that the Gateway and VirtualServer hosts are correct
-func TestIngressTraitHostsForVirtualServerAndGateway(t *testing.T) {
+// THEN verify that the correct Gateways and VirtualServices are created
+//
+//	AND that the Gateway and VirtualService hosts are correct
+func TestIngressTraitHostsForVirtualServiceAndGateway(t *testing.T) {
 	assert := asserts.New(t)
 	const appName = "hello"
 


### PR DESCRIPTION
Fix a problem where every host from the IngressTrait was being added to every VirtualService.  There should be a VirtualService for every IngressTrait rule, and the VS hosts should only have the hosts that are in the rule.
