### PR TITLE
VZ-8840: Grafana datasource support for Thanos

### DIFF
--- a/platform-operator/controllers/verrazzano/component/common/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/common/vmi.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package common

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana.go
@@ -1,14 +1,21 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package grafana
 
 import (
 	"fmt"
+	"path"
 
+	"github.com/pkg/errors"
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/thanos"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -48,4 +55,67 @@ func newDeployments() []types.NamespacedName {
 			Namespace: ComponentNamespace,
 		},
 	}
+}
+
+// applyDatasourcesConfigmap applies a configmap containing Grafana datasources. If Thanos Query is enabled
+// we set Thanos as the default datasource, otherwise Prometheus is the default datasource.
+func applyDatasourcesConfigmap(ctx spi.ComponentContext) error {
+	// create template key/value map
+	args := make(map[string]interface{})
+	args["namespace"] = constants.VerrazzanoSystemNamespace
+	args["name"] = datasourcesConfigMapName
+
+	cr := ctx.EffectiveCR()
+	promEnabled := vzcr.IsPrometheusEnabled(cr) && vzcr.IsPrometheusOperatorEnabled(cr)
+	args["isPrometheusEnabled"] = promEnabled
+	if promEnabled {
+		args["prometheusURL"] = "http://prometheus-operator-kube-p-prometheus.verrazzano-monitoring"
+		args["prometheusPort"] = 9090
+	}
+
+	thanosQueryEnabled, err := isThanosQueryFrontendEnabled(ctx)
+	if err != nil {
+		return err
+	}
+	args["isThanosQueryEnabled"] = thanosQueryEnabled
+	if thanosQueryEnabled {
+		args["thanosQueryURL"] = "http://thanos-query-frontend.verrazzano-monitoring"
+		args["thanosQueryPort"] = 9090
+	}
+
+	// substitute template values in the datasources configmap template and apply the resulting YAML
+	fpath := path.Join(config.GetThirdPartyManifestsDir(), "grafana", "datasources-configmap.yaml")
+	yamlApplier := k8sutil.NewYAMLApplier(ctx.Client(), "")
+	err = yamlApplier.ApplyFT(fpath, args)
+	if err != nil {
+		return ctx.Log().ErrorfNewErr("Failed to substitute template values in Grafana datasources configmap: %v", err)
+	}
+	return nil
+}
+
+// isThanosQueryFrontendEnabled returns true if the Thanos component is enabled and Thanos Query Frontend is
+// enabled in the Helm chart
+func isThanosQueryFrontendEnabled(ctx spi.ComponentContext) (bool, error) {
+	const queryFrontendEnabledHelmKey = "queryFrontend.enabled"
+
+	if !vzcr.IsThanosEnabled(ctx.EffectiveCR()) {
+		return false, nil
+	}
+
+	thanosComp := thanos.NewComponent().(thanos.ThanosComponent)
+	vals, err := thanosComp.GetComputedValues(ctx)
+	if err != nil {
+		return false, errors.Errorf("Unable to fetch computed Helm values for Thanos: %v", err)
+	}
+	enabledVal, err := vals.PathValue(queryFrontendEnabledHelmKey)
+	if err != nil {
+		return false, errors.Errorf("Unable to find Helm key %s in Thanos chart: %v", queryFrontendEnabledHelmKey, err)
+	}
+
+	enabled, ok := enabledVal.(bool)
+	if !ok {
+		return false, errors.Errorf("Thanos chart value %s expected to be of type bool", queryFrontendEnabledHelmKey)
+	}
+
+	return enabled, nil
 }

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package grafana
@@ -169,6 +169,9 @@ func (g grafanaComponent) PreInstall(ctx spi.ComponentContext) error {
 
 // Install performs Grafana install processing
 func (g grafanaComponent) Install(ctx spi.ComponentContext) error {
+	if err := applyDatasourcesConfigmap(ctx); err != nil {
+		return err
+	}
 	return common.CreateOrUpdateVMI(ctx, updateFunc)
 }
 
@@ -207,6 +210,9 @@ func (g grafanaComponent) PreUpgrade(ctx spi.ComponentContext) error {
 
 // Install performs Grafana upgrade processing
 func (g grafanaComponent) Upgrade(ctx spi.ComponentContext) error {
+	if err := applyDatasourcesConfigmap(ctx); err != nil {
+		return err
+	}
 	return common.CreateOrUpdateVMI(ctx, updateFunc)
 }
 

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package grafana
@@ -14,6 +14,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -736,6 +737,12 @@ func TestUpgrade(t *testing.T) {
 
 // testInstallOrUpgrade tests both the Grafana component Install and Update functions
 func testInstallOrUpgrade(t *testing.T, installOrUpgradeFunc func(spi.ComponentContext) error) {
+	oldConfig := config.Get()
+	defer config.Set(oldConfig)
+	config.Set(config.OperatorConfig{
+		VerrazzanoRootDir: "../../../../..",
+	})
+
 	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
 	vz := &vzapi.Verrazzano{
 		Spec: vzapi.VerrazzanoSpec{

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_test.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_test.go
@@ -210,11 +210,8 @@ type datasources struct {
 	Datasources []datasource `json:"datasources"`
 }
 
+// TestApplyDatasourcesConfigmap tests the applyDatasourcesConfigmap function.
 func TestApplyDatasourcesConfigmap(t *testing.T) {
-
-	// Thanos and Prom enabled
-	// Thanos disabled, Prom enabled
-	// Both disabled
 	oldConfig := config.Get()
 	defer config.Set(oldConfig)
 	config.Set(config.OperatorConfig{
@@ -260,18 +257,27 @@ func TestApplyDatasourcesConfigmap(t *testing.T) {
 		expectPromDatasource   bool
 		expectThanosDatasource bool
 	}{
+		// GIVEN Thanos is disabled and Prometheus is enabled
+		// WHEN the applyDatasourcesConfigmap function is called
+		// THEN the Grafana datasources configmap contains Prometheus as the only datasource
 		{
 			name:                   "Thanos is disabled (by default)",
 			vzCR:                   &vzapi.Verrazzano{},
 			expectPromDatasource:   true,
 			expectThanosDatasource: false,
 		},
+		// GIVEN Thanos is enabled and Prometheus is enabled
+		// WHEN the applyDatasourcesConfigmap function is called
+		// THEN the Grafana datasources configmap contains Thanos and Prometheus datasources and Thanos is the default
 		{
 			name:                   "Thanos is enabled, Query Frontend is enabled by default",
 			vzCR:                   thanosEnabledCR,
 			expectPromDatasource:   true,
 			expectThanosDatasource: true,
 		},
+		// GIVEN Thanos and Prometheus are both disabled
+		// WHEN the applyDatasourcesConfigmap function is called
+		// THEN the Grafana datasources configmap contains no datasources
 		{
 			name:                   "Thanos and Prometheus both disabled",
 			vzCR:                   thanosAndPrometheusDisabledCR,
@@ -316,6 +322,7 @@ func TestApplyDatasourcesConfigmap(t *testing.T) {
 	}
 }
 
+// TestIsThanosQueryFrontendEnabled tests the isThanosQueryFrontendEnabled function.
 func TestIsThanosQueryFrontendEnabled(t *testing.T) {
 	oldConfig := config.Get()
 	defer config.Set(oldConfig)
@@ -372,16 +379,25 @@ func TestIsThanosQueryFrontendEnabled(t *testing.T) {
 		ctx           spi.ComponentContext
 		expectEnabled bool
 	}{
+		// GIVEN Thanos is disabled
+		// WHEN the isThanosQueryFrontendEnabled function is called
+		// THEN the function should return false
 		{
 			name:          "Thanos is disabled (by default)",
 			ctx:           spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false),
 			expectEnabled: false,
 		},
+		// GIVEN Thanos is enabled
+		// WHEN the isThanosQueryFrontendEnabled function is called
+		// THEN the function should return true
 		{
 			name:          "Thanos is enabled, Query Frontend is enabled by default",
 			ctx:           spi.NewFakeContext(client, thanosEnabledCR, nil, false),
 			expectEnabled: true,
 		},
+		// GIVEN Thanos is enabled but the Query Frontend is disabled
+		// WHEN the isThanosQueryFrontendEnabled function is called
+		// THEN the function should return false
 		{
 			name:          "Thanos is enabled, Query Frontend is explicitly disabled",
 			ctx:           spi.NewFakeContext(client, thanosQueryFrontendDisabledCR, nil, false),

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_test.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_test.go
@@ -1,24 +1,36 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package grafana
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	"github.com/verrazzano/verrazzano/pkg/helm"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/release"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+const testBomFilePath = "../../testdata/test_bom.json"
 
 var testScheme = runtime.NewScheme()
 var replicas int32
@@ -179,6 +191,208 @@ func TestIsGrafanaReady(t *testing.T) {
 			assert.Equal(t, tt.expectTrue, isGrafanaReady(ctx))
 			ctx = spi.NewFakeContext(tt.client, &vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{Components: vzapi.ComponentSpec{Grafana: &vzapi.GrafanaComponent{Replicas: &replicas}}}}, nil, false)
 			assert.Equal(t, true, isGrafanaReady(ctx))
+		})
+	}
+}
+
+// testActionConfigNoInstallation fakes a Helm release that is in the uninstalled state
+func testActionConfigNoInstallation(log vzlog.VerrazzanoLogger, settings *cli.EnvSettings, namespace string) (*action.Configuration, error) {
+	return helm.CreateActionConfig(false, "my-release", release.StatusUninstalled, vzlog.DefaultLogger(), nil)
+}
+
+// structs that allow us to unmarshal the Grafana datasources configmap YAML
+type datasource struct {
+	Name      string `json:"name"`
+	IsDefault bool   `json:"isDefault"`
+}
+
+type datasources struct {
+	Datasources []datasource `json:"datasources"`
+}
+
+func TestApplyDatasourcesConfigmap(t *testing.T) {
+
+	// Thanos and Prom enabled
+	// Thanos disabled, Prom enabled
+	// Both disabled
+	oldConfig := config.Get()
+	defer config.Set(oldConfig)
+	config.Set(config.OperatorConfig{
+		VerrazzanoRootDir: "../../../../..",
+	})
+
+	config.SetDefaultBomFilePath(testBomFilePath)
+
+	// needed to fake the Helm calls otherwise Helm tries to connect to a running cluster
+	defer helm.SetDefaultActionConfigFunction()
+	helm.SetActionConfigFunction(testActionConfigNoInstallation)
+
+	trueValue := true
+	falseValue := false
+	thanosEnabledCR := &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				Thanos: &vzapi.ThanosComponent{
+					Enabled: &trueValue,
+				},
+				Ingress: &vzapi.IngressNginxComponent{
+					Enabled: &falseValue,
+				},
+			},
+		},
+	}
+	thanosAndPrometheusDisabledCR := &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				Prometheus: &vzapi.PrometheusComponent{
+					Enabled: &falseValue,
+				},
+				PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+					Enabled: &falseValue,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                   string
+		vzCR                   *vzapi.Verrazzano
+		expectPromDatasource   bool
+		expectThanosDatasource bool
+	}{
+		{
+			name:                   "Thanos is disabled (by default)",
+			vzCR:                   &vzapi.Verrazzano{},
+			expectPromDatasource:   true,
+			expectThanosDatasource: false,
+		},
+		{
+			name:                   "Thanos is enabled, Query Frontend is enabled by default",
+			vzCR:                   thanosEnabledCR,
+			expectPromDatasource:   true,
+			expectThanosDatasource: true,
+		},
+		{
+			name:                   "Thanos and Prometheus both disabled",
+			vzCR:                   thanosAndPrometheusDisabledCR,
+			expectPromDatasource:   false,
+			expectThanosDatasource: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().Build()
+			ctx := spi.NewFakeContext(client, tt.vzCR, nil, false)
+			err := applyDatasourcesConfigmap(ctx)
+			assert.NoError(t, err)
+
+			cm := &v1.ConfigMap{}
+			err = client.Get(context.TODO(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: datasourcesConfigMapName}, cm)
+			assert.NoError(t, err)
+			dsYaml := cm.Data["datasource.yaml"]
+			ds := &datasources{}
+			err = yaml.Unmarshal([]byte(dsYaml), ds)
+			assert.NoError(t, err)
+
+			promIsDefault := false
+			thanosIsDefault := false
+			for _, d := range ds.Datasources {
+				if d.Name == "Prometheus" {
+					assert.True(t, tt.expectPromDatasource, "Found an unexpected Prometheus datasource")
+					promIsDefault = d.IsDefault
+				} else if d.Name == "Thanos" {
+					assert.True(t, tt.expectThanosDatasource, "Found an unexpected Thanos datasource")
+					thanosIsDefault = d.IsDefault
+				} else {
+					assert.Fail(t, "Found unexpected datasource name", "Name", d.Name)
+				}
+			}
+
+			// if we expect Thanos in the list of datasources, we also expect it to be the default datasource, otherwise Prometheus should
+			// be marked as the default datasource if it's enabled
+			assert.Equal(t, tt.expectThanosDatasource, thanosIsDefault)
+			assert.Equal(t, !tt.expectThanosDatasource && tt.expectPromDatasource, promIsDefault)
+		})
+	}
+}
+
+func TestIsThanosQueryFrontendEnabled(t *testing.T) {
+	oldConfig := config.Get()
+	defer config.Set(oldConfig)
+	config.Set(config.OperatorConfig{
+		VerrazzanoRootDir: "../../../../..",
+	})
+
+	config.SetDefaultBomFilePath(testBomFilePath)
+
+	// needed to fake the Helm calls otherwise Helm tries to connect to a running cluster
+	defer helm.SetDefaultActionConfigFunction()
+	helm.SetActionConfigFunction(testActionConfigNoInstallation)
+
+	client := fake.NewClientBuilder().Build()
+
+	trueValue := true
+	falseValue := false
+	thanosEnabledCR := &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				Thanos: &vzapi.ThanosComponent{
+					Enabled: &trueValue,
+				},
+				Ingress: &vzapi.IngressNginxComponent{
+					Enabled: &falseValue,
+				},
+			},
+		},
+	}
+	thanosQueryFrontendDisabledCR := &vzapi.Verrazzano{
+		Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				Thanos: &vzapi.ThanosComponent{
+					Enabled: &trueValue,
+					InstallOverrides: vzapi.InstallOverrides{
+						ValueOverrides: []vzapi.Overrides{
+							{
+								Values: &apiextensionsv1.JSON{
+									Raw: []byte(`{"queryFrontend": {"enabled": false}}`),
+								},
+							},
+						},
+					},
+				},
+				Ingress: &vzapi.IngressNginxComponent{
+					Enabled: &falseValue,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		ctx           spi.ComponentContext
+		expectEnabled bool
+	}{
+		{
+			name:          "Thanos is disabled (by default)",
+			ctx:           spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false),
+			expectEnabled: false,
+		},
+		{
+			name:          "Thanos is enabled, Query Frontend is enabled by default",
+			ctx:           spi.NewFakeContext(client, thanosEnabledCR, nil, false),
+			expectEnabled: true,
+		},
+		{
+			name:          "Thanos is enabled, Query Frontend is explicity disabled",
+			ctx:           spi.NewFakeContext(client, thanosQueryFrontendDisabledCR, nil, false),
+			expectEnabled: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enabled, err := isThanosQueryFrontendEnabled(tt.ctx)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectEnabled, enabled)
 		})
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_test.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_test.go
@@ -383,7 +383,7 @@ func TestIsThanosQueryFrontendEnabled(t *testing.T) {
 			expectEnabled: true,
 		},
 		{
-			name:          "Thanos is enabled, Query Frontend is explicity disabled",
+			name:          "Thanos is enabled, Query Frontend is explicitly disabled",
 			ctx:           spi.NewFakeContext(client, thanosQueryFrontendDisabledCR, nil, false),
 			expectEnabled: false,
 		},

--- a/platform-operator/controllers/verrazzano/component/grafana/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/vmi.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package grafana

--- a/platform-operator/controllers/verrazzano/component/grafana/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/vmi.go
@@ -12,6 +12,8 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 )
 
+const datasourcesConfigMapName = "vmi-system-datasource"
+
 // updateFunc mutates the VMI struct and ensures the Grafana component is configured properly
 func updateFunc(ctx spi.ComponentContext, storage *common.ResourceRequestValues, vmi *vmov1.VerrazzanoMonitoringInstance, existingVMI *vmov1.VerrazzanoMonitoringInstance) error {
 	vmi.Spec.Grafana = newGrafana(ctx.EffectiveCR(), storage, existingVMI, ctx.Log())
@@ -27,7 +29,7 @@ func newGrafana(cr *vzapi.Verrazzano, storage *common.ResourceRequestValues, exi
 	grafana := vmov1.Grafana{
 		Enabled:              grafanaSpec.Enabled != nil && *grafanaSpec.Enabled,
 		DashboardsConfigMap:  "verrazzano-dashboard-provider",
-		DatasourcesConfigMap: "vmi-system-datasource",
+		DatasourcesConfigMap: datasourcesConfigMapName,
 		Resources: vmov1.Resources{
 			RequestMemory: "48Mi",
 		},

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
@@ -36,12 +36,12 @@ const (
 	frontendDeployment = "thanos-query-frontend"
 )
 
-type thanosComponent struct {
+type ThanosComponent struct {
 	helm.HelmComponent
 }
 
 func NewComponent() spi.Component {
-	return thanosComponent{
+	return ThanosComponent{
 		helm.HelmComponent{
 			ReleaseName:               ComponentName,
 			JSONName:                  ComponentJSONName,
@@ -72,23 +72,23 @@ func NewComponent() spi.Component {
 }
 
 // IsReady component check for Thanos
-func (t thanosComponent) IsReady(ctx spi.ComponentContext) bool {
+func (t ThanosComponent) IsReady(ctx spi.ComponentContext) bool {
 	return t.HelmComponent.IsReady(ctx) && t.isThanosReady(ctx)
 }
 
 // isThanosReady returns true if the availability objects have the minimum number of expected replicas
-func (t thanosComponent) isThanosReady(ctx spi.ComponentContext) bool {
+func (t ThanosComponent) isThanosReady(ctx spi.ComponentContext) bool {
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
 	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), t.AvailabilityObjects.DeploymentNames, 1, prefix)
 }
 
 // IsEnabled Thanos enabled check for installation
-func (t thanosComponent) IsEnabled(effectiveCR runtime.Object) bool {
+func (t ThanosComponent) IsEnabled(effectiveCR runtime.Object) bool {
 	return vzcr.IsThanosEnabled(effectiveCR)
 }
 
 // PreInstall handles the pre-install operations for the Thanos component
-func (t thanosComponent) PreInstall(ctx spi.ComponentContext) error {
+func (t ThanosComponent) PreInstall(ctx spi.ComponentContext) error {
 	if err := preInstallUpgrade(ctx); err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func (t thanosComponent) PreInstall(ctx spi.ComponentContext) error {
 }
 
 // PreUpgrade handles the pre-upgrade operations for the Thanos component
-func (t thanosComponent) PreUpgrade(ctx spi.ComponentContext) error {
+func (t ThanosComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	if err := preInstallUpgrade(ctx); err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func (t thanosComponent) PreUpgrade(ctx spi.ComponentContext) error {
 }
 
 // GetIngressNames returns the Thanos ingress names
-func (t thanosComponent) GetIngressNames(ctx spi.ComponentContext) []types.NamespacedName {
+func (t ThanosComponent) GetIngressNames(ctx spi.ComponentContext) []types.NamespacedName {
 	var ingressNames []types.NamespacedName
 	if !vzcr.IsThanosEnabled(ctx.EffectiveCR()) || !vzcr.IsNGINXEnabled(ctx.EffectiveCR()) {
 		return ingressNames
@@ -126,7 +126,7 @@ func (t thanosComponent) GetIngressNames(ctx spi.ComponentContext) []types.Names
 }
 
 // GetCertificateNames returns the TLS secret for the Thanos component
-func (t thanosComponent) GetCertificateNames(ctx spi.ComponentContext) []types.NamespacedName {
+func (t ThanosComponent) GetCertificateNames(ctx spi.ComponentContext) []types.NamespacedName {
 	var certificateNames []types.NamespacedName
 
 	if !vzcr.IsThanosEnabled(ctx.EffectiveCR()) || !vzcr.IsNGINXEnabled(ctx.EffectiveCR()) {

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
@@ -51,6 +51,17 @@ spec:
         - operation:
             ports:
               - "10901"
+    # allow grafana to talk to query-frontend
+    - from:
+        - source:
+            namespaces:
+              - verrazzano-system
+            principals:
+              - cluster.local/ns/verrazzano-system/sa/verrazzano-monitoring-operator
+      to:
+        - operation:
+            ports:
+              - "10902"
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
@@ -24,6 +24,21 @@ spec:
         # web ui port
         - port: 10902
           protocol: TCP
+    # allow grafana to talk to thanos-query-frontend
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-system
+          podSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - system-grafana
+      ports:
+        # http api port
+        - port: 10902
+          protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}

--- a/platform-operator/thirdparty/manifests/grafana/datasources-configmap.yaml
+++ b/platform-operator/thirdparty/manifests/grafana/datasources-configmap.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+data:
+  datasource.yaml: |2-
+    apiVersion: 1
+    datasources:
+{{ if .isThanosQueryEnabled }}
+    - name: Thanos
+      type: prometheus
+      orgId: 1
+      access: proxy
+      url: {{ .thanosQueryURL }}:{{ .thanosQueryPort }}
+      isDefault: true
+{{ end }}
+{{ if .isPrometheusEnabled }}
+    - name: Prometheus
+      type: prometheus
+      orgId: 1
+      access: proxy
+      url: {{ .prometheusURL }}:{{ .prometheusPort }}
+{{ if .isThanosQueryEnabled }}
+      isDefault: false
+{{ else }}
+      isDefault: true
+{{ end }}
+{{ end }}


### PR DESCRIPTION
This PR adds Thanos to the list of configured datasources in Grafana. If Thanos Query Frontend is enabled, Thanos is added to the Grafana datasources list and Thanos is set as the default datasource. Dashboards will then fetch metrics from Thanos. If Thanos Query Frontend is not enabled but Prometheus is enabled, Prometheus will be the only configured datasource.

To test, I installed in a local cluster with the following configurations and validated the datasources in Grafana:
- Thanos component enabled, Thanos Query Frontend enabled, Prometheus enabled
- Thanos component enabled, Thanos Query Frontend disabled, Prometheus enabled
- Thanos disabled, Prometheus enabled
- Thanos disabled, Prometheus disabled

I ran the same scenarios but upgrading from Verrazzano 1.5.2 and confirmed the datasources were updated correctly.