### PR TITLE
VZ-8943: Uptake Thanos v0.30.2

### DIFF
--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
@@ -118,7 +118,7 @@ func TestAppendOverrides(t *testing.T) {
 	imageKVS := map[string]string{
 		"image.registry":   "ghcr.io",
 		"image.repository": "verrazzano/thanos",
-		"image.tag":        `v0.28.0-.+-.+`,
+		"image.tag":        `v\d+\.\d+\.\d+-.+-.+`,
 	}
 
 	tests := []struct {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -780,7 +780,7 @@
     },
     {
       "name": "thanos",
-      "version": "v0.28.0",
+      "version": "v0.30.2",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -788,7 +788,7 @@
           "images": [
             {
               "image": "thanos",
-              "tag": "v0.28.0-20230327140642-44e53eff",
+              "tag": "v0.30.2-20230329204202-4b7a94ea",
               "helmRegKey": "image.registry",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"


### PR DESCRIPTION
I tested this new Thanos image in a local cluster and it seems to behave as expected.

I also fixed the unit test to remove the hardcoded version in the override check so we don't have to update the unit test whenever the image version changes.