### PR TITLE
Add HelmComponent function for fetching computed values

### DIFF
--- a/pkg/helm/helmcli_test.go
+++ b/pkg/helm/helmcli_test.go
@@ -4,12 +4,13 @@
 package helm
 
 import (
+	"testing"
+
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/time"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -124,7 +125,7 @@ func TestUpgrade(t *testing.T) {
 	})
 	defer SetDefaultLoadChartFunction()
 
-	err := Upgrade(vzlog.DefaultLogger(), helmRelease, ns, chartdir, false, false, overrides)
+	_, err := Upgrade(vzlog.DefaultLogger(), helmRelease, ns, chartdir, false, false, overrides)
 	assertion.NoError(err, "Upgrade returned an error")
 }
 
@@ -141,7 +142,7 @@ func TestUpgradeFail(t *testing.T) {
 	defer SetDefaultActionConfigFunction()
 	// no chart load function should generate an error
 
-	err := Upgrade(vzlog.DefaultLogger(), helmRelease, ns, "", false, false, overrides)
+	_, err := Upgrade(vzlog.DefaultLogger(), helmRelease, ns, "", false, false, overrides)
 	assertion.Error(err, "Upgrade should have returned an error")
 }
 

--- a/platform-operator/controllers/configmaps/components/controller_test.go
+++ b/platform-operator/controllers/configmaps/components/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -217,18 +218,18 @@ func buildFakeClient(cm corev1.ConfigMap) client.Client {
 }
 
 // fakeUpgrade verifies that the correct parameter values are passed to upgrade
-func fakeUpgrade(_ vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, _ bool, _ bool, overrides []helmcli.HelmOverrides) (err error) {
+func fakeUpgrade(_ vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, _ bool, _ bool, overrides []helmcli.HelmOverrides) (*release.Release, error) {
 	if releaseName != "test-component" {
-		return fmt.Errorf("Incorrect  releaseName, expecting test-component, got %s", releaseName)
+		return nil, fmt.Errorf("Incorrect  releaseName, expecting test-component, got %s", releaseName)
 	}
 	if chartDir != "/verrazzano/platform-operator/thirdparty/charts/test-component" {
-		return fmt.Errorf("Incorrect  releaseName, expecting test-component, got %s", chartDir)
+		return nil, fmt.Errorf("Incorrect  releaseName, expecting test-component, got %s", chartDir)
 	}
 	if namespace != constants.VerrazzanoSystemNamespace {
-		return fmt.Errorf("Incorrect release namespace, expecting verrazzano-system, got %s", namespace)
+		return nil, fmt.Errorf("Incorrect release namespace, expecting verrazzano-system, got %s", namespace)
 	}
 	if len(overrides) != 2 {
-		return fmt.Errorf("Incorrect number of overrides, expecting 2, got %d", len(overrides))
+		return nil, fmt.Errorf("Incorrect number of overrides, expecting 2, got %d", len(overrides))
 	}
-	return nil
+	return nil, nil
 }

--- a/tools/psr/psrctl/cmd/start/start_test.go
+++ b/tools/psr/psrctl/cmd/start/start_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/verrazzano/verrazzano/tools/psr/psrctl/pkg/manifest"
 	"github.com/verrazzano/verrazzano/tools/psr/psrctl/pkg/scenario"
 	"github.com/verrazzano/verrazzano/tools/vz/test/helpers"
+	"helm.sh/helm/v3/pkg/release"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -49,13 +50,13 @@ func TestStartCmd(t *testing.T) {
 	}
 
 	defer func() { scenario.StartUpgradeFunc = helmcli.Upgrade }()
-	scenario.StartUpgradeFunc = func(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides []helmcli.HelmOverrides) (err error) {
+	scenario.StartUpgradeFunc = func(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides []helmcli.HelmOverrides) (*release.Release, error) {
 		assert.Equal(t, 4, len(overrides))
 		assert.Equal(t, "psr-ops-s1-ops-writelogs-0", releaseName)
 		assert.Equal(t, "psr", namespace)
 		assert.Contains(t, chartDir, "manifests/charts/worker")
 
-		return nil
+		return nil, nil
 	}
 
 	// Send the command output to a byte buffer
@@ -201,13 +202,13 @@ func TestStartDir(t *testing.T) {
 	}
 
 	defer func() { scenario.StartUpgradeFunc = helmcli.Upgrade }()
-	scenario.StartUpgradeFunc = func(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides []helmcli.HelmOverrides) (err error) {
+	scenario.StartUpgradeFunc = func(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides []helmcli.HelmOverrides) (*release.Release, error) {
 		assert.Equal(t, 4, len(overrides))
 		assert.Equal(t, "psr-ops-test-ops-writelogs-0", releaseName)
 		assert.Equal(t, "default", namespace)
 		assert.Contains(t, chartDir, "manifests/charts/worker")
 
-		return nil
+		return nil, nil
 	}
 
 	// Send the command output to a byte buffer

--- a/tools/psr/psrctl/cmd/update/update_test.go
+++ b/tools/psr/psrctl/cmd/update/update_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/verrazzano/verrazzano/tools/psr/psrctl/pkg/manifest"
 	"github.com/verrazzano/verrazzano/tools/psr/psrctl/pkg/scenario"
 	"github.com/verrazzano/verrazzano/tools/vz/test/helpers"
+	"helm.sh/helm/v3/pkg/release"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -82,12 +83,12 @@ Usecases:
 	}
 
 	defer func() { scenario.UpdateUpgradeFunc = helmcli.Upgrade }()
-	scenario.UpdateUpgradeFunc = func(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides []helmcli.HelmOverrides) (err error) {
+	scenario.UpdateUpgradeFunc = func(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides []helmcli.HelmOverrides) (*release.Release, error) {
 		assert.Equal(t, 3, len(overrides))
 		assert.Equal(t, "psr-ops-s1-writelogs-0", releaseName)
 		assert.Equal(t, "psr", namespace)
 		assert.Contains(t, chartDir, "manifests/charts/worker")
-		return nil
+		return nil, nil
 	}
 
 	// Send the command output to a byte buffer

--- a/tools/psr/psrctl/pkg/scenario/start.go
+++ b/tools/psr/psrctl/pkg/scenario/start.go
@@ -5,13 +5,13 @@ package scenario
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"os"
 	"path/filepath"
 	"strings"
 
 	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/tools/psr/psrctl/pkg/manifest"
+	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 )
@@ -68,7 +68,7 @@ func (m ScenarioMananger) StartScenario(manifestMan manifest.ManifestManager, sc
 		if m.Verbose {
 			fmt.Fprintf(vzHelper.GetOutputStream(), "Installing use case %s as Helm release %s/%s\n", uc.UsecasePath, m.Namespace, relname)
 		}
-		err = StartUpgradeFunc(m.Log, relname, m.Namespace, manifestMan.Manifest.WorkerChartAbsDir, true, m.DryRun, helmOverrides)
+		_, err = StartUpgradeFunc(m.Log, relname, m.Namespace, manifestMan.Manifest.WorkerChartAbsDir, true, m.DryRun, helmOverrides)
 		if err != nil {
 			return err.Error(), err
 		}

--- a/tools/psr/psrctl/pkg/scenario/update.go
+++ b/tools/psr/psrctl/pkg/scenario/update.go
@@ -5,11 +5,12 @@ package scenario
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/tools/psr/psrctl/pkg/manifest"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
-	"os"
-	"path/filepath"
 )
 
 var UpdateUpgradeFunc = helmcli.Upgrade
@@ -65,7 +66,7 @@ func (m ScenarioMananger) doHelmUpgrade(manifestMan manifest.ManifestManager, sc
 	if m.Verbose {
 		fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Updating use case %s for Helm release %s/%s\n", hr.Usecase.UsecasePath, hr.Namespace, hr.Name))
 	}
-	err = UpdateUpgradeFunc(m.Log, hr.Name, m.Namespace, manifestMan.Manifest.WorkerChartAbsDir, true, m.DryRun, helmOverrides)
+	_, err = UpdateUpgradeFunc(m.Log, hr.Name, m.Namespace, manifestMan.Manifest.WorkerChartAbsDir, true, m.DryRun, helmOverrides)
 	if err != nil {
 		return err.Error(), err
 	}


### PR DESCRIPTION
This PR updates the HelmComponent Upgrade function to return the Helm Release object. I also added a new function that calls Upgrade with the dry run flag set to true, and coalesces the chart values to produce a map of computed Helm values.

This new GetComputedValues function can be used by install components to inspect the computed Helm values at install/upgrade/reconcile time.

I did some local cluster testing with a modified install component and it seems to work as expected.