### PR TITLE
Move "logging trait Helidon workload" test to different stage

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -527,6 +527,14 @@ pipeline {
                                 runGinkgo('examples/helidonmetrics')
                             }
                         }
+                        stage('logging trait Helidon workload') {
+                            environment {
+                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/loggingtrait-helidonworkload"
+                            }
+                            steps {
+                                runGinkgo('loggingtrait/helidonworkload')
+                            }
+                        }
                     }
                     post {
                         always {
@@ -573,14 +581,6 @@ pipeline {
                             }
                             steps {
                                 runGinkgo('workloads/oam')
-                            }
-                        }
-                        stage('logging trait Helidon workload') {
-                            environment {
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/loggingtrait-helidonworkload"
-                            }
-                            steps {
-                                runGinkgo('loggingtrait/helidonworkload')
                             }
                         }
                         stage('logging trait Coherence workload') {


### PR DESCRIPTION
This pull request moves the "logging trait Helidon workload' test from the 3rd parallel stage to the 2nd parallel stage.  This is a workaround for intermittent failure of this test.