### PR TITLE
VZ-7915.  Add check to ensure disabled pods not running in promstack tests

### DIFF
--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -858,7 +858,7 @@ func IsPrometheusOperatorEnabled(kubeconfigPath string) bool {
 		return true
 	}
 	if vz.Spec.Components.PrometheusOperator == nil || vz.Spec.Components.PrometheusOperator.Enabled == nil {
-		return true
+		return vz.Spec.Profile != v1alpha1.None
 	}
 	return *vz.Spec.Components.PrometheusOperator.Enabled
 }
@@ -871,7 +871,7 @@ func IsPrometheusEnabled(kubeconfigPath string) bool {
 		return false
 	}
 	if vz.Spec.Components.Prometheus == nil || vz.Spec.Components.Prometheus.Enabled == nil {
-		return true
+		return vz.Spec.Profile != v1alpha1.None
 	}
 	return *vz.Spec.Components.Prometheus.Enabled
 }
@@ -923,7 +923,7 @@ func IsPrometheusNodeExporterEnabled(kubeconfigPath string) bool {
 		return false
 	}
 	if vz.Spec.Components.PrometheusNodeExporter == nil || vz.Spec.Components.PrometheusNodeExporter.Enabled == nil {
-		return false
+		return IsPrometheusEnabled(kubeconfigPath)
 	}
 	return *vz.Spec.Components.PrometheusNodeExporter.Enabled
 }


### PR DESCRIPTION
Add a negative test case to the promstack tests to ensure disabled component pods are not running.
- also enhance Prometheus `IsXXXXEnabled` functions to account for None profile defaults
- update IsNodeExporterEnabled to account for case where NodeExporter fields are not in spec but prometheus is enabled (NE is enabled in that case)