### PR TITLE
VZ-9109: Install latest version of Trivy and Grype scanner for daily scan job in release-1.3

### DIFF
--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     triggers { cron("@daily") }
 
     environment {
-        CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}
+        CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
 
         OCI_CLI_TENANCY = credentials('oci-dev-tenancy')
         OCI_CLI_USER = credentials('oci-dev-user-ocid')

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -60,19 +60,19 @@ pipeline {
                     }
 
                     sh """
+                        git fetch --tags
+                        echo "${env.GITHUB_ACCESS_TOKEN}" | gh auth login --with-token
+
+                        # Install Trivy and Grype
                         mkdir -p ~/scanners
                         echo "Download and install Grype"
                         curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b ~/scanners
 
                         echo "Download and install Trivy"
                         curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ~/scanners
-                    """
-
-                    sh """
-                        git fetch --tags
-                        echo "${env.GITHUB_ACCESS_TOKEN}" | gh auth login --with-token
-                        echo "Fetching scan results for branch: ${CLEAN_BRANCH_NAME}"
                         export PATH=~/scanners:$PATH
+
+                        echo "Fetching scan results for branch: ${CLEAN_BRANCH_NAME}"
                         ci/scripts/get_branch_scan_results.sh
                         python ci/scripts/generate_html_report.py scan-results/latest-periodic/consolidated.csv scan-results/latest-periodic
                     """

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     triggers { cron("@daily") }
 
     environment {
-        CLEAN_BRANCH_NAME = "release-1.3"
+        CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}
 
         OCI_CLI_TENANCY = credentials('oci-dev-tenancy')
         OCI_CLI_USER = credentials('oci-dev-user-ocid')
@@ -65,7 +65,7 @@ pipeline {
                         curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b ~/scanners
 
                         echo "Download and install Trivy"
-                        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ~/scanners
+                        curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ~/scanners
                     """
 
                     sh """

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     triggers { cron("@daily") }
 
     environment {
-        CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
+        CLEAN_BRANCH_NAME = "release-1.3"
 
         OCI_CLI_TENANCY = credentials('oci-dev-tenancy')
         OCI_CLI_USER = credentials('oci-dev-user-ocid')

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -60,9 +60,19 @@ pipeline {
                     }
 
                     sh """
+                        mkdir -p ~/scanners
+                        echo "Download and install Grype"
+                        curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b ~/scanners
+
+                        echo "Download and install Trivy"
+                        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ~/scanners
+                    """
+
+                    sh """
                         git fetch --tags
                         echo "${env.GITHUB_ACCESS_TOKEN}" | gh auth login --with-token
                         echo "Fetching scan results for branch: ${CLEAN_BRANCH_NAME}"
+                        export PATH=~/scanners:$PATH
                         ci/scripts/get_branch_scan_results.sh
                         python ci/scripts/generate_html_report.py scan-results/latest-periodic/consolidated.csv scan-results/latest-periodic
                     """

--- a/release/scripts/scan_bom_images.sh
+++ b/release/scripts/scan_bom_images.sh
@@ -129,10 +129,12 @@ function verify_prerequisites() {
   command -v grype >/dev/null 2>&1 || {
     usage 1 "grype scanner is not installed"
   }
-  echo "Print Grype and Trivy path"
-  which trivy
-  which grype
+  echo "Grype path: $(which grype)"
+  echo "Trivy path: $(which trivy)"
+  echo "Trivy version:"
   trivy version
+  echo "Grype version:"
+  grype version
 }
 
 while getopts 'hb:a:o:n:r:p:x:' opt; do

--- a/release/scripts/scan_bom_images.sh
+++ b/release/scripts/scan_bom_images.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Scan images in a specified BOM
@@ -129,6 +129,10 @@ function verify_prerequisites() {
   command -v grype >/dev/null 2>&1 || {
     usage 1 "grype scanner is not installed"
   }
+  echo "Print Grype and Trivy path"
+  which trivy
+  which grype
+  trivy version
 }
 
 while getopts 'hb:a:o:n:r:p:x:' opt; do

--- a/release/scripts/scan_bom_images.sh
+++ b/release/scripts/scan_bom_images.sh
@@ -129,12 +129,8 @@ function verify_prerequisites() {
   command -v grype >/dev/null 2>&1 || {
     usage 1 "grype scanner is not installed"
   }
-  echo "Grype path: $(which grype)"
-  echo "Trivy path: $(which trivy)"
-  echo "Trivy version:"
-  trivy version
-  echo "Grype version:"
-  grype version
+  echo "Grype installation directory: $(which grype)"
+  echo "Trivy installation directory: $(which trivy)"
 }
 
 while getopts 'hb:a:o:n:r:p:x:' opt; do


### PR DESCRIPTION
This change installs latest version of Trivy and Grype scanner for daily scan job for release-1.3, and sets the installed directory ahead of everything in the PATH.
