### PR TITLE
VZ-9232: Fix Jaeger configuration in Fluentd

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-fluentd/templates/fluentd-config-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-fluentd/templates/fluentd-config-configmap.yaml
@@ -747,6 +747,11 @@ data:
         </pattern>
         # Log patterns for Jaeger operator
         <pattern>
+          format /^(?<logtime>.*?) (?<level>\S+?) (?<message>[\s\S]*?)$/
+          time_key logtime
+          time_type float
+        </pattern>
+        <pattern>
           format /^(?<logtime>.*?) (?<level>\S+?) (?<component>[\.\S]+?) (?<message>[\s\S]*?)$/
           time_key logtime
           time_type float


### PR DESCRIPTION
Added missing pattern for jaeger-operator.

Example:  fluentd parsing error 
`
2023-04-03 19:02:03 +0000 [warn]: #0 dump an error event: error_class=Fluent::Plugin::Parser::ParserError error="pattern not matched with data '1.6805485233680496e+09\tINFO\tdetecting orphaned deployments.'" location=nil tag="kubernetes.var.log.containers.jaeger-operator-548956957-7pdb6_verrazzano-monitoring_jaeger-operator-d086bdeffc49bc12106b08060909a02a89a8ec56b086b244ab7c8c37a4f60607.log" time=2023-04-03 19:02:03.734614128 +0000 record={"stream"=>"stderr", "flags"=>"F", "log"=>"1.6805485233680496e+09\tINFO\tdetecting orphaned deployments.", "docker"=>{"container_id"=>"d086bdeffc49bc12106b08060909a02a89a8ec56b086b244ab7c8c37a4f60607"}, "kubernetes"=>{"container_name"=>"jaeger-operator", "namespace_name"=>"verrazzano-monitoring", "pod_name"=>"jaeger-operator-548956957-7pdb6", "container_image"=>"ghcr.io/verrazzano/jaeger-operator:1.42.0-20230327230723-9970d003", "container_image_id"=>"ghcr.io/verrazzano/jaeger-operator@sha256:b2026ddc2a5b09f4113115185aa9777ca4636651eb05e6e259e4384d98655ab4", "pod_id"=>"33b85f6e-0a20-422b-b57b-5c70175035ca", "pod_ip"=>"10.244.0.58", "host"=>"vz-dev-control-plane", "labels"=>{"pod-template-hash"=>"548956957", "app_kubernetes_io/instance"=>"jaeger-operator", "app_kubernetes_io/name"=>"jaeger-operator", "sidecar_istio_io/inject"=>"false"}, "master_url"=>"https://10.96.0.1:443/api", "namespace_id"=>"1e22bd4a-2476-4be6-be2e-4c7aa667ad52", "namespace_labels"=>{"istio-injection"=>"enabled", "kubernetes_io/metadata_name"=>"verrazzano-monitoring", "verrazzano_io/namespace"=>"verrazzano-monitoring"}}, "kubernetes_namespace_container_name"=>"verrazzano-monitoring.jaeger-operator", "message"=>"1.6805485233680496e+09\tINFO\tdetecting orphaned deployments."}
`


