### PR TITLE
VZ-8964: Uptake latest rancher 2.7.1 bfs images

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -130,14 +130,14 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "v2.7.1-20230404005853-65304ed87",
+              "tag": "20230404181615-a17fe5d5c",
               "dashboard": "v2.7.1-20230314212735-270d0ef83",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.1-20230404005853-65304ed87"
+              "tag": "20230404181615-a17fe5d5c"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -130,14 +130,14 @@
           "images": [
             {
               "image": "rancher",
-              "tag": "20230404181615-a17fe5d5c",
+              "tag": "v2.7.1-20230404232005-67b976f5e",
               "dashboard": "v2.7.1-20230314212735-270d0ef83",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "20230404181615-a17fe5d5c"
+              "tag": "v2.7.1-20230404232005-67b976f5e"
             }
           ]
         },


### PR DESCRIPTION
This PR updates latest rancher and rancher-agent images which has the follow change:
- Replaces rancher charts upstream repo with the Verrazzano rancher charts BFS repo. 