### PR TITLE
VZ-9210: Update VMO image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -222,8 +222,8 @@
           "name": "verrazzano-monitoring-operator",
           "images": [
             {
-              "image": "verrazzano-monitoring-operator-jenkins",
-              "tag": "v1.6.0-20230407113849-6a06311",
+              "image": "verrazzano-monitoring-operator",
+              "tag": "v1.6.0-20230407153516-0c37bfb",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -222,8 +222,8 @@
           "name": "verrazzano-monitoring-operator",
           "images": [
             {
-              "image": "verrazzano-monitoring-operator",
-              "tag": "v1.6.0-20230302034628-8ea4e6c",
+              "image": "verrazzano-monitoring-operator-jenkins",
+              "tag": "v1.6.0-20230405163110-b8ba4d9",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -223,7 +223,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator-jenkins",
-              "tag": "v1.6.0-20230405163110-b8ba4d9",
+              "tag": "v1.6.0-20230407113849-6a06311",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
 Update VMO image to add annotations proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }' to OS/OSD pods.
This annotation adds hooks to delay application startup until the pod proxy is ready to accept traffic, mitigating some startup race conditions