### PR TITLE
VZ-9096: Disable startupapicheck in cert-manager

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@ Component version updates:
 - WebLogic Kubernetes Operator v4.0.5
 - WebLogic Monitoring Exporter v2.1.2
 
+Fixes:
+
+- Disabled the startupapicheck job in cert-manager startup.
+
 ### v1.5.0
 Features:
 

--- a/platform-operator/helm_config/overrides/cert-manager-values.yaml
+++ b/platform-operator/helm_config/overrides/cert-manager-values.yaml
@@ -65,3 +65,6 @@ webhook:
     capabilities:
       drop:
         - ALL
+
+startupapicheck:
+  enabled: false

--- a/platform-operator/thirdparty/charts/cert-manager/values.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/values.yaml
@@ -453,7 +453,7 @@ cainjector:
 # due to the Job never being completed because the sidecar proxy does not exit.
 # See https://github.com/cert-manager/cert-manager/pull/4414 for context.
 startupapicheck:
-  enabled: false
+  enabled: true
 
   # Pod Security Context to be set on the startupapicheck component Pod
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

--- a/platform-operator/thirdparty/charts/cert-manager/values.yaml
+++ b/platform-operator/thirdparty/charts/cert-manager/values.yaml
@@ -453,7 +453,7 @@ cainjector:
 # due to the Job never being completed because the sidecar proxy does not exit.
 # See https://github.com/cert-manager/cert-manager/pull/4414 for context.
 startupapicheck:
-  enabled: true
+  enabled: false
 
   # Pod Security Context to be set on the startupapicheck component Pod
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
In cert-manager 1.9.1, `startupapicheck` job is enabled by default and pulls an image quay.io/jetstack/cert-manager-ctl:v1.9.1 which we don't distribute and hence will cause issues in air-gapped installs. This PR to disable this job till we start distributing the image.
