### PR TITLE
Fix the issue with PATH variable in daily scanning job, release-1.3

### DIFF
--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -39,6 +39,8 @@ pipeline {
         OCI_SCAN_BUCKET = "verrazzano-scan-results"
 
         GITHUB_ACCESS_TOKEN = credentials('github-api-token-release-process')
+
+        SCANNER_PATH = "~/scanners"
     }
 
     stages {
@@ -66,11 +68,10 @@ pipeline {
                         # Install Trivy and Grype
                         mkdir -p ~/scanners
                         echo "Download and install Grype"
-                        curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b ~/scanners
+                        curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b ${env.SCANNER_PATH}
 
                         echo "Download and install Trivy"
-                        curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ~/scanners
-                        export PATH=~/scanners:$PATH
+                        curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ${env.SCANNER_PATH}
 
                         echo "Fetching scan results for branch: ${CLEAN_BRANCH_NAME}"
                         ci/scripts/get_branch_scan_results.sh

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -19,7 +19,8 @@ pipeline {
     triggers { cron("@daily") }
 
     environment {
-        CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
+        // CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
+        CLEAN_BRANCH_NAME = "master"
 
         OCI_CLI_TENANCY = credentials('oci-dev-tenancy')
         OCI_CLI_USER = credentials('oci-dev-user-ocid')

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -19,8 +19,7 @@ pipeline {
     triggers { cron("@daily") }
 
     environment {
-        // CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
-        CLEAN_BRANCH_NAME = "master"
+        CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
 
         OCI_CLI_TENANCY = credentials('oci-dev-tenancy')
         OCI_CLI_USER = credentials('oci-dev-user-ocid')

--- a/ci/scripts/get_branch_scan_results.sh
+++ b/ci/scripts/get_branch_scan_results.sh
@@ -71,6 +71,18 @@ SCAN_RESULTS_BASE_DIR=${WORKSPACE}/scan-results
 export SCAN_RESULTS_DIR=${SCAN_RESULTS_BASE_DIR}/latest
 mkdir -p ${SCAN_RESULTS_DIR}
 
+if [[ -z "${SCANNER_PATH}" ]]; then
+  echo "Environment variable SCANNER_PATH is not set"
+else
+  export PATH="${SCANNER_PATH}:${PATH}"
+fi
+echo "PATH in get_branch_scan_results.sh ${PATH}"
+
+command -v gh >/dev/null 2>&1 || {
+  echo "Github CLI not in PATH"
+  exit 1
+}
+
 # Where the results are kept for the branch depend on what kind of branch it is and where the updated bom is stored:
 #    master, release-* branches are regularly updated using the periodic pipelines only
 #

--- a/ci/scripts/get_branch_scan_results.sh
+++ b/ci/scripts/get_branch_scan_results.sh
@@ -79,7 +79,7 @@ fi
 echo "PATH in get_branch_scan_results.sh ${PATH}"
 
 command -v gh >/dev/null 2>&1 || {
-  echo "Github CLI not in PATH"
+  echo "Github CLI is not in PATH"
   exit 1
 }
 


### PR DESCRIPTION
This PR sets the latest Grype and Trivy to PATH, ahead of all other entries, so that the daily scan always uses the latest version of these scanners.