### PR TITLE
VZ-9137.  Fix MonitorChanges checks in some of the prometheus stack components

### DIFF
--- a/pkg/vzcr/enabled.go
+++ b/pkg/vzcr/enabled.go
@@ -194,7 +194,7 @@ func IsExternalDNSEnabled(cr runtime.Object) bool {
 
 // IsVMOEnabled - Returns false if all VMO components are disabled
 func IsVMOEnabled(vz runtime.Object) bool {
-	return IsPrometheusEnabled(vz) || IsOpenSearchDashboardsEnabled(vz) || IsOpenSearchEnabled(vz) || IsGrafanaEnabled(vz)
+	return IsOpenSearchDashboardsEnabled(vz) || IsOpenSearchEnabled(vz) || IsGrafanaEnabled(vz)
 }
 
 // IsPrometheusOperatorEnabled returns false only if the Prometheus Operator is explicitly disabled in the CR

--- a/pkg/vzcr/enabled.go
+++ b/pkg/vzcr/enabled.go
@@ -194,7 +194,7 @@ func IsExternalDNSEnabled(cr runtime.Object) bool {
 
 // IsVMOEnabled - Returns false if all VMO components are disabled
 func IsVMOEnabled(vz runtime.Object) bool {
-	return IsOpenSearchDashboardsEnabled(vz) || IsOpenSearchEnabled(vz) || IsGrafanaEnabled(vz)
+	return IsPrometheusEnabled(vz) || IsOpenSearchDashboardsEnabled(vz) || IsOpenSearchEnabled(vz) || IsGrafanaEnabled(vz)
 }
 
 // IsPrometheusOperatorEnabled returns false only if the Prometheus Operator is explicitly disabled in the CR

--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package adapter
@@ -87,7 +87,6 @@ func (c prometheusAdapterComponent) MonitorOverrides(ctx spi.ComponentContext) b
 		if ctx.EffectiveCR().Spec.Components.PrometheusAdapter.MonitorChanges != nil {
 			return *ctx.EffectiveCR().Spec.Components.PrometheusAdapter.MonitorChanges
 		}
-		return true
 	}
-	return false
+	return true
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package adapter
@@ -95,7 +95,7 @@ func TestMonitorOverride(t *testing.T) {
 			// THEN the call returns false
 			name:       "Test MonitorOverride when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: false,
+			expectTrue: true,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Adapter enabled

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package kubestatemetrics
@@ -90,9 +90,8 @@ func (c kubeStateMetricsComponent) MonitorOverrides(ctx spi.ComponentContext) bo
 		if ctx.EffectiveCR().Spec.Components.KubeStateMetrics.MonitorChanges != nil {
 			return *ctx.EffectiveCR().Spec.Components.KubeStateMetrics.MonitorChanges
 		}
-		return true
 	}
-	return false
+	return true
 }
 
 // AppendOverrides appends install overrides for the Prometheus kube-state-metrics component's Helm chart

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nodeexporter
@@ -105,9 +105,8 @@ func (c prometheusNodeExporterComponent) MonitorOverrides(ctx spi.ComponentConte
 		if ctx.EffectiveCR().Spec.Components.PrometheusNodeExporter.MonitorChanges != nil {
 			return *ctx.EffectiveCR().Spec.Components.PrometheusNodeExporter.MonitorChanges
 		}
-		return true
 	}
-	return false
+	return true
 }
 
 // PostInstall creates/updates associated resources after this component is installed

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nodeexporter
@@ -201,7 +201,7 @@ func TestMonitorOverride(t *testing.T) {
 			// THEN the call returns false
 			name:       "Test MonitorOverride when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: false,
+			expectTrue: true,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the Prometheus Node Exporter enabled

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pushgateway
@@ -91,9 +91,8 @@ func (c prometheusPushgatewayComponent) MonitorOverrides(ctx spi.ComponentContex
 		if ctx.EffectiveCR().Spec.Components.PrometheusPushgateway.MonitorChanges != nil {
 			return *ctx.EffectiveCR().Spec.Components.PrometheusPushgateway.MonitorChanges
 		}
-		return true
 	}
-	return false
+	return true
 }
 
 // AppendOverrides appends install overrides for the Prometheus PrometheusPushgateway component's Helm chart

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pushgateway
@@ -124,7 +124,7 @@ func TestMonitorOverride(t *testing.T) {
 			// THEN the call returns false
 			name:       "Test MonitorOverride when using default Verrazzano CR",
 			actualCR:   vzapi.Verrazzano{},
-			expectTrue: false,
+			expectTrue: true,
 		},
 		{
 			// GIVEN a Verrazzano custom resource with the PrometheusPushgatewayComponent enabled


### PR DESCRIPTION
Fixes a bug in the `MonitorChanges` override in a subset of the Prometheus components that is preventing them from being disabled by removing them from the CR when a `none` profile is deployed.

This affects:
 * prometheusAdapter
 * kubeStateMetrics
 * prometheusPushgateway
 * prometheusNodeExporter

If you enable these after deploying a `none` profile:

```
  profile: none
  components:
    kubeStateMetrics:
      enabled: true
    prometheus:
      enabled: true
    prometheusOperator:
      enabled: true
    prometheusAdapter:
      enabled: true
    prometheusNodeExporter:
      enabled: true
    prometheusPushgateway:
      enabled: true
```

and the disable them by removing them from the CR:

```
  profile: none
  components:
    prometheus:
      enabled: true
    prometheusOperator:
      enabled: true
```

the components will not uninstall.  This is because the `MonitorChanges()` call returns `false` by default if there is nothing defined for those components in the CR, and this blocks reconciling those components.

The fix is to return `true` from that method in those cases.
