### PR TITLE
VZ-9108: Configure basic auth in Thanos Query

### DIFF
--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -947,7 +947,7 @@ func configureKeycloakRealms(ctx spi.ComponentContext) error {
 	}
 
 	// Create Verrazzano Internal Thanos User if the corresponding secret exists. The secret is installed via the Thanos Helm chart.
-	const thanosSecretName = "verrazzano-thanos-internal"
+	const thanosSecretName = "verrazzano-thanos-internal" //nolint:gosec //#gosec G101
 	secret := &corev1.Secret{}
 	err = ctx.Client().Get(context.TODO(), client.ObjectKey{Namespace: constants.VerrazzanoMonitoringNamespace, Name: thanosSecretName}, secret)
 	if client.IgnoreNotFound(err) != nil {

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -140,6 +140,11 @@ func (c KeycloakComponent) PostInstall(ctx spi.ComponentContext) error {
 	if err != nil {
 		return err
 	}
+	// Create secret for the verrazzano-thanos-internal user
+	err = createAuthSecret(ctx, constants.VerrazzanoMonitoringNamespace, "verrazzano-thanos-internal", "verrazzano-thanos-internal")
+	if err != nil {
+		return err
+	}
 
 	// Create secret for the verrazzano-es-internal user
 	err = createAuthSecret(ctx, constants.VerrazzanoSystemNamespace, "verrazzano-es-internal", "verrazzano-es-internal")

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -140,11 +140,6 @@ func (c KeycloakComponent) PostInstall(ctx spi.ComponentContext) error {
 	if err != nil {
 		return err
 	}
-	// Create secret for the verrazzano-thanos-internal user
-	err = createAuthSecret(ctx, constants.VerrazzanoMonitoringNamespace, "verrazzano-thanos-internal", "verrazzano-thanos-internal")
-	if err != nil {
-		return err
-	}
 
 	// Create secret for the verrazzano-es-internal user
 	err = createAuthSecret(ctx, constants.VerrazzanoSystemNamespace, "verrazzano-es-internal", "verrazzano-es-internal")

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
@@ -718,6 +718,41 @@ func TestConfigureKeycloakRealms(t *testing.T) {
 			"",
 			fakeConfigureRealmCommands,
 		},
+		{
+			"should pass when able to successfully exec commands on the keycloak pod and thanos secret does not exist (because thanos is not installed)",
+			fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(loginSecret, nginxService, keycloakPod, &authConfig, osIngress,
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "verrazzano",
+						Namespace: "verrazzano-system",
+					},
+					Data: map[string][]byte{
+						"password": []byte("blah di blah"),
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "verrazzano-prom-internal",
+						Namespace: "verrazzano-system",
+					},
+					Data: map[string][]byte{
+						"password": []byte("blah di blah"),
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "verrazzano-es-internal",
+						Namespace: "verrazzano-system",
+					},
+					Data: map[string][]byte{
+						"password": []byte("blah di blah"),
+					},
+				}).Build(),
+			"blahblah'id",
+			false,
+			"",
+			fakeConfigureRealmCommands,
+		},
 	}
 
 	for _, tt := range tests {

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_test.go
@@ -609,6 +609,15 @@ func TestConfigureKeycloakRealms(t *testing.T) {
 				},
 				&v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:      "verrazzano-thanos-internal",
+						Namespace: "verrazzano-monitoring",
+					},
+					Data: map[string][]byte{
+						"password": []byte("blah di blah"),
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "verrazzano-es-internal",
 						Namespace: "verrazzano-system",
 					},
@@ -644,6 +653,15 @@ func TestConfigureKeycloakRealms(t *testing.T) {
 				},
 				&v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:      "verrazzano-thanos-internal",
+						Namespace: "verrazzano-monitoring",
+					},
+					Data: map[string][]byte{
+						"password": []byte("blah di blah"),
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
 						Name:      "verrazzano-es-internal",
 						Namespace: "verrazzano-system",
 					},
@@ -672,6 +690,15 @@ func TestConfigureKeycloakRealms(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "verrazzano-prom-internal",
 						Namespace: "verrazzano-system",
+					},
+					Data: map[string][]byte{
+						"password": []byte("blah di blah"),
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "verrazzano-thanos-internal",
+						Namespace: "verrazzano-monitoring",
 					},
 					Data: map[string][]byte{
 						"password": []byte("blah di blah"),

--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -19,7 +19,17 @@ query:
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
       # Turn off hostname to disable auto-generated backend
       hostname: ""
-
+  extraEnvVars:
+    - name: CLIENT_BASIC_AUTH_USER
+      valueFrom:
+        secretKeyRef:
+          name: verrazzano-thanos-internal
+          key: username
+    - name: CLIENT_BASIC_AUTH_PASS
+      valueFrom:
+        secretKeyRef:
+          name: verrazzano-thanos-internal
+          key: password
   # Adds the Prometheus Thanos sidecar as a Store API endpoint to Query
   stores:
     - prometheus-operator-kube-p-prometheus:10901

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/usersecret.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/usersecret.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "verrazzano-thanos-internal"
+  namespace: {{ .Release.Namespace | quote }}
+type: Opaque
+data:
+  # retrieve existing secret if it exists
+  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "verrazzano-thanos-internal") | default dict }}
+  {{- $secretData := (get $secretObj "data") | default dict }}
+  # use existing password if it exists, otherwise generate a new password
+  {{- $password := (get $secretData "password") | default (randAlphaNum 15 | b64enc) }}
+  password: {{ $password }}
+  username: {{ "verrazzano-thanos-internal" | b64enc }}

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -788,7 +788,7 @@
           "images": [
             {
               "image": "thanos",
-              "tag": "v0.28.0-20230322155710-8af2d756",
+              "tag": "v0.28.0-20230327140642-44e53eff",
               "helmRegKey": "image.registry",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"


### PR DESCRIPTION
**Changes**:

1. Add a secret to the Thanos Helm chart that generates a password for the verrazzano-thanos-internal user.
2. Create a Keycloak user for verrazzano-thanos-internal.
3. Mount the secret in the Thanos Query container as environment variables.

**Tests**:
1. Installed in a local cluster with Thanos enabled, verified that the secret and Keycloak user are created, and that the Thanos Query container has the secret env vars set, tested through the ingress to verify that basic auth works.
2. Upgrade the installation to validate that the existing verrazzano-thanos-internal password in the secret is not changed.
3. Installed in a local cluster with Thanos disabled, verified that the Keycloak user is not created.