### PR TITLE
VZ-6947 Periodic pipeline updates Pt. 1

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -502,7 +502,7 @@ pipeline {
                 stage("Build Release Distributions") {
                     steps {
                         sh """
-                            ci/scripts/update_periodic_on_success.sh ${env.GIT_COMMIT} ${SHORT_COMMIT_HASH} ${VERRAZZANO_DEV_VERSION}
+                            ci/scripts/build_distribution.sh ${env.GIT_COMMIT} ${SHORT_COMMIT_HASH} ${VERRAZZANO_DEV_VERSION}
                         """
                     }
                 }

--- a/ci/scripts/build_distribution.sh
+++ b/ci/scripts/build_distribution.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 


### PR DESCRIPTION
This PR renames an outdated helper script to reflect what it is doing more accurately. `build-distribution.sh` calls `generate_vz_distribution.sh`, which subsequently builds and pushes the full release distribution to object store.
