### PR TITLE
Refresh component images in release-1.5, after updating golang.org/x/net and golang.org/x/text

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -234,7 +234,7 @@
             },
             {
               "image": "grafana",
-              "tag": "v7.5.17-20230209071114-4d2e32e8",
+              "tag": "v7.5.17-20230324124607-7afbf50a",
               "helmFullImageKey": "monitoringOperator.grafanaImage"
             },
             {
@@ -378,7 +378,7 @@
           "images": [
             {
               "image": "kiali",
-              "tag": "v1.57.1-20230223193254-0e6b42d8",
+              "tag": "v1.57.1-20230324120010-d94b80c9",
               "helmFullImageKey": "deployment.image_name",
               "helmTagKey": "deployment.image_version"
             }
@@ -507,7 +507,7 @@
           "images": [
             {
               "image": "alertmanager",
-              "tag": "v0.24.0-20230221214421-a20fd08d",
+              "tag": "v0.24.0-20230324104837-18128160",
               "helmFullImageKey": "alertmanager.alertmanagerSpec.image.repository",
               "helmTagKey": "alertmanager.alertmanagerSpec.image.tag"
             }
@@ -519,7 +519,7 @@
           "images": [
             {
               "image": "prometheus",
-              "tag": "v2.38.0-20230221215349-cf7b5418",
+              "tag": "v2.38.0-20230324105920-186a8ee6",
               "helmFullImageKey": "prometheus.prometheusSpec.image.repository",
               "helmTagKey": "prometheus.prometheusSpec.image.tag"
             }
@@ -587,7 +587,7 @@
           "images": [
             {
               "image": "node-exporter",
-              "tag": "v1.3.1-20230209071824-2bb925b2",
+              "tag": "v1.3.1-20230323153951-b7f69924",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -605,7 +605,7 @@
           "images": [
             {
               "image": "jaeger-operator",
-              "tag": "1.37.0-20230209065122-0760c0d3",
+              "tag": "1.37.0-20230324105128-d87b5769",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -617,7 +617,7 @@
           "images": [
             {
               "image": "jaeger-agent",
-              "tag": "1.37.0-20230209101805-55f6b454",
+              "tag": "1.37.0-20230324122806-8df5ebad",
               "helmFullImageKey": "jaegerAgentImage"
             }
           ]
@@ -628,7 +628,7 @@
           "images": [
             {
               "image": "jaeger-collector",
-              "tag": "1.37.0-20230209101805-55f6b454",
+              "tag": "1.37.0-20230324122806-8df5ebad",
               "helmFullImageKey": "jaegerCollectorImage"
             }
           ]
@@ -639,7 +639,7 @@
           "images": [
             {
               "image": "jaeger-query",
-              "tag": "1.37.0-20230209101805-55f6b454",
+              "tag": "1.37.0-20230324122806-8df5ebad",
               "helmFullImageKey": "jaegerQueryImage"
             }
           ]
@@ -650,7 +650,7 @@
           "images": [
             {
               "image": "jaeger-ingester",
-              "tag": "1.37.0-20230209101805-55f6b454",
+              "tag": "1.37.0-20230324122806-8df5ebad",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -661,7 +661,7 @@
           "images": [
             {
               "image": "jaeger-es-index-cleaner",
-              "tag": "1.37.0-20230209101805-55f6b454",
+              "tag": "1.37.0-20230324122806-8df5ebad",
               "helmFullImageKey": "jaegerESIndexCleanerImage"
             }
           ]
@@ -672,7 +672,7 @@
           "images": [
             {
               "image": "jaeger-es-rollover",
-              "tag": "1.37.0-20230209101805-55f6b454",
+              "tag": "1.37.0-20230324122806-8df5ebad",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]
@@ -683,7 +683,7 @@
           "images": [
             {
               "image": "jaeger-all-in-one",
-              "tag": "1.37.0-20230209101805-55f6b454",
+              "tag": "1.37.0-20230324122806-8df5ebad",
               "helmFullImageKey": "jaegerAllInOneImage"
             }
           ]

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -605,7 +605,7 @@
           "images": [
             {
               "image": "jaeger-operator",
-              "tag": "1.37.0-20230324105128-d87b5769",
+              "tag": "1.37.0-20230209065122-0760c0d3",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -617,7 +617,7 @@
           "images": [
             {
               "image": "jaeger-agent",
-              "tag": "1.37.0-20230324122806-8df5ebad",
+              "tag": "1.37.0-20230209101805-55f6b454",
               "helmFullImageKey": "jaegerAgentImage"
             }
           ]
@@ -628,7 +628,7 @@
           "images": [
             {
               "image": "jaeger-collector",
-              "tag": "1.37.0-20230324122806-8df5ebad",
+              "tag": "1.37.0-20230209101805-55f6b454",
               "helmFullImageKey": "jaegerCollectorImage"
             }
           ]
@@ -639,7 +639,7 @@
           "images": [
             {
               "image": "jaeger-query",
-              "tag": "1.37.0-20230324122806-8df5ebad",
+              "tag": "1.37.0-20230209101805-55f6b454",
               "helmFullImageKey": "jaegerQueryImage"
             }
           ]
@@ -650,7 +650,7 @@
           "images": [
             {
               "image": "jaeger-ingester",
-              "tag": "1.37.0-20230324122806-8df5ebad",
+              "tag": "1.37.0-20230209101805-55f6b454",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -661,7 +661,7 @@
           "images": [
             {
               "image": "jaeger-es-index-cleaner",
-              "tag": "1.37.0-20230324122806-8df5ebad",
+              "tag": "1.37.0-20230209101805-55f6b454",
               "helmFullImageKey": "jaegerESIndexCleanerImage"
             }
           ]
@@ -672,7 +672,7 @@
           "images": [
             {
               "image": "jaeger-es-rollover",
-              "tag": "1.37.0-20230324122806-8df5ebad",
+              "tag": "1.37.0-20230209101805-55f6b454",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]
@@ -683,7 +683,7 @@
           "images": [
             {
               "image": "jaeger-all-in-one",
-              "tag": "1.37.0-20230324122806-8df5ebad",
+              "tag": "1.37.0-20230209101805-55f6b454",
               "helmFullImageKey": "jaegerAllInOneImage"
             }
           ]

--- a/tests/testdata/jaeger/hotrod/hotrod-tracing-comp.yaml
+++ b/tests/testdata/jaeger/hotrod/hotrod-tracing-comp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: hotrod-container
-          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20221219184221-55f6b454"
+          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20230324122806-8df5ebad"
           env:
             - name: JAEGER_AGENT_HOST
               value: "localhost"

--- a/tests/testdata/jaeger/hotrod/hotrod-tracing-comp.yaml
+++ b/tests/testdata/jaeger/hotrod/hotrod-tracing-comp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: hotrod-container
-          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20230324122806-8df5ebad"
+          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20221219184221-55f6b454"
           env:
             - name: JAEGER_AGENT_HOST
               value: "localhost"

--- a/tests/testdata/jaeger/hotrod/hotrod-tracing-comp.yaml
+++ b/tests/testdata/jaeger/hotrod/hotrod-tracing-comp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: Component

--- a/tests/testdata/jaeger/hotrod/multicluster/hotrod-tracing-comp.yaml
+++ b/tests/testdata/jaeger/hotrod/multicluster/hotrod-tracing-comp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: hotrod-container
-          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20221219184221-55f6b454"
+          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20230324122806-8df5ebad"
           env:
             - name: JAEGER_AGENT_HOST
               value: "localhost"

--- a/tests/testdata/jaeger/hotrod/multicluster/hotrod-tracing-comp.yaml
+++ b/tests/testdata/jaeger/hotrod/multicluster/hotrod-tracing-comp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: hotrod-container
-          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20230324122806-8df5ebad"
+          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.37.0-20221219184221-55f6b454"
           env:
             - name: JAEGER_AGENT_HOST
               value: "localhost"

--- a/tests/testdata/jaeger/hotrod/multicluster/hotrod-tracing-comp.yaml
+++ b/tests/testdata/jaeger/hotrod/multicluster/hotrod-tracing-comp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: Component


### PR DESCRIPTION
Refreshes component images, after updating golang.org/x/net and golang.org/x/text
