### PR TITLE
Honor wait parameter to helmcli.Upgrade()

### DIFF
--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -134,6 +134,7 @@ func Upgrade(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 		client := action.NewUpgrade(actionConfig)
 		client.Namespace = namespace
 		client.DryRun = dryRun
+		client.Wait = wait
 
 		rel, err = client.Run(releaseName, chart, vals)
 		if err != nil {
@@ -148,6 +149,7 @@ func Upgrade(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 		client.ReleaseName = releaseName
 		client.DryRun = dryRun
 		client.Replace = true
+		client.Wait = wait
 
 		rel, err = client.Run(chart, vals)
 		if err != nil {

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -491,7 +491,7 @@ func (h HelmComponent) Upgrade(context spi.ComponentContext) error {
 	// Generate a list of override files making helm get values overrides first
 	overrides = append([]helm.HelmOverrides{{FileOverride: tmpFile.Name()}}, overrides...)
 
-	_, err = upgradeFunc(context.Log(), h.ReleaseName, resolvedNamespace, h.ChartDir, true, context.IsDryRun(), overrides)
+	_, err = upgradeFunc(context.Log(), h.ReleaseName, resolvedNamespace, h.ChartDir, false, context.IsDryRun(), overrides)
 	return err
 }
 


### PR DESCRIPTION
Fix the `helmcli.Upgrade()` to honor the `wait` parameter using the newly-incorporated Helm API.
- use `wait=false` for `HelmComponent.Upgrade()`, as using `wait=true` causes upgrade timeouts
- Existing component ready checks should ensure when components are finished upgrading

Previous releases used `wait=true` for upgrades, but it seems like the new API will cause timeouts.  It also seems that we've been running with `wait=false` since use of the Helm API was introduced, so it should be safe.