### PR TITLE
VZ-8551: VPO status Init:CrashLoopBackOff after applying operator.yaml

### DIFF
--- a/pkg/k8sutil/apply_yaml.go
+++ b/pkg/k8sutil/apply_yaml.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/verrazzano/verrazzano/pkg/kubectlutil"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -173,6 +174,11 @@ func (y *YAMLApplier) applyAction(obj *unstructured.Unstructured) error {
 		}
 		cf.typeOf = reflect.TypeOf(fieldObj).String()
 		clientFields = append(clientFields, cf)
+	}
+
+	err = kubectlutil.SetLastAppliedConfigurationAnnotation(obj)
+	if err != nil {
+		return err
 	}
 
 	result, err := controllerruntime.CreateOrUpdate(context.TODO(), y.client, obj, func() error {

--- a/pkg/k8sutil/apply_yaml_test.go
+++ b/pkg/k8sutil/apply_yaml_test.go
@@ -5,6 +5,7 @@ package k8sutil_test
 
 import (
 	"context"
+	"github.com/google/go-cmp/cmp"
 	"testing"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -64,34 +65,40 @@ func TestApplyD(t *testing.T) {
 
 func TestApplyF(t *testing.T) {
 	var tests = []struct {
-		name    string
-		file    string
-		count   int
-		isError bool
+		name                                 string
+		file                                 string
+		count                                int
+		isError                              bool
+		expectedLastAppliedConfigAnnotations []string
 	}{
 		{
 			"should apply file",
 			objects + "/service.yaml",
 			1,
 			false,
+			[]string{"{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"name\":\"my-service\",\"namespace\":\"test\"},\"spec\":{\"ports\":[{\"port\":80,\"protocol\":\"TCP\",\"targetPort\":9376}],\"selector\":{\"app\":\"MyApp\"}}}\n"},
 		},
 		{
 			"should apply file with two objects",
 			testdata + "/two_objects.yaml",
 			2,
 			false,
+			[]string{"{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"name\":\"service1\",\"namespace\":\"test\"},\"spec\":{\"ports\":[{\"port\":80,\"protocol\":\"TCP\",\"targetPort\":9376}],\"selector\":{\"app\":\"MyApp\"}}}\n",
+				"{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"name\":\"service2\",\"namespace\":\"test\"},\"spec\":{\"ports\":[{\"port\":80,\"protocol\":\"TCP\",\"targetPort\":9376}],\"selector\":{\"app\":\"MyApp\"}}}\n"},
 		},
 		{
 			"should fail to apply files that are not YAML",
 			"blahblah",
 			0,
 			true,
+			nil,
 		},
 		{
 			"should fail when file is not YAML",
 			objects + "/not-yaml.txt",
 			0,
 			true,
+			nil,
 		},
 	}
 
@@ -106,6 +113,15 @@ func TestApplyF(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.count, len(y.Objects()))
+
+			for i, actualObj := range y.Objects() {
+				actual := actualObj.GetAnnotations()[corev1.LastAppliedConfigAnnotation]
+				expected := tt.expectedLastAppliedConfigAnnotations[i]
+				if diff := cmp.Diff(actual, expected); diff != "" {
+					t.Errorf("expected %v\n, got %v instead", expected, actual)
+					t.Logf("Difference: %s", diff)
+				}
+			}
 		})
 	}
 }
@@ -240,11 +256,12 @@ func TestApplyFClusterRole(t *testing.T) {
 
 func TestApplyFT(t *testing.T) {
 	var tests = []struct {
-		name    string
-		file    string
-		args    map[string]interface{}
-		count   int
-		isError bool
+		name                                 string
+		file                                 string
+		args                                 map[string]interface{}
+		count                                int
+		isError                              bool
+		expectedLastAppliedConfigAnnotations []string
 	}{
 		{
 			"should apply a template file",
@@ -252,6 +269,7 @@ func TestApplyFT(t *testing.T) {
 			map[string]interface{}{"namespace": "default"},
 			1,
 			false,
+			[]string{"{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"name\":\"tmpl-service\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"port\":80,\"protocol\":\"TCP\",\"targetPort\":9376}],\"selector\":{\"app\":\"MyApp\"}}}\n"},
 		},
 		{
 			"should fail to apply when template is incomplete",
@@ -259,6 +277,7 @@ func TestApplyFT(t *testing.T) {
 			map[string]interface{}{},
 			0,
 			true,
+			nil,
 		},
 	}
 
@@ -273,6 +292,16 @@ func TestApplyFT(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.count, len(y.Objects()))
+
+			for i, actualObj := range y.Objects() {
+				actual := actualObj.GetAnnotations()[corev1.LastAppliedConfigAnnotation]
+				assert.NotEmpty(t, actual)
+				expected := tt.expectedLastAppliedConfigAnnotations[i]
+				if diff := cmp.Diff(actual, expected); diff != "" {
+					t.Errorf("expected %v\n, got %v instead", expected, actual)
+					t.Logf("Difference: %s", diff)
+				}
+			}
 		})
 	}
 }

--- a/pkg/kubectlutil/kubectl_util.go
+++ b/pkg/kubectlutil/kubectl_util.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package kubectlutil
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/util"
+)
+
+// SetLastAppliedConfigurationAnnotation applies the kubectl.kubernetes.io/last-applied-configuration annotation
+// in order to calculate correct 3-way merges between object configuration file/configuration file,
+// live object configuration/live configuration and declarative configuration writer/declarative writer
+// (e.g. vz cli install or upgrade)
+func SetLastAppliedConfigurationAnnotation(obj runtime.Object) error {
+	err := util.CreateOrUpdateAnnotation(true, obj, unstructured.UnstructuredJSONScheme)
+	if err != nil {
+		return fmt.Errorf("error while applying %s annotation on the "+
+			"object: %v", v1.LastAppliedConfigAnnotation, err)
+	}
+	return nil
+}

--- a/pkg/kubectlutil/kubectlutil_test.go
+++ b/pkg/kubectlutil/kubectlutil_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package kubectlutil_test
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/verrazzano/verrazzano/pkg/kubectlutil"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestSetLastAppliedConfigurationAnnotation(t *testing.T) {
+	vz := &v1beta1.Verrazzano{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec:       v1beta1.VerrazzanoSpec{},
+	}
+
+	err := kubectlutil.SetLastAppliedConfigurationAnnotation(vz)
+	if err != nil {
+		t.Errorf("expected no error, got error %v", err)
+	}
+
+	value, ok := vz.Annotations[v1.LastAppliedConfigAnnotation]
+	if !ok {
+		t.Errorf("expected "+v1.LastAppliedConfigAnnotation+" , not found on object %v", vz)
+	}
+	expected := "{\"metadata\":{\"creationTimestamp\":null},\"spec\":{\"components\":{},\"security\":{}},\"status\":{}}\n"
+	if diff := cmp.Diff(expected, value); diff != "" {
+		t.Errorf("expected %v, got %v instead", expected, value)
+		t.Logf("Difference: %s", diff)
+	}
+}

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/verrazzano/verrazzano/pkg/kubectlutil"
 	"github.com/verrazzano/verrazzano/pkg/semver"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
@@ -206,6 +207,11 @@ func installVerrazzano(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 
 		// Wait for the platform operator to be ready before we create the Verrazzano resource.
 		_, err = cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondInstallComplete, vpoTimeout)
+		if err != nil {
+			return err
+		}
+
+		err = kubectlutil.SetLastAppliedConfigurationAnnotation(vz)
 		if err != nil {
 			return err
 		}

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -59,6 +59,9 @@ func TestInstallCmdDefaultNoWait(t *testing.T) {
 	vz := v1alpha1.Verrazzano{}
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "verrazzano"}, &vz)
 	assert.NoError(t, err)
+
+	expectedLastAppliedConfigAnnotation := "{\"apiVersion\":\"install.verrazzano.io/v1alpha1\",\"kind\":\"Verrazzano\",\"metadata\":{\"annotations\":{},\"name\":\"verrazzano\",\"namespace\":\"default\"}}\n"
+	testhelpers.VerifyLastAppliedConfigAnnotation(t, vz.ObjectMeta, expectedLastAppliedConfigAnnotation)
 }
 
 // TestInstallCmdDefaultTimeoutBugReport

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -5,6 +5,7 @@ package upgrade
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/kubectlutil"
 	"github.com/verrazzano/verrazzano/tools/vz/cmd/bugreport"
 	"time"
 
@@ -157,6 +158,11 @@ func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 
 		// Wait for the platform operator to be ready before we update the verrazzano install resource
 		_, err = cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondUpgradeComplete, vpoTimeout)
+		if err != nil {
+			return err
+		}
+
+		err = kubectlutil.SetLastAppliedConfigurationAnnotation(vz)
 		if err != nil {
 			return err
 		}

--- a/tools/vz/cmd/upgrade/upgrade_test.go
+++ b/tools/vz/cmd/upgrade/upgrade_test.go
@@ -52,6 +52,11 @@ func TestUpgradeCmdDefaultNoWait(t *testing.T) {
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, "", errBuf.String())
+
+	// Verify the vz resource is as expected
+	vzResource := v1beta1.Verrazzano{}
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "verrazzano"}, &vzResource)
+	assert.NoError(t, err)
 }
 
 // TestUpgradeCmdDefaultTimeoutBugReport
@@ -239,14 +244,20 @@ func TestUpgradeCmdOperatorFile(t *testing.T) {
 	sa := corev1.ServiceAccount{}
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "verrazzano-install", Name: "verrazzano-platform-operator"}, &sa)
 	assert.NoError(t, err)
+	expectedLastAppliedConfigAnnotation := "{\"apiVersion\":\"v1\",\"kind\":\"ServiceAccount\",\"metadata\":{\"annotations\":{},\"name\":\"verrazzano-platform-operator\",\"namespace\":\"verrazzano-install\"}}\n"
+	testhelpers.VerifyLastAppliedConfigAnnotation(t, sa.ObjectMeta, expectedLastAppliedConfigAnnotation)
 
 	ns := corev1.Namespace{}
 	err = c.Get(context.TODO(), types.NamespacedName{Name: "verrazzano-install"}, &ns)
 	assert.NoError(t, err)
+	expectedLastAppliedConfigAnnotation = "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"verrazzano-install\"}}\n"
+	testhelpers.VerifyLastAppliedConfigAnnotation(t, ns.ObjectMeta, expectedLastAppliedConfigAnnotation)
 
 	svc := corev1.Service{}
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "verrazzano-install", Name: "verrazzano-platform-operator"}, &svc)
 	assert.NoError(t, err)
+	expectedLastAppliedConfigAnnotation = "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"verrazzano-platform-operator\"},\"name\":\"verrazzano-platform-operator\",\"namespace\":\"verrazzano-install\"},\"spec\":{\"ports\":[{\"name\":\"webhook\",\"port\":443,\"targetPort\":9443}],\"selector\":{\"app\":\"verrazzano-platform-operator\"}}}\n"
+	testhelpers.VerifyLastAppliedConfigAnnotation(t, svc.ObjectMeta, expectedLastAppliedConfigAnnotation)
 
 	// Verify the version got updated
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "verrazzano"}, vz)

--- a/tools/vz/test/helpers/kubectl.go
+++ b/tools/vz/test/helpers/kubectl.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helpers
+
+import (
+	"github.com/google/go-cmp/cmp"
+	v12 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func VerifyLastAppliedConfigAnnotation(t *testing.T, object v1.ObjectMeta, expectedLastAppliedConfigAnnotation string) {
+	actual := object.GetAnnotations()[v12.LastAppliedConfigAnnotation]
+	if diff := cmp.Diff(actual, expectedLastAppliedConfigAnnotation); diff != "" {
+		t.Errorf("expected %v\n, got %v instead", expectedLastAppliedConfigAnnotation, actual)
+		t.Logf("Difference: %s", diff)
+	}
+}


### PR DESCRIPTION
Set the kubectl.kubernetes.io/last-applied-configuration annotation when doing install or upgrade using vz cli for correct merge calculation of Kubernetes resources.

This will allow us to use any combination of install & upgrade using either kubectl or vz cli.
