### PR TITLE
VZ-9103 Fix issue where managed cluster connection from Thanos query fails when Thanos is enabled after VZ install

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -259,3 +259,9 @@ const ServiceMonitorNameKubelet = "prometheus-operator-kube-p-kubelet"
 
 // ServiceMonitorNameKubeStateMetrics indicates the name of serviceMonitor resource for kube-state-metrics monitoring
 const ServiceMonitorNameKubeStateMetrics = "kube-state-metrics"
+
+// ThanosInternalUserSecretName is the name of the secret used to store the VZ internal Thanos user credentials
+const ThanosInternalUserSecretName = "verrazzano-thanos-internal" //nolint:gosec //#gosec G101
+
+// ThanosInternalUserName is the name of the VZ internal Thanos user
+const ThanosInternalUserName = "verrazzano-thanos-internal"

--- a/platform-operator/controllers/verrazzano/reconcile/controller.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/authproxy"
 	"io"
+
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/authproxy"
 
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -855,7 +856,17 @@ func (r *Reconciler) watchResources(namespace string, name string, log vzlog.Ver
 	if err != nil {
 		return err
 	}
-	log.Debugf("Watching for the registration secret to reconcile Verrzzano CR %s/%s", namespace, name)
+
+	log.Debugf("Watching for the managed cluster registration secret to reconcile Verrzzano CR %s/%s", namespace, name)
+	if err := r.watchManagedClusterRegistrationSecret(namespace, name); err != nil {
+		return err
+	}
+
+	log.Debugf("Watching for the Thanos internal user secret to re-reconcile Keycloak")
+	return r.watchThanosInternalUserSecret(namespace, name)
+}
+
+func (r *Reconciler) watchManagedClusterRegistrationSecret(namespace string, name string) error {
 	return r.Controller.Watch(
 		&source.Kind{Type: &corev1.Secret{}},
 		createReconcileEventHandler(namespace, name),
@@ -874,12 +885,37 @@ func (r *Reconciler) watchResources(namespace string, name string, log vzlog.Ver
 	)
 }
 
+func (r *Reconciler) watchThanosInternalUserSecret(namespace string, name string) error {
+	return r.Controller.Watch(
+		&source.Kind{Type: &corev1.Secret{}},
+		createReconcileEventHandler(namespace, name),
+		// Reconcile if there is an event related to the registration secret
+		predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return r.isThanosInternalUserSecret(e.Object)
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return r.isThanosInternalUserSecret(e.ObjectNew)
+			},
+		},
+	)
+}
+
 func (r *Reconciler) isManagedClusterRegistrationSecret(o client.Object) bool {
 	secret := o.(*corev1.Secret)
 	if secret.Namespace != vzconst.VerrazzanoSystemNamespace || secret.Name != vzconst.MCRegistrationSecret {
 		return false
 	}
 	r.AddWatch(fluentd.ComponentJSONName, jaegeroperator.ComponentJSONName, authproxy.ComponentJSONName)
+	return true
+}
+
+func (r *Reconciler) isThanosInternalUserSecret(o client.Object) bool {
+	secret := o.(*corev1.Secret)
+	if secret.Namespace != vzconst.VerrazzanoMonitoringNamespace || secret.Name != vzconst.ThanosInternalUserSecretName {
+		return false
+	}
+	r.AddWatch(keycloak.ComponentJSONName)
 	return true
 }
 

--- a/platform-operator/controllers/verrazzano/reconcile/controller_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller_test.go
@@ -6,14 +6,6 @@ package reconcile
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
-	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/cli"
-	"helm.sh/helm/v3/pkg/release"
-	time2 "helm.sh/helm/v3/pkg/time"
-	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/client-go/dynamic"
 	"reflect"
 	"sync"
 	"testing"
@@ -21,13 +13,24 @@ import (
 
 	clustersapi "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
 	constants3 "github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysql"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
 	vzContext "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/context"
 	vzstatus "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/healthcheck"
-	v1 "k8s.io/api/batch/v1"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/release"
+	time2 "helm.sh/helm/v3/pkg/time"
+	batchv1 "k8s.io/api/batch/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/client-go/dynamic"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/golang/mock/gomock"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -1471,7 +1474,7 @@ func TestUninstallJobCleanup(t *testing.T) {
 	asserts := assert.New(t)
 	_ = vzapi.AddToScheme(k8scheme.Scheme)
 	c := fakes.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
-		&v1.Job{
+		&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: constants.VerrazzanoInstallNamespace,
 				Name:      "uninstall-201321",
@@ -1486,7 +1489,7 @@ func TestUninstallJobCleanup(t *testing.T) {
 	reconciler := newVerrazzanoReconciler(c)
 	err := reconciler.cleanupUninstallJob("uninstall-201321", constants.VerrazzanoInstallNamespace, vzlog.DefaultLogger())
 	asserts.Nil(err)
-	job := &v1.Job{}
+	job := &batchv1.Job{}
 	err = c.Get(context.TODO(), client.ObjectKey{Name: "one-off-backup-20221018-201321", Namespace: constants.KeycloakNamespace}, job)
 	asserts.NotNil(err)
 	asserts.True(errors.IsNotFound(err))
@@ -1500,7 +1503,7 @@ func TestMysqlBackupJobCleanup(t *testing.T) {
 	asserts := assert.New(t)
 	_ = vzapi.AddToScheme(k8scheme.Scheme)
 	c := fakes.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
-		&v1.Job{
+		&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: constants.KeycloakNamespace,
 				Name:      "one-off-backup-20221018-201321",
@@ -1528,7 +1531,7 @@ func TestMysqlBackupJobCleanup(t *testing.T) {
 	reconciler := newVerrazzanoReconciler(c)
 	err := reconciler.cleanupMysqlBackupJob(vzlog.DefaultLogger())
 	asserts.Nil(err)
-	job := &v1.Job{}
+	job := &batchv1.Job{}
 	err = c.Get(context.TODO(), client.ObjectKey{Name: "one-off-backup-20221018-201321", Namespace: constants.KeycloakNamespace}, job)
 	asserts.NotNil(err)
 	asserts.True(errors.IsNotFound(err))
@@ -1542,20 +1545,20 @@ func TestMysqlScheduledBackupJobCleanup(t *testing.T) {
 	asserts := assert.New(t)
 	_ = vzapi.AddToScheme(k8scheme.Scheme)
 	c := fakes.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
-		&v1.Job{
+		&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "one-off-backup-schedule20221018-201321",
 				Namespace: constants.KeycloakNamespace,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "batch/v1",
+						APIVersion: "batch/batchv1",
 						Kind:       "CronJob",
 						Name:       "one-off-backup-schedule-20221018-201321",
 					},
 				},
 			},
 		},
-		&v1.CronJob{
+		&batchv1.CronJob{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: constants.KeycloakNamespace,
 				Name:      "one-off-backup-schedule-20221018-201321",
@@ -1583,11 +1586,11 @@ func TestMysqlScheduledBackupJobCleanup(t *testing.T) {
 	reconciler := newVerrazzanoReconciler(c)
 	err := reconciler.cleanupMysqlBackupJob(vzlog.DefaultLogger())
 	asserts.Nil(err)
-	job := &v1.Job{}
+	job := &batchv1.Job{}
 	err = c.Get(context.TODO(), client.ObjectKey{Name: "one-off-backup-20221018-201321", Namespace: constants.KeycloakNamespace}, job)
 	asserts.NotNil(err)
 	asserts.True(errors.IsNotFound(err))
-	cronJob := &v1.CronJob{}
+	cronJob := &batchv1.CronJob{}
 	err = c.Get(context.TODO(), client.ObjectKey{Name: "one-off-backup-schedule-20221018-201321", Namespace: constants.KeycloakNamespace}, cronJob)
 	asserts.Nil(err)
 }
@@ -1600,7 +1603,7 @@ func TestInProgressMysqlBackupJobCleanup(t *testing.T) {
 	asserts := assert.New(t)
 	_ = vzapi.AddToScheme(k8scheme.Scheme)
 	c := fakes.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
-		&v1.Job{
+		&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: constants.KeycloakNamespace,
 				Name:      "one-off-backup-20221018-201321",
@@ -1626,7 +1629,7 @@ func TestInProgressMysqlBackupJobCleanup(t *testing.T) {
 	reconciler := newVerrazzanoReconciler(c)
 	err := reconciler.cleanupMysqlBackupJob(vzlog.DefaultLogger())
 	asserts.NotNil(err)
-	job := &v1.Job{}
+	job := &batchv1.Job{}
 	err = c.Get(context.TODO(), client.ObjectKey{Name: "one-off-backup-20221018-201321", Namespace: constants.KeycloakNamespace}, job)
 	asserts.Nil(err)
 	asserts.NotNil(job)
@@ -1640,7 +1643,7 @@ func TestFailedMysqlBackupJobCleanup(t *testing.T) {
 	asserts := assert.New(t)
 	_ = vzapi.AddToScheme(k8scheme.Scheme)
 	c := fakes.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
-		&v1.Job{
+		&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: constants.KeycloakNamespace,
 				Name:      "one-off-backup-20221018-201321",
@@ -1668,7 +1671,7 @@ func TestFailedMysqlBackupJobCleanup(t *testing.T) {
 	reconciler := newVerrazzanoReconciler(c)
 	err := reconciler.cleanupMysqlBackupJob(vzlog.DefaultLogger())
 	asserts.NotNil(err)
-	job := &v1.Job{}
+	job := &batchv1.Job{}
 	err = c.Get(context.TODO(), client.ObjectKey{Name: "one-off-backup-20221018-201321", Namespace: constants.KeycloakNamespace}, job)
 	asserts.Nil(err)
 	asserts.NotNil(job)
@@ -1706,7 +1709,7 @@ func TestMysqlOperatorJobPredicateWrongNamespace(t *testing.T) {
 	_ = vzapi.AddToScheme(k8scheme.Scheme)
 	c := fakes.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 	reconciler := newVerrazzanoReconciler(c)
-	job := &v1.Job{
+	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "WrongNamespace",
 			Name:      "one-off-backup-20221018-201321",
@@ -1725,7 +1728,7 @@ func TestMysqlOperatorJobPredicateOwnedByOperatorCronJob(t *testing.T) {
 	asserts := assert.New(t)
 	_ = vzapi.AddToScheme(k8scheme.Scheme)
 	c := fakes.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
-		&v1.CronJob{
+		&batchv1.CronJob{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: constants.KeycloakNamespace,
 				Name:      "one-off-backup-schedule-20221018-201321",
@@ -1734,13 +1737,13 @@ func TestMysqlOperatorJobPredicateOwnedByOperatorCronJob(t *testing.T) {
 		},
 	).Build()
 	reconciler := newVerrazzanoReconciler(c)
-	job := &v1.Job{
+	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: mysql.ComponentNamespace,
 			Name:      "one-off-backup-20221018-201321",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "batch/v1",
+					APIVersion: "batch/batchv1",
 					Kind:       "CronJob",
 					Name:       "one-off-backup-schedule-20221018-201321",
 				},
@@ -1760,7 +1763,7 @@ func TestMysqlOperatorJobPredicateValidBackupJob(t *testing.T) {
 	_ = vzapi.AddToScheme(k8scheme.Scheme)
 	c := fakes.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
 	reconciler := newVerrazzanoReconciler(c)
-	job := &v1.Job{
+	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: mysql.ComponentNamespace,
 			Name:      "one-off-backup-20221018-201321",
@@ -1779,6 +1782,9 @@ func TestReconcilerInitForVzResource(t *testing.T) {
 	}
 	logger := vzlog.DefaultLogger()
 	mocker := gomock.NewController(t)
+	podKind := &source.Kind{Type: &corev1.Pod{}}
+	jobKind := &source.Kind{Type: &batchv1.Job{}}
+	secretKind := &source.Kind{Type: &corev1.Secret{}}
 	getNoErrorMock := func() client.Client {
 		mockClient := mocks.NewMockClient(mocker)
 		mockClient.EXPECT().Delete(context.TODO(), gomock.Not(nil), gomock.Any()).Return(nil).AnyTimes()
@@ -1802,12 +1808,34 @@ func TestReconcilerInitForVzResource(t *testing.T) {
 	}
 	setMockControllerNoErr := func(reconciler *Reconciler) {
 		controller := mocks.NewMockController(mocker)
-		controller.EXPECT().Watch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		controller.EXPECT().Watch(gomock.Eq(podKind), gomock.Any(), gomock.Any()).Return(nil)
+		controller.EXPECT().Watch(gomock.Eq(jobKind), gomock.Any(), gomock.Any()).Return(nil)
+		// watches 2 secrets - managed cluster registration and Thanos internal user
+		controller.EXPECT().Watch(gomock.Eq(secretKind), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 		reconciler.Controller = controller
 	}
-	setMockControllerErr := func(reconciler *Reconciler) {
+	setMockControllerPodWatchErr := func(reconciler *Reconciler) {
 		controller := mocks.NewMockController(mocker)
-		controller.EXPECT().Watch(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf(unExpectedError))
+		controller.EXPECT().Watch(gomock.Eq(podKind), gomock.Any(), gomock.Any()).Return(fmt.Errorf(unExpectedError))
+		reconciler.Controller = controller
+	}
+	setMockControllerJobWatchErr := func(reconciler *Reconciler) {
+		controller := mocks.NewMockController(mocker)
+		// pod watch succeeds, job watch fails
+		controller.EXPECT().Watch(gomock.Eq(podKind), gomock.Any(), gomock.Any()).Return(nil)
+		controller.EXPECT().Watch(gomock.Eq(jobKind), gomock.Any(), gomock.Any()).Return(fmt.Errorf(unExpectedError))
+		reconciler.Controller = controller
+	}
+	setMockControllerSecretWatchErr := func(reconciler *Reconciler) {
+		controller := mocks.NewMockController(mocker)
+		// pod and job watch succeeds, first secret watch fails
+		// TODO find a way to know which secret is being watched and fail each one selectively
+		controller.EXPECT().Watch(gomock.Eq(podKind), gomock.Any(), gomock.Any()).Return(nil)
+		controller.EXPECT().Watch(gomock.Eq(jobKind), gomock.Any(), gomock.Any()).Return(nil)
+		controller.EXPECT().Watch(gomock.Eq(secretKind), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(kind *source.Kind, handler handler.EventHandler, funcs predicate.Funcs) error {
+				return fmt.Errorf(unExpectedError)
+			})
 		reconciler.Controller = controller
 	}
 	vzName := "vzTestName"
@@ -1909,10 +1937,30 @@ func TestReconcilerInitForVzResource(t *testing.T) {
 		// GIVEN Verrazzano CR
 		// WHEN initForVzResource is called and error occurs while watching pods
 		// THEN error is returned with result for requeue with delay
-		{"TestReconcilerInitForVzResource when watching for pods get failed",
+		{"TestReconcilerInitForVzResource when watching for pods failed",
 			argWithFinalizer,
 			getNoErrorMock,
-			setMockControllerErr,
+			setMockControllerPodWatchErr,
+			newRequeueWithDelay(),
+			true,
+		},
+		// GIVEN Verrazzano CR
+		// WHEN initForVzResource is called and error occurs while watching Jobs
+		// THEN error is returned with result for requeue with delay
+		{"TestReconcilerInitForVzResource when watching for jobs failed",
+			argWithFinalizer,
+			getNoErrorMock,
+			setMockControllerJobWatchErr,
+			newRequeueWithDelay(),
+			true,
+		},
+		// GIVEN Verrazzano CR
+		// WHEN initForVzResource is called and error occurs while watching Jobs
+		// THEN error is returned with result for requeue with delay
+		{"TestReconcilerInitForVzResource when watching for registration secret failed",
+			argWithFinalizer,
+			getNoErrorMock,
+			setMockControllerSecretWatchErr,
 			newRequeueWithDelay(),
 			true,
 		},
@@ -1975,6 +2023,37 @@ func TestIsManagedClusterRegistrationSecret(t *testing.T) {
 	secret := corev1.Secret{}
 	asserts.True(reconciler.isManagedClusterRegistrationSecret(&vzSecret))
 	asserts.False(reconciler.isManagedClusterRegistrationSecret(&secret))
+}
+
+// TestIsThanosInternalUserSecret tests isThanosInternalUserSecret
+// GIVEN Secret resource
+// WHEN isThanosInternalUserSecret is called
+// THEN true is returned if secret is the Thanos internal user secret
+// THEN false is returned if secret is not the Thanos internal user secret
+func TestIsThanosInternalUserSecret(t *testing.T) {
+	asserts := assert.New(t)
+	reconciler := newVerrazzanoReconciler(nil)
+	thanosSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.ThanosInternalUserSecretName,
+			Namespace: constants.VerrazzanoMonitoringNamespace,
+		},
+	}
+	secretSameNS := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-other-secret",
+			Namespace: constants.VerrazzanoMonitoringNamespace,
+		},
+	}
+	secretSameNameDiffNS := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.ThanosInternalUserSecretName,
+			Namespace: constants.VerrazzanoSystemNamespace,
+		},
+	}
+	asserts.True(reconciler.isThanosInternalUserSecret(&thanosSecret))
+	asserts.False(reconciler.isThanosInternalUserSecret(&secretSameNS))
+	asserts.False(reconciler.isThanosInternalUserSecret(&secretSameNameDiffNS))
 }
 
 // TestReconcile tests Reconcile
@@ -2053,7 +2132,7 @@ func TestReconcile(t *testing.T) {
 // THEN false is returned if no error occurs
 func TestPersistJobLog(t *testing.T) {
 	type args struct {
-		backupJob v1.Job
+		backupJob batchv1.Job
 		jobPod    *corev1.Pod
 		log       vzlog.VerrazzanoLogger
 	}
@@ -2064,7 +2143,7 @@ func TestPersistJobLog(t *testing.T) {
 	}{
 		{
 			"TestPersistJobLog",
-			args{v1.Job{ObjectMeta: metav1.ObjectMeta{
+			args{batchv1.Job{ObjectMeta: metav1.ObjectMeta{
 				Name: "test-schedule-1",
 			}}, &corev1.Pod{}, vzlog.DefaultLogger()},
 			false,


### PR DESCRIPTION
(Adds watch for Thanos internal user secret, and re-reconcile Keycloak so that it picks up that user if Thanos is enabled post VZ install)
