### PR TITLE
JIRA: VZ-8334 update istioctl rpm to version with Helm CVE fix (update to v3.10.3)

### DIFF
--- a/platform-operator/Dockerfile
+++ b/platform-operator/Dockerfile
@@ -24,7 +24,7 @@ ARG VERRAZZANO_APPLICATION_OPERATOR_IMAGE
 COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano/platform-operator/repos/*.repo /etc/yum.repos.d/
 
 RUN microdnf update -y \
-    && microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs openssl jq kubectl-1.23.11-1.el8 istio-istioctl-1.15.3-1.el8 \
+    && microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs openssl jq kubectl-1.23.11-1.el8 istio-istioctl-1.15.3-2.el8 \
     && microdnf clean all \
     && rm -rf /var/cache/yum /var/lib/rpm/* \
     && groupadd -r verrazzano \


### PR DESCRIPTION
Updated the rpm to istio-istioctl-1.15.3-2.el8.  Scan results indicate the Helm CVEs associated with v.3.9.2 are resolved.