### PR TITLE
VZ-8973: Support gRPC traffic through NGINX ingress and AuthProxy

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
@@ -501,8 +501,8 @@ data:
         return 'http://vmi-system-'..backend..'.verrazzano-system.svc.cluster.local'..':'..port
     end
 
-    function me.makeMonitoringComponentBackendUrl(serviceName, port)
-        return 'http://'..serviceName..'.verrazzano-monitoring.svc.cluster.local'..':'..port
+    function me.makeMonitoringComponentBackendUrl(protocol, serviceName, port)
+        return protocol..'://'..serviceName..'.verrazzano-monitoring.svc.cluster.local'..':'..port
     end
 
     function me.getBackendServerUrlFromName(backend)
@@ -517,11 +517,11 @@ data:
         elseif backend == 'grafana' then
             serverUrl = me.makeVmiBackendUrl(backend, '3000')
         elseif backend == 'prometheus' then
-            serverUrl = me.makeMonitoringComponentBackendUrl('prometheus-operator-kube-p-prometheus', '9090')
+            serverUrl = me.makeMonitoringComponentBackendUrl('http', 'prometheus-operator-kube-p-prometheus', '9090')
         elseif backend == 'thanos-sidecar' then
-            serverUrl = me.makeMonitoringComponentBackendUrl('prometheus-operator-kube-p-prometheus', '10901')
+            serverUrl = me.makeMonitoringComponentBackendUrl('grpc', 'prometheus-operator-kube-p-prometheus', '10901')
         elseif backend == 'thanos-query' then
-            serverUrl = me.makeMonitoringComponentBackendUrl('thanos-query-frontend', '9090')
+            serverUrl = me.makeMonitoringComponentBackendUrl('http', 'thanos-query-frontend', '9090')
         elseif backend == 'kibana' then
             serverUrl = me.makeVmiBackendUrl('osd', '5601')
         elseif backend == 'osd' then
@@ -533,7 +533,7 @@ data:
         elseif backend == 'kiali' then
             serverUrl = me.makeVmiBackendUrl(backend, '20001')
         elseif backend == 'jaeger' then
-            serverUrl = me.makeMonitoringComponentBackendUrl('jaeger-operator-jaeger-query', '16686')
+            serverUrl = me.makeMonitoringComponentBackendUrl('http', 'jaeger-operator-jaeger-query', '16686')
         else
             me.not_found("Invalid backend name '"..backend.."'")
         end
@@ -1354,6 +1354,24 @@ data:
                 stub_status;
                 allow 127.0.0.1;
                 deny all;
+            }
+        }
+
+        # Verrazzano gRPC proxy
+        server {
+            listen       8776 http2;
+            server_name  verrazzano-grpc-proxy;
+
+            location / {
+                lua_ssl_verify_depth 2;
+                lua_ssl_trusted_certificate /etc/nginx/upstream.pem;
+
+                set $oidc_user "";
+                set $backend_server_url "";
+                rewrite_by_lua_file /etc/nginx/conf.lua;
+                proxy_set_header X-WEBAUTH-USER $oidc_user;
+                grpc_pass $backend_server_url;
+                proxy_ssl_trusted_certificate /etc/nginx/upstream.pem;
             }
         }
     }

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -111,6 +111,7 @@ spec:
           value: "20210501"
         ports:
         - containerPort: {{ .Values.port }}
+        - containerPort: {{ .Values.grpcPort }}
         livenessProbe:
           initialDelaySeconds: 30
           periodSeconds: 5
@@ -192,6 +193,10 @@ spec:
     port: {{ .Values.port }}
     protocol: TCP
     targetPort: {{ .Values.port }}
+  - name: grpc
+    port: {{ .Values.grpcPort }}
+    protocol: TCP
+    targetPort: {{ .Values.grpcPort }}
   selector:
     app: {{ .Values.name }}
 ---

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
@@ -12,6 +12,7 @@ replicas:
 # is obtained from the bill of materials file (verrazzano-bom.json).
 pullPolicy: IfNotPresent
 port: 8775
+grpcPort: 8776
 impersonatorRoleName: impersonate-api-user
 managedClusterRegistered: false
 proxy:

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/networkpolicy.yaml
@@ -28,6 +28,8 @@ spec:
       ports:
         - protocol: TCP
           port: 8775
+        - protocol: TCP
+          port: 8776
     - from:
         - namespaceSelector:
             matchLabels:

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 {{- if .Values.authproxy.enabled }}

--- a/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 #

--- a/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/templates/authorizationpolicy.yaml
@@ -23,7 +23,7 @@ spec:
             principals: ["cluster.local/ns/ingress-nginx/sa/ingress-controller-ingress-nginx"]
       to:
         - operation:
-            ports: ["{{ .Values.api.port }}"]
+            ports: ["{{ .Values.api.port }}", "{{ .Values.api.grpcPort }}"]
     # verrazzano-authproxy:8775 <- fluentd
     - from:
         - source:

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -61,6 +61,7 @@ console:
 api:
   name: verrazzano-authproxy
   port: 8775
+  grpcPort: 8776
 
 config:
   envName:

--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 name: verrazzano
 

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -28,13 +28,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20230302040354-bf21e9603",
+              "tag": "v1.3.1-20230322153500-05e7a995d",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "v1.3.1-20230302040354-bf21e9603",
+              "tag": "v1.3.1-20230322153500-05e7a995d",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -199,7 +199,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20230302040354-bf21e9603",
+              "tag": "v1.3.1-20230322153500-05e7a995d",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
@@ -254,7 +254,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20230302040354-bf21e9603",
+              "tag": "v1.3.1-20230322153500-05e7a995d",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]
@@ -788,7 +788,7 @@
           "images": [
             {
               "image": "thanos",
-              "tag": "v0.28.0-20230307214739-f86032ae",
+              "tag": "v0.28.0-20230322155710-8af2d756",
               "helmRegKey": "image.registry",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"

--- a/tests/e2e/verify-install/verrazzano/verrazzano_test.go
+++ b/tests/e2e/verify-install/verrazzano/verrazzano_test.go
@@ -799,7 +799,9 @@ func validateCorrectNumberOfPodsRunningSts(stsName string, nameSpace string, lab
 }
 
 // Validate the verrazzano-system service ports to make sure they follow Istio conventions for
-// naming ports.  Ports should have the prefix of "http-" or "https-" or be equal to "http" or "https".
+// naming ports.  Ports should have the prefix of "http-", "https-", or "grpc-", or be equal to
+// "http", "https", or "grpc". Note that this is not an exhaustive list of valid Istio port names; these
+// are the port names that we currently use.
 func validateVerrazzanoSystemServicePorts() {
 	// Get the list of verrazzano-system services
 	var services *corev1.ServiceList
@@ -825,9 +827,10 @@ func validateVerrazzanoSystemServicePorts() {
 			}
 			if checkName {
 				hasPrefix := false
-				if strings.Compare(port.Name, "http") == 0 || strings.Compare(port.Name, "https") == 0 ||
-					strings.HasPrefix(port.Name, "http-") || strings.HasPrefix(port.Name, "https-") ||
-					(port.AppProtocol != nil && (strings.Compare(*port.AppProtocol, "http") == 0 || strings.Compare(*port.AppProtocol, "https") == 0)) {
+				if strings.Compare(port.Name, "http") == 0 || strings.Compare(port.Name, "https") == 0 || strings.Compare(port.Name, "grpc") == 0 ||
+					strings.HasPrefix(port.Name, "http-") || strings.HasPrefix(port.Name, "https-") || strings.HasPrefix(port.Name, "grpc-") ||
+					(port.AppProtocol != nil &&
+						(strings.Compare(*port.AppProtocol, "http") == 0 || strings.Compare(*port.AppProtocol, "https") == 0 || strings.Compare(*port.AppProtocol, "grpc") == 0)) {
 					hasPrefix = true
 				}
 				Expect(hasPrefix).Should(BeTrue(), fmt.Sprintf("Service \"%s\" port name \"%s\" is not a valid port name", service.Name, port.Name))


### PR DESCRIPTION
This PR uptakes the latest NGINX ingress controller image that supports gRPC ingresses. It also modifies the AuthProxy configuration as follows:

1. Change the Lua code that creates backend monitoring endpoints to accept a protocol. "grpc" is passed for gRPC backends.
2. Add a server entry that listens on a new port and proxies gRPC traffic.

There are also associated changes to the AuthProxy deployment, service, network, and auth policies for the new port.
This PR also uptakes the latest Thanos image that supports basic auth.

I tested this by installing in a local cluster, and modifying the Thanos Query config to talk to the sidecar through the ingress controller. I verified that all gRPC traffic is being proxied correctly.