### PR TITLE
VZ-9085: TestFailure: verify-cert-manager-update

### DIFF
--- a/tests/e2e/multicluster/multicluster_helper.go
+++ b/tests/e2e/multicluster/multicluster_helper.go
@@ -519,6 +519,7 @@ func (c *Cluster) GetCR(waitForReady bool) *vzapi.Verrazzano {
 				return err
 			}
 			if cr.Status.State != vzapi.VzStateReady {
+				pkg.Log(pkg.Error, fmt.Sprintf("CR resource not ready yet: %v", cr))
 				return fmt.Errorf("CR in state %s, not Ready yet", cr.Status.State)
 			}
 			return nil

--- a/tests/e2e/update/certac/certac_test.go
+++ b/tests/e2e/update/certac/certac_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package certac
@@ -92,7 +92,7 @@ func updateAdminClusterCA() string {
 		Certificate: vzapi.Certificate{CA: vzapi.CA{SecretName: genCA, ClusterResourceNamespace: constants.CertManagerNamespace}},
 	}
 	m := &CertModifier{CertManager: newCM}
-	update.RetryUpdate(m, adminCluster.KubeConfigPath, false, pollingInterval, waitTimeout)
+	update.RetryUpdate(m, adminCluster.KubeConfigPath, true, pollingInterval, waitTimeout)
 	return oldIngressCaCrt
 }
 
@@ -108,7 +108,7 @@ func revertToDefaultCertManager() string {
 	oldIngressCaCrt := adminCluster.
 		GetSecretDataAsString(constants.VerrazzanoSystemNamespace, pocnst.VerrazzanoIngressSecret, mcconstants.CaCrtKey)
 	m := &CertModifier{CertManager: originalCM}
-	update.RetryUpdate(m, adminCluster.KubeConfigPath, false, pollingInterval, waitTimeout)
+	update.RetryUpdate(m, adminCluster.KubeConfigPath, true, pollingInterval, waitTimeout)
 	return oldIngressCaCrt
 }
 

--- a/tests/e2e/update/certmc/certmc_test.go
+++ b/tests/e2e/update/certmc/certmc_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package certmc
@@ -86,7 +86,7 @@ func updateCustomCA() {
 		}
 		originalCMs[managedCluster.Name] = oldCM
 		m := &CertModifier{CertManager: newCM}
-		update.RetryUpdate(m, managedCluster.KubeConfigPath, false, pollingInterval, waitTimeout)
+		update.RetryUpdate(m, managedCluster.KubeConfigPath, true, pollingInterval, waitTimeout)
 	}
 }
 
@@ -101,7 +101,7 @@ func revertToDefaultCertManager() {
 		oldCaCrts[managedCluster.Name] = oldCaCrt
 		oldCm := originalCMs[managedCluster.Name]
 		m := &CertModifier{CertManager: oldCm}
-		update.RetryUpdate(m, managedCluster.KubeConfigPath, false, pollingInterval, waitTimeout)
+		update.RetryUpdate(m, managedCluster.KubeConfigPath, true, pollingInterval, waitTimeout)
 	}
 }
 


### PR DESCRIPTION
The cert manager test suites for admin and managed clusters fail intermittently at different places. This is for the initial set of fixes and log troubleshooting information when Verrazzano custom resource (CR) is not ready.

I will be keeping the ticket open even after the PR is merged to monitor these intermittent failing tests.
