### PR TITLE
VZ-8713 - subtask VZ-8984 - Add thanosHost to VMC status and populate it from managed cluster (from query store API ingress) 

### DIFF
--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -169,15 +169,15 @@ func (s *Syncer) updateVMCStatus() error {
 		vmc.Status.PrometheusHost = prometheusHost
 	}
 
-	// Get the Thanos Query component's ingress URL from the local managed cluster, and populate
+	// Get the Thanos API ingress URL from the local managed cluster, and populate
 	// it in the VMC status on the admin cluster, so that admin cluster's Thanos query wire up
 	// to the managed cluster
-	thanosQueryHost, err := s.GetThanosQueryHost()
+	thanosAPIHost, err := s.getThanosQueryStoreAPIHost()
 	if err != nil {
 		return fmt.Errorf("Failed to get Thanos query URL to update VMC %s: %v", vmcName, err)
 	}
-	if thanosQueryHost != "" {
-		vmc.Status.ThanosQueryHost = thanosQueryHost
+	if thanosAPIHost != "" {
+		vmc.Status.ThanosHost = thanosAPIHost
 	}
 
 	// update status of VMC
@@ -321,10 +321,10 @@ func (s *Syncer) GetPrometheusHost() (string, error) {
 	return ingress.Spec.Rules[0].Host, nil
 }
 
-// GetThanosQueryHost returns the Thanos Query URL for Verrazzano instance.
-func (s *Syncer) GetThanosQueryHost() (string, error) {
+// getThanosQueryStoreAPIHost returns the Thanos Query Store API Endpoint URL for Verrazzano instance.
+func (s *Syncer) getThanosQueryStoreAPIHost() (string, error) {
 	ingress := &networkingv1.Ingress{}
-	err := s.LocalClient.Get(context.TODO(), types.NamespacedName{Name: vzconstants.ThanosQueryIngress, Namespace: constants.VerrazzanoSystemNamespace}, ingress)
+	err := s.LocalClient.Get(context.TODO(), types.NamespacedName{Name: vzconstants.ThanosQueryStoreIngress, Namespace: constants.VerrazzanoSystemNamespace}, ingress)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", nil

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package mcagent
@@ -6,9 +6,10 @@ package mcagent
 import (
 	"context"
 	"fmt"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	oamv1alpha2 "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
@@ -162,11 +163,21 @@ func (s *Syncer) updateVMCStatus() error {
 	vmc.Status.APIUrl = apiURL
 	prometheusHost, err := s.GetPrometheusHost()
 	if err != nil {
-		return fmt.Errorf("Failed to get api prometheus host for vmc %s with error %v", vmcName, err)
+		return fmt.Errorf("Failed to get api prometheus host to update VMC %s: %v", vmcName, err)
 	}
-
 	if prometheusHost != "" {
 		vmc.Status.PrometheusHost = prometheusHost
+	}
+
+	// Get the Thanos Query component's ingress URL from the local managed cluster, and populate
+	// it in the VMC status on the admin cluster, so that admin cluster's Thanos query wire up
+	// to the managed cluster
+	thanosQueryHost, err := s.GetThanosQueryHost()
+	if err != nil {
+		return fmt.Errorf("Failed to get Thanos query URL to update VMC %s: %v", vmcName, err)
+	}
+	if thanosQueryHost != "" {
+		vmc.Status.ThanosQueryHost = thanosQueryHost
 	}
 
 	// update status of VMC
@@ -301,6 +312,19 @@ func (s *Syncer) GetAPIServerURL() (string, error) {
 func (s *Syncer) GetPrometheusHost() (string, error) {
 	ingress := &networkingv1.Ingress{}
 	err := s.LocalClient.Get(context.TODO(), types.NamespacedName{Name: constants.VzPrometheusIngress, Namespace: constants.VerrazzanoSystemNamespace}, ingress)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("unable to fetch ingress %s/%s, %v", constants.VerrazzanoSystemNamespace, constants.VzPrometheusIngress, err)
+	}
+	return ingress.Spec.Rules[0].Host, nil
+}
+
+// GetThanosQueryHost returns the Thanos Query URL for Verrazzano instance.
+func (s *Syncer) GetThanosQueryHost() (string, error) {
+	ingress := &networkingv1.Ingress{}
+	err := s.LocalClient.Get(context.TODO(), types.NamespacedName{Name: vzconstants.ThanosQueryIngress, Namespace: constants.VerrazzanoSystemNamespace}, ingress)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", nil

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -322,7 +322,8 @@ func expectAdminVMCStatusUpdateSuccess(adminMock *mocks.MockClient, vmcName type
 			assert.NotNil(vmc.Status)
 			assert.NotNil(vmc.Status.LastAgentConnectTime)
 			assert.NotNil(vmc.Status.APIUrl)
-			assert.NotNil(vmc.Status.PrometheusHost)
+			assert.Equal(testManagedPrometheusHost, vmc.Status.PrometheusHost)
+			assert.Equal(testManagedThanosQueryHost, vmc.Status.ThanosQueryHost)
 			return nil
 		})
 }

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -37,7 +37,7 @@ var validSecret = corev1.Secret{
 }
 
 const testManagedPrometheusHost = "prometheus"
-const testManagedThanosQueryHost = "thanos.example.com"
+const testManagedThanosQueryStoreAPIHost = "thanos-grpc.example.com"
 
 // TestProcessAgentThreadNoProjects tests agent thread when no projects exist
 // GIVEN a request to process the agent loop
@@ -323,7 +323,7 @@ func expectAdminVMCStatusUpdateSuccess(adminMock *mocks.MockClient, vmcName type
 			assert.NotNil(vmc.Status.LastAgentConnectTime)
 			assert.NotNil(vmc.Status.APIUrl)
 			assert.Equal(testManagedPrometheusHost, vmc.Status.PrometheusHost)
-			assert.Equal(testManagedThanosQueryHost, vmc.Status.ThanosQueryHost)
+			assert.Equal(testManagedThanosQueryStoreAPIHost, vmc.Status.ThanosHost)
 			return nil
 		})
 }
@@ -446,7 +446,7 @@ func expectGetPrometheusHostCalled(mock *mocks.MockClient) {
 
 func expectGetThanosQueryHostCalled(mock *mocks.MockClient) {
 	// Expect a call to get the Thanos query ingress and return the host.
-	expectGetIngress(mock, constants.VerrazzanoSystemNamespace, vzconstants.ThanosQueryIngress, testManagedThanosQueryHost)
+	expectGetIngress(mock, constants.VerrazzanoSystemNamespace, vzconstants.ThanosQueryStoreIngress, testManagedThanosQueryStoreAPIHost)
 }
 
 // Expects a call to get an ingress with the given name and namespace, and returns an ingress with the specified

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package mcagent
@@ -35,6 +35,9 @@ var validSecret = corev1.Secret{
 	},
 	Data: map[string][]byte{constants.ClusterNameData: []byte("cluster1"), mcconstants.KubeconfigKey: []byte("kubeconfig")},
 }
+
+const managedPrometheusHost = "prometheus"
+const managedThanosQueryHost = "thanos.example.com"
 
 // TestProcessAgentThreadNoProjects tests agent thread when no projects exist
 // GIVEN a request to process the agent loop
@@ -74,6 +77,7 @@ func TestProcessAgentThreadNoProjects(t *testing.T) {
 	vmcName := types.NamespacedName{Name: string(validSecret.Data[constants.ClusterNameData]), Namespace: constants.VerrazzanoMultiClusterNamespace}
 	expectGetAPIServerURLCalled(mcMock)
 	expectGetPrometheusHostCalled(mcMock)
+	expectGetThanosQueryHostCalled(mcMock)
 	expectAdminVMCStatusUpdateSuccess(adminMock, vmcName, adminStatusMock, assert)
 
 	// Admin Cluster - expect call to list VerrazzanoProject objects - return an empty list
@@ -404,6 +408,7 @@ func TestSyncer_updateVMCStatus(t *testing.T) {
 
 	expectGetAPIServerURLCalled(localClientMock)
 	expectGetPrometheusHostCalled(localClientMock)
+	expectGetThanosQueryHostCalled(localClientMock)
 	// Mock the success of status updates and assert that updateVMCStatus returns nil error
 	expectAdminVMCStatusUpdateSuccess(adminMock, vmcName, adminStatusMock, assert)
 	assert.Nil(s.updateVMCStatus())
@@ -435,8 +440,19 @@ func expectGetAPIServerURLCalled(mock *mocks.MockClient) {
 
 func expectGetPrometheusHostCalled(mock *mocks.MockClient) {
 	// Expect a call to get the prometheus ingress and return the host.
+	expectGetIngress(mock, constants.VerrazzanoSystemNamespace, constants.VzPrometheusIngress, managedPrometheusHost)
+}
+
+func expectGetThanosQueryHostCalled(mock *mocks.MockClient) {
+	// Expect a call to get the Thanos query ingress and return the host.
+	expectGetIngress(mock, constants.VerrazzanoSystemNamespace, vzconstants.ThanosQueryIngress, managedThanosQueryHost)
+}
+
+// Expects a call to get an ingress with the given name and namespace, and returns an ingress with the specified
+// ingressHost
+func expectGetIngress(mock *mocks.MockClient, ingressNamespace string, ingressName string, ingressHost string) {
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VzPrometheusIngress}, gomock.Not(gomock.Nil())).
+		Get(gomock.Any(), types.NamespacedName{Namespace: ingressNamespace, Name: ingressName}, gomock.Not(gomock.Nil())).
 		DoAndReturn(func(ctx context.Context, name types.NamespacedName, ingress *networkingv1.Ingress) error {
 			ingress.TypeMeta = metav1.TypeMeta{
 				APIVersion: "networking.k8s.io/v1",
@@ -445,7 +461,7 @@ func expectGetPrometheusHostCalled(mock *mocks.MockClient) {
 				Namespace: name.Namespace,
 				Name:      name.Name}
 			ingress.Spec.Rules = []networkingv1.IngressRule{{
-				Host: "prometheus",
+				Host: ingressHost,
 			}}
 			return nil
 		})

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -36,8 +36,8 @@ var validSecret = corev1.Secret{
 	Data: map[string][]byte{constants.ClusterNameData: []byte("cluster1"), mcconstants.KubeconfigKey: []byte("kubeconfig")},
 }
 
-const managedPrometheusHost = "prometheus"
-const managedThanosQueryHost = "thanos.example.com"
+const testManagedPrometheusHost = "prometheus"
+const testManagedThanosQueryHost = "thanos.example.com"
 
 // TestProcessAgentThreadNoProjects tests agent thread when no projects exist
 // GIVEN a request to process the agent loop
@@ -440,12 +440,12 @@ func expectGetAPIServerURLCalled(mock *mocks.MockClient) {
 
 func expectGetPrometheusHostCalled(mock *mocks.MockClient) {
 	// Expect a call to get the prometheus ingress and return the host.
-	expectGetIngress(mock, constants.VerrazzanoSystemNamespace, constants.VzPrometheusIngress, managedPrometheusHost)
+	expectGetIngress(mock, constants.VerrazzanoSystemNamespace, constants.VzPrometheusIngress, testManagedPrometheusHost)
 }
 
 func expectGetThanosQueryHostCalled(mock *mocks.MockClient) {
 	// Expect a call to get the Thanos query ingress and return the host.
-	expectGetIngress(mock, constants.VerrazzanoSystemNamespace, vzconstants.ThanosQueryIngress, managedThanosQueryHost)
+	expectGetIngress(mock, constants.VerrazzanoSystemNamespace, vzconstants.ThanosQueryIngress, testManagedThanosQueryHost)
 }
 
 // Expects a call to get an ingress with the given name and namespace, and returns an ingress with the specified

--- a/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
+++ b/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
@@ -126,6 +126,8 @@ type VerrazzanoManagedClusterStatus struct {
 	LastAgentConnectTime *metav1.Time `json:"lastAgentConnectTime,omitempty"`
 	// The Prometheus host for this managed cluster.
 	PrometheusHost string `json:"prometheusHost,omitempty"`
+	// The Thanos query host for this managed cluster.
+	ThanosQueryHost string `json:"thanosQueryHost,omitempty"`
 	// The state of Rancher registration for this managed cluster.
 	RancherRegistration RancherRegistration `json:"rancherRegistration,omitempty"`
 	// The state of ArgoCD registration for this managed cluster.

--- a/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
+++ b/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
@@ -126,8 +126,8 @@ type VerrazzanoManagedClusterStatus struct {
 	LastAgentConnectTime *metav1.Time `json:"lastAgentConnectTime,omitempty"`
 	// The Prometheus host for this managed cluster.
 	PrometheusHost string `json:"prometheusHost,omitempty"`
-	// The Thanos query host for this managed cluster.
-	ThanosQueryHost string `json:"thanosQueryHost,omitempty"`
+	// The Thanos API host name for this managed cluster.
+	ThanosHost string `json:"thanosHost,omitempty"`
 	// The state of Rancher registration for this managed cluster.
 	RancherRegistration RancherRegistration `json:"rancherRegistration,omitempty"`
 	// The state of ArgoCD registration for this managed cluster.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -202,3 +202,6 @@ const (
 
 // ThanosQueryIngress is the name of the ingress for the Thanos Query
 const ThanosQueryIngress = "thanos-query"
+
+// ThanosQueryStoreIngress is the name of the ingress for the Thanos Query Store API
+const ThanosQueryStoreIngress = "thanos-grpc"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -199,3 +199,6 @@ const (
 	Fluentd               = "fluentd"
 	MySQLOperator         = "mysql-operator"
 )
+
+// ThanosQueryIngress is the name of the ingress for the Thanos Query
+const ThanosQueryIngress = "thanos-query"

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -95,9 +95,6 @@ const PrometheusIngress = "vmi-system-prometheus"
 // ThanosSidecarIngress is the name of the ingress for the Thanos sidecar
 const ThanosSidecarIngress = "thanos-sidecar"
 
-// ThanosQueryStoreIngress is the name of the ingress for the Thanos Query Store API
-const ThanosQueryStoreIngress = "thanos-grpc"
-
 // GlobalImagePullSecName is the name of the global image pull secret
 const GlobalImagePullSecName = "verrazzano-container-registry"
 

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -95,9 +95,6 @@ const PrometheusIngress = "vmi-system-prometheus"
 // ThanosSidecarIngress is the name of the ingress for the Thanos sidecar
 const ThanosSidecarIngress = "thanos-sidecar"
 
-// ThanosQueryIngress is the name of the ingress for the Thanos Query
-const ThanosQueryIngress = "thanos-query-frontend"
-
 // ThanosQueryStoreIngress is the name of the ingress for the Thanos Query Store API
 const ThanosQueryStoreIngress = "thanos-grpc"
 

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
@@ -121,7 +121,7 @@ func (t thanosComponent) GetIngressNames(ctx spi.ComponentContext) []types.Names
 	})
 	return append(ingressNames, types.NamespacedName{
 		Namespace: ns,
-		Name:      constants.ThanosQueryStoreIngress,
+		Name:      vzconst.ThanosQueryStoreIngress,
 	})
 }
 

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -116,7 +117,7 @@ func (t thanosComponent) GetIngressNames(ctx spi.ComponentContext) []types.Names
 	}
 	ingressNames = append(ingressNames, types.NamespacedName{
 		Namespace: ns,
-		Name:      constants.ThanosQueryIngress,
+		Name:      vzconst.ThanosQueryIngress,
 	})
 	return append(ingressNames, types.NamespacedName{
 		Namespace: ns,

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -198,7 +199,7 @@ func TestGetIngressNames(t *testing.T) {
 				},
 			},
 			ingNames: []types.NamespacedName{
-				{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.ThanosQueryIngress},
+				{Namespace: constants.VerrazzanoSystemNamespace, Name: vzconst.ThanosQueryIngress},
 				{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.ThanosQueryStoreIngress},
 			},
 		},
@@ -222,7 +223,7 @@ func TestGetIngressNames(t *testing.T) {
 				},
 			},
 			ingNames: []types.NamespacedName{
-				{Namespace: authproxy.ComponentNamespace, Name: constants.ThanosQueryIngress},
+				{Namespace: authproxy.ComponentNamespace, Name: vzconst.ThanosQueryIngress},
 				{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.ThanosQueryStoreIngress},
 			},
 		},

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component_test.go
@@ -200,7 +200,7 @@ func TestGetIngressNames(t *testing.T) {
 			},
 			ingNames: []types.NamespacedName{
 				{Namespace: constants.VerrazzanoSystemNamespace, Name: vzconst.ThanosQueryIngress},
-				{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.ThanosQueryStoreIngress},
+				{Namespace: constants.VerrazzanoSystemNamespace, Name: vzconst.ThanosQueryStoreIngress},
 			},
 		},
 		// GIVEN a call to GetIngressNames
@@ -224,7 +224,7 @@ func TestGetIngressNames(t *testing.T) {
 			},
 			ingNames: []types.NamespacedName{
 				{Namespace: authproxy.ComponentNamespace, Name: vzconst.ThanosQueryIngress},
-				{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.ThanosQueryStoreIngress},
+				{Namespace: constants.VerrazzanoSystemNamespace, Name: vzconst.ThanosQueryStoreIngress},
 			},
 		},
 	}

--- a/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance.go
+++ b/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance.go
@@ -6,6 +6,8 @@ package vzinstance
 import (
 	"context"
 	"fmt"
+
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/argocd"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/grafana"
@@ -60,7 +62,7 @@ func GetInstanceInfo(ctx spi.ComponentContext) *v1alpha1.InstanceInfo {
 		KialiURL:       getComponentIngressURL(ingressList.Items, ctx, kiali.ComponentName, constants.KialiIngress),
 		JaegerURL:      getComponentIngressURL(ingressList.Items, ctx, jaegeroperator.ComponentName, constants.JaegerIngress),
 		ArgoCDURL:      getComponentIngressURL(ingressList.Items, ctx, argocd.ComponentName, constants.ArgoCDIngress),
-		ThanosQueryURL: getComponentIngressURL(ingressList.Items, ctx, thanos.ComponentName, constants.ThanosQueryIngress),
+		ThanosQueryURL: getComponentIngressURL(ingressList.Items, ctx, thanos.ComponentName, vzconst.ThanosQueryIngress),
 	}
 	return instanceInfo
 }

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
@@ -142,6 +142,9 @@ spec:
               state:
                 description: The state of this managed cluster.
                 type: string
+              thanosQueryURL:
+                description: The Thanos query URL for this managed cluster.
+                type: string
             required:
             - state
             type: object

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
@@ -142,8 +142,8 @@ spec:
               state:
                 description: The state of this managed cluster.
                 type: string
-              thanosQueryHost:
-                description: The Thanos query host for this managed cluster.
+              thanosHost:
+                description: The Thanos API host name for this managed cluster.
                 type: string
             required:
             - state

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
@@ -142,8 +142,8 @@ spec:
               state:
                 description: The state of this managed cluster.
                 type: string
-              thanosQueryURL:
-                description: The Thanos query URL for this managed cluster.
+              thanosQueryHost:
+                description: The Thanos query host for this managed cluster.
                 type: string
             required:
             - state


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
