### PR TITLE
Reintroduce "Skip OCI Node driver activation aamitra/rancher phase1" to rancher-master

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -399,26 +399,6 @@ func DeleteLocalCluster(log vzlog.VerrazzanoLogger, c client.Client) {
 	log.Once("Successfully deleted Rancher local cluster")
 }
 
-// activateOCIDriver activates the OCI nodeDriver
-func activateOCIDriver(log vzlog.VerrazzanoLogger, c client.Client) error {
-	ociDriver := unstructured.Unstructured{}
-	ociDriver.SetGroupVersionKind(GVKNodeDriver)
-	ociDriverName := types.NamespacedName{Name: NodeDriverOCI}
-	err := c.Get(context.Background(), ociDriverName, &ociDriver)
-	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting OCI Driver: %s", err.Error())
-	}
-
-	ociDriverMerge := client.MergeFrom(ociDriver.DeepCopy())
-	ociDriver.UnstructuredContent()["spec"].(map[string]interface{})["active"] = true
-	err = c.Patch(context.Background(), &ociDriver, ociDriverMerge)
-	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed patching OCI Driver: %s", err.Error())
-	}
-
-	return nil
-}
-
 // activateDrivers activates the oraclecontainerengine kontainerDriver
 func activatOKEDriver(log vzlog.VerrazzanoLogger, c client.Client) error {
 	okeDriver := unstructured.Unstructured{}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -506,17 +506,7 @@ func (r rancherComponent) PostUpgrade(ctx spi.ComponentContext) error {
 
 // activateDrivers activates the nodeDriver oci and oraclecontainerengine kontainerDriver
 func activateDrivers(log vzlog.VerrazzanoLogger, c client.Client) error {
-	err := activateOCIDriver(log, c)
-	if err != nil {
-		return err
-	}
-
-	err = activatOKEDriver(log, c)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return activatOKEDriver(log, c)
 }
 
 // ConfigureAuthProviders


### PR DESCRIPTION
This reintroduces the fix from https://github.com/verrazzano/verrazzano/pull/5627 into the `anders/rancher-master` branch.