### PR TITLE
VZ-9103 - Populate managed cluster query store endpoints in an admin cluster Thanos Query SD ConfigMap, add needed DestinationRule/ServiceEntry for communicating with managed cluster Thanos Query

### DIFF
--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -57,6 +57,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncThanosQuery(ctx context.Context
 	if err := r.createOrUpdateDestinationRule(vmc.Name, vmc.Status.ThanosHost, thanosGrpcIngressPort); err != nil {
 		return err
 	}
+	return nil
 }
 
 // syncThanosQueryEndpoint will update the config map used by Thanos Query with the managed cluster

--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -32,7 +32,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncThanosQueryEndpoint(ctx context
 	vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
 
 	if vmc.Status.ThanosHost == "" {
-		r.log.Progressf("Managed cluster Thanos Host not found in VMC Status for VMC %s. Not updating Thanos endpoints", vmc.Name)
+		r.log.Oncef("Managed cluster Thanos Host not found in VMC Status for VMC %s. Not updating Thanos endpoints", vmc.Name)
 		return nil
 	}
 

--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
 )
 
@@ -189,13 +188,6 @@ func (r *VerrazzanoManagedClusterReconciler) getThanosEndpointsConfigMap(ctx con
 		return nil, r.log.ErrorfNewErr("failed to fetch the Thanos endpoints ConfigMap %s/%s, %v", configMapNsn.Namespace, configMapNsn.Name, err)
 	}
 	return &configMap, nil
-}
-
-// createOrUpdateArgoCDSecret create or update the Argo CD cluster secret
-func (r *VerrazzanoManagedClusterReconciler) createOrUpdateThanosConfigMap(configMap *v1.ConfigMap, mutateFn controllerutil.MutateFn) error {
-	// Create or update on the local cluster
-	_, err := controllerruntime.CreateOrUpdate(context.TODO(), r.Client, configMap, mutateFn)
-	return err
 }
 
 func (r *VerrazzanoManagedClusterReconciler) isThanosEnabled() (bool, error) {

--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -89,7 +89,16 @@ func (r *VerrazzanoManagedClusterReconciler) deleteClusterThanosEndpoint(ctx con
 		return nil
 	}
 
-	return r.removeThanosHostFromConfigMap(ctx, vmc.Status.ThanosHost, r.log)
+	if err := r.removeThanosHostFromConfigMap(ctx, vmc.Status.ThanosHost, r.log); err != nil {
+		return err
+	}
+	if err := r.deleteDestinationRule(vmc.Name); err != nil {
+		return err
+	}
+	if err := r.deleteServiceEntry(vmc.Name); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *VerrazzanoManagedClusterReconciler) removeThanosHostFromConfigMap(ctx context.Context, host string, log vzlog.VerrazzanoLogger) error {

--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -209,7 +209,6 @@ func (r *VerrazzanoManagedClusterReconciler) getThanosEndpointsConfigMap(ctx con
 		Name:      ThanosManagedClusterEndpointsConfigMap,
 	}
 	configMap := v1.ConfigMap{}
-	// validate secret if it exists
 	if err := r.Get(ctx, configMapNsn, &configMap); err != nil {
 		return nil, r.log.ErrorfNewErr("failed to fetch the Thanos endpoints ConfigMap %s/%s, %v", configMapNsn.Namespace, configMapNsn.Name, err)
 	}

--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package vmc
+
+import (
+	"context"
+
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/thanos"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
+)
+
+type thanosServiceDiscovery struct {
+	targets []string
+}
+
+const ThanosManagedClusterEndpointsConfigMap = "verrazzano-thanos-endpoints"
+const serviceDiscoveryKey = "servicediscovery.yml"
+
+// syncThanosQueryEndpoint will update the config map used by Thanos Query with the managed cluster
+// Thanos store API endpoint. TODO - we will also need to add the cluster's CA cert for Thanos Query to use
+func (r *VerrazzanoManagedClusterReconciler) syncThanosQueryEndpoint(ctx context.Context,
+	vmc *clustersv1alpha1.VerrazzanoManagedCluster, log vzlog.VerrazzanoLogger) error {
+
+	if vmc.Status.ThanosHost == "" {
+		log.Progressf("Managed cluster Thanos Host not found in VMC Status for VMC %s. Not updating Thanos endpoints", vmc.Name)
+		return r.removeThanosHostFromConfigMap(ctx, vmc.Status.ThanosHost, log)
+	}
+
+	return r.addThanosHostIfNotPresent(ctx, vmc.Status.ThanosHost, log)
+}
+
+func (r *VerrazzanoManagedClusterReconciler) removeThanosHostFromConfigMap(ctx context.Context, host string, log vzlog.VerrazzanoLogger) error {
+	configMap, err := r.getThanosEndpointsConfigMap(ctx, log)
+	if err != nil {
+		return err
+	}
+	serviceDiscovery, err := parseThanosEndpointsConfigMap(configMap, log)
+	if err != nil || serviceDiscovery.targets == nil {
+		// nothing to do - there are no endpoints needing removal
+		return nil
+	}
+	hostEndpoint := toGrpcTarget(host)
+	foundIndex := findHost(serviceDiscovery, hostEndpoint)
+	if foundIndex > -1 {
+		serviceDiscovery.targets = append(serviceDiscovery.targets[:foundIndex], serviceDiscovery.targets[foundIndex+1:]...)
+		newServiceDiscoveryYaml, err := yaml.Marshal(serviceDiscovery)
+		if err != nil {
+			return log.ErrorfNewErr("Failed to serialize after removing endpoint %s from Thanos endpoints config map: %v", hostEndpoint, err)
+		}
+		_, err = controllerruntime.CreateOrUpdate(context.TODO(), r.Client, configMap, func() error {
+			configMap.Data[serviceDiscoveryKey] = string(newServiceDiscoveryYaml)
+			return nil
+		})
+		if err != nil {
+			return log.ErrorfNewErr("Failed to update Thanos endpoints config map after removing endpoint %s: %v", hostEndpoint, err)
+		}
+	}
+	return nil
+}
+
+func (r *VerrazzanoManagedClusterReconciler) addThanosHostIfNotPresent(ctx context.Context, host string, log vzlog.VerrazzanoLogger) error {
+	configMap, err := r.getThanosEndpointsConfigMap(ctx, log)
+	if err != nil {
+		return err
+	}
+	serviceDiscovery, err := parseThanosEndpointsConfigMap(configMap, log)
+	if err != nil {
+		// We will wipe out and repopulate the config map if it could not be parsed
+		log.Info("Clearing and repopulating Thanos endpoints ConfigMap due to parse error")
+		serviceDiscovery = &thanosServiceDiscovery{targets: []string{}}
+	}
+	if serviceDiscovery.targets == nil {
+		serviceDiscovery.targets = []string{}
+	}
+	hostEndpoint := toGrpcTarget(host)
+	foundIndex := findHost(serviceDiscovery, hostEndpoint)
+	if foundIndex > -1 {
+		// already exists, nothing to be added
+		return nil
+	}
+	// not found, add this host endpoint and update the config map
+	serviceDiscovery.targets = append(serviceDiscovery.targets, hostEndpoint)
+	newServiceDiscoveryYaml, err := yaml.Marshal(serviceDiscovery)
+	if err != nil {
+		return log.ErrorfNewErr("Failed to serialize after adding endpoint %s to Thanos endpoints config map: %v", hostEndpoint, err)
+	}
+	_, err = controllerruntime.CreateOrUpdate(context.TODO(), r.Client, configMap, func() error {
+		configMap.Data[serviceDiscoveryKey] = string(newServiceDiscoveryYaml)
+		return nil
+	})
+	if err != nil {
+		return log.ErrorfNewErr("Failed to update Thanos endpoints config map after adding endpoint %s: %v", hostEndpoint, err)
+	}
+	return nil
+}
+
+func findHost(serviceDiscovery *thanosServiceDiscovery, host string) int {
+	foundIndex := -1
+	for i, target := range serviceDiscovery.targets {
+		if target == host {
+			foundIndex = i
+		}
+	}
+	return foundIndex
+}
+
+func parseThanosEndpointsConfigMap(configMap *v1.ConfigMap, log vzlog.VerrazzanoLogger) (*thanosServiceDiscovery, error) {
+	// ConfigMap format for Thanos endpoints is
+	// servicediscovery.yml: |
+	//  - targets:
+	//    - example.com:443
+	serviceDiscoveryYaml, exists := configMap.Data[serviceDiscoveryKey]
+	serviceDiscoveryContent := thanosServiceDiscovery{}
+	var err error
+	if exists {
+		err = yaml.Unmarshal([]byte(serviceDiscoveryYaml), &serviceDiscoveryContent)
+		// TODO if parse fails wipe it out and let it be repopulated
+		if err != nil {
+			return nil, log.ErrorfNewErr("Failed to parse Thanos endpoints config map %s/%s, error: %v", configMap.Namespace, configMap.Name, err)
+		}
+	}
+	return &serviceDiscoveryContent, nil
+}
+
+func (r *VerrazzanoManagedClusterReconciler) getThanosEndpointsConfigMap(ctx context.Context, log vzlog.VerrazzanoLogger) (*v1.ConfigMap, error) {
+	configMapNsn := types.NamespacedName{
+		Namespace: thanos.ComponentNamespace,
+		Name:      ThanosManagedClusterEndpointsConfigMap,
+	}
+	configMap := v1.ConfigMap{}
+	// validate secret if it exists
+	if err := r.Get(ctx, configMapNsn, &configMap); err != nil {
+		return nil, log.ErrorfNewErr("failed to fetch the Thanos endpoints ConfigMap %s/%s, %v", configMapNsn.Namespace, configMapNsn.Name, err)
+	}
+	return &configMap, nil
+}
+
+// createOrUpdateArgoCDSecret create or update the Argo CD cluster secret
+func (r *VerrazzanoManagedClusterReconciler) createOrUpdateThanosConfigMap(configMap *v1.ConfigMap, mutateFn controllerutil.MutateFn) error {
+	// Create or update on the local cluster
+	_, err := controllerruntime.CreateOrUpdate(context.TODO(), r.Client, configMap, mutateFn)
+	return err
+}
+
+func toGrpcTarget(hostname string) string {
+	return hostname + ":443"
+}

--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -98,7 +98,9 @@ func (r *VerrazzanoManagedClusterReconciler) addThanosHostIfNotPresent(ctx conte
 	if err != nil {
 		// We will wipe out and repopulate the config map if it could not be parsed
 		r.log.Info("Clearing and repopulating Thanos endpoints ConfigMap due to parse error")
-		serviceDiscoveryList = []*thanosServiceDiscovery{}
+		serviceDiscoveryList = []*thanosServiceDiscovery{
+			{Targets: []string{}},
+		}
 	}
 	hostEndpoint := toGrpcTarget(host)
 	for _, serviceDiscovery := range serviceDiscoveryList {

--- a/cluster-operator/controllers/vmc/sync_thanos_test.go
+++ b/cluster-operator/controllers/vmc/sync_thanos_test.go
@@ -50,7 +50,7 @@ func TestVerrazzanoManagedClusterReconciler_addThanosHostIfNotPresent(t *testing
 				Client: cli,
 				log:    log,
 			}
-			err := r.addThanosHostIfNotPresent(ctx, tt.host, log)
+			err := r.addThanosHostIfNotPresent(ctx, tt.host)
 			if tt.expectError {
 				assert.Error(t, err, "Expected error")
 			} else {
@@ -148,7 +148,7 @@ func TestVerrazzanoManagedClusterReconciler_syncThanosQueryEndpoint(t *testing.T
 				Client: cli,
 				log:    log,
 			}
-			err := r.syncThanosQueryEndpoint(ctx, vmc, log)
+			err := r.syncThanosQueryEndpoint(ctx, vmc)
 			assert.NoError(t, err)
 			assertThanosEndpointsConfigMap(t, cli, ctx, tt.expectedConfigMapHosts, tt.hostname, tt.hostShouldExistInCM)
 		})

--- a/cluster-operator/controllers/vmc/sync_thanos_test.go
+++ b/cluster-operator/controllers/vmc/sync_thanos_test.go
@@ -77,7 +77,7 @@ func TestRemoveThanosHostFromConfigMap(t *testing.T) {
 			log := vzlog.DefaultLogger()
 			ctx := context.TODO()
 			cli := fake.NewClientBuilder().WithRuntimeObjects(
-				makeThanosConfigMapWithExistingHosts(t, tt.existingHosts, false),
+				makeThanosConfigMapWithExistingHosts(t, tt.existingHosts, tt.useValidCM),
 			).Build()
 			r := &VerrazzanoManagedClusterReconciler{
 				Client: cli,
@@ -143,7 +143,7 @@ func TestSyncThanosQueryEndpoint(t *testing.T) {
 				Status:     vmcStatus,
 			}
 			cli := fake.NewClientBuilder().WithRuntimeObjects(
-				makeThanosConfigMapWithExistingHosts(t, tt.configMapExistingHosts, false),
+				makeThanosConfigMapWithExistingHosts(t, tt.configMapExistingHosts, true),
 			).Build()
 			r := &VerrazzanoManagedClusterReconciler{
 				Client: cli,

--- a/cluster-operator/controllers/vmc/sync_thanos_test.go
+++ b/cluster-operator/controllers/vmc/sync_thanos_test.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package vmc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/thanos"
+	v1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+)
+
+type syncThanosTestType struct {
+	name           string
+	host           string
+	existingHosts  []string
+	expectError    bool
+	expectNumHosts int
+	hostShoudExist bool
+}
+
+func TestVerrazzanoManagedClusterReconciler_addThanosHostIfNotPresent(t *testing.T) {
+	tests := []syncThanosTestType{
+		// TODO: Add test cases.
+		{"no existing hosts", "newhostname", []string{}, false, 1, true},
+		{"host already exists", "newhostname", []string{"otherhost", "newhostname"}, false, 2, true},
+		{"host does not exist", "newhostname", []string{"otherhost", "yetanotherhost"}, false, 3, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := vzlog.DefaultLogger()
+			ctx := context.TODO()
+			// existingHostInfo := thanosServiceDiscovery{targets: tt.existingHosts}
+			existingHostInfo := map[string]interface{}{"targets": []string{}}
+			yamlExistingHostInfo, err := yaml.Marshal(existingHostInfo)
+			assert.NoError(t, err)
+			cli := fake.NewClientBuilder().WithRuntimeObjects(
+				&v1.ConfigMap{
+					ObjectMeta: v12.ObjectMeta{Namespace: thanos.ComponentNamespace, Name: ThanosManagedClusterEndpointsConfigMap},
+					Data: map[string]string{
+						serviceDiscoveryKey: string(yamlExistingHostInfo),
+					},
+				},
+			).Build()
+			r := &VerrazzanoManagedClusterReconciler{
+				Client: cli,
+				log:    log,
+			}
+			err = r.addThanosHostIfNotPresent(ctx, tt.host, log)
+			if tt.expectError {
+				assert.Error(t, err, "Expected error")
+			} else {
+				modifiedConfigMap := &v1.ConfigMap{}
+				err = cli.Get(ctx, types.NamespacedName{Namespace: thanos.ComponentNamespace, Name: ThanosManagedClusterEndpointsConfigMap}, modifiedConfigMap)
+				assert.NoError(t, err)
+				modifiedContent := thanosServiceDiscovery{}
+				err = yaml.Unmarshal([]byte(modifiedConfigMap.Data[serviceDiscoveryKey]), &modifiedContent)
+				assert.NoError(t, err)
+				assert.Equalf(t, tt.expectNumHosts, len(modifiedContent.targets), "Expected %d hosts in modified config map", tt.expectNumHosts)
+				if tt.hostShoudExist {
+					assert.Contains(t, modifiedContent.targets, toGrpcTarget(tt.host))
+				}
+			}
+		})
+	}
+}
+
+func TestVerrazzanoManagedClusterReconciler_getThanosEndpointsConfigMap(t *testing.T) {
+	type fields struct {
+		Client client.Client
+		Scheme *runtime.Scheme
+		log    vzlog.VerrazzanoLogger
+	}
+	type args struct {
+		ctx context.Context
+		log vzlog.VerrazzanoLogger
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *v1.ConfigMap
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &VerrazzanoManagedClusterReconciler{
+				Client: tt.fields.Client,
+				Scheme: tt.fields.Scheme,
+				log:    tt.fields.log,
+			}
+			got, err := r.getThanosEndpointsConfigMap(tt.args.ctx, tt.args.log)
+			if !tt.wantErr(t, err, fmt.Sprintf("getThanosEndpointsConfigMap(%v, %v)", tt.args.ctx, tt.args.log)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "getThanosEndpointsConfigMap(%v, %v)", tt.args.ctx, tt.args.log)
+		})
+	}
+}
+
+func TestVerrazzanoManagedClusterReconciler_removeThanosHostFromConfigMap(t *testing.T) {
+	type fields struct {
+		Client client.Client
+		Scheme *runtime.Scheme
+		log    vzlog.VerrazzanoLogger
+	}
+	type args struct {
+		ctx  context.Context
+		host string
+		log  vzlog.VerrazzanoLogger
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &VerrazzanoManagedClusterReconciler{
+				Client: tt.fields.Client,
+				Scheme: tt.fields.Scheme,
+				log:    tt.fields.log,
+			}
+			tt.wantErr(t, r.removeThanosHostFromConfigMap(tt.args.ctx, tt.args.host, tt.args.log), fmt.Sprintf("removeThanosHostFromConfigMap(%v, %v, %v)", tt.args.ctx, tt.args.host, tt.args.log))
+		})
+	}
+}
+
+func TestVerrazzanoManagedClusterReconciler_syncThanosQueryEndpoint(t *testing.T) {
+	type fields struct {
+		Client client.Client
+		Scheme *runtime.Scheme
+		log    vzlog.VerrazzanoLogger
+	}
+	type args struct {
+		ctx context.Context
+		vmc *clustersv1alpha1.VerrazzanoManagedCluster
+		log vzlog.VerrazzanoLogger
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &VerrazzanoManagedClusterReconciler{
+				Client: tt.fields.Client,
+				Scheme: tt.fields.Scheme,
+				log:    tt.fields.log,
+			}
+			tt.wantErr(t, r.syncThanosQueryEndpoint(tt.args.ctx, tt.args.vmc, tt.args.log), fmt.Sprintf("syncThanosQueryEndpoint(%v, %v, %v)", tt.args.ctx, tt.args.vmc, tt.args.log))
+		})
+	}
+}
+
+func Test_findHost(t *testing.T) {
+	type args struct {
+		serviceDiscovery *thanosServiceDiscovery
+		host             string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, findHost(tt.args.serviceDiscovery, tt.args.host), "findHost(%v, %v)", tt.args.serviceDiscovery, tt.args.host)
+		})
+	}
+}
+
+func Test_parseThanosEndpointsConfigMap(t *testing.T) {
+	type args struct {
+		configMap *v1.ConfigMap
+		log       vzlog.VerrazzanoLogger
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *thanosServiceDiscovery
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseThanosEndpointsConfigMap(tt.args.configMap, tt.args.log)
+			if !tt.wantErr(t, err, fmt.Sprintf("parseThanosEndpointsConfigMap(%v, %v)", tt.args.configMap, tt.args.log)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "parseThanosEndpointsConfigMap(%v, %v)", tt.args.configMap, tt.args.log)
+		})
+	}
+}
+
+func Test_toGrpcTarget(t *testing.T) {
+	type args struct {
+		hostname string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, toGrpcTarget(tt.args.hostname), "toGrpcTarget(%v)", tt.args.hostname)
+		})
+	}
+}

--- a/cluster-operator/controllers/vmc/vmc_controller.go
+++ b/cluster-operator/controllers/vmc/vmc_controller.go
@@ -271,7 +271,7 @@ func (r *VerrazzanoManagedClusterReconciler) doReconcile(ctx context.Context, lo
 		}
 	}
 
-	err = r.syncThanosQueryEndpoint(ctx, vmc)
+	err = r.syncThanosQuery(ctx, vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to update Thanos Query endpoint managed cluster", err, log)
 		return newRequeueWithDelay(), err

--- a/cluster-operator/controllers/vmc/vmc_controller.go
+++ b/cluster-operator/controllers/vmc/vmc_controller.go
@@ -271,6 +271,12 @@ func (r *VerrazzanoManagedClusterReconciler) doReconcile(ctx context.Context, lo
 		}
 	}
 
+	err = r.syncThanosQueryEndpoint(ctx, vmc, log)
+	if err != nil {
+		r.handleError(ctx, vmc, "Failed to update Thanos Query endpoint managed cluster", err, log)
+		return newRequeueWithDelay(), err
+	}
+
 	log.Debugf("Creating or updating keycloak client for %s", vmc.Name)
 	err = r.createManagedClusterKeycloakClient(vmc)
 	if err != nil {

--- a/cluster-operator/controllers/vmc/vmc_controller.go
+++ b/cluster-operator/controllers/vmc/vmc_controller.go
@@ -271,7 +271,7 @@ func (r *VerrazzanoManagedClusterReconciler) doReconcile(ctx context.Context, lo
 		}
 	}
 
-	err = r.syncThanosQueryEndpoint(ctx, vmc, log)
+	err = r.syncThanosQueryEndpoint(ctx, vmc)
 	if err != nil {
 		r.handleError(ctx, vmc, "Failed to update Thanos Query endpoint managed cluster", err, log)
 		return newRequeueWithDelay(), err
@@ -407,6 +407,9 @@ func (r *VerrazzanoManagedClusterReconciler) reconcileManagedClusterDelete(ctx c
 		return err
 	}
 	if err := r.unregisterClusterFromArgoCD(ctx, vmc); err != nil {
+		return err
+	}
+	if err := r.deleteClusterThanosEndpoint(ctx, vmc); err != nil {
 		return err
 	}
 	return r.deleteClusterFromRancher(ctx, vmc)

--- a/cluster-operator/controllers/vmc/vmc_controller.go
+++ b/cluster-operator/controllers/vmc/vmc_controller.go
@@ -261,7 +261,7 @@ func (r *VerrazzanoManagedClusterReconciler) doReconcile(ctx context.Context, lo
 	}
 
 	if vmc.Status.PrometheusHost == "" {
-		log.Progressf("Managed cluster Prometheus Host not found in VMC Status for VMC %s. Waiting for VMC to be registered...", vmc.Name)
+		log.Oncef("Managed cluster Prometheus Host not found in VMC Status for VMC %s. Waiting for VMC to be registered...", vmc.Name)
 	} else {
 		log.Debugf("Syncing the prometheus scraper for VMC %s", vmc.Name)
 		err = r.syncPrometheusScraper(ctx, vmc)

--- a/cluster-operator/main.go
+++ b/cluster-operator/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package main

--- a/cluster-operator/main.go
+++ b/cluster-operator/main.go
@@ -12,6 +12,8 @@ import (
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"go.uber.org/zap"
+	istioclinet "istio.io/client-go/pkg/apis/networking/v1beta1"
+	k8sapiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -34,6 +36,8 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(k8sapiext.AddToScheme(scheme))
+	utilruntime.Must(istioclinet.AddToScheme(scheme))
 
 	utilruntime.Must(clustersv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(v1beta1.AddToScheme(scheme))

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -642,6 +642,22 @@ func createOrUpdatePrometheusAuthPolicy(ctx spi.ComponentContext) error {
 						},
 					}},
 				},
+				{
+					// allow Thanos Query to access Prometheus Thanos sidecar on port 10901
+					From: []*securityv1beta1.Rule_From{{
+						Source: &securityv1beta1.Source{
+							Principals: []string{
+								fmt.Sprintf("cluster.local/ns/%s/sa/thanos-query", constants.VerrazzanoMonitoringNamespace),
+							},
+							Namespaces: []string{constants.VerrazzanoMonitoringNamespace},
+						},
+					}},
+					To: []*securityv1beta1.Rule_To{{
+						Operation: &securityv1beta1.Operation{
+							Ports: []string{"10901"},
+						},
+					}},
+				},
 			},
 		}
 		return nil

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -915,12 +915,13 @@ func TestCreateOrUpdatePrometheusAuthPolicy(t *testing.T) {
 	err = client.Get(context.TODO(), types.NamespacedName{Namespace: ComponentNamespace, Name: prometheusAuthPolicyName}, authPolicy)
 	assertions.NoError(err)
 
-	assertions.Len(authPolicy.Spec.Rules, 3)
+	assertions.Len(authPolicy.Spec.Rules, 4)
 	assertions.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-authproxy")
 	assertions.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator")
 	assertions.Contains(authPolicy.Spec.Rules[0].From[0].Source.Principals, "cluster.local/ns/verrazzano-system/sa/vmi-system-kiali")
 	assertions.Contains(authPolicy.Spec.Rules[1].From[0].Source.Principals, serviceAccount)
 	assertions.Contains(authPolicy.Spec.Rules[2].From[0].Source.Principals, "cluster.local/ns/verrazzano-monitoring/sa/jaeger-operator-jaeger")
+	assertions.Contains(authPolicy.Spec.Rules[3].From[0].Source.Principals, "cluster.local/ns/verrazzano-monitoring/sa/thanos-query")
 
 	// GIVEN Prometheus Operator is being installed or upgraded
 	// AND   Istio is disabled

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
@@ -16,6 +16,26 @@ rules:
     - patch
     - update
   - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - destinationrules
+      - serviceentries
+    verbs:
+      - create
+      - update
+      - delete
+      - get
+      - list
+      - watch
+  - apiGroups:
       - clusters.verrazzano.io
     resources:
       - verrazzanomanagedclusters

--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -34,6 +34,9 @@ query:
   stores:
     - prometheus-operator-kube-p-prometheus:10901
 
+  # ConfigMap containing Verrazzano managed cluster Thanos endpoints that the admin cluster Thanos Query should use
+  # This configmap is managed by the VMC controller
+  existingSDConfigmap: "verrazzano-thanos-endpoints"
 queryFrontend:
   podSecurityContext:
     seccompProfile:

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/mcendpointsconfigmap.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/mcendpointsconfigmap.yaml
@@ -8,3 +8,4 @@ metadata:
 # TODO labels?
 data:
   servicediscovery.yml: ""
+{{- end}}

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/mcendpointsconfigmap.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/mcendpointsconfigmap.yaml
@@ -7,5 +7,4 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 # TODO labels?
 data:
-  servicediscovery.yml: |
-    - targets: []
+  servicediscovery.yml: ""

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/mcendpointsconfigmap.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/mcendpointsconfigmap.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+{{- if .Values.query.existingSDConfigmap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: verrazzano-thanos-endpoints
+  namespace: {{ .Release.Namespace | quote }}
+# TODO labels?
+data:
+  servicediscovery.yml: |
+    - targets: []

--- a/platform-operator/thirdparty/charts/thanos/values.yaml
+++ b/platform-operator/thirdparty/charts/thanos/values.yaml
@@ -184,7 +184,7 @@ query:
   ## @param query.existingSDConfigmap Name of existing ConfigMap with Ruler configuration
   ## NOTE: This will override query.sdConfig
   ##
-  existingSDConfigmap:
+  existingSDConfigmap: ""
   ## @param query.extraEnvVars Extra environment variables for Thanos Query container
   ## e.g:
   ## extraEnvVars:

--- a/platform-operator/thirdparty/charts/thanos/values.yaml
+++ b/platform-operator/thirdparty/charts/thanos/values.yaml
@@ -184,7 +184,7 @@ query:
   ## @param query.existingSDConfigmap Name of existing ConfigMap with Ruler configuration
   ## NOTE: This will override query.sdConfig
   ##
-  existingSDConfigmap: ""
+  existingSDConfigmap:
   ## @param query.extraEnvVars Extra environment variables for Thanos Query container
   ## e.g:
   ## extraEnvVars:


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
