### PR TITLE
VZ-8999 correctly configure Gateway and VirtuaService for multiple IngressTraits and multiple hosts

### DIFF
--- a/application-operator/controllers/ingresstrait/ingresstrait_controller.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller.go
@@ -230,6 +230,11 @@ func (r *Reconciler) addFinalizerIfRequired(ctx context.Context, trait *vzapi.In
 
 // createOrUpdateChildResources creates or updates the Gateway and VirtualService resources that
 // should be used to setup ingress to the service.
+// This is the cardinality:
+//
+//	1 Gateway per Application
+//	1 Gateway server per IngressTrait
+//	1 VirtualService per IngressTrait rule
 func (r *Reconciler) createOrUpdateChildResources(ctx context.Context, trait *vzapi.IngressTrait, log vzlog.VerrazzanoLogger) (*reconcileresults.ReconcileResults, ctrl.Result, error) {
 	status := reconcileresults.ReconcileResults{}
 	rules := trait.Spec.Rules
@@ -247,9 +252,12 @@ func (r *Reconciler) createOrUpdateChildResources(ctx context.Context, trait *vz
 		if err != nil {
 			status.Errors = append(status.Errors, err)
 		} else {
-			// The Gateway is shared across all traits, update it with all known hosts for the trait
+			// The Gateway is shared across all ingress traits for the app, update it with all known hosts for the trait
 			// - Must create GW before service so that external DNS sees the GW once the service is created
-			gateway := r.createOrUpdateGateway(ctx, trait, allHostsForTrait, gwName, secretName, &status, log)
+			gateway, err := r.createOrUpdateGateway(ctx, trait, allHostsForTrait, gwName, secretName, &status, log)
+			if err != nil {
+				return &status, ctrl.Result{}, err
+			}
 			for index, rule := range rules {
 				// Find the services associated with the trait in the application configuration.
 				var services []*corev1.Service
@@ -261,10 +269,18 @@ func (r *Reconciler) createOrUpdateChildResources(ctx context.Context, trait *vz
 					return &status, reconcile.Result{Requeue: true, RequeueAfter: clusters.GetRandomRequeueDelay()}, err
 				}
 
+				// Get the list of hosts for this rule.  A virtual service can have the same hosts as another virtual service
+				// using the same gateway.  Istio will combine the rules to figure out the routing.
+				// See https://istio.io/latest/docs/ops/best-practices/traffic-management/#split-virtual-services
+				vsHosts, err := createHostsFromIngressTraitRule(r, rule, trait)
+				if err != nil {
+					status.Errors = append(status.Errors, err)
+				}
+
 				vsName := fmt.Sprintf("%s-rule-%d-vs", trait.Name, index)
 				drName := fmt.Sprintf("%s-rule-%d-dr", trait.Name, index)
 				authzPolicyName := fmt.Sprintf("%s-rule-%d-authz", trait.Name, index)
-				r.createOrUpdateVirtualService(ctx, trait, rule, allHostsForTrait, vsName, services, gateway, &status, log)
+				r.createOrUpdateVirtualService(ctx, trait, rule, vsHosts, vsName, services, gateway, &status, log)
 				r.createOrUpdateDestinationRule(ctx, trait, rule, drName, &status, log, services)
 				r.createOrUpdateAuthorizationPolicies(ctx, trait, rule, authzPolicyName, allHostsForTrait, &status, log)
 			}
@@ -533,7 +549,7 @@ func (r *Reconciler) validateConfiguredSecret(trait *vzapi.IngressTrait, status 
 
 // createOrUpdateGateway creates or updates the Gateway child resource of the trait.
 // Results are added to the status object.
-func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.IngressTrait, hostsForTrait []string, gwName string, secretName string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) *istioclient.Gateway {
+func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.IngressTrait, hostsForTrait []string, gwName string, secretName string, status *reconcileresults.ReconcileResults, log vzlog.VerrazzanoLogger) (*istioclient.Gateway, error) {
 	// Create a gateway populating only gwName metadata.
 	// This is used as default if the gateway needs to be created.
 	gateway := &istioclient.Gateway{
@@ -550,7 +566,7 @@ func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.Ing
 
 	// Return if no changes
 	if err == nil && res == controllerutil.OperationResultNone {
-		return gateway
+		return gateway, nil
 	}
 
 	ref := vzapi.QualifiedResourceRelation{APIVersion: gatewayAPIVersion, Kind: gatewayKind, Name: gwName, Role: "gateway"}
@@ -560,9 +576,10 @@ func (r *Reconciler) createOrUpdateGateway(ctx context.Context, trait *vzapi.Ing
 
 	if err != nil {
 		log.Errorf("Failed to create or update gateway: %v", err)
+		return nil, err
 	}
 
-	return gateway
+	return gateway, nil
 }
 
 // mutateGateway mutates the output Gateway child resource.
@@ -607,7 +624,7 @@ func formatGatewaySeverPortName(traitName string) string {
 }
 
 // updateGatewayServersList Update/add the Server entry for the IngressTrait to the gateway servers list
-//   - There will be a 1:1 mapping of Server-to-VirtualService
+// Each gateway server entry has a TLS field for the certificate.  This corresponds to the IngressTrait TLS field.
 func (r *Reconciler) updateGatewayServersList(servers []*istionet.Server, server *istionet.Server) []*istionet.Server {
 	if len(servers) == 0 {
 		servers = append(servers, server)

--- a/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
+++ b/application-operator/controllers/ingresstrait/ingresstrait_controller_test.go
@@ -58,6 +58,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+type appFakeResources struct {
+	appConfig       *v1alpha2.ApplicationConfiguration
+	workload        *v1alpha2.ContainerizedWorkload
+	workloadDef     *v1alpha2.WorkloadDefinition
+	workloadService *k8score.Service
+}
+
 const (
 	testTraitName                   = "test-trait"
 	testTraitPortName               = "https-test-trait"
@@ -2166,8 +2173,188 @@ func TestCreateHostsFromIngressTraitRuleWildcards(t *testing.T) {
 	assert.Equal("myapp.myns.my.host.com", hosts[0])
 }
 
+// TestIngressTraitHostsForVirtualServiceAndGateway tests the host in a Gateways and VirtualServices
+// GIVEN a list of IngressTraits
+// WHEN createOrUpdateChildResources is called
+// THEN verify that the correct Gateways and VirtualServices are created
+//
+//	AND that the Gateway and VirtualService hosts are correct
+func TestIngressTraitHostsForVirtualServiceAndGateway(t *testing.T) {
+	assert := asserts.New(t)
+	const appName = "hello"
+
+	tests := []struct {
+		name   string
+		traits []*vzapi.IngressTrait
+	}{
+		{name: "1trait-1rule-1host",
+			traits: []*vzapi.IngressTrait{{
+				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: testNamespace,
+					Labels: map[string]string{oam.LabelAppName: appName},
+				},
+				Spec: vzapi.IngressTraitSpec{
+					Rules: []vzapi.IngressRule{
+						{Hosts: []string{"host1"}},
+					},
+				}},
+			}},
+		{name: "1trait-1rule-2host",
+			traits: []*vzapi.IngressTrait{{
+				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: testNamespace,
+					Labels: map[string]string{oam.LabelAppName: appName},
+				},
+				Spec: vzapi.IngressTraitSpec{
+					Rules: []vzapi.IngressRule{
+						{Hosts: []string{"host1"}},
+						{Hosts: []string{"host2"}},
+					},
+				}},
+			}},
+		{name: "1trait-2rule-3host-same-names",
+			traits: []*vzapi.IngressTrait{{
+				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: testNamespace,
+					Labels: map[string]string{oam.LabelAppName: appName},
+				},
+				Spec: vzapi.IngressTraitSpec{
+					Rules: []vzapi.IngressRule{
+						{Hosts: []string{"host1", "host2", "host3"}},
+						{Hosts: []string{"host1", "host2", "host3"}},
+					},
+				}},
+			}},
+		{name: "2traits-1rule-each",
+			traits: []*vzapi.IngressTrait{{
+				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: testNamespace,
+					Labels: map[string]string{oam.LabelAppName: appName},
+				},
+				Spec: vzapi.IngressTraitSpec{
+					Rules: []vzapi.IngressRule{
+						{Hosts: []string{"host1", "host2", "host3"}},
+					},
+				}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "hello-2", Namespace: testNamespace,
+					Labels: map[string]string{oam.LabelAppName: appName},
+				},
+					Spec: vzapi.IngressTraitSpec{
+						Rules: []vzapi.IngressRule{
+							{Hosts: []string{"host1-a", "host2-a", "host3-a"}},
+						},
+					}},
+			}},
+		{name: "3traits-multiple-rules-and-hosts",
+			traits: []*vzapi.IngressTrait{{
+				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: testNamespace,
+					Labels: map[string]string{oam.LabelAppName: appName},
+				},
+				Spec: vzapi.IngressTraitSpec{
+					Rules: []vzapi.IngressRule{
+						{Hosts: []string{"host1", "host2", "host3"}},
+					},
+				}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "hello-2", Namespace: testNamespace,
+					Labels: map[string]string{oam.LabelAppName: appName},
+				},
+					Spec: vzapi.IngressTraitSpec{
+						Rules: []vzapi.IngressRule{
+							{Hosts: []string{"host1-a", "host2-a", "host3-a"}},
+							{Hosts: []string{"host4-a", "host5-a", "host6-a"}},
+						},
+					}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "hello-3", Namespace: testNamespace,
+					Labels: map[string]string{oam.LabelAppName: appName},
+				},
+					Spec: vzapi.IngressTraitSpec{
+						Rules: []vzapi.IngressRule{
+							{Hosts: []string{"host1-b"}},
+							{Hosts: []string{"host2-b", "host3-b"}},
+							{Hosts: []string{"host4-b", "host5-b", "host6-b"}},
+						},
+					}},
+			}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create the fake reconciler up front with all traits
+			cli := fake.NewClientBuilder().WithScheme(newScheme())
+			cli = cli.WithObjects(getAppFakeResources(setupAppFakes(appName))...)
+
+			// Finish configuration traits
+			for _, trait := range test.traits {
+				trait.TypeMeta = metav1.TypeMeta{
+					APIVersion: apiVersion,
+					Kind:       "IngressTrait",
+				}
+				trait.Spec.WorkloadReference = oamrt.TypedReference{
+					APIVersion: "core.oam.dev/v1alpha2",
+					Kind:       "ContainerizedWorkload",
+					Name:       testWorkloadName}
+				cli = cli.WithObjects(trait)
+			}
+			r := newIngressTraitReconciler(cli.Build())
+
+			// Reconcile each trait
+			for i, trait := range test.traits {
+				_, _, err := r.createOrUpdateChildResources(context.TODO(), test.traits[i], vzlog.DefaultLogger())
+				assert.NoError(err)
+
+				// Every trait rule must have a VS with all the hosts.  This test must use explicit hosts
+				for i, rule := range trait.Spec.Rules {
+					// The VS and the rule must have the same set of hosts
+					vsName := fmt.Sprintf("%s-rule-%d-vs", trait.Name, i)
+					vs := istioclient.VirtualService{}
+					err = r.Get(context.Background(), client.ObjectKey{Namespace: trait.Namespace, Name: vsName}, &vs)
+					assert.NoError(err)
+					hostSet := vzstring.SliceToSet(rule.Hosts)
+					for _, h := range vs.Spec.Hosts {
+						_, ok := hostSet[h]
+						if ok {
+							delete(hostSet, h)
+						} else {
+							assert.Fail(fmt.Sprintf("unexpected host %s in VS %s", h, vs.Name))
+						}
+					}
+					assert.Len(hostSet, 0)
+				}
+
+				// get the gateway
+				gwName, _ := buildGatewayName(trait)
+				gw := istioclient.Gateway{}
+				err = r.Get(context.Background(), client.ObjectKey{Namespace: trait.Namespace, Name: gwName}, &gw)
+				assert.NoError(err)
+
+				// There must be a gateway server for each trait.
+				for _, server := range gw.Spec.Servers {
+					if server.Name != trait.Name {
+						continue
+					}
+					// The hosts in the gateway server must match the hosts in the trait
+					traitHosts := getHostsInTrait(trait)
+					hostSet := vzstring.SliceToSet(traitHosts)
+					for _, h := range server.Hosts {
+						_, ok := hostSet[h]
+						if ok {
+							delete(hostSet, h)
+						} else {
+							assert.Fail(fmt.Sprintf("unexpected host %s in server %s", h, server.Name))
+						}
+					}
+					assert.Len(hostSet, 0)
+				}
+			}
+		})
+	}
+}
+
+func getHostsInTrait(trait *vzapi.IngressTrait) []string {
+	hosts := []string{}
+	for _, rule := range trait.Spec.Rules {
+		hosts = append(hosts, rule.Hosts...)
+	}
+	return hosts
+}
+
 // TestHostRules tests host name rules
-// GIVEN a trait with a set of rules where each rule has a hostname
+// GIVEN a trait with a set of rules
 // WHEN coallateAllHostsForTrait is called
 // THEN verify that the correct set of host names are returned
 func TestHostRules(t *testing.T) {
@@ -2349,6 +2536,7 @@ func TestHostRules(t *testing.T) {
 					assert.Fail(fmt.Sprintf("unexpected host %s returned from coallateAllHostsForTrait", h))
 				}
 			}
+			assert.Len(hostSet, 0)
 		})
 	}
 }
@@ -4265,6 +4453,60 @@ func setupTraitTestFakes(appName string, gw *istioclient.Gateway) Reconciler {
 
 	reconciler := createReconcilerWithFake(appConfig, workload, workloadDef, workloadService, gw)
 	return reconciler
+}
+func setupAppFakes(appName string) appFakeResources {
+	appConfig := &v1alpha2.ApplicationConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: testNamespace},
+	}
+
+	workload := &v1alpha2.ContainerizedWorkload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testWorkloadName,
+			Namespace: testNamespace,
+			UID:       testWorkloadID,
+		},
+	}
+
+	workloadDef := &v1alpha2.WorkloadDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "containerizedworkloads.core.oam.dev"},
+		Spec: v1alpha2.WorkloadDefinitionSpec{
+			ChildResourceKinds: []v1alpha2.ChildResourceKind{
+				{APIVersion: "apps/v1", Kind: "Deployment", Selector: nil},
+				{APIVersion: "v1", Kind: "Service", Selector: nil},
+			},
+		},
+	}
+
+	workloadService := &k8score.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testService",
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "ContainerizedWorkload",
+				Name:       testWorkloadName,
+				UID:        testWorkloadID,
+			}}},
+		Spec: k8score.ServiceSpec{
+			ClusterIP: testClusterIP,
+			Ports:     []k8score.ServicePort{{Port: 42}}},
+	}
+
+	return appFakeResources{
+		appConfig:       appConfig,
+		workload:        workload,
+		workloadDef:     workloadDef,
+		workloadService: workloadService,
+	}
+}
+
+func getAppFakeResources(appFakes appFakeResources) []client.Object {
+	var objs []client.Object
+	objs = append(objs, appFakes.appConfig)
+	objs = append(objs, appFakes.workload)
+	objs = append(objs, appFakes.workloadDef)
+	objs = append(objs, appFakes.workloadService)
+	return objs
 }
 
 func createGatewayServer(traitName string, traitHosts []string, secretName ...string) *istionet.Server {


### PR DESCRIPTION
Fix a problem where every host from the IngressTrait was being added to every VirtualService. There should be a VirtualService for every IngressTrait rule, and the VS hosts should only have the hosts that are in the rule.

cherry-pick of https://github.com/verrazzano/verrazzano/commit/0c35efa7a05fd9d24f293f228b9a6b4182e62df9
