### PR TITLE
VZ-7916 Add Upgrade and Uninstall for dev component controller

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -212,6 +212,9 @@ const JaegerCollectorService = "service-collector"
 // OverridesFinalizer is a label value for value override object finalizer
 const OverridesFinalizer = "overrides.finalizers.verrazzano.io/finalizer"
 
+// DevComponentFinalizer is a label value for dev components configmap finalizer
+const DevComponentFinalizer = "components.finalizers.verrazzano.io/finalizer"
+
 // ConfigMapKind is a label value for ConfigMap kind
 const ConfigMapKind = "ConfigMap"
 

--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -161,11 +161,6 @@ const UpgradeRetryVersion = "verrazzano.io/upgrade-retry-version"
 // ObservedUpgradeRetryVersion is the previous restart version annotation field
 const ObservedUpgradeRetryVersion = "verrazzano.io/observed-upgrade-retry-version"
 
-// VerrazzanoDevComponentAnnotationName is the name of the annotation to be used on a ConfigMap,
-// which indicates that the ConfigMap is used to install a dev component. The value of the annotation is
-// the dev component name unless the name field is otherwise definied in the ConfigMap data
-const VerrazzanoDevComponentAnnotationName = "verrazzano.io/devComponent"
-
 // NGINXControllerServiceName is the nginx ingress controller name
 const NGINXControllerServiceName = "ingress-controller-ingress-nginx-controller"
 

--- a/platform-operator/controllers/configmaps/components/controller.go
+++ b/platform-operator/controllers/configmaps/components/controller.go
@@ -152,7 +152,7 @@ func (r *ComponentConfigMapReconciler) processComponent(ctx spi.ComponentContext
 			ctx.Log().Errorf("Error removing finalizer %s for dev component %s: %v", constants.DevComponentFinalizer, comp.ReleaseName, err)
 			return newRequeueWithDelay(), err
 		}
-		ctx.Log().Infof("dev component %s has been successfully deleted", comp.ReleaseName)
+		ctx.Log().Infof("dev component %s has been successfully uninstalled", comp.ReleaseName)
 		return reconcile.Result{Requeue: true}, nil
 	}
 

--- a/platform-operator/controllers/configmaps/components/controller.go
+++ b/platform-operator/controllers/configmaps/components/controller.go
@@ -152,7 +152,7 @@ func (r *ComponentConfigMapReconciler) processComponent(ctx spi.ComponentContext
 			return newRequeueWithDelay(), err
 		}
 		ctx.Log().Infof("dev component %s has been successfully deleted", comp.ReleaseName)
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	// Check if our finalizer is already present and add it if not
@@ -164,7 +164,8 @@ func (r *ComponentConfigMapReconciler) processComponent(ctx spi.ComponentContext
 			return newRequeueWithDelay(), err
 		}
 		ctx.Log().Infof("Successfully added finalizer %s to configmap %s for dev component", constants.DevComponentFinalizer, configMap.Name, comp.ReleaseName)
-		return newRequeueWithDelay(), nil
+		// adding finalizer to ConfigMap will
+		return reconcile.Result{}, nil
 	}
 
 	// if the release has not been installed, install it

--- a/platform-operator/controllers/configmaps/components/controller.go
+++ b/platform-operator/controllers/configmaps/components/controller.go
@@ -145,7 +145,7 @@ func (r *ComponentConfigMapReconciler) processComponent(ctx spi.ComponentContext
 		}
 		ctx.Log().Infof("Successfully uninstalled dev component %s", comp.ReleaseName)
 
-		// remove finalizer to delete te component
+		// remove finalizer to delete the component
 		controllerutil.RemoveFinalizer(configMap, constants.DevComponentFinalizer)
 		err := r.Update(context.TODO(), configMap)
 		if err != nil {
@@ -165,7 +165,7 @@ func (r *ComponentConfigMapReconciler) processComponent(ctx spi.ComponentContext
 			return newRequeueWithDelay(), err
 		}
 		ctx.Log().Infof("Successfully added finalizer %s to configmap %s for dev component", constants.DevComponentFinalizer, configMap.Name, comp.ReleaseName)
-		// adding finalizer to ConfigMap will
+		// adding finalizer to ConfigMap will trigger a requeue so no need to requeue here
 		return reconcile.Result{}, nil
 	}
 

--- a/platform-operator/controllers/configmaps/components/controller_test.go
+++ b/platform-operator/controllers/configmaps/components/controller_test.go
@@ -46,11 +46,13 @@ func TestConfigMapReconciler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-component",
 					Namespace: constants.VerrazzanoInstallNamespace,
-					Annotations: map[string]string{
-						constants.VerrazzanoDevComponentAnnotationName: "test-component",
+					Labels: map[string]string{
+						devComponentConfigMapKindLabel:       devComponentConfigMapKindHelmComponent,
+						devComponentConfigMapAPIVersionLabel: devComponentConfigMapAPIVersionv1beta2,
 					},
 				},
 				Data: map[string]string{
+					componentNameKey:      "test-component",
 					chartPathKey:          "test-component",
 					componentNamespaceKey: constants.VerrazzanoSystemNamespace,
 					overridesKey:          "overrideKey: overrideVal",
@@ -65,8 +67,30 @@ func TestConfigMapReconciler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-component",
 					Namespace: constants.VerrazzanoSystemNamespace,
-					Annotations: map[string]string{
-						constants.VerrazzanoDevComponentAnnotationName: "test-component",
+					Labels: map[string]string{
+						devComponentConfigMapKindLabel:       devComponentConfigMapKindHelmComponent,
+						devComponentConfigMapAPIVersionLabel: devComponentConfigMapAPIVersionv1beta2,
+					},
+				},
+				Data: map[string]string{
+					componentNameKey:      "test-component",
+					chartPathKey:          "test-component",
+					componentNamespaceKey: constants.VerrazzanoSystemNamespace,
+					overridesKey:          "overrideKey: overrideVal",
+				},
+			},
+			returnError: true,
+			requeue:     false,
+		},
+		{
+			name: "no name",
+			cm: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-component",
+					Namespace: constants.VerrazzanoSystemNamespace,
+					Labels: map[string]string{
+						devComponentConfigMapKindLabel:       devComponentConfigMapKindHelmComponent,
+						devComponentConfigMapAPIVersionLabel: devComponentConfigMapAPIVersionv1beta2,
 					},
 				},
 				Data: map[string]string{
@@ -84,11 +108,13 @@ func TestConfigMapReconciler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-component",
 					Namespace: constants.VerrazzanoInstallNamespace,
-					Annotations: map[string]string{
-						constants.VerrazzanoDevComponentAnnotationName: "test-component",
+					Labels: map[string]string{
+						devComponentConfigMapKindLabel:       devComponentConfigMapKindHelmComponent,
+						devComponentConfigMapAPIVersionLabel: devComponentConfigMapAPIVersionv1beta2,
 					},
 				},
 				Data: map[string]string{
+					componentNameKey:      "test-component",
 					componentNamespaceKey: constants.VerrazzanoSystemNamespace,
 					overridesKey:          "overrideKey: overrideVal",
 				},
@@ -102,13 +128,15 @@ func TestConfigMapReconciler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-component",
 					Namespace: constants.VerrazzanoInstallNamespace,
-					Annotations: map[string]string{
-						constants.VerrazzanoDevComponentAnnotationName: "test-component",
+					Labels: map[string]string{
+						devComponentConfigMapKindLabel:       devComponentConfigMapKindHelmComponent,
+						devComponentConfigMapAPIVersionLabel: devComponentConfigMapAPIVersionv1beta2,
 					},
 				},
 				Data: map[string]string{
-					chartPathKey: "test-component",
-					overridesKey: "overrideKey: overrideVal",
+					componentNameKey: "test-component",
+					chartPathKey:     "test-component",
+					overridesKey:     "overrideKey: overrideVal",
 				},
 			},
 			returnError: true,


### PR DESCRIPTION
This change adds upgrade and uninstall lifecycle operations for the dev component controller. It also adds a finalizer to the configmap that is cleaned up during uninstall.