### PR TITLE
VZ-9172.  Add VMI tests to a-la-carte pipeline

### DIFF
--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -338,14 +338,14 @@ pipeline {
                         runGinkgoRandomize('verify-install/promstack')
                     }
                 }
-                //stage('verify-infra vmi') {
-                //    environment {
-                //        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-infra/vmi"
-                //    }
-                //    steps {
-                //        runGinkgoRandomize('verify-infra/vmi')
-                //    }
-                //}
+                stage('verify-infra vmi') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-infra/vmi"
+                    }
+                    steps {
+                        runGinkgoRandomize('verify-infra/vmi')
+                    }
+                }
             }
             post {
                 failure {

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -330,7 +330,7 @@ pipeline {
 
         stage('Verify App Stack') {
             parallel {
-                stage('verify-install promstack') {
+                stage('verify-install/promstack') {
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-install/promstack"
                     }
@@ -338,7 +338,7 @@ pipeline {
                         runGinkgoRandomize('verify-install/promstack')
                     }
                 }
-                stage('verify-infra vmi') {
+                stage('verify-infra/vmi') {
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-infra/vmi"
                     }

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -207,7 +207,7 @@ pipeline {
         }
 
 
-        stage('Install Edge Stack') {
+        stage('Install Prometheus Edge Stack') {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
@@ -246,7 +246,7 @@ pipeline {
             }
         }
 
-        stage('Verify Edge Stack') {
+        stage('Verify Prometheus Edge Stack') {
             parallel {
                 stage('verify-install/promstack') {
                     environment {
@@ -276,7 +276,7 @@ pipeline {
         }
 
 
-        stage('Install Application stack') {
+        stage('Install App stack') {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"

--- a/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
+++ b/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
@@ -13,13 +13,18 @@ i=0
 
 resName=$(kubectl get vz -o jsonpath='{.items[*].metadata.name}')
 echo "waiting for install of resource ${resName} to complete"
-
 while [[ $retval_success -ne 0 ]] && [[ $retval_failed -ne 0 ]]  && [[ $i -lt 45 ]]  ; do
   sleep 60
-  output=$(kubectl wait --for=condition=InstallFailed verrazzano/${resName} --timeout=0 2>&1)
-  retval_failed=$?
-  output=$(kubectl wait --for=condition=InstallComplete verrazzano/${resName} --timeout=0 2>&1)
-  retval_success=$?
+  vzstate=$(kubectl get vz my-verrazzano -o jsonpath={.status.state})
+  echo "vz/${resName} state: ${vzstate}"
+  # Only check the status if the CR is in the ready state
+  if [ "${vzstate}" == "Ready" ]; then
+    echo "vz/${resName} Ready, checking conditions"
+    output=$(kubectl wait --for=condition=InstallFailed verrazzano/${resName} --timeout=0 2>&1)
+    retval_failed=$?
+    output=$(kubectl wait --for=condition=InstallComplete verrazzano/${resName} --timeout=0 2>&1)
+    retval_success=$?
+  fi
   i=$((i+1))
 done
 
@@ -28,5 +33,7 @@ if [[ $retval_failed -eq 0 ]] || [[ $i -eq 45 ]] ; then
     kubectl get vz ${resName} -o yaml
     exit 1
 fi
+
+kubectl get vz ${resName}
 
 echo "Installation completed.  Wait time: $SECONDS seconds"

--- a/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
+++ b/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
@@ -15,7 +15,7 @@ resName=$(kubectl get vz -o jsonpath='{.items[*].metadata.name}')
 echo "waiting for install of resource ${resName} to complete"
 while [[ $retval_success -ne 0 ]] && [[ $retval_failed -ne 0 ]]  && [[ $i -lt 45 ]]  ; do
   sleep 60
-  vzstate=$(kubectl get vz my-verrazzano -o jsonpath={.status.state})
+  vzstate=$(kubectl get vz ${resName} -o jsonpath={.status.state})
   echo "vz/${resName} state: ${vzstate}"
   # Only check the status if the CR is in the ready state
   if [ "${vzstate}" == "Ready" ]; then


### PR DESCRIPTION
Adds the `verify-infra/vmi` tests to the post-app-stack install stage for the a-la-carte pipeline.

This also modifies the `wait-for-verrazzano-install.sh` script to check the VZ CR state before checking install condition.  The ability to to do a 

```
kubectl wait --for=condition
```

seems to be broken.  I will open a bug for that behavior, but this tweak should allow the test pipeline to behave as expected.