### PR TITLE
Update metrics tests to a centrally managed package for ease of use

### DIFF
--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -46,7 +46,8 @@ var (
 		"bobbys-helidon-stock-application",
 		"robert-helidon",
 		"mysql"}
-	host = ""
+	host        = ""
+	metricsTest pkg.MetricsTest
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -121,6 +122,16 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 		host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 		return host, err
 	}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()), "Bobs Books Application Failed to Deploy: Gateway is not ready")
+
+	kubeconfig, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
+	}
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
+
 	metrics.Emit(t.Metrics.With("get_host_name_elapsed_time", time.Since(start).Milliseconds()))
 
 	beforeSuitePassed = true
@@ -332,52 +343,52 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("base_jvm_uptime_seconds", "app", "bobbys-helidon-stock-application")
+						return metricsTest.MetricsExist("base_jvm_uptime_seconds", map[string]string{"app": "bobbys-helidon-stock-application"})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("base_jvm_uptime_seconds", "app", "robert-helidon")
+						return metricsTest.MetricsExist("base_jvm_uptime_seconds", map[string]string{"app": "robert-helidon"})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "bobby-helidon")
+						return metricsTest.MetricsExist("vendor_requests_count_total", map[string]string{"app_oam_dev_component": "bobby-helidon"})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "robert-helidon")
+						return metricsTest.MetricsExist("vendor_requests_count_total", map[string]string{"app_oam_dev_component": "robert-helidon"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", "bobbys-front-end")
+						return metricsTest.MetricsExist("wls_jvm_process_cpu_load", map[string]string{"weblogic_domainName": "bobbys-front-end"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", "bobs-bookstore")
+						return metricsTest.MetricsExist("wls_jvm_process_cpu_load", map[string]string{"weblogic_domainName": "bobs-bookstore"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", "bobbys-front-end")
+						return metricsTest.MetricsExist("wls_scrape_mbeans_count_total", map[string]string{"weblogic_domainName": "bobbys-front-end"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", "bobs-bookstore")
+						return metricsTest.MetricsExist("wls_scrape_mbeans_count_total", map[string]string{"weblogic_domainName": "bobs-bookstore"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("vendor:coherence_cluster_size", "coherenceCluster", "bobbys-coherence")
+						return metricsTest.MetricsExist("vendor:coherence_cluster_size", map[string]string{"coherenceCluster": "bobbys-coherence"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("vendor:coherence_cluster_size", "coherenceCluster", "roberts-coherence")
+						return metricsTest.MetricsExist("vendor:coherence_cluster_size", map[string]string{"coherenceCluster": "roberts-coherence"})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)
@@ -390,32 +401,32 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("istio_tcp_received_bytes_total", "destination_canonical_service", "bobbys-helidon-stock-application")
+						return metricsTest.MetricsExist("istio_tcp_received_bytes_total", map[string]string{"destination_canonical_service": "bobbys-helidon-stock-application"})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("istio_tcp_received_bytes_total", "destination_canonical_service", "robert-helidon")
+						return metricsTest.MetricsExist("istio_tcp_received_bytes_total", map[string]string{"destination_canonical_service": "robert-helidon"})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("istio_tcp_received_bytes_total", "destination_canonical_service", "bobbys-front-end")
+						return metricsTest.MetricsExist("istio_tcp_received_bytes_total", map[string]string{"destination_canonical_service": "bobbys-front-end"})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("istio_tcp_received_bytes_total", "destination_canonical_service", "bobs-bookstore")
+						return metricsTest.MetricsExist("istio_tcp_received_bytes_total", map[string]string{"destination_canonical_service": "bobs-bookstore"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("envoy_cluster_http2_pending_send_bytes", "pod_name", "bobbys-front-end-adminserver")
+						return metricsTest.MetricsExist("envoy_cluster_http2_pending_send_bytes", map[string]string{"pod_name": "bobbys-front-end-adminserver"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("envoy_cluster_http2_pending_send_bytes", "pod_name", "bobs-bookstore-adminserver")
+						return metricsTest.MetricsExist("envoy_cluster_http2_pending_send_bytes", map[string]string{"pod_name": "bobs-bookstore-adminserver"})
 					}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 				},
 			)

--- a/tests/e2e/examples/helidonmetrics/helidon_metrics_test.go
+++ b/tests/e2e/examples/helidonmetrics/helidon_metrics_test.go
@@ -34,6 +34,8 @@ var (
 	t                  = framework.NewTestFramework("helidonmetrics")
 	generatedNamespace = pkg.GenerateNamespace("helidon-metrics")
 	host               = ""
+	kubeconfig         string
+	metricsTest        pkg.MetricsTest
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -100,6 +102,16 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 		host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 		return host, err
 	}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()), "Helidon Example: Gateway is not ready")
+
+	kubeconfig, err = k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
+	}
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
+
 	metrics.Emit(t.Metrics.With("get_host_name_elapsed_time", time.Since(start).Milliseconds()))
 
 })
@@ -237,7 +249,17 @@ func serviceMonitorExists() bool {
 }
 
 func scrapeTargetExists() bool {
-	targets, _ := pkg.ScrapeTargets()
+	promSource, err := pkg.NewPrometheusSource(kubeconfig)
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Failed to produce a Prometheus source: %v", err))
+		return false
+	}
+	targets, err := promSource.GetTargets()
+	if err != nil {
+		pkg.Log(pkg.Error, fmt.Sprintf("Failed to get Prometheus targets from the cluster: %v", err))
+		return false
+	}
+
 	for _, t := range targets {
 		m := t.(map[string]interface{})
 		scrapePool := m["scrapePool"].(string)

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -34,6 +34,7 @@ var (
 	generatedNamespace        = pkg.GenerateNamespace("springboot")
 	expectedPodsSpringBootApp = []string{"springboot-workload"}
 	host                      = ""
+	metricsTest               pkg.MetricsTest
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -87,6 +88,16 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 		host, err = k8sutil.GetHostnameFromGateway(namespace, "")
 		return host, err
 	}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()), "Spring Boot Application Failed to Deploy: Gateway is not ready")
+
+	kubeconfig, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
+	}
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
+
 	metrics.Emit(t.Metrics.With("get_host_name_elapsed_time", time.Since(start).Milliseconds()))
 
 	beforeSuitePassed = true
@@ -180,12 +191,12 @@ var _ = t.Describe("Spring Boot test", Label("f:app-lcm.oam",
 	t.Context("for metrics.", Label("f:observability.monitoring.prom"), func() {
 		t.It("Retrieve Prometheus scraped metrics for App Component", func() {
 			Eventually(func() bool {
-				return pkg.MetricsExist("http_server_requests_seconds_count", "app_oam_dev_name", "springboot-appconf")
+				return metricsTest.MetricsExist("http_server_requests_seconds_count", map[string]string{"app_oam_dev_name": "springboot-appconf"})
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find Prometheus scraped metrics for App Component.")
 		})
 		t.It("Retrieve Prometheus scraped metrics for App Config", func() {
 			Eventually(func() bool {
-				return pkg.MetricsExist("tomcat_sessions_created_sessions_total", "app_oam_dev_component", "springboot-component")
+				return metricsTest.MetricsExist("tomcat_sessions_created_sessions_total", map[string]string{"app_oam_dev_component": "springboot-component"})
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find Prometheus scraped metrics for App Config.")
 		})
 	})

--- a/tests/e2e/jaeger/system/jaeger_system_test.go
+++ b/tests/e2e/jaeger/system/jaeger_system_test.go
@@ -34,11 +34,16 @@ var (
 var beforeSuite = t.BeforeSuiteFunc(func() {
 	var err error
 	kubeconfigPath, err = k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to find Kubeconfig location: %v", err))
+	}
 	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}
 })
+
+var _ = BeforeSuite(beforeSuite)
 
 var whenJaegerOperatorEnabledIt = t.WhenMeetsConditionFunc(jaeger.OperatorCondition, jaeger.IsJaegerEnabled)
 

--- a/tests/e2e/jaeger/system/jaeger_system_test.go
+++ b/tests/e2e/jaeger/system/jaeger_system_test.go
@@ -38,7 +38,6 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}
-
 })
 
 var whenJaegerOperatorEnabledIt = t.WhenMeetsConditionFunc(jaeger.OperatorCondition, jaeger.IsJaegerEnabled)

--- a/tests/e2e/jaeger/system/jaeger_system_test.go
+++ b/tests/e2e/jaeger/system/jaeger_system_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package system
@@ -56,7 +56,7 @@ var _ = t.Describe("Verrazzano System traces with Jaeger", Label("f:jaeger.syste
 		// WHEN we query for metrics related to Jaeger operator
 		// THEN we see that the metrics are present in prometheus
 		whenJaegerOperatorEnabledIt("metrics of jaeger operator are available in prometheus", func() {
-			validatorFn := pkg.ValidateJaegerOperatorMetricFunc()
+			validatorFn := pkg.ValidateJaegerOperatorMetricFunc(pkg.QueryMetric)
 			Eventually(validatorFn).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
 		})
 
@@ -64,7 +64,7 @@ var _ = t.Describe("Verrazzano System traces with Jaeger", Label("f:jaeger.syste
 		// WHEN we query for metrics related to Jaeger collector
 		// THEN we see that the metrics are present in prometheus
 		whenJaegerOperatorEnabledIt("metrics of jaeger collector are available in prometheus", func() {
-			validatorFn := pkg.ValidateJaegerCollectorMetricFunc()
+			validatorFn := pkg.ValidateJaegerCollectorMetricFunc(pkg.QueryMetric)
 			Eventually(validatorFn).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
 		})
 
@@ -72,7 +72,7 @@ var _ = t.Describe("Verrazzano System traces with Jaeger", Label("f:jaeger.syste
 		// WHEN we query for metrics related to Jaeger collector
 		// THEN we see that the metrics are present in prometheus
 		whenJaegerOperatorEnabledIt("metrics of jaeger query are available in prometheus", func() {
-			validatorFn := pkg.ValidateJaegerQueryMetricFunc()
+			validatorFn := pkg.ValidateJaegerQueryMetricFunc(pkg.QueryMetric)
 			Eventually(validatorFn).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
 		})
 
@@ -80,7 +80,7 @@ var _ = t.Describe("Verrazzano System traces with Jaeger", Label("f:jaeger.syste
 		// WHEN we query for metrics related to Jaeger collector
 		// THEN we see that the metrics are present in prometheus
 		whenJaegerOperatorEnabledIt("metrics of jaeger agent are available in prometheus", func() {
-			validatorFn := pkg.ValidateJaegerAgentMetricFunc()
+			validatorFn := pkg.ValidateJaegerAgentMetricFunc(pkg.QueryMetric)
 			Eventually(validatorFn).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
 		})
 	})

--- a/tests/e2e/jwt/helidon-svc/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon-svc/helidon_example_test.go
@@ -40,10 +40,10 @@ const (
 )
 
 var (
-	t                  = framework.NewTestFramework("helidon")
-	generatedNamespace = pkg.GenerateNamespace("hello-helidon-svc")
-	//yamlApplier              = k8sutil.YAMLApplier{}
+	t                        = framework.NewTestFramework("helidon")
+	generatedNamespace       = pkg.GenerateNamespace("hello-helidon-svc")
 	expectedPodsHelloHelidon = []string{"hello-helidon-svc-deployment"}
+	metricsTest              pkg.MetricsTest
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -63,6 +63,16 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if !skipVerify {
 		Eventually(helloHelidonPodsRunning, longWaitTimeout, longPollingInterval).Should(BeTrue())
 	}
+
+	kubeconfig, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
+	}
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
+
 	beforeSuitePassed = true
 })
 
@@ -367,21 +377,21 @@ func appEndpointAccess(url string, hostname string, token string, requestShouldS
 }
 
 func appMetricsExists() bool {
-	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", "hello-helidon-svc-application")
+	return metricsTest.MetricsExist("base_jvm_uptime_seconds", map[string]string{"app": "hello-helidon-svc-application"})
 }
 
 func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "hello-helidon-svc-application")
+	return metricsTest.MetricsExist("vendor_requests_count_total", map[string]string{"app_oam_dev_name": "hello-helidon-svc-application"})
 }
 
 func appConfigMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "hello-helidon-deploy-component")
+	return metricsTest.MetricsExist("vendor_requests_count_total", map[string]string{"app_oam_dev_component": "hello-helidon-deploy-component"})
 }
 
 func nodeExporterProcsRunning() bool {
-	return pkg.MetricsExist("node_procs_running", "job", nodeExporterJobName)
+	return metricsTest.MetricsExist("node_procs_running", map[string]string{"job": nodeExporterJobName})
 }
 
 func nodeExporterDiskIoNow() bool {
-	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterJobName)
+	return metricsTest.MetricsExist("node_disk_io_now", map[string]string{"job": nodeExporterJobName})
 }

--- a/tests/e2e/jwt/helidon/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_test.go
@@ -33,10 +33,10 @@ const (
 )
 
 var (
-	t                  = framework.NewTestFramework("helidon")
-	generatedNamespace = pkg.GenerateNamespace(helloHelidon)
-	//yamlApplier              = k8sutil.YAMLApplier{}
+	t                        = framework.NewTestFramework("helidon")
+	generatedNamespace       = pkg.GenerateNamespace(helloHelidon)
 	expectedPodsHelloHelidon = []string{"hello-helidon-deployment"}
+	metricsTest              pkg.MetricsTest
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -56,6 +56,16 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if !skipVerify {
 		Eventually(helloHelidonPodsRunning, longWaitTimeout, longPollingInterval).Should(BeTrue())
 	}
+
+	kubeconfig, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
+	}
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
+
 	beforeSuitePassed = true
 })
 
@@ -276,21 +286,21 @@ func appEndpointAccess(url string, hostname string, token string, requestShouldS
 }
 
 func appMetricsExists() bool {
-	return pkg.MetricsExist("base_jvm_uptime_seconds", "app", helloHelidon)
+	return metricsTest.MetricsExist("base_jvm_uptime_seconds", map[string]string{"app": helloHelidon})
 }
 
 func appComponentMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", helloHelidon)
+	return metricsTest.MetricsExist("vendor_requests_count_total", map[string]string{"app_oam_dev_name": helloHelidon})
 }
 
 func appConfigMetricsExists() bool {
-	return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_component", "hello-helidon-component")
+	return metricsTest.MetricsExist("vendor_requests_count_total", map[string]string{"app_oam_dev_component": "hello-helidon-component"})
 }
 
 func nodeExporterProcsRunning() bool {
-	return pkg.MetricsExist("node_procs_running", "job", nodeExporterJobName)
+	return metricsTest.MetricsExist("node_procs_running", map[string]string{"job": nodeExporterJobName})
 }
 
 func nodeExporterDiskIoNow() bool {
-	return pkg.MetricsExist("node_disk_io_now", "job", nodeExporterJobName)
+	return metricsTest.MetricsExist("node_disk_io_now", map[string]string{"job": nodeExporterJobName})
 }

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -38,6 +38,7 @@ const (
 var (
 	expectedPodsDeploymetricsApp = []string{"deploymetrics-workload"}
 	generatedNamespace           = pkg.GenerateNamespace("deploymetrics")
+	metricsTest                  pkg.MetricsTest
 
 	waitTimeout              = 10 * time.Minute
 	pollingInterval          = 30 * time.Second
@@ -90,6 +91,11 @@ var beforeSuite = clusterDump.BeforeSuiteFunc(func() {
 			}
 			return nil
 		}, waitTimeout, pollingInterval).Should(BeNil(), "Expected to be able to create the metrics service")
+	}
+
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}
 })
 var _ = clusterDump.AfterEach(func() {})             // Dump cluster if spec fails
@@ -243,7 +249,7 @@ var _ = t.Describe("DeployMetrics Application test", Label("f:app-lcm.oam"), fun
 				clusterNameLabel:   clusterName,
 			}
 			Eventually(func() bool {
-				return pkg.MetricsExistInCluster("http_server_requests_seconds_count", metricLabels, kubeconfig)
+				return metricsTest.MetricsExist("http_server_requests_seconds_count", metricLabels)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find Prometheus scraped metrics for App Component.")
 		})
 		t.It("App Config", func() {
@@ -259,7 +265,7 @@ var _ = t.Describe("DeployMetrics Application test", Label("f:app-lcm.oam"), fun
 				clusterNameLabel:        clusterName,
 			}
 			Eventually(func() bool {
-				return pkg.MetricsExistInCluster("tomcat_sessions_created_sessions_total", metricLabels, kubeconfig)
+				return metricsTest.MetricsExist("tomcat_sessions_created_sessions_total", metricLabels)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find Prometheus scraped metrics for App Config.")
 		})
 	})

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package deploymetrics

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -11,9 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 )
@@ -99,6 +97,7 @@ var excludePodsIstio = []string{
 	"istiocoredns",
 	"istiod",
 }
+var metricsTest pkg.MetricsTest
 
 var t = framework.NewTestFramework("syscomponents")
 
@@ -124,6 +123,15 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		Fail(err.Error())
 	}
+
+	defaultLabels := map[string]string{}
+	if clusterLabelVal := getClusterNameForPromQuery(); clusterLabelVal != "" {
+		defaultLabels[getClusterNameMetricLabel()] = clusterLabelVal
+	}
+	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeConfig}, adminKubeConfig, defaultLabels)
+	if err != nil {
+		Fail(err.Error())
+	}
 })
 
 var _ = BeforeSuite(beforeSuite)
@@ -134,10 +142,10 @@ var _ = AfterSuite(afterSuite)
 
 var _ = t.AfterEach(func() {})
 
-var _ = t.Describe("Prometheus Metrics", Label("f:observability.monitoring.prom"), func() {
+var _ = t.Describe("Thanos Metrics", Label("f:observability.monitoring.prom"), func() {
 	// Query Prometheus for the sample metrics from the default scraping jobs
 	var _ = t.Describe("for the system components", func() {
-		t.It("Verify sample NGINX metrics can be queried from Prometheus", func() {
+		t.It("Verify sample NGINX metrics can be queried from Thanos", func() {
 			eventuallyMetricsContainLabels(ingressControllerSuccess, map[string]string{
 				controllerNamespace: ingressNginxNamespace,
 				appK8SIOInstance:    ingressController,
@@ -145,80 +153,80 @@ var _ = t.Describe("Prometheus Metrics", Label("f:observability.monitoring.prom"
 		})
 
 		if !pkg.IsManagedClusterProfile() {
-			t.ItMinimumVersion("Verify sample OpenSearch metrics can be queried from Prometheus", "1.5.0", kubeConfig, func() {
+			t.ItMinimumVersion("Verify sample OpenSearch metrics can be queried from Thanos", "1.5.0", kubeConfig, func() {
 				eventuallyMetricsContainLabels(esClusterStatusMetric, map[string]string{
 					container: esMaster,
 				})
 			})
 		}
 
-		t.It("Verify sample Container Advisor metrics can be queried from Prometheus", func() {
+		t.It("Verify sample Container Advisor metrics can be queried from Thanos", func() {
 			eventuallyMetricsContainLabels(containerStartTimeSeconds, map[string]string{})
 		})
-		t.ItMinimumVersion("Verify VPO summary counter metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VPO summary counter metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels("vz_platform_operator_reconcile_duration_count", map[string]string{})
 		})
-		t.ItMinimumVersion("Verify VPO summary sum times can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VPO summary sum times can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels("vz_platform_operator_reconcile_duration_sum", map[string]string{})
 		})
-		t.ItMinimumVersion("Verify VPO counter metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VPO counter metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels("vz_platform_operator_reconcile_total", map[string]string{})
 		})
-		t.ItMinimumVersion("Verify VPO error counter metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VPO error counter metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels("vz_platform_operator_error_reconcile_total", map[string]string{})
 		})
-		t.ItMinimumVersion("Verify VPO install metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VPO install metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels("vz_platform_operator_component_install_duration_seconds", map[string]string{})
 		})
-		t.ItMinimumVersion("Verify VPO upgrade counter metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VPO upgrade counter metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels("vz_platform_operator_component_upgrade_duration_seconds", map[string]string{})
 		})
 
-		t.ItMinimumVersion("Verify VMO function metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VMO function metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels(vmoFunctionMetric, map[string]string{})
 		})
 
-		t.ItMinimumVersion("Verify VMO counter metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VMO counter metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels(vmoCounterMetric, map[string]string{})
 		})
 
-		t.ItMinimumVersion("Verify VMO gauge metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VMO gauge metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels(vmoGaugeMetric, map[string]string{})
 		})
 
-		t.ItMinimumVersion("Verify VMO timestamp metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VMO timestamp metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels(vmoTimestampMetric, map[string]string{})
 		})
-		t.ItMinimumVersion("Verify VAO successful counter metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VAO successful counter metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels(vaoSuccessCountMetric, map[string]string{})
 		})
-		t.ItMinimumVersion("Verify VAO failed counter metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VAO failed counter metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels(vaoFailCountMetric, map[string]string{})
 		})
-		t.ItMinimumVersion("Verify VAO Duration summary metrics can be queried from Prometheus", metricsVersion, kubeConfig, func() {
+		t.ItMinimumVersion("Verify VAO Duration summary metrics can be queried from Thanos", metricsVersion, kubeConfig, func() {
 			eventuallyMetricsContainLabels(vaoDurationCountMetric, map[string]string{})
 		})
 
-		t.It("Verify sample Node Exporter metrics can be queried from Prometheus", func() {
+		t.It("Verify sample Node Exporter metrics can be queried from Thanos", func() {
 			Eventually(func() bool {
 				kv := map[string]string{
 					job: nodeExporter,
 				}
-				return metricsContainLabels(cpuSecondsTotal, kv)
+				return metricsTest.MetricsExist(cpuSecondsTotal, kv)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 
 		if istioInjection == "enabled" {
-			t.It("Verify sample mesh metrics can be queried from Prometheus", func() {
+			t.It("Verify sample mesh metrics can be queried from Thanos", func() {
 				Eventually(func() bool {
 					kv := map[string]string{
 						namespace: verrazzanoSystemNamespace,
 					}
-					return metricsContainLabels(istioRequestsTotal, kv)
+					return metricsTest.MetricsExist(istioRequestsTotal, kv)
 				}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 			})
 
-			t.It("Verify sample istiod metrics can be queried from Prometheus", func() {
+			t.It("Verify sample istiod metrics can be queried from Thanos", func() {
 				Eventually(func() bool {
 					kv := map[string]string{
 						app: istiod,
@@ -236,12 +244,12 @@ var _ = t.Describe("Prometheus Metrics", Label("f:observability.monitoring.prom"
 							job: istiod,
 						}
 					}
-					return metricsContainLabels(sidecarInjectionRequests, kv)
+					return metricsTest.MetricsExist(sidecarInjectionRequests, kv)
 				}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 			})
 		}
 
-		t.It("Verify sample metrics can be queried from Prometheus", func() {
+		t.It("Verify sample metrics can be queried from Thanos", func() {
 			Eventually(func() bool {
 				kv := map[string]string{
 					job: oldPrometheus,
@@ -257,7 +265,7 @@ var _ = t.Describe("Prometheus Metrics", Label("f:observability.monitoring.prom"
 						job: prometheus,
 					}
 				}
-				return metricsContainLabels(prometheusTargetIntervalLength, kv)
+				return metricsTest.MetricsExist(prometheusTargetIntervalLength, kv)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 		})
 		if istioInjection == "enabled" {
@@ -267,40 +275,11 @@ var _ = t.Describe("Prometheus Metrics", Label("f:observability.monitoring.prom"
 				}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 			})
 		}
-
-		t.It("Verify metrics can be queried from Thanos", func() {
-			minVer16, err := pkg.IsVerrazzanoMinVersion("1.6.0", adminKubeConfig)
-			if err != nil {
-				pkg.Log(pkg.Error, fmt.Sprintf("Failed to verify the Verrazzano version was min 1.6.0: %v", err))
-				return
-			}
-			if !minVer16 {
-				return
-			}
-			vz, err := pkg.GetVerrazzanoInstallResourceInCluster(adminKubeConfig)
-			if err != nil {
-				pkg.Log(pkg.Error, fmt.Sprintf("Failed to get Verrazzano resource from the cluster: %v", err))
-				return
-			}
-			if !vzcr.IsThanosEnabled(vz) {
-				return
-			}
-
-			// If the min version is >= 1.6 and Thanos is enabled, try to query metrics from its source
-			// this test assumes that the Thanos sidecar is also enabled with the Thanos installation
-			Eventually(func() (bool, error) {
-				return ThanosMetricsExist(prometheusTargetIntervalLength, adminKubeConfig)
-			}, longWaitTimeout, longPollingInterval).Should(BeTrue())
-		})
 	})
 })
 
 // Validate the Istio envoy stats for the pods in the namespaces defined in envoyStatsNamespaces
 func verifyEnvoyStats(metricName string) bool {
-	envoyStatsMetric, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, getClusterNameMetricLabel(), getClusterNameForPromQuery())
-	if err != nil {
-		return false
-	}
 	clientset, err := pkg.GetKubernetesClientsetForCluster(kubeConfig)
 	if err != nil {
 		t.Logs.Errorf("Error getting clienset for %s, error: %v", kubeConfig, err)
@@ -312,28 +291,15 @@ func verifyEnvoyStats(metricName string) bool {
 			t.Logs.Errorf("Error listing pods in cluster for namespace: %s, error: %v", namespace, err)
 			return false
 		}
+		labels := map[string]string{}
 		for _, pod := range pods.Items {
-			var retValue bool
-			switch ns {
-			case istioSystemNamespace:
-				if excludePods(pod.Name, excludePodsIstio) {
-					retValue = true
-				} else {
-					retValue = verifyLabels(envoyStatsMetric, ns, pod.Name)
-				}
-			case verrazzanoSystemNamespace:
-				if excludePods(pod.Name, excludePodsVS) {
-					retValue = true
-				} else {
-					retValue = verifyLabels(envoyStatsMetric, ns, pod.Name)
-				}
-			default:
-				retValue = verifyLabels(envoyStatsMetric, ns, pod.Name)
+			if ns == istioSystemNamespace && excludePods(pod.Name, excludePodsIstio) ||
+				ns == verrazzanoSystemNamespace && excludePods(pod.Name, excludePodsVS) {
+				continue
 			}
-			if !retValue {
-				return false
-			}
+			labels[ns] = pod.Name
 		}
+		metricsTest.MetricsExist(metricName, labels)
 	}
 	return true
 }
@@ -348,78 +314,6 @@ func getClusterNameMetricLabel() string {
 		clusterNameMetricsLabel = lbl
 	}
 	return clusterNameMetricsLabel
-}
-
-// Assert the existence of labels for namespace and pod in the envoyStatsMetric
-func verifyLabels(envoyStatsMetric string, ns string, pod string) bool {
-	metrics := pkg.JTq(envoyStatsMetric, "data", "result").([]interface{})
-	for _, metric := range metrics {
-		if pkg.Jq(metric, "metric", namespace) == ns && pkg.Jq(metric, "metric", podName) == pod {
-			if isManagedClusterProfile {
-				// when the admin cluster scrapes the metrics from a managed cluster, as label verrazzano_cluster with value
-				// name of the managed cluster is added to the metrics
-				if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == clusterName {
-					return true
-				}
-			} else {
-				// the metrics for the admin cluster or in the single cluster installation should contain the label
-				// verrazzano_cluster with the value "local" when version 1.1 or higher.
-				if isMinVersion110 {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == "local" {
-						return true
-					}
-				} else {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == nil {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
-}
-
-// Validate the metrics contain the labels with values specified as key-value pairs of the map
-func metricsContainLabels(metricName string, kv map[string]string) bool {
-	clusterNameValue := getClusterNameForPromQuery()
-	t.Logs.Debugf("Looking for metric name %s with label %s = %s", metricName, getClusterNameMetricLabel(), clusterNameValue)
-	compMetrics, err := pkg.QueryMetricWithLabel(metricName, adminKubeConfig, getClusterNameMetricLabel(), clusterNameValue)
-	if err != nil {
-		return false
-	}
-	metrics := pkg.JTq(compMetrics, "data", "result").([]interface{})
-	for _, metric := range metrics {
-		metricFound := true
-		for key, value := range kv {
-			if pkg.Jq(metric, "metric", key) != value {
-				metricFound = false
-				break
-			}
-		}
-
-		if metricFound {
-			if isManagedClusterProfile {
-				// when the admin cluster scrapes the metrics from a managed cluster, as label verrazzano_cluster with value
-				// name of the managed cluster is added to the metrics
-				if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == clusterName {
-					return true
-				}
-			} else {
-				// the metrics for the admin cluster or in the single cluster installation should contain the label
-				// verrazzano_cluster with the local cluster as its value when version 1.1 or higher
-				if isMinVersion110 {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == "local" {
-						return true
-					}
-				} else {
-					if pkg.Jq(metric, "metric", getClusterNameMetricLabel()) == nil {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
 }
 
 // Exclude the pods where envoy stats are not available
@@ -443,19 +337,9 @@ func getClusterNameForPromQuery() string {
 	return ""
 }
 
-// Queries Prometheus for a given metric name and a map of labels for the metric
+// Queries Thanos for a given metric name and a map of labels for the metric
 func eventuallyMetricsContainLabels(metricName string, kv map[string]string) {
 	Eventually(func() bool {
-		return metricsContainLabels(metricName, kv)
+		return metricsTest.MetricsExist(metricName, kv)
 	}, longWaitTimeout, longPollingInterval).Should(BeTrue())
-}
-
-func ThanosMetricsExist(metricsName, kubeconfigPath string) (bool, error) {
-	metrics, err := pkg.QueryThanosMetric(metricsName, kubeconfigPath)
-	if err != nil {
-		t.Logs.Errorf("Failed to query Thanos metric %s: %v", metricsName, err)
-		return false, err
-	}
-	metricsList := pkg.JTq(metrics, "data", "result").([]interface{})
-	return len(metricsList) > 0, nil
 }

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package sock_shop

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
@@ -35,6 +35,7 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
+var metricsTest pkg.MetricsTest
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -63,6 +64,13 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	Eventually(func() error {
 		return DeploySockShopApp(adminKubeconfig, sourceDir)
 	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
+
+	var err error
+	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeconfig, managedKubeconfig}, adminKubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
+
 	beforeSuitePassed = true
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
@@ -174,7 +182,7 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 					m := make(map[string]string)
 					m["app"] = testApp
 					m[clusterNameMetricsLabel] = clusterName
-					return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
+					return metricsTest.MetricsExist("base_jvm_uptime_seconds", m)
 				}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find base_jvm_uptime_seconds metric")
 			})
 
@@ -184,7 +192,7 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 					m := make(map[string]string)
 					m["app"] = testApp
 					m[clusterNameMetricsLabel] = "DNE"
-					return pkg.MetricsExistInCluster("base_jvm_uptime_seconds", m, adminKubeconfig)
+					return metricsTest.MetricsExist("base_jvm_uptime_seconds", m)
 				}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Not expected to find base_jvm_uptime_seconds metric")
 			})
 
@@ -194,7 +202,7 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 					m := make(map[string]string)
 					m["app"] = testApp
 					m[clusterNameMetricsLabel] = clusterName
-					return pkg.MetricsExistInCluster("vendor_requests_count_total", m, adminKubeconfig)
+					return metricsTest.MetricsExist("vendor_requests_count_total", m)
 				}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find vendor_requests_count_total metric")
 			})
 
@@ -204,7 +212,7 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 					m := make(map[string]string)
 					m["namespace"] = testNamespace
 					m[clusterNameMetricsLabel] = clusterName
-					return pkg.MetricsExistInCluster("container_cpu_cfs_periods_total", m, adminKubeconfig)
+					return metricsTest.MetricsExist("container_cpu_cfs_periods_total", m)
 				}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find container_cpu_cfs_periods_total metric")
 			})
 
@@ -214,7 +222,7 @@ var _ = t.Describe("In Multi-cluster, verify sock-shop", Label("f:multicluster.m
 					m := make(map[string]string)
 					m["cluster"] = testCluster
 					m[clusterNameMetricsLabel] = clusterName
-					return pkg.MetricsExistInCluster("vendor:coherence_service_messages_local", m, adminKubeconfig)
+					return metricsTest.MetricsExist("vendor:coherence_service_messages_local", m)
 				}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find coherence metric")
 			})
 		}

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
@@ -37,6 +37,7 @@ const (
 var clusterName = os.Getenv("MANAGED_CLUSTER_NAME")
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
+var metricsTest pkg.MetricsTest
 
 // failed indicates whether any of the tests has failed
 var failed = false
@@ -85,6 +86,13 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	Eventually(func() error {
 		return DeployTodoListApp(adminKubeconfig, sourceDir)
 	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
+
+	var err error
+	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeconfig, managedKubeconfig}, adminKubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
+
 	beforeSuitePassed = true
 	metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 })
@@ -236,7 +244,7 @@ var _ = t.Describe("In Multi-cluster, verify todo-list", Label("f:multicluster.m
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
 				m[clusterNameMetricsLabel] = clusterName
-				return pkg.MetricsExistInCluster("scrape_duration_seconds", m, adminKubeconfig)
+				return metricsTest.MetricsExist("scrape_duration_seconds", m)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find base_jvm_uptime_seconds metric")
 		})
 
@@ -246,7 +254,7 @@ var _ = t.Describe("In Multi-cluster, verify todo-list", Label("f:multicluster.m
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
 				m[clusterNameMetricsLabel] = "DNE"
-				return pkg.MetricsExistInCluster("scrape_duration_seconds", m, adminKubeconfig)
+				return metricsTest.MetricsExist("scrape_duration_seconds", m)
 			}, longWaitTimeout, longPollingInterval).Should(BeFalse(), "Not expected to find base_jvm_uptime_seconds metric")
 		})
 
@@ -256,7 +264,7 @@ var _ = t.Describe("In Multi-cluster, verify todo-list", Label("f:multicluster.m
 				m := make(map[string]string)
 				m["namespace"] = testNamespace
 				m[clusterNameMetricsLabel] = clusterName
-				return pkg.MetricsExistInCluster("container_cpu_cfs_periods_total", m, adminKubeconfig)
+				return metricsTest.MetricsExist("container_cpu_cfs_periods_total", m)
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find container_cpu_cfs_periods_total metric")
 		})
 	})

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package todo_list

--- a/tests/e2e/multicluster/multicluster_helper.go
+++ b/tests/e2e/multicluster/multicluster_helper.go
@@ -613,6 +613,14 @@ func (c *Cluster) GetPrometheusIngress() string {
 	return pkg.GetPrometheusIngressHost(c.KubeConfigPath)
 }
 
+func (c *Cluster) GetThanosIngress() string {
+	return pkg.GetThanosQueryIngressHost(c.KubeConfigPath)
+}
+
+func (c *Cluster) GetQueryIngress() string {
+	return pkg.GetQueryStoreIngressHost(c.KubeConfigPath)
+}
+
 func newCluster(name, kubeCfgPath string) *Cluster {
 	server := serverFromDockerInspect(name)
 	if server == "" {

--- a/tests/e2e/multicluster/verify-jaeger/system/jaeger_system_test.go
+++ b/tests/e2e/multicluster/verify-jaeger/system/jaeger_system_test.go
@@ -31,6 +31,7 @@ var t = framework.NewTestFramework("jaeger_mc_system_test")
 var (
 	adminKubeConfigPath = os.Getenv("ADMIN_KUBECONFIG")
 	clusterName         = os.Getenv("CLUSTER_NAME")
+	clusterNameLabel    string
 	metricsTest         pkg.MetricsTest
 	failed              = false
 )
@@ -43,7 +44,14 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	}
 
 	var err error
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeConfigPath}, adminKubeConfigPath, map[string]string{})
+	clusterNameLabel, err = pkg.GetClusterNameMetricLabel(adminKubeConfigPath)
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to get cluster label for metric collection: %v", err))
+	}
+
+	m := make(map[string]string)
+	m[clusterNameLabel] = getClusterName()
+	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeConfigPath}, adminKubeConfigPath, m)
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/multicluster/verify-jaeger/system/jaeger_system_test.go
+++ b/tests/e2e/multicluster/verify-jaeger/system/jaeger_system_test.go
@@ -42,14 +42,8 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 		AbortSuite("Required env variable ADMIN_KUBECONFIG not set.")
 	}
 
-	clusterNameMetricsLabel, err := pkg.GetClusterNameMetricLabel(adminKubeConfigPath)
-	if err != nil {
-		AbortSuite(fmt.Sprintf("Failed to get Cluster Name Metric Label: %v", err))
-	}
-	m := make(map[string]string)
-	m[clusterNameMetricsLabel] = clusterName
-
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeConfigPath}, adminKubeConfigPath, m)
+	var err error
+	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeConfigPath}, adminKubeConfigPath, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/multicluster/verify-jaeger/system/jaeger_system_test.go
+++ b/tests/e2e/multicluster/verify-jaeger/system/jaeger_system_test.go
@@ -29,11 +29,10 @@ var start time.Time
 var t = framework.NewTestFramework("jaeger_mc_system_test")
 
 var (
-	adminKubeConfigPath   = os.Getenv("ADMIN_KUBECONFIG")
-	managedKubeConfigPath = os.Getenv("MANAGED_KUBECONFIG")
-	clusterName           = os.Getenv("CLUSTER_NAME")
-	metricsTest           pkg.MetricsTest
-	failed                = false
+	adminKubeConfigPath = os.Getenv("ADMIN_KUBECONFIG")
+	clusterName         = os.Getenv("CLUSTER_NAME")
+	metricsTest         pkg.MetricsTest
+	failed              = false
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -41,9 +40,6 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	start = time.Now().Add(-3 * time.Hour)
 	if adminKubeConfigPath == "" {
 		AbortSuite("Required env variable ADMIN_KUBECONFIG not set.")
-	}
-	if managedKubeConfigPath == "" {
-		AbortSuite("Required env variable MANAGED_KUBECONFIG not set.")
 	}
 
 	clusterNameMetricsLabel, err := pkg.GetClusterNameMetricLabel(adminKubeConfigPath)
@@ -53,7 +49,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	m := make(map[string]string)
 	m[clusterNameMetricsLabel] = clusterName
 
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeConfigPath, managedKubeConfigPath}, adminKubeConfigPath, m)
+	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeConfigPath}, adminKubeConfigPath, m)
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -18,7 +18,6 @@ import (
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 	v1 "k8s.io/api/core/v1"
@@ -39,15 +38,23 @@ const multiclusterNamespace = "verrazzano-mc"
 const verrazzanoSystemNamespace = "verrazzano-system"
 
 var managedClusterName = os.Getenv("MANAGED_CLUSTER_NAME")
+var managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
 var vmiEsIngressURL = getVmiEsIngressURL()
 var adminKubeconfig = os.Getenv("ADMIN_KUBECONFIG")
 var externalEsURL = pkg.GetExternalOpenSearchURL(adminKubeconfig)
+var metricsTest pkg.MetricsTest
 
 var t = framework.NewTestFramework("register_test")
 
 var afterSuite = t.AfterSuiteFunc(func() {})
 var _ = AfterSuite(afterSuite)
-var beforeSuite = t.BeforeSuiteFunc(func() {})
+var beforeSuite = t.BeforeSuiteFunc(func() {
+	var err error
+	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeconfig, managedKubeconfig}, adminKubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
+})
 var _ = BeforeSuite(beforeSuite)
 var _ = t.AfterEach(func() {})
 
@@ -250,14 +257,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 			clusterNameMetricsLabel := getClusterNameMetricLabel(adminKubeconfig)
 			pkg.Log(pkg.Info, fmt.Sprintf("Looking for metric with label %s with value %s", clusterNameMetricsLabel, managedClusterName))
 			Eventually(func() (bool, error) {
-				vz, err := pkg.GetVerrazzano()
-				if err != nil {
-					return false, err
-				}
-				if vzcr.IsThanosEnabled(vz) {
-					return pkg.ThanosMetricsExist("up", clusterNameMetricsLabel, managedClusterName), nil
-				}
-				return pkg.MetricsExist("up", clusterNameMetricsLabel, managedClusterName), nil
+				return metricsTest.MetricsExist("up", map[string]string{clusterNameMetricsLabel: managedClusterName}), nil
 			}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find metrics from managed cluster")
 		})
 
@@ -289,7 +289,7 @@ var _ = t.Describe("Multi Cluster Verify Register", Label("f:multicluster.regist
 
 	t.Context("Managed Cluster", func() {
 		t.BeforeEach(func() {
-			os.Setenv(k8sutil.EnvVarTestKubeConfig, os.Getenv("MANAGED_KUBECONFIG"))
+			os.Setenv(k8sutil.EnvVarTestKubeConfig, managedKubeconfig)
 		})
 
 		t.It("has the expected secrets", func() {

--- a/tests/e2e/multicluster/workloads/mccoherence/coherence_workload_mc_test.go
+++ b/tests/e2e/multicluster/workloads/mccoherence/coherence_workload_mc_test.go
@@ -1,11 +1,10 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package mccoherence
 
 import (
 	"fmt"
-	dump "github.com/verrazzano/verrazzano/tests/e2e/pkg/test/clusterdump"
 	"net/http"
 	"os"
 	"strconv"
@@ -15,8 +14,10 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/tests/e2e/multicluster"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
+	dump "github.com/verrazzano/verrazzano/tests/e2e/pkg/test/clusterdump"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework/metrics"
 )
@@ -78,6 +79,7 @@ var (
 	clusterName       = os.Getenv("MANAGED_CLUSTER_NAME")
 	adminKubeconfig   = os.Getenv("ADMIN_KUBECONFIG")
 	managedKubeconfig = os.Getenv("MANAGED_KUBECONFIG")
+	metricsFunc       = pkg.MetricsExistInCluster
 	failed            = false
 	beforeSuitePassed = false
 )
@@ -111,6 +113,15 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 		}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 		metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 	}
+
+	vz, err := pkg.GetVerrazzanoInstallResourceInCluster(adminKubeconfig)
+	if err != nil {
+		AbortSuite("Failed to get the Verrazzano resource from the cluster")
+	}
+	if vzcr.IsThanosEnabled(vz) {
+		metricsFunc = pkg.ThanosMetricsExistInCluster
+	}
+
 	beforeSuitePassed = true
 })
 
@@ -315,7 +326,7 @@ var _ = t.Describe("In Multi-cluster, verify Coherence application", Label("f:mu
 							m := make(map[string]string)
 							m[labelApp] = appName
 							m[clusterNameMetricsLabel] = clusterName
-							return pkg.MetricsExistInCluster(jvmUptime, m, adminKubeconfig)
+							return metricsFunc(jvmUptime, m, adminKubeconfig)
 						}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 					},
 					func() {
@@ -324,7 +335,7 @@ var _ = t.Describe("In Multi-cluster, verify Coherence application", Label("f:mu
 							m := make(map[string]string)
 							m[labelApp] = appName
 							m[clusterNameMetricsLabel] = clusterName
-							return pkg.MetricsExistInCluster(vendorRequestsCount, m, adminKubeconfig)
+							return metricsFunc(vendorRequestsCount, m, adminKubeconfig)
 						}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 					},
 					func() {
@@ -333,7 +344,7 @@ var _ = t.Describe("In Multi-cluster, verify Coherence application", Label("f:mu
 							m := make(map[string]string)
 							m[labelNS] = appNamespace
 							m[clusterNameMetricsLabel] = clusterName
-							return pkg.MetricsExistInCluster(memUsageBytes, m, adminKubeconfig)
+							return metricsFunc(memUsageBytes, m, adminKubeconfig)
 						}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 					},
 					func() {
@@ -342,7 +353,7 @@ var _ = t.Describe("In Multi-cluster, verify Coherence application", Label("f:mu
 							m := make(map[string]string)
 							m[labelCluster] = cohClusterName
 							m[clusterNameMetricsLabel] = clusterName
-							return pkg.MetricsExistInCluster(clusterSize, m, adminKubeconfig)
+							return metricsFunc(clusterSize, m, adminKubeconfig)
 						}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find coherence metric")
 					},
 					func() {
@@ -351,7 +362,7 @@ var _ = t.Describe("In Multi-cluster, verify Coherence application", Label("f:mu
 							m := make(map[string]string)
 							m[labelCluster] = cohClusterName
 							m[clusterNameMetricsLabel] = clusterName
-							return pkg.MetricsExistInCluster(serviceMessagesLocal, m, adminKubeconfig)
+							return metricsFunc(serviceMessagesLocal, m, adminKubeconfig)
 						}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find coherence metric")
 					},
 				)

--- a/tests/e2e/pkg/jaeger.go
+++ b/tests/e2e/pkg/jaeger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pkg
@@ -199,8 +199,8 @@ func GetJaegerSpanIndexName(kubeconfigPath string) (string, error) {
 }
 
 // IsJaegerMetricFound validates if the given jaeger metrics contain the labels with values specified as key-value pairs of the map
-func IsJaegerMetricFound(kubeconfigPath, metricName, clusterName string, kv map[string]string) bool {
-	compMetrics, err := QueryMetricWithLabel(metricName, kubeconfigPath, jaegerClusterNameLabel, clusterName)
+func IsJaegerMetricFound(kubeconfigPath, metricName, clusterName string, kv map[string]string, queryFunc func(string, string) (string, error)) bool {
+	compMetrics, err := QueryMetricWithLabelByHost(metricName, kubeconfigPath, jaegerClusterNameLabel, clusterName, queryFunc, GetPrometheusIngressHost(kubeconfigPath))
 	if err != nil {
 		return false
 	}
@@ -372,46 +372,46 @@ func GetJaegerSystemServicesInAdminCluster() []string {
 }
 
 // ValidateJaegerOperatorMetricFunc returns a function that validates if metrics of Jaeger operator is scraped by prometheus.
-func ValidateJaegerOperatorMetricFunc() func() bool {
+func ValidateJaegerOperatorMetricFunc(queryFunc func(string, string) (string, error)) func() bool {
 	return func() bool {
 		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 		if err != nil {
 			return false
 		}
-		return IsJaegerMetricFound(kubeconfigPath, jaegerOperatorSampleMetric, adminClusterName, nil)
+		return IsJaegerMetricFound(kubeconfigPath, jaegerOperatorSampleMetric, adminClusterName, nil, queryFunc)
 	}
 }
 
 // ValidateJaegerCollectorMetricFunc returns a function that validates if metrics of Jaeger collector is scraped by prometheus.
-func ValidateJaegerCollectorMetricFunc() func() bool {
+func ValidateJaegerCollectorMetricFunc(queryFunc func(string, string) (string, error)) func() bool {
 	return func() bool {
 		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 		if err != nil {
 			return false
 		}
-		return IsJaegerMetricFound(kubeconfigPath, jaegerCollectorSampleMetric, adminClusterName, nil)
+		return IsJaegerMetricFound(kubeconfigPath, jaegerCollectorSampleMetric, adminClusterName, nil, queryFunc)
 	}
 }
 
 // ValidateJaegerQueryMetricFunc returns a function that validates if metrics of Jaeger query is scraped by prometheus.
-func ValidateJaegerQueryMetricFunc() func() bool {
+func ValidateJaegerQueryMetricFunc(queryFunc func(string, string) (string, error)) func() bool {
 	return func() bool {
 		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 		if err != nil {
 			return false
 		}
-		return IsJaegerMetricFound(kubeconfigPath, jaegerQuerySampleMetric, adminClusterName, nil)
+		return IsJaegerMetricFound(kubeconfigPath, jaegerQuerySampleMetric, adminClusterName, nil, queryFunc)
 	}
 }
 
 // ValidateJaegerAgentMetricFunc returns a function that validates if metrics of Jaeger agent is scraped by prometheus.
-func ValidateJaegerAgentMetricFunc() func() bool {
+func ValidateJaegerAgentMetricFunc(queryFunc func(string, string) (string, error)) func() bool {
 	return func() bool {
 		kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
 		if err != nil {
 			return false
 		}
-		return IsJaegerMetricFound(kubeconfigPath, jaegerAgentSampleMetric, adminClusterName, nil)
+		return IsJaegerMetricFound(kubeconfigPath, jaegerAgentSampleMetric, adminClusterName, nil, queryFunc)
 	}
 }
 

--- a/tests/e2e/pkg/metric_source.go
+++ b/tests/e2e/pkg/metric_source.go
@@ -90,7 +90,7 @@ func (m metricSourceBase) getTargetsByHostAndPath(host, path string, jsonPath []
 	if err != nil {
 		return nil, err
 	}
-	resp, err := GetWebPageWithBasicAuth(metricsURL, "", "verrazzano", password, host)
+	resp, err := GetWebPageWithBasicAuth(metricsURL, "", "verrazzano", password, m.kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/pkg/metric_source.go
+++ b/tests/e2e/pkg/metric_source.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package pkg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// MetricSource implements an interface to interact with metrics sources
+type MetricSource interface {
+	GetHost() string
+	GetTargets() ([]interface{}, error)
+	getKubeConfigPath() string
+}
+
+// metricSourceBase implements shared functions between metric sources
+type metricSourceBase struct {
+	client         *kubernetes.Clientset
+	kubeconfigPath string
+}
+
+// ThanosSource provides a struct to interact with the Thanos metric source
+type ThanosSource struct {
+	metricSourceBase
+}
+
+// PrometheusSource provides a struct to interact with Prometheus metric source
+type PrometheusSource struct {
+	metricSourceBase
+}
+
+var _ MetricSource = ThanosSource{}
+var _ MetricSource = PrometheusSource{}
+
+func newMetricsSourceBase(kubeconfigPath string) (metricSourceBase, error) {
+	cli, err := GetKubernetesClientsetForCluster(kubeconfigPath)
+	return metricSourceBase{
+		kubeconfigPath: kubeconfigPath,
+		client:         cli,
+	}, err
+}
+
+func NewThanosSource(kubeconfigPath string) (ThanosSource, error) {
+	msb, err := newMetricsSourceBase(kubeconfigPath)
+	return ThanosSource{metricSourceBase: msb}, err
+}
+
+func NewPrometheusSource(kubeconfigPath string) (PrometheusSource, error) {
+	msb, err := newMetricsSourceBase(kubeconfigPath)
+	return PrometheusSource{metricSourceBase: msb}, err
+}
+
+func (m metricSourceBase) getKubeConfigPath() string {
+	return m.kubeconfigPath
+}
+
+// getHostByName returns the hostname given the ingress name
+func (m metricSourceBase) getHostByIngressName(name string) string {
+	ingress, err := m.client.NetworkingV1().Ingresses(constants.VerrazzanoSystemNamespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed get Thanos Frontend Ingress %s from the cluster: %v", constants.ThanosQueryIngress, err))
+		return ""
+	}
+	return ingress.Spec.Rules[0].Host
+}
+
+// GetHost returns the host for the Thanos ingress
+func (t ThanosSource) GetHost() string {
+	return t.metricSourceBase.getHostByIngressName(constants.ThanosQueryIngress)
+}
+
+// GetHost returns the host for the Prometheus ingress
+func (p PrometheusSource) GetHost() string {
+	return p.metricSourceBase.getHostByIngressName(vzconst.PrometheusIngress)
+}
+
+// getTargetsByHostAndPath returns an unstructred target interface given the host and the path
+func (m metricSourceBase) getTargetsByHostAndPath(host, path string, jsonPath []string) ([]interface{}, error) {
+	metricsURL := fmt.Sprintf("https://%s%s", host, path)
+	password, err := GetVerrazzanoPasswordInCluster(m.kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := GetWebPageWithBasicAuth(metricsURL, "", "verrazzano", password, host)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error retrieving targets %d", resp.StatusCode)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(resp.Body, &result)
+	if err != nil {
+		return nil, err
+	}
+	queryStores, ok := Jq(result, jsonPath...).([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("error finding query store in the Thanos store list")
+	}
+	return queryStores, nil
+}
+
+// GetTargets returns the Thanos store targets
+func (t ThanosSource) GetTargets() ([]interface{}, error) {
+	return t.metricSourceBase.getTargetsByHostAndPath(t.GetHost(), "/api/v1/stores", []string{"data", "query"})
+}
+
+// GetTargets returns the Prometheus targets
+func (p PrometheusSource) GetTargets() ([]interface{}, error) {
+	return p.metricSourceBase.getTargetsByHostAndPath(p.GetHost(), "/api/v1/targets", []string{"data", "activeTargets"})
+}

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -80,7 +80,7 @@ func (m MetricsTest) MetricsExist(metricName string, labels map[string]string) b
 		return false
 	}
 
-	metricList, ok := Jq(result, "data", "result").([]interface{})
+	metricList, ok := JTq(result, "data", "result").([]interface{})
 	if !ok {
 		Log(Error, "error extracting metric result, format is not a list type")
 	}

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -7,15 +7,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+
 	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 type MetricsTest struct {

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -75,11 +75,16 @@ func (m MetricsTest) QueryMetric(metricName string, labels map[string]string) (s
 }
 
 func (m MetricsTest) MetricsExist(metricName string, labels map[string]string) bool {
-	metric, err := m.QueryMetric(metricName, labels)
+	result, err := m.QueryMetric(metricName, labels)
 	if err != nil {
 		return false
 	}
-	return metric != ""
+
+	metricList, ok := Jq(result, "data", "result").([]interface{})
+	if !ok {
+		Log(Error, "error extracting metric result, format is not a list type")
+	}
+	return ok && len(metricList) > 0
 }
 
 func (m MetricsTest) appendLabels(query string, labels map[string]string) string {

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -7,18 +7,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"strings"
-	"time"
-
 	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	vaoClient "github.com/verrazzano/verrazzano/application-operator/clientset/versioned"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 )
 
 type MetricsTest struct {
@@ -100,114 +97,22 @@ func (m MetricsTest) appendLabels(query string, labels map[string]string) string
 	return fmt.Sprintf("%s{%s}", query, strings.Join(labelStrings, ","))
 }
 
-// QueryMetricWithLabelByHost queries a metric using a label from the given query function, derived from the kubeconfig
-func QueryMetricWithLabelByHost(metricsName string, kubeconfigPath string, label string, labelValue string, queryFunc func(string, string) (string, error), host string) (string, error) {
-	if len(labelValue) == 0 {
-		return queryFunc(metricsName, kubeconfigPath)
-	}
-	metricsURL := fmt.Sprintf("https://%s/api/v1/query?query=%s{%s=\"%s\"}", host, metricsName,
-		label, labelValue)
-
-	password, err := GetVerrazzanoPasswordInCluster(kubeconfigPath)
-	if err != nil {
-		return "", err
-	}
-	resp, err := GetWebPageWithBasicAuth(metricsURL, "", "verrazzano", password, kubeconfigPath)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("error retrieving metric %s, status %d", metricsName, resp.StatusCode)
-	}
-	Log(Info, fmt.Sprintf("metric: %s", resp.Body))
-	return string(resp.Body), nil
-}
-
-// QueryMetricRange queries a metric from the Prometheus host over a specified range, derived from the kubeconfig
-//
-// Parameters:
-// - metricsName The name of the metric being queried
-// - start The start time for the range
-// - end The end time for the range
-// - stepDuration Query resolution step width
-func QueryMetricRange(metricsName string, start *time.Time, end *time.Time, stepSeconds int64, kubeconfigPath string) (string, error) {
-	start.Unix()
-	metricsURL := fmt.Sprintf("https://%s/api/v1/query_range?query=%s&start=%v&end=%v&step=%v", GetPrometheusIngressHost(kubeconfigPath), metricsName,
-		start.Unix(), end.Unix(), stepSeconds)
-	password, err := GetVerrazzanoPasswordInCluster(kubeconfigPath)
-	if err != nil {
-		return "", err
-	}
-	resp, err := GetWebPageWithBasicAuth(metricsURL, "", "verrazzano", password, kubeconfigPath)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("error retrieving metric %s, status %d", metricsName, resp.StatusCode)
-	}
-	Log(Info, fmt.Sprintf("metric: %s", resp.Body))
-	return string(resp.Body), nil
-}
-
-// QueryMetric queries a metric from the Prometheus host, derived from the kubeconfig
-func QueryMetric(metricsName string, kubeconfigPath string) (string, error) {
-	return QueryMetricByHost(metricsName, kubeconfigPath, GetPrometheusIngressHost(kubeconfigPath))
-}
-
-// QueryThanosMetric queries a metric from the Thanos host, derived from the kubeconfig
-func QueryThanosMetric(metricsName string, kubeconfigPath string) (string, error) {
-	return QueryMetricByHost(metricsName, kubeconfigPath, GetThanosQueryIngressHost(kubeconfigPath))
-}
-
-func QueryMetricByHost(metricsName, kubeconfigPath, host string) (string, error) {
-	metricsURL := fmt.Sprintf("https://%s/api/v1/query?query=%s", host, metricsName)
-	password, err := GetVerrazzanoPasswordInCluster(kubeconfigPath)
-	if err != nil {
-		return "", err
-	}
-	resp, err := GetWebPageWithBasicAuth(metricsURL, "", "verrazzano", password, kubeconfigPath)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("error retrieving metric %s, status %d", metricsName, resp.StatusCode)
-	}
-	Log(Info, fmt.Sprintf("metric: %s", resp.Body))
-	return string(resp.Body), nil
-}
-
 // GetPrometheusIngressHost gets the host used for ingress to the system Prometheus in the given cluster
 func GetPrometheusIngressHost(kubeconfigPath string) string {
-	clientset, err := GetKubernetesClientsetForCluster(kubeconfigPath)
+	source, err := NewPrometheusSource(kubeconfigPath)
 	if err != nil {
-		Log(Error, fmt.Sprintf("Failed to get clientset for cluster %v", err))
 		return ""
 	}
-	ingressList, _ := clientset.NetworkingV1().Ingresses("verrazzano-system").List(context.TODO(), metav1.ListOptions{})
-	for _, ingress := range ingressList.Items {
-		if ingress.Name == "vmi-system-prometheus" {
-			Log(Info, fmt.Sprintf("Found Ingress %v", ingress.Name))
-			return ingress.Spec.Rules[0].Host
-		}
-	}
-	return ""
+	return source.GetHost()
 }
 
 // GetThanosQueryIngressHost gets the host used for ingress to Thanos Query in the given cluster
 func GetThanosQueryIngressHost(kubeconfigPath string) string {
-	clientset, err := GetKubernetesClientsetForCluster(kubeconfigPath)
+	source, err := NewThanosSource(kubeconfigPath)
 	if err != nil {
-		Log(Error, fmt.Sprintf("Failed to get clientset for cluster %v", err))
 		return ""
 	}
-	ingressList, _ := clientset.NetworkingV1().Ingresses("verrazzano-system").List(context.TODO(), metav1.ListOptions{})
-	for _, ingress := range ingressList.Items {
-		if ingress.Name == "thanos-query-frontend" {
-			Log(Info, fmt.Sprintf("Found Ingress %v", ingress.Name))
-			return ingress.Spec.Rules[0].Host
-		}
-	}
-	return ""
+	return source.GetHost()
 }
 
 // GetQueryStoreIngressHost gets the host used for ingress to Thanos Query Store in the given cluster
@@ -222,32 +127,6 @@ func GetQueryStoreIngressHost(kubeconfigPath string) string {
 		Log(Error, fmt.Sprintf("Failed to get Ingress thanos-grpc from the cluster: %v", err))
 	}
 	return ingress.Spec.Rules[0].Host
-}
-
-// MetricsExistInCluster validates the availability of a given metric in the given cluster
-func MetricsExistInCluster(metricsName string, keyMap map[string]string, kubeconfigPath string) bool {
-	metric, err := QueryMetric(metricsName, kubeconfigPath)
-	if err != nil {
-		return false
-	}
-	metrics := JTq(metric, "data", "result").([]interface{})
-	if metrics != nil {
-		return FindMetric(metrics, keyMap)
-	}
-	return false
-}
-
-// ThanosMetricsExistInCluster validates the availability of a given metric in the given cluster in Thanos
-func ThanosMetricsExistInCluster(metricsName string, keyMap map[string]string, kubeconfigPath string) bool {
-	metric, err := QueryThanosMetric(metricsName, kubeconfigPath)
-	if err != nil {
-		return false
-	}
-	metrics := JTq(metric, "data", "result").([]interface{})
-	if metrics != nil {
-		return FindMetric(metrics, keyMap)
-	}
-	return false
 }
 
 // GetClusterNameMetricLabel returns the label name used for labeling metrics with the Verrazzano cluster
@@ -271,74 +150,6 @@ func JTq(jtext string, path ...string) interface{} {
 	var j map[string]interface{}
 	json.Unmarshal([]byte(jtext), &j)
 	return Jq(j, path...)
-}
-
-// FindMetric parses a Prometheus response to find a specified set of metric values
-func FindMetric(metrics []interface{}, keyMap map[string]string) bool {
-	for _, metric := range metrics {
-
-		// allExist only remains true if all metrics are found in a given JSON response
-		allExist := true
-
-		for key, value := range keyMap {
-			exists := false
-			if Jq(metric, "metric", key) == value {
-				// exists is true if the specific key-value pair is found in a given JSON response
-				exists = true
-			}
-			allExist = exists && allExist
-		}
-		if allExist {
-			return true
-		}
-	}
-	// if metric is not found, list unhealthy scrape targets if any for debugging
-	ListUnhealthyScrapeTargets()
-	return false
-}
-
-// MetricsExist is identical to MetricsExistInCluster, except that it uses the cluster specified in the environment
-func MetricsExist(metricsName, key, value string) bool {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting kubeconfig, error: %v", err))
-		return false
-	}
-
-	// map with single key-value pair
-	m := make(map[string]string)
-	m[key] = value
-
-	return MetricsExistInCluster(metricsName, m, kubeconfigPath)
-}
-
-// ThanosMetricsExist is identical to ThanosMetricsExistInCluster, except that it uses the cluster specified in the environment
-func ThanosMetricsExist(metricsName, key, value string) bool {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting kubeconfig, error: %v", err))
-		return false
-	}
-
-	// map with single key-value pair
-	m := make(map[string]string)
-	m[key] = value
-
-	return ThanosMetricsExistInCluster(metricsName, m, kubeconfigPath)
-}
-
-// ListUnhealthyScrapeTargets lists all the scrape targets that are unhealthy
-func ListUnhealthyScrapeTargets() {
-	targets, err := ScrapeTargets()
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting scrape targets: %v", err))
-		return
-	}
-	for _, target := range targets {
-		if Jq(target, "health") != "up" {
-			Log(Info, fmt.Sprintf("target: %s is not ready", Jq(target, "scrapeUrl")))
-		}
-	}
 }
 
 // ScrapeTargets queries Prometheus API /api/v1/targets to list scrape targets
@@ -368,39 +179,6 @@ func ScrapeTargets() ([]interface{}, error) {
 	return activeTargets, nil
 }
 
-// ThanosQueryStores queries Thanos API /api/v1/stores to list query stores
-func ThanosQueryStores() ([]interface{}, error) {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting kubeconfig, error: %v", err))
-		return nil, err
-	}
-
-	metricsURL := fmt.Sprintf("https://%s/api/v1/stores", GetThanosQueryIngressHost(kubeconfigPath))
-	password, err := GetVerrazzanoPasswordInCluster(kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := GetWebPageWithBasicAuth(metricsURL, "", "verrazzano", password, kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("error retrieving targets %d", resp.StatusCode)
-	}
-
-	var result map[string]interface{}
-	err = json.Unmarshal(resp.Body, &result)
-	if err != nil {
-		return nil, err
-	}
-	queryStores, ok := Jq(result, "data", "query").([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("error finding query store in the Thanos store list")
-	}
-	return queryStores, nil
-}
-
 // Jq queries JSON nodes with a JSON path
 func Jq(node interface{}, path ...string) interface{} {
 	for _, p := range path {
@@ -415,39 +193,6 @@ func Jq(node interface{}, path ...string) interface{} {
 		}
 	}
 	return node
-}
-
-// DoesMetricsTemplateExist takes a metrics template name and checks if it exists
-func DoesMetricsTemplateExist(namespacedName types.NamespacedName) bool {
-	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting kubeconfig, error: %v", err))
-		return false
-	}
-	config, err := k8sutil.GetKubeConfigGivenPath(kubeconfigPath)
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error getting config from kubeconfig, error: %v", err))
-		return false
-	}
-	client, err := vaoClient.NewForConfig(config)
-	if err != nil {
-		Log(Error, fmt.Sprintf("Error creating client from config, error: %v", err))
-		return false
-	}
-
-	metricsTemplateClient := client.AppV1alpha1().MetricsTemplates(namespacedName.Namespace)
-	metricsTemplates, err := metricsTemplateClient.List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		Log(Error, fmt.Sprintf("Could not list metrics templates, error: %v", err))
-		return false
-	}
-
-	for _, template := range metricsTemplates.Items {
-		if template.Name == namespacedName.Name {
-			return true
-		}
-	}
-	return false
 }
 
 // getPromOperatorClient returns a client for fetching ServiceMonitor resources

--- a/tests/e2e/update/certmc/certmc_test.go
+++ b/tests/e2e/update/certmc/certmc_test.go
@@ -140,7 +140,7 @@ func verifyCaSync() {
 func verifyThanosStore() {
 	for _, managedCluster := range managedClusters {
 		gomega.Eventually(func() (bool, error) {
-			metricsTest, err := pkg.NewMetricsTest([]string{managedCluster.KubeConfigPath}, managedCluster.KubeConfigPath, map[string]string{})
+			metricsTest, err := pkg.NewMetricsTest([]string{adminCluster.KubeConfigPath, managedCluster.KubeConfigPath}, adminCluster.KubeConfigPath, map[string]string{})
 			if err != nil {
 				return false, err
 			}

--- a/tests/e2e/update/certmc/certmc_test.go
+++ b/tests/e2e/update/certmc/certmc_test.go
@@ -140,10 +140,16 @@ func verifyCaSync() {
 func verifyThanosStore() {
 	for _, managedCluster := range managedClusters {
 		gomega.Eventually(func() (bool, error) {
-			queryStores, err := pkg.ThanosQueryStores()
+			metricsTest, err := pkg.NewMetricsTest([]string{managedCluster.KubeConfigPath}, managedCluster.KubeConfigPath, map[string]string{})
 			if err != nil {
 				return false, err
 			}
+
+			queryStores, err := metricsTest.Source.GetTargets()
+			if err != nil {
+				return false, err
+			}
+
 			expectedName := fmt.Sprintf("%s:443", managedCluster.GetQueryIngress())
 			for _, store := range queryStores {
 				storeMap, ok := store.(map[string]interface{})

--- a/tests/e2e/update/certmc/certmc_test.go
+++ b/tests/e2e/update/certmc/certmc_test.go
@@ -40,13 +40,13 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	adminCluster = multicluster.AdminCluster()
 	managedClusters = multicluster.ManagedClusters()
 	verifyRegistration()
-	verifyScrapeTargets()
+	verifyThanosStore()
 })
 
 var _ = BeforeSuite(beforeSuite)
 
 var afterSuite = t.AfterSuiteFunc(func() {
-	verifyScrapeTargets()
+	verifyThanosStore()
 })
 
 var _ = AfterSuite(afterSuite)
@@ -56,7 +56,7 @@ var _ = t.Describe("Update managed-cluster cert-manager", Label("f:platform-lcm.
 		t.It("managed-cluster cert-manager custom CA", func() {
 			updateCustomCA()
 			verifyCaSync()
-			verifyScrapeTargets()
+			verifyThanosStore()
 		})
 	})
 	t.Describe("multicluster cert-manager verify", Label("f:platform-lcm.multicluster-verify"), func() {
@@ -137,29 +137,39 @@ func verifyCaSync() {
 	}
 }
 
-func verifyScrapeTargets() {
+func verifyThanosStore() {
 	for _, managedCluster := range managedClusters {
-		start := time.Now()
-		gomega.Eventually(func() bool {
-			targets, err := pkg.ScrapeTargets()
+		gomega.Eventually(func() (bool, error) {
+			queryStores, err := pkg.ThanosQueryStores()
 			if err != nil {
-				return false
+				return false, err
 			}
-			var target map[string]interface{}
-			for _, item := range targets {
-				t := item.(map[string]interface{})
-				scrapePool := t["scrapePool"].(string)
-				if scrapePool == managedCluster.Name {
-					target = t
+			expectedName := fmt.Sprintf("%s:443", managedCluster.GetQueryIngress())
+			for _, store := range queryStores {
+				storeMap, ok := store.(map[string]interface{})
+				if !ok {
+					t.Logs.Infof("Thanos store empty, skipping entry")
+					continue
+				}
+				name, ok := storeMap["name"]
+				if !ok {
+					t.Logs.Infof("Name not found for store, skipping entry")
+					continue
+				}
+				nameString, nameOk := name.(string)
+				if !nameOk {
+					t.Logs.Infof("Name not valid format, skipping entry")
+					continue
+				}
+				if ok {
+					t.Logs.Infof("Found store in Thanos %s, want is equal to %s", nameString, expectedName)
+				}
+				if ok && nameString == expectedName {
+					return true, nil
 				}
 			}
-			health, ok := target["health"]
-			if ok {
-				pkg.Log(pkg.Error, fmt.Sprintf("ScrapeTargets:%v health:%v ok:%v time:%v \n", len(target), health, ok, time.Since(start)))
-				return health.(string) == "up"
-			}
-			return false
-		}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("scrape target of %s is not ready", managedCluster.Name))
+			return false, nil
+		}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("store of %s is not ready", managedCluster.Name))
 	}
 }
 

--- a/tests/e2e/update/certmc/certmc_test.go
+++ b/tests/e2e/update/certmc/certmc_test.go
@@ -142,11 +142,13 @@ func verifyThanosStore() {
 		gomega.Eventually(func() (bool, error) {
 			metricsTest, err := pkg.NewMetricsTest([]string{adminCluster.KubeConfigPath, managedCluster.KubeConfigPath}, adminCluster.KubeConfigPath, map[string]string{})
 			if err != nil {
+				t.Logs.Errorf("Failed to create metrics test object for cluster: %v", err)
 				return false, err
 			}
 
 			queryStores, err := metricsTest.Source.GetTargets()
 			if err != nil {
+				t.Logs.Errorf("Failed to create get metrics target source: %v", err)
 				return false, err
 			}
 

--- a/tests/e2e/update/dnsmc/dnsmc_test.go
+++ b/tests/e2e/update/dnsmc/dnsmc_test.go
@@ -103,7 +103,7 @@ func verifyThanosIngress() {
 func verifyThanosStore() {
 	for _, managedCluster := range managedClusters {
 		gomega.Eventually(func() (bool, error) {
-			metricsTest, err := pkg.NewMetricsTest([]string{managedCluster.KubeConfigPath}, managedCluster.KubeConfigPath, map[string]string{})
+			metricsTest, err := pkg.NewMetricsTest([]string{adminCluster.KubeConfigPath, managedCluster.KubeConfigPath}, adminCluster.KubeConfigPath, map[string]string{})
 			if err != nil {
 				return false, err
 			}

--- a/tests/e2e/update/dnsmc/dnsmc_test.go
+++ b/tests/e2e/update/dnsmc/dnsmc_test.go
@@ -103,10 +103,16 @@ func verifyThanosIngress() {
 func verifyThanosStore() {
 	for _, managedCluster := range managedClusters {
 		gomega.Eventually(func() (bool, error) {
-			queryStores, err := pkg.ThanosQueryStores()
+			metricsTest, err := pkg.NewMetricsTest([]string{managedCluster.KubeConfigPath}, managedCluster.KubeConfigPath, map[string]string{})
 			if err != nil {
 				return false, err
 			}
+
+			queryStores, err := metricsTest.Source.GetTargets()
+			if err != nil {
+				return false, err
+			}
+
 			expectedName := fmt.Sprintf("%s:443", managedCluster.GetQueryIngress())
 			for _, store := range queryStores {
 				storeMap, ok := store.(map[string]interface{})

--- a/tests/e2e/update/dnsmc/dnsmc_test.go
+++ b/tests/e2e/update/dnsmc/dnsmc_test.go
@@ -105,11 +105,13 @@ func verifyThanosStore() {
 		gomega.Eventually(func() (bool, error) {
 			metricsTest, err := pkg.NewMetricsTest([]string{adminCluster.KubeConfigPath, managedCluster.KubeConfigPath}, adminCluster.KubeConfigPath, map[string]string{})
 			if err != nil {
+				t.Logs.Errorf("Failed to create metrics test object for cluster: %v", err)
 				return false, err
 			}
 
 			queryStores, err := metricsTest.Source.GetTargets()
 			if err != nil {
+				t.Logs.Errorf("Failed to create get metrics target source: %v", err)
 				return false, err
 			}
 

--- a/tests/e2e/update/dnsmc/dnsmc_test.go
+++ b/tests/e2e/update/dnsmc/dnsmc_test.go
@@ -1,11 +1,10 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package dnsmc
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -46,19 +45,22 @@ var _ = t.Describe("Update managed-cluster dns", Serial, Ordered, Label("f:platf
 		t.It("managed-cluster dns wildcard sslip.io config", func() {
 			updateManagedClusterDNS()
 			verifyPrometheusIngress()
-			verifyScrapeTargets()
+			verifyThanosIngress()
+			verifyThanosStore()
 		})
 	})
 	t.Describe("multicluster dns verify", Label("f:platform-lcm.multicluster-verify"), func() {
 		t.It("managed-cluster dns default nip.io config", func() {
 			updateManagedClusterDNS()
 			verifyPrometheusIngress()
-			verifyScrapeTargets()
+			verifyThanosIngress()
+			verifyThanosStore()
 		})
 	})
 })
 
 var oldPromIngs = map[string]string{}
+var oldThanosIngs = map[string]string{}
 
 // updateManagedClusterDNS switch dns config to sslip.io or nip.io
 func updateManagedClusterDNS() {
@@ -69,6 +71,7 @@ func updateManagedClusterDNS() {
 			newDNS = &vzapi.DNSComponent{Wildcard: &vzapi.Wildcard{Domain: pkg.SslipDomain}}
 		}
 		oldPromIngs[managedCluster.Name] = managedCluster.GetPrometheusIngress()
+		oldThanosIngs[managedCluster.Name] = managedCluster.GetThanosIngress()
 		m := &DNSModifier{DNS: newDNS}
 		update.RetryUpdate(m, managedCluster.KubeConfigPath, false, pollingInterval, waitTimeout)
 	}
@@ -85,41 +88,52 @@ func verifyPrometheusIngress() {
 	}
 }
 
-func verifyScrapeTargets() {
+func verifyThanosIngress() {
 	start := time.Now()
 	for _, managedCluster := range managedClusters {
+		oldThanosIng := oldThanosIngs[managedCluster.Name]
 		gomega.Eventually(func() bool {
-			managedClusterPromIng := managedCluster.GetPrometheusIngress()
-			target := findScrapeTarget(managedCluster.Name)
-			pkg.Log(pkg.Info, fmt.Sprintf("Cluster %v ScrapeTarget updated to %v %v %v for %v", managedCluster.Name, managedClusterPromIng, target["scrapeUrl"], target["health"], time.Since(start)))
-			scrape, ok := target["scrapeUrl"]
-			if ok && !strings.Contains(scrape.(string), managedClusterPromIng) {
-				pkg.Log(pkg.Error, fmt.Sprintf("ScrapeTargets:%v scrapeUrl:%v expecting:%v time:%v \n", len(target), scrape, managedClusterPromIng, time.Since(start)))
-				return false
-			}
-			health, ok := target["health"]
-			if ok {
-				pkg.Log(pkg.Error, fmt.Sprintf("ScrapeTargets:%v health:%v ok:%v time:%v \n", len(target), health, ok, time.Since(start)))
-				return health.(string) == "up"
-			}
-			return false
-		}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("scrape target of %s is not ready", managedCluster.Name))
+			newThanosIng := managedCluster.GetThanosIngress()
+			pkg.Log(pkg.Info, fmt.Sprintf("Cluster %v ThanosIngress updated %v from %v to %v for %v", managedCluster.Name, newThanosIng != oldThanosIng, oldThanosIng, newThanosIng, time.Since(start)))
+			return newThanosIng != oldThanosIng
+		}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("%s of %s is not updated for %v", oldThanosIng, managedCluster.Name, time.Since(start)))
 	}
 }
 
-func findScrapeTarget(name string) map[string]interface{} {
-	targets, err := pkg.ScrapeTargets()
-	if err != nil {
-		return map[string]interface{}{}
+func verifyThanosStore() {
+	for _, managedCluster := range managedClusters {
+		gomega.Eventually(func() (bool, error) {
+			queryStores, err := pkg.ThanosQueryStores()
+			if err != nil {
+				return false, err
+			}
+			expectedName := fmt.Sprintf("%s:443", managedCluster.GetQueryIngress())
+			for _, store := range queryStores {
+				storeMap, ok := store.(map[string]interface{})
+				if !ok {
+					t.Logs.Infof("Thanos store empty, skipping entry")
+					continue
+				}
+				name, ok := storeMap["name"]
+				if !ok {
+					t.Logs.Infof("Name not found for store, skipping entry")
+					continue
+				}
+				nameString, nameOk := name.(string)
+				if !nameOk {
+					t.Logs.Infof("Name not valid format, skipping entry")
+					continue
+				}
+				if ok {
+					t.Logs.Infof("Found store in Thanos %s, want is equal to %s", nameString, expectedName)
+				}
+				if ok && nameString == expectedName {
+					return true, nil
+				}
+			}
+			return false, nil
+		}, waitTimeout, pollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("store of %s is not ready", managedCluster.Name))
 	}
-	for _, item := range targets {
-		t := item.(map[string]interface{})
-		scrapePool := t["scrapePool"].(string)
-		if scrapePool == name {
-			return t
-		}
-	}
-	return map[string]interface{}{}
 }
 
 func verifyRegistration() {

--- a/tests/e2e/update/jaeger/jaeger_update_test.go
+++ b/tests/e2e/update/jaeger/jaeger_update_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package jaeger
@@ -79,7 +79,7 @@ var _ = t.Describe("Update Jaeger", Label("f:platform-lcm.update"), func() {
 	// WHEN Jaeger operator is enabled,
 	// THEN we see that the metrics of Jaeger operator are present in prometheus
 	whenJaegerOperatorEnabledIt("metrics of jaeger operator are available in prometheus", func() {
-		validatorFn := pkg.ValidateJaegerOperatorMetricFunc()
+		validatorFn := pkg.ValidateJaegerOperatorMetricFunc(pkg.QueryMetric)
 		Eventually(validatorFn).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
 	})
 
@@ -87,7 +87,7 @@ var _ = t.Describe("Update Jaeger", Label("f:platform-lcm.update"), func() {
 	// WHEN Jaeger operator is enabled,
 	// THEN we see that the metrics of Jaeger collector are present in prometheus
 	whenJaegerOperatorEnabledIt("metrics of jaeger collector are available in prometheus", func() {
-		validatorFn := pkg.ValidateJaegerCollectorMetricFunc()
+		validatorFn := pkg.ValidateJaegerCollectorMetricFunc(pkg.QueryMetric)
 		Eventually(validatorFn).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
 	})
 
@@ -95,7 +95,7 @@ var _ = t.Describe("Update Jaeger", Label("f:platform-lcm.update"), func() {
 	// WHEN Jaeger operator is enabled,
 	// THEN we see that the metrics of Jaeger query are present in prometheus
 	whenJaegerOperatorEnabledIt("metrics of jaeger query are available in prometheus", func() {
-		validatorFn := pkg.ValidateJaegerQueryMetricFunc()
+		validatorFn := pkg.ValidateJaegerQueryMetricFunc(pkg.QueryMetric)
 		Eventually(validatorFn).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
 	})
 
@@ -103,7 +103,7 @@ var _ = t.Describe("Update Jaeger", Label("f:platform-lcm.update"), func() {
 	// WHEN Jaeger operator is enabled,
 	// THEN we see that the metrics of Jaeger agent are present in prometheus
 	whenJaegerOperatorEnabledIt("metrics of jaeger agent are available in prometheus", func() {
-		validatorFn := pkg.ValidateJaegerAgentMetricFunc()
+		validatorFn := pkg.ValidateJaegerAgentMetricFunc(pkg.QueryMetric)
 		Eventually(validatorFn).WithPolling(shortPollingInterval).WithTimeout(shortWaitTimeout).Should(BeTrue())
 	})
 

--- a/tests/e2e/update/jaeger/jaeger_update_test.go
+++ b/tests/e2e/update/jaeger/jaeger_update_test.go
@@ -47,6 +47,9 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 
 	var err error
 	kubeconfigPath, err = k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to find Kubeconfig location: %v", err))
+	}
 	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))

--- a/tests/e2e/workloads/coherence/coherence_workload_test.go
+++ b/tests/e2e/workloads/coherence/coherence_workload_test.go
@@ -108,6 +108,9 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	}
 
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to find Kubeconfig location: %v", err))
+	}
 	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))

--- a/tests/e2e/workloads/coherence/coherence_workload_test.go
+++ b/tests/e2e/workloads/coherence/coherence_workload_test.go
@@ -45,6 +45,7 @@ var (
 	generatedNamespace = pkg.GenerateNamespace("hello-coherence")
 	expectedPods       = []string{"hello-coh-"}
 	host               = ""
+	metricsTest        pkg.MetricsTest
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -105,6 +106,13 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 		}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()), "Coherence Application Failed to Deploy: Gateway is not ready")
 		metrics.Emit(t.Metrics.With("get_host_name_elapsed_time", time.Since(start).Milliseconds()))
 	}
+
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
+
 	beforeSuitePassed = true
 })
 
@@ -200,7 +208,7 @@ var _ = t.Describe("Validate deployment of VerrazzanoCoherenceWorkload", Label("
 			// Coherence metric fix available only from 1.3.0
 			if ok, _ := pkg.IsVerrazzanoMinVersion("1.3.0", kubeConfig); ok {
 				Eventually(func() bool {
-					return pkg.MetricsExist("vendor:coherence_service_messages_local", "role", "HelloCoherenceRole")
+					return metricsTest.MetricsExist("vendor:coherence_service_messages_local", map[string]string{"role": "HelloCoherenceRole"})
 				}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 			}
 		})
@@ -212,12 +220,12 @@ var _ = t.Describe("Validate deployment of VerrazzanoCoherenceWorkload", Label("
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("base_jvm_uptime_seconds", "app_oam_dev_name", "hello-appconf")
+						return metricsTest.MetricsExist("base_jvm_uptime_seconds", map[string]string{"app_oam_dev_name": "hello-appconf"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("vendor_requests_count_total", "app_oam_dev_name", "hello-appconf")
+						return metricsTest.MetricsExist("vendor_requests_count_total", map[string]string{"app_oam_dev_name": "hello-appconf"})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 			)

--- a/tests/e2e/workloads/weblogic-cluster/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic-cluster/weblogic_workload_test.go
@@ -48,6 +48,7 @@ var (
 	generatedNamespace = pkg.GenerateNamespace("hello-wls")
 	expectedPods       = []string{wlsAdminServer, wlsManagedServer1}
 	host               = ""
+	metricsTest        pkg.MetricsTest
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -133,6 +134,12 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 		return host, err
 	}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()), "Failed to deploy the WebLogic Application: Gateway is not ready")
 	metrics.Emit(t.Metrics.With("get_host_name_elapsed_time", time.Since(start).Milliseconds()))
+
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
 
 	beforeSuitePassed = true
 })
@@ -272,17 +279,17 @@ var _ = t.Describe("Validate deployment of VerrazzanoWebLogicWorkload", Label("f
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", wlDomain)
+						return metricsTest.MetricsExist("wls_jvm_process_cpu_load", map[string]string{"weblogic_domainName": wlDomain})
 					}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", wlDomain)
+						return metricsTest.MetricsExist("wls_scrape_mbeans_count_total", map[string]string{"weblogic_domainName": wlDomain})
 					}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_server_state_val", "weblogic_domainName", wlDomain)
+						return metricsTest.MetricsExist("wls_server_state_val", map[string]string{"weblogic_domainName": wlDomain})
 					}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 			)
@@ -297,17 +304,17 @@ var _ = t.Describe("Validate deployment of VerrazzanoWebLogicWorkload", Label("f
 				pkg.Concurrently(
 					func() {
 						Eventually(func() bool {
-							return pkg.MetricsExist("istio_tcp_received_bytes_total", "destination_canonical_service", "hello-domain")
+							return metricsTest.MetricsExist("istio_tcp_received_bytes_total", map[string]string{"destination_canonical_service": "hello-domain"})
 						}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 					},
 					func() {
 						Eventually(func() bool {
-							return pkg.MetricsExist("envoy_cluster_http2_pending_send_bytes", "pod_name", wlsAdminServer)
+							return metricsTest.MetricsExist("envoy_cluster_http2_pending_send_bytes", map[string]string{"pod_name": wlsAdminServer})
 						}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
 					},
 					func() {
 						Eventually(func() bool {
-							return pkg.MetricsExist("envoy_cluster_http2_pending_send_bytes", "pod_name", wlsManagedServer1)
+							return metricsTest.MetricsExist("envoy_cluster_http2_pending_send_bytes", map[string]string{"pod_name": wlsManagedServer1})
 						}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
 					},
 				)

--- a/tests/e2e/workloads/weblogic/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_test.go
@@ -47,6 +47,7 @@ var (
 	generatedNamespace = pkg.GenerateNamespace("hello-wls")
 	expectedPods       = []string{wlsAdminServer}
 	host               = ""
+	metricsTest        pkg.MetricsTest
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -105,6 +106,12 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 		return host, err
 	}, shortWaitTimeout, shortPollingInterval).Should(Not(BeEmpty()), "Failed to deploy the WebLogic Application: Gateway is not ready")
 	metrics.Emit(t.Metrics.With("get_host_name_elapsed_time", time.Since(start).Milliseconds()))
+
+	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
 
 	beforeSuitePassed = true
 })
@@ -244,17 +251,17 @@ var _ = t.Describe("Validate deployment of VerrazzanoWebLogicWorkload", Label("f
 			pkg.Concurrently(
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_jvm_process_cpu_load", "weblogic_domainName", wlDomain)
+						return metricsTest.MetricsExist("wls_jvm_process_cpu_load", map[string]string{"weblogic_domainName": wlDomain})
 					}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_scrape_mbeans_count_total", "weblogic_domainName", wlDomain)
+						return metricsTest.MetricsExist("wls_scrape_mbeans_count_total", map[string]string{"weblogic_domainName": wlDomain})
 					}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 				func() {
 					Eventually(func() bool {
-						return pkg.MetricsExist("wls_server_state_val", "weblogic_domainName", wlDomain)
+						return metricsTest.MetricsExist("wls_server_state_val", map[string]string{"weblogic_domainName": wlDomain})
 					}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
 				},
 			)
@@ -269,12 +276,12 @@ var _ = t.Describe("Validate deployment of VerrazzanoWebLogicWorkload", Label("f
 				pkg.Concurrently(
 					func() {
 						Eventually(func() bool {
-							return pkg.MetricsExist("istio_tcp_received_bytes_total", "destination_canonical_service", "hello-domain")
+							return metricsTest.MetricsExist("istio_tcp_received_bytes_total", map[string]string{"destination_canonical_service": "hello-domain"})
 						}, shortWaitTimeout, shortPollingInterval).Should(BeTrue())
 					},
 					func() {
 						Eventually(func() bool {
-							return pkg.MetricsExist("envoy_cluster_http2_pending_send_bytes", "pod_name", wlsAdminServer)
+							return metricsTest.MetricsExist("envoy_cluster_http2_pending_send_bytes", map[string]string{"pod_name": wlsAdminServer})
 						}, shortWaitTimeout, longPollingInterval).Should(BeTrue())
 					},
 				)

--- a/tools/psr/tests/scenarios/opensearch/s1/opensearch_s1_test.go
+++ b/tools/psr/tests/scenarios/opensearch/s1/opensearch_s1_test.go
@@ -32,7 +32,8 @@ var (
 	httpClient     *retryablehttp.Client
 	vmiCredentials *pkg.UsernamePassword
 
-	kubeconfig string
+	kubeconfig  string
+	metricsTest pkg.MetricsTest
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -44,6 +45,11 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 
 	httpClient = pkg.EventuallyVerrazzanoRetryableHTTPClient()
 	vmiCredentials = pkg.EventuallyGetSystemVMICredentials()
+
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
 })
 
 func sbsFunc() []byte {
@@ -107,7 +113,7 @@ var _ = t.Describe("ops-s1", Label("f:psr-ops-s1"), func() {
 	t.DescribeTable("Verify Opensearch ops-s1 Worker Metrics",
 		func(metricName string) {
 			Eventually(func() bool {
-				return pkg.MetricsExistInCluster(metricName, common.GetMetricLabels(""), kubeconfig)
+				return metricsTest.MetricsExist(metricName, common.GetMetricLabels(""))
 			}, waitTimeout, pollingInterval).Should(BeTrue(),
 				fmt.Sprintf("No metrics found for %s", metricName))
 		},

--- a/tools/psr/tests/scenarios/opensearch/s1/opensearch_s1_test.go
+++ b/tools/psr/tests/scenarios/opensearch/s1/opensearch_s1_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package s1

--- a/tools/psr/tests/scenarios/opensearch/s2/opensearch_s2_test.go
+++ b/tools/psr/tests/scenarios/opensearch/s2/opensearch_s2_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package s2

--- a/tools/psr/tests/scenarios/opensearch/s2/opensearch_s2_test.go
+++ b/tools/psr/tests/scenarios/opensearch/s2/opensearch_s2_test.go
@@ -32,7 +32,8 @@ var (
 	httpClient     *retryablehttp.Client
 	vmiCredentials *pkg.UsernamePassword
 
-	kubeconfig string
+	kubeconfig  string
+	metricsTest pkg.MetricsTest
 )
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
@@ -44,6 +45,11 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 
 	httpClient = pkg.EventuallyVerrazzanoRetryableHTTPClient()
 	vmiCredentials = pkg.EventuallyGetSystemVMICredentials()
+
+	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	if err != nil {
+		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
+	}
 })
 
 func sbsFunc() []byte {
@@ -109,7 +115,7 @@ var _ = t.Describe("ops-s2", Label("f:psr-ops-s2"), func() {
 	t.DescribeTable("Verify Opensearch ops-s2 Worker Metrics",
 		func(metricName string) {
 			Eventually(func() bool {
-				return pkg.MetricsExistInCluster(metricName, common.GetMetricLabels(""), kubeconfig)
+				return metricsTest.MetricsExist(metricName, common.GetMetricLabels(""))
 			}, waitTimeout, pollingInterval).Should(BeTrue(),
 				fmt.Sprintf("No metrics found for %s", metricName))
 		},


### PR DESCRIPTION
This ticket creates a new metrics testing object that can be used to test metrics in e2e testing. This object requires no prior knowledge of the metrics options installed and should be flexible given the new Thanos introduction into the tests.

The rest of the tickets updates the existing metrics tests to use the new object. This should simplify the metrics collection and make it more cohesive throughout the tests.
