### PR TITLE
Add a cron schedule to run backend tests every Friday 

### DIFF
--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -57,6 +57,7 @@ pipeline {
             label "${agentLabel}"
         }
     }
+
     triggers {
         cron(branchSpecificSchedule)
         URLTrigger(

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -580,12 +580,3 @@ def getLatestReleaseVersion() {
     echo "gitTags = ${gitTags}"
     return gitTags.pop()
 }
-
-def getCronSchedule() {
-    if (env.BRANCH_NAME.equals("master")) {
-
-        //Set cron job to run every Friday at 9 AM
-        return "0 9 * * 5"
-    }
-    return ""
-}

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
@@ -57,7 +58,9 @@ pipeline {
             label "${agentLabel}"
         }
     }
-
+    triggers {
+        cron(branchSpecificSchedule)
+    }
     triggers {
         URLTrigger(
             cronTabSpec: branchSpecificSchedule,
@@ -579,4 +582,13 @@ def getLatestReleaseVersion() {
     list gitTags = extractReleaseTags(releaseTags)
     echo "gitTags = ${gitTags}"
     return gitTags.pop()
+}
+
+def getCronSchedule() {
+    if (env.BRANCH_NAME.equals("master")) {
+
+        //Set cron job to run every Friday at 9 AM
+        return "0 9 * * 5"
+    }
+    return ""
 }

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -60,25 +60,33 @@ pipeline {
 
     triggers {
         cron(branchSpecificSchedule)
-/*        URLTrigger(
-            cronTabSpec: branchSpecificSchedule,
-            entries: [
-                URLTriggerEntry(
-                    url: "https://objectstorage.${ociOsRegion}.oraclecloud.com/n/${OS_NAMESPACE_URL_TRIGGER}/b/${ociOsBucket}/o/${urlTriggerBranchName}/${lastStableCommitFile}",
-                    checkETag: false,
-                    checkStatus: true,
-                    statusCode: 403,
-                    checkLastModificationDate: true,
-                    timeout: 200,
-                    requestHeaders: [
-                        RequestHeader( headerName: "Accept" , headerValue: "application/json" )
-                    ],
-                    contentTypes: [
-                        MD5Sum()
-                    ]
-                )
-            ]
-        ) */
+
+    // There is an issue with URLTrigger for backend tests where the polling URL maintains a global state that does not work with specific jobs.
+    // Therefore, the below code is disabled until the global state issue is fixed.
+    // Ex: - Each job has an URL Trigger poll cron schedule
+    //      - When a job’s cron triggers, it checks the state of whether the specific URL X has changed or not.
+    //      - If it has changed, then it triggers only the job whose cron schedule fired off (no other jobs that look for that URL X will trigger)
+    //      - Any other jobs that wake up and poll on URL X will not see it as changing unless it actually changed again since this time
+
+    //        URLTrigger(
+    //            cronTabSpec: branchSpecificSchedule,
+    //            entries: [
+    //                URLTriggerEntry(
+    //                    url: "https://objectstorage.${ociOsRegion}.oraclecloud.com/n/${OS_NAMESPACE_URL_TRIGGER}/b/${ociOsBucket}/o/${urlTriggerBranchName}/${lastStableCommitFile}",
+    //                    checkETag: false,
+    //                    checkStatus: true,
+    //                    statusCode: 403,
+    //                    checkLastModificationDate: true,
+    //                    timeout: 200,
+    //                    requestHeaders: [
+    //                        RequestHeader( headerName: "Accept" , headerValue: "application/json" )
+    //                    ],
+    //                   contentTypes: [
+    //                        MD5Sum()
+    //                    ]
+    //                )
+    //            ]
+    //        )
     }
 
     parameters {

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -60,8 +60,8 @@ pipeline {
 
     triggers {
         cron(branchSpecificSchedule)
-        URLTrigger(
-//            cronTabSpec: branchSpecificSchedule,
+/*        URLTrigger(
+            cronTabSpec: branchSpecificSchedule,
             entries: [
                 URLTriggerEntry(
                     url: "https://objectstorage.${ociOsRegion}.oraclecloud.com/n/${OS_NAMESPACE_URL_TRIGGER}/b/${ociOsBucket}/o/${urlTriggerBranchName}/${lastStableCommitFile}",
@@ -78,7 +78,7 @@ pipeline {
                     ]
                 )
             ]
-        )
+        ) */
     }
 
     parameters {

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -59,10 +59,8 @@ pipeline {
     }
     triggers {
         cron(branchSpecificSchedule)
-    }
-    triggers {
         URLTrigger(
-            cronTabSpec: branchSpecificSchedule,
+//            cronTabSpec: branchSpecificSchedule,
             entries: [
                 URLTriggerEntry(
                     url: "https://objectstorage.${ociOsRegion}.oraclecloud.com/n/${OS_NAMESPACE_URL_TRIGGER}/b/${ociOsBucket}/o/${urlTriggerBranchName}/${lastStableCommitFile}",

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 


### PR DESCRIPTION
This PR addes the cron schedule to the backend tests to trigger the job every Friday. The job will not be validated against last stable commit. 