### PR TITLE
Update k8s-dump-cluster.sh to handle the syntax issue while capturing the dump in CI pipeline.

### DIFF
--- a/tools/scripts/k8s-dump-cluster.sh
+++ b/tools/scripts/k8s-dump-cluster.sh
@@ -310,6 +310,7 @@ function analyze_dump() {
                   $GO_REPO_PATH/vz analyze --capture-dir $FULL_PATH_CAPTURE_DIR || true
               else
                   echo "Warning: VZ tool is not available. Pleaes download and configured" $GO_REPO_PATH
+              fi
             else
               if [[ -x $GOPATH/bin/vz ]]; then
                   $GOPATH/vz analyze --capture-dir $FULL_PATH_CAPTURE_DIR --report-format detailed --report-file $SAVE_DIR/$REPORT_FILE || true


### PR DESCRIPTION
There was a typo error when creating the cluster snapshot using the k8-dump-cluster.sh because of a syntax issue.
This will fix the syntax issue.
