### PR TITLE
Use DNS discovery for Thanos sidecar endpoint

### DIFF
--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -32,7 +32,7 @@ query:
           key: password
   # Adds the Prometheus Thanos sidecar as a Store API endpoint to Query
   stores:
-    - prometheus-operator-kube-p-prometheus:10901
+    - dnssrv+_grpc._tcp.prometheus-operator-kube-p-prometheus
 
   # ConfigMap containing Verrazzano managed cluster Thanos endpoints that the admin cluster Thanos Query should use
   # This configmap is managed by the VMC controller


### PR DESCRIPTION
This also makes the sidecar endpoint consistent with the Store Gateway endpoint (using DNS discovery).