### PR TITLE
VZ-9081: Remove activate of odi driver and update rancher image

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -399,26 +399,6 @@ func DeleteLocalCluster(log vzlog.VerrazzanoLogger, c client.Client) {
 	log.Once("Successfully deleted Rancher local cluster")
 }
 
-// activateOCIDriver activates the OCI nodeDriver
-func activateOCIDriver(log vzlog.VerrazzanoLogger, c client.Client) error {
-	ociDriver := unstructured.Unstructured{}
-	ociDriver.SetGroupVersionKind(GVKNodeDriver)
-	ociDriverName := types.NamespacedName{Name: NodeDriverOCI}
-	err := c.Get(context.Background(), ociDriverName, &ociDriver)
-	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting OCI Driver: %s", err.Error())
-	}
-
-	ociDriverMerge := client.MergeFrom(ociDriver.DeepCopy())
-	ociDriver.UnstructuredContent()["spec"].(map[string]interface{})["active"] = true
-	err = c.Patch(context.Background(), &ociDriver, ociDriverMerge)
-	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed patching OCI Driver: %s", err.Error())
-	}
-
-	return nil
-}
-
 // activateDrivers activates the oraclecontainerengine kontainerDriver
 func activatOKEDriver(log vzlog.VerrazzanoLogger, c client.Client) error {
 	okeDriver := unstructured.Unstructured{}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -506,12 +506,7 @@ func (r rancherComponent) PostUpgrade(ctx spi.ComponentContext) error {
 
 // activateDrivers activates the nodeDriver oci and oraclecontainerengine kontainerDriver
 func activateDrivers(log vzlog.VerrazzanoLogger, c client.Client) error {
-	err := activateOCIDriver(log, c)
-	if err != nil {
-		return err
-	}
-
-	err = activatOKEDriver(log, c)
+	err := activatOKEDriver(log, c)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -131,13 +131,13 @@
             {
               "image": "rancher",
               "dashboard": "v2.7.1-20230314212735-270d0ef83",
-              "tag": "20230320160519-1ddb28fa2",
+              "tag": "20230331143034-fd33d16e3",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "20230320160519-1ddb28fa2"
+              "tag": "20230331143034-fd33d16e3"
             }
           ]
         },


### PR DESCRIPTION
This pull request removes the activation of the Rancher oci driver and updates Rancher images in the BOM.

Installation testing verified that install was no longer failing with:
```
Failed getting OCI Driver: nodedrivers.management.cattle.io \"oci\" not found
```