### PR TITLE
VZ-8983 Create the Thanos ingresses in the Helm chart

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -137,6 +137,9 @@ const VerrazzanoAuthProxyServiceName = "verrazzano-authproxy"
 // VerrazzanoAuthProxyServicePort is the port exposed by the Verrazzano auth proxy service
 const VerrazzanoAuthProxyServicePort = 8775
 
+// VerrazzanoAuthProxyGRPCServicePort is the port exposed by the Verrazzano auth proxy service for gRPC traffic
+const VerrazzanoAuthProxyGRPCServicePort = 8776
+
 // DefaultEnvironmentName is the default name for install environment
 const DefaultEnvironmentName = "default"
 

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -96,7 +96,10 @@ const PrometheusIngress = "vmi-system-prometheus"
 const ThanosSidecarIngress = "thanos-sidecar"
 
 // ThanosQueryIngress is the name of the ingress for the Thanos Query
-const ThanosQueryIngress = "thanos-query"
+const ThanosQueryIngress = "thanos-query-frontend"
+
+// ThanosQueryStoreIngress is the name of the ingress for the Thanos Query Store API
+const ThanosQueryStoreIngress = "thanos-grpc"
 
 // GlobalImagePullSecName is the name of the global image pull secret
 const GlobalImagePullSecName = "verrazzano-container-registry"

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos.go
@@ -4,6 +4,8 @@
 package thanos
 
 import (
+	"fmt"
+
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -12,6 +14,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -19,6 +22,10 @@ const (
 	// Thanos Query ingress constants
 	queryHostName        = "thanos-query"
 	queryCertificateName = "system-tls-thanos-query"
+
+	// Thanos Query StoreAPI constants
+	queryStoreHostName        = "query-store"
+	queryStoreCertificateName = "system-tls-query-store"
 )
 
 // GetOverrides gets the install overrides for the Thanos component
@@ -38,16 +45,25 @@ func GetOverrides(object runtime.Object) interface{} {
 }
 
 // AppendOverrides appends the default overrides for the Thanos component
-func AppendOverrides(_ spi.ComponentContext, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
+func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
 	bomFile, err := bom.NewBom(config.GetDefaultBOMFilePath())
 	if err != nil {
 		return kvs, err
 	}
+
 	image, err := bomFile.BuildImageOverrides(ComponentName)
 	if err != nil {
 		return kvs, err
 	}
-	return append(kvs, image...), nil
+	kvs = append(kvs, image...)
+
+	ingresses, err := appendIngressOverrides(ctx, kvs)
+	if err != nil {
+		return kvs, err
+	}
+	kvs = append(kvs, ingresses...)
+
+	return kvs, nil
 }
 
 // preInstallUpgrade handles pre-install and pre-upgrade processing for the Thanos Component
@@ -63,29 +79,68 @@ func preInstallUpgrade(ctx spi.ComponentContext) error {
 	return common.EnsureVerrazzanoMonitoringNamespace(ctx)
 }
 
-// preInstallUpgrade handles post-install and post-upgrade processing for the Thanos Component
-func postInstallUpgrade(ctx spi.ComponentContext) error {
-	// Do nothing if dry run
-	if ctx.IsDryRun() {
-		ctx.Log().Debug("Thanos postInstallUpgrade dry run")
-		return nil
+// appendIngressOverrides generates overrides for ingress objects in the Thanos component
+func appendIngressOverrides(ctx spi.ComponentContext, kvs []bom.KeyValue) ([]bom.KeyValue, error) {
+	// If NGINX is disabled, prevent the ingresses from being created
+	if !vzcr.IsNGINXEnabled(ctx.EffectiveCR()) {
+		return append(kvs, []bom.KeyValue{
+			{Key: "query.ingress.grpc.enabled", Value: "false"},
+			{Key: "queryFrontend.ingress.enabled", Value: "false"},
+		}...), nil
 	}
 
-	return createOrUpdateComponentIngress(ctx)
+	ingressClassName := vzconfig.GetIngressClassName(ctx.EffectiveCR())
+	dnsSubDomain, err := vzconfig.BuildDNSDomain(ctx.Client(), ctx.EffectiveCR())
+	if err != nil {
+		return kvs, ctx.Log().ErrorfNewErr("Failed building DNS domain name for Thanos Ingress: %v", err)
+	}
+
+	frontendHostName := fmt.Sprintf("%s.%s", queryHostName, dnsSubDomain)
+	frontendProps := ingressOverrideProperties{
+		KeyPrefix:        "queryFrontend.ingress",
+		Subdomain:        dnsSubDomain,
+		HostName:         frontendHostName,
+		IngressClassName: ingressClassName,
+		TLSSecretName:    queryCertificateName,
+	}
+	kvs = formatIngressOverrides(ctx, frontendProps, kvs)
+	kvs = append(kvs, bom.KeyValue{Key: `queryFrontend.ingress.annotations.nginx\.ingress\.kubernetes\.io/session-cookie-name`, Value: frontendHostName})
+
+	storeHostName := fmt.Sprintf("%s.%s", queryStoreHostName, dnsSubDomain)
+	storeProps := ingressOverrideProperties{
+		KeyPrefix:        "query.ingress.grpc",
+		Subdomain:        dnsSubDomain,
+		HostName:         storeHostName,
+		IngressClassName: ingressClassName,
+		TLSSecretName:    queryStoreCertificateName,
+	}
+	return formatIngressOverrides(ctx, storeProps, kvs), nil
 }
 
-func createOrUpdateComponentIngress(ctx spi.ComponentContext) error {
-	// If NGINX is not enabled, skip the ingress creation
-	if !vzcr.IsNGINXEnabled(ctx.EffectiveCR()) {
-		return nil
-	}
+// ingressOverrideProperties creates a structure to host Override property strings for Thanos ingresses
+type ingressOverrideProperties struct {
+	KeyPrefix        string
+	Subdomain        string
+	HostName         string
+	IngressClassName string
+	TLSSecretName    string
+}
 
-	// Create the Thanos Query Ingress
-	thanosProps := common.IngressProperties{
-		IngressName:      constants.ThanosQueryIngress,
-		HostName:         queryHostName,
-		TLSSecretName:    queryCertificateName,
-		ExtraAnnotations: common.SameSiteCookieAnnotations(queryHostName),
+// formatIngressOverrides appends the correct overrides to a given ingress prefix based on generated properties for Ingress values
+func formatIngressOverrides(ctx spi.ComponentContext, props ingressOverrideProperties, kvs []bom.KeyValue) []bom.KeyValue {
+	kvs = append(kvs, []bom.KeyValue{
+		{Key: fmt.Sprintf("%s.namespace", props.KeyPrefix), Value: constants.VerrazzanoSystemNamespace},
+		{Key: fmt.Sprintf("%s.ingressClassName", props.KeyPrefix), Value: props.IngressClassName},
+		{Key: fmt.Sprintf("%s.extraRules[0].host", props.KeyPrefix), Value: props.HostName},
+		{Key: fmt.Sprintf("%s.extraTls[0].hosts[0]", props.KeyPrefix), Value: props.HostName},
+		{Key: fmt.Sprintf("%s.extraTls[0].secretName", props.KeyPrefix), Value: props.TLSSecretName},
+	}...)
+	if vzcr.IsExternalDNSEnabled(ctx.EffectiveCR()) {
+		ingressTarget := fmt.Sprintf("verrazzano-ingress.%s", props.Subdomain)
+		kvs = append(kvs, []bom.KeyValue{
+			{Key: fmt.Sprintf(`%s.annotations.external-dns\.alpha\.kubernetes\.io/target`, props.KeyPrefix), Value: ingressTarget},
+			{Key: fmt.Sprintf(`%s.annotations.external-dns\.alpha\.kubernetes\.io/ttl`, props.KeyPrefix), Value: "60"},
+		}...)
 	}
-	return common.CreateOrUpdateSystemComponentIngress(ctx, thanosProps)
+	return kvs
 }

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
@@ -104,26 +104,6 @@ func (t thanosComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	return t.HelmComponent.PreUpgrade(ctx)
 }
 
-// PostInstall handles the post-install operations for the Thanos component
-func (t thanosComponent) PostInstall(ctx spi.ComponentContext) error {
-	if err := postInstallUpgrade(ctx); err != nil {
-		return err
-	}
-
-	t.IngressNames = t.GetIngressNames(ctx)
-	t.Certificates = t.GetCertificateNames(ctx)
-	return t.HelmComponent.PostInstall(ctx)
-}
-
-// PostUpgrade handles the post-upgrade operations for the Thanos component
-func (t thanosComponent) PostUpgrade(ctx spi.ComponentContext) error {
-	if err := postInstallUpgrade(ctx); err != nil {
-		return err
-	}
-
-	return t.HelmComponent.PostUpgrade(ctx)
-}
-
 // GetIngressNames returns the Thanos ingress names
 func (t thanosComponent) GetIngressNames(ctx spi.ComponentContext) []types.NamespacedName {
 	var ingressNames []types.NamespacedName
@@ -134,9 +114,13 @@ func (t thanosComponent) GetIngressNames(ctx spi.ComponentContext) []types.Names
 	if vzcr.IsAuthProxyEnabled(ctx.EffectiveCR()) {
 		ns = authproxy.ComponentNamespace
 	}
-	return append(ingressNames, types.NamespacedName{
+	ingressNames = append(ingressNames, types.NamespacedName{
 		Namespace: ns,
 		Name:      constants.ThanosQueryIngress,
+	})
+	return append(ingressNames, types.NamespacedName{
+		Namespace: ns,
+		Name:      constants.ThanosQueryStoreIngress,
 	})
 }
 
@@ -151,6 +135,10 @@ func (t thanosComponent) GetCertificateNames(ctx spi.ComponentContext) []types.N
 	if vzcr.IsAuthProxyEnabled(ctx.EffectiveCR()) {
 		ns = authproxy.ComponentNamespace
 	}
+	certificateNames = append(certificateNames, types.NamespacedName{
+		Namespace: ns,
+		Name:      queryCertificateName,
+	})
 	return append(certificateNames, types.NamespacedName{
 		Namespace: ns,
 		Name:      queryCertificateName,

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
@@ -141,6 +141,6 @@ func (t thanosComponent) GetCertificateNames(ctx spi.ComponentContext) []types.N
 	})
 	return append(certificateNames, types.NamespacedName{
 		Namespace: ns,
-		Name:      queryCertificateName,
+		Name:      queryStoreCertificateName,
 	})
 }

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component_test.go
@@ -363,7 +363,7 @@ func TestGetCertificateNames(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(scheme).Build()
 			ctx := spi.NewFakeContext(client, &test.vz, nil, false)
 			nsn := NewComponent().GetCertificateNames(ctx)
-			assert.Equal(t, nsn, test.ingNames)
+			assert.Equal(t, test.ingNames, nsn)
 		})
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component_test.go
@@ -199,6 +199,7 @@ func TestGetIngressNames(t *testing.T) {
 			},
 			ingNames: []types.NamespacedName{
 				{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.ThanosQueryIngress},
+				{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.ThanosQueryStoreIngress},
 			},
 		},
 		// GIVEN a call to GetIngressNames
@@ -222,6 +223,7 @@ func TestGetIngressNames(t *testing.T) {
 			},
 			ingNames: []types.NamespacedName{
 				{Namespace: authproxy.ComponentNamespace, Name: constants.ThanosQueryIngress},
+				{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.ThanosQueryStoreIngress},
 			},
 		},
 	}
@@ -328,6 +330,7 @@ func TestGetCertificateNames(t *testing.T) {
 			},
 			ingNames: []types.NamespacedName{
 				{Namespace: constants.VerrazzanoSystemNamespace, Name: queryCertificateName},
+				{Namespace: constants.VerrazzanoSystemNamespace, Name: queryStoreCertificateName},
 			},
 		},
 		// GIVEN a call to GetCertificateNames
@@ -351,6 +354,7 @@ func TestGetCertificateNames(t *testing.T) {
 			},
 			ingNames: []types.NamespacedName{
 				{Namespace: authproxy.ComponentNamespace, Name: queryCertificateName},
+				{Namespace: constants.VerrazzanoSystemNamespace, Name: queryStoreCertificateName},
 			},
 		},
 	}

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
@@ -94,9 +94,6 @@ func TestGetOverrides(t *testing.T) {
 }
 
 // TestAppendOverrides tests if Thanos overrides are appended
-// GIVEN a call to AppendOverrides
-// WHEN the bom is populated with the Thanos image
-// THEN the overrides are returned from this function
 func TestAppendOverrides(t *testing.T) {
 	config.SetDefaultBomFilePath(bomFilePathOverride)
 	scheme := k8scheme.Scheme
@@ -127,6 +124,9 @@ func TestAppendOverrides(t *testing.T) {
 		vz       *v1alpha1.Verrazzano
 		extraKVS map[string]string
 	}{
+		// GIVEN a call to AppendOverrides
+		// WHEN the NGINX is disabled
+		// THEN query ingresses are disabled
 		{
 			name: "test NGINX Disabled",
 			vz: &v1alpha1.Verrazzano{
@@ -143,6 +143,9 @@ func TestAppendOverrides(t *testing.T) {
 				"queryFrontend.ingress.enabled": "false",
 			},
 		},
+		// GIVEN a call to AppendOverrides
+		// WHEN wildcard is enabled
+		// THEN the proper overrides are populated
 		{
 			name: "test ExternalDNS Disabled",
 			vz: &v1alpha1.Verrazzano{
@@ -170,6 +173,9 @@ func TestAppendOverrides(t *testing.T) {
 				"query.ingress.grpc.extraTls[0].secretName":                                            queryStoreCertificateName,
 			},
 		},
+		// GIVEN a call to AppendOverrides
+		// WHEN wildcard is enabled
+		// THEN the extra external DNS overrides are added
 		{
 			name: "test ExternalDNS Enabled",
 			vz: &v1alpha1.Verrazzano{

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
@@ -6,6 +6,7 @@ package thanos
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	asserts "github.com/stretchr/testify/assert"
@@ -17,6 +18,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	v1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -163,12 +165,20 @@ func TestAppendOverrides(t *testing.T) {
 				"queryFrontend.ingress.namespace":                                                      constants.VerrazzanoSystemNamespace,
 				"queryFrontend.ingress.ingressClassName":                                               "verrazzano-nginx",
 				"queryFrontend.ingress.extraRules[0].host":                                             "thanos-query.default.11.22.33.44.xip.io",
+				"queryFrontend.ingress.extraRules[0].http.paths[0].backend.service.name":               constants.VerrazzanoAuthProxyServiceName,
+				"queryFrontend.ingress.extraRules[0].http.paths[0].backend.service.port.number":        strconv.Itoa(constants.VerrazzanoAuthProxyServicePort),
+				"queryFrontend.ingress.extraRules[0].http.paths[0].path":                               "/(.*)()",
+				"queryFrontend.ingress.extraRules[0].http.paths[0].pathType":                           string(netv1.PathTypeImplementationSpecific),
 				"queryFrontend.ingress.extraTls[0].hosts[0]":                                           "thanos-query.default.11.22.33.44.xip.io",
 				"queryFrontend.ingress.extraTls[0].secretName":                                         queryCertificateName,
 				`queryFrontend.ingress.annotations.nginx\.ingress\.kubernetes\.io/session-cookie-name`: queryHostName,
 				"query.ingress.grpc.namespace":                                                         constants.VerrazzanoSystemNamespace,
 				"query.ingress.grpc.ingressClassName":                                                  "verrazzano-nginx",
 				"query.ingress.grpc.extraRules[0].host":                                                "query-store.default.11.22.33.44.xip.io",
+				"query.ingress.grpc.extraRules[0].http.paths[0].backend.service.name":                  constants.VerrazzanoAuthProxyServiceName,
+				"query.ingress.grpc.extraRules[0].http.paths[0].backend.service.port.number":           strconv.Itoa(constants.VerrazzanoAuthProxyGRPCServicePort),
+				"query.ingress.grpc.extraRules[0].http.paths[0].path":                                  "/",
+				"query.ingress.grpc.extraRules[0].http.paths[0].pathType":                              string(netv1.PathTypePrefix),
 				"query.ingress.grpc.extraTls[0].hosts[0]":                                              "query-store.default.11.22.33.44.xip.io",
 				"query.ingress.grpc.extraTls[0].secretName":                                            queryStoreCertificateName,
 			},
@@ -193,6 +203,10 @@ func TestAppendOverrides(t *testing.T) {
 				"queryFrontend.ingress.namespace":                                                      constants.VerrazzanoSystemNamespace,
 				"queryFrontend.ingress.ingressClassName":                                               "verrazzano-nginx",
 				"queryFrontend.ingress.extraRules[0].host":                                             "thanos-query.default.mydomain.com",
+				"queryFrontend.ingress.extraRules[0].http.paths[0].backend.service.name":               constants.VerrazzanoAuthProxyServiceName,
+				"queryFrontend.ingress.extraRules[0].http.paths[0].backend.service.port.number":        strconv.Itoa(constants.VerrazzanoAuthProxyServicePort),
+				"queryFrontend.ingress.extraRules[0].http.paths[0].path":                               "/(.*)()",
+				"queryFrontend.ingress.extraRules[0].http.paths[0].pathType":                           string(netv1.PathTypeImplementationSpecific),
 				"queryFrontend.ingress.extraTls[0].hosts[0]":                                           "thanos-query.default.mydomain.com",
 				"queryFrontend.ingress.extraTls[0].secretName":                                         queryCertificateName,
 				`queryFrontend.ingress.annotations.external-dns\.alpha\.kubernetes\.io/target`:         "verrazzano-ingress.default.mydomain.com",
@@ -201,6 +215,10 @@ func TestAppendOverrides(t *testing.T) {
 				"query.ingress.grpc.namespace":                                                         constants.VerrazzanoSystemNamespace,
 				"query.ingress.grpc.ingressClassName":                                                  "verrazzano-nginx",
 				"query.ingress.grpc.extraRules[0].host":                                                "query-store.default.mydomain.com",
+				"query.ingress.grpc.extraRules[0].http.paths[0].backend.service.name":                  constants.VerrazzanoAuthProxyServiceName,
+				"query.ingress.grpc.extraRules[0].http.paths[0].backend.service.port.number":           strconv.Itoa(constants.VerrazzanoAuthProxyGRPCServicePort),
+				"query.ingress.grpc.extraRules[0].http.paths[0].path":                                  "/",
+				"query.ingress.grpc.extraRules[0].http.paths[0].pathType":                              string(netv1.PathTypePrefix),
 				"query.ingress.grpc.extraTls[0].hosts[0]":                                              "query-store.default.mydomain.com",
 				"query.ingress.grpc.extraTls[0].secretName":                                            queryStoreCertificateName,
 				`query.ingress.grpc.annotations.external-dns\.alpha\.kubernetes\.io/target`:            "verrazzano-ingress.default.mydomain.com",

--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -49,11 +49,11 @@ queryFrontend:
       nginx.ingress.kubernetes.io/rewrite-target: "/$2"
       nginx.ingress.kubernetes.io/service-upstream: "true"
       nginx.ingress.kubernetes.io/upstream-vhost: "${service_name}.${namespace}.svc.cluster.local"
-      nginx.ingress.kubernetes.io/affinity: "cookie",
-      nginx.ingress.kubernetes.io/session-cookie-conditional-samesite-none: "true",
-      nginx.ingress.kubernetes.io/session-cookie-expires: "86400",
-      nginx.ingress.kubernetes.io/session-cookie-max-age: "86400",
-      nginx.ingress.kubernetes.io/session-cookie-samesite: "Strict",
+      nginx.ingress.kubernetes.io/affinity: "cookie"
+      nginx.ingress.kubernetes.io/session-cookie-conditional-samesite-none: "true"
+      nginx.ingress.kubernetes.io/session-cookie-expires: "86400"
+      nginx.ingress.kubernetes.io/session-cookie-max-age: "86400"
+      nginx.ingress.kubernetes.io/session-cookie-samesite: "Strict"
     extraRules:
     - http:
         paths:

--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -10,6 +10,23 @@ query:
     capabilities:
       drop:
         - ALL
+  ingress:
+    grpc:
+      enabled: true
+      annotations:
+        kubernetes.io/tls-acme: "true"
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      extraRules:
+      - http:
+          paths:
+          - backend:
+            service:
+              name: verrazzano-authproxy
+              port:
+                number: 8776
+            path: /
+            pathType: Prefix
 
   # Adds the Prometheus Thanos sidecar as a Store API endpoint to Query
   stores:
@@ -24,6 +41,29 @@ queryFrontend:
     capabilities:
       drop:
         - ALL
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/tls-acme: "true"
+      nginx.ingress.kubernetes.io/proxy-body-size: "6M"
+      nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+      nginx.ingress.kubernetes.io/service-upstream: "true"
+      nginx.ingress.kubernetes.io/upstream-vhost: "${service_name}.${namespace}.svc.cluster.local"
+      nginx.ingress.kubernetes.io/affinity: "cookie",
+      nginx.ingress.kubernetes.io/session-cookie-conditional-samesite-none: "true",
+      nginx.ingress.kubernetes.io/session-cookie-expires: "86400",
+      nginx.ingress.kubernetes.io/session-cookie-max-age: "86400",
+      nginx.ingress.kubernetes.io/session-cookie-samesite: "Strict",
+    extraRules:
+    - http:
+        paths:
+        - backend:
+          service:
+            name: verrazzano-authproxy
+            port:
+              number: 8775
+          path: /()(.*)
+          pathType: ImplementationSpecific
 
 compactor:
   podSecurityContext:

--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -17,16 +17,6 @@ query:
         kubernetes.io/tls-acme: "true"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-      extraRules:
-      - http:
-          paths:
-          - backend:
-            service:
-              name: verrazzano-authproxy
-              port:
-                number: 8776
-            path: /
-            pathType: Prefix
 
   # Adds the Prometheus Thanos sidecar as a Store API endpoint to Query
   stores:
@@ -54,16 +44,6 @@ queryFrontend:
       nginx.ingress.kubernetes.io/session-cookie-expires: "86400"
       nginx.ingress.kubernetes.io/session-cookie-max-age: "86400"
       nginx.ingress.kubernetes.io/session-cookie-samesite: "Strict"
-    extraRules:
-    - http:
-        paths:
-        - backend:
-          service:
-            name: verrazzano-authproxy
-            port:
-              number: 8775
-          path: /()(.*)
-          pathType: ImplementationSpecific
 
 compactor:
   podSecurityContext:

--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -17,6 +17,8 @@ query:
         kubernetes.io/tls-acme: "true"
         nginx.ingress.kubernetes.io/ssl-redirect: "true"
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      # Turn off hostname to disable auto-generated backend
+      hostname: ""
 
   # Adds the Prometheus Thanos sidecar as a Store API endpoint to Query
   stores:
@@ -44,6 +46,8 @@ queryFrontend:
       nginx.ingress.kubernetes.io/session-cookie-expires: "86400"
       nginx.ingress.kubernetes.io/session-cookie-max-age: "86400"
       nginx.ingress.kubernetes.io/session-cookie-samesite: "Strict"
+    # Turn off hostname to disable auto-generated backend
+    hostname: ""
 
 compactor:
   podSecurityContext:

--- a/platform-operator/thirdparty/charts/thanos/templates/query-frontend/ingress.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/query-frontend/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Values.queryFrontend.ingress.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
     {{- if .Values.commonLabels }}

--- a/platform-operator/thirdparty/charts/thanos/templates/query/ingress-grpc.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/query/ingress-grpc.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}-grpc
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Values.query.ingress.grpc.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
     {{- if .Values.commonLabels }}

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
@@ -16,6 +16,7 @@ spec:
       to:
         - operation:
             ports:
+              - "10901"
               - "10902"
   selector:
     matchLabels:

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
@@ -18,6 +18,9 @@ spec:
                 values:
                   - verrazzano-authproxy
       ports:
+        # Store API port
+        - port: 10901
+          protocol: TCP
         # web ui port
         - port: 10902
           protocol: TCP


### PR DESCRIPTION
**Changes**
- Add the Thanos Store ingress through the helm chart
- Move the Thanos Query ingress to the helm chart
**Testing**
- Installed on cluster and Verified ingress access for the query ingress