### PR TITLE
VZ-9156: CA cert checking for Thanos on managed clusters

### DIFF
--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -62,7 +62,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncThanosQuery(ctx context.Context
 	if err := r.syncThanosQueryEndpoint(ctx, vmc); err != nil {
 		return err
 	}
-	if err := r.createOrUpdateCACertVolume(vmc, r.removeCACertFromDeployment); err != nil {
+	if err := r.createOrUpdateCACertVolume(vmc, r.addCACertToDeployment); err != nil {
 		return err
 	}
 	if err := r.createOrUpdateServiceEntry(vmc.Name, vmc.Status.ThanosHost, thanosGrpcIngressPort); err != nil {

--- a/cluster-operator/controllers/vmc/sync_thanos_test.go
+++ b/cluster-operator/controllers/vmc/sync_thanos_test.go
@@ -15,7 +15,8 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/thanos"
 	istionet "istio.io/api/networking/v1beta1"
 	istioclinet "istio.io/client-go/pkg/apis/networking/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8sapiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,6 +109,8 @@ func TestSyncThanosQuery(t *testing.T) {
 	otherHost1 := toGrpcTarget("otherhost1")
 	otherHost2 := toGrpcTarget("otherhost2")
 	newHost := toGrpcTarget(newHostName)
+	managedClusterName := "somename"
+
 	tests := []struct {
 		name                   string
 		vmcStatus              *clustersv1alpha1.VerrazzanoManagedClusterStatus
@@ -148,7 +151,7 @@ func TestSyncThanosQuery(t *testing.T) {
 				vmcStatus = *tt.vmcStatus
 			}
 			vmc := &clustersv1alpha1.VerrazzanoManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "somename", Namespace: constants.VerrazzanoMultiClusterNamespace},
+				ObjectMeta: metav1.ObjectMeta{Name: managedClusterName, Namespace: constants.VerrazzanoMultiClusterNamespace},
 				Status:     vmcStatus,
 			}
 			cli := fake.NewClientBuilder().WithScheme(makeThanosTestScheme()).WithRuntimeObjects(
@@ -156,6 +159,16 @@ func TestSyncThanosQuery(t *testing.T) {
 				makeThanosEnabledVerrazzano(),
 				&k8sapiext.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: serviceEntryCRDName}},
 				&k8sapiext.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: destinationRuleCRDName}},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      constants.PromManagedClusterCACertsSecretName,
+						Namespace: constants.VerrazzanoMonitoringNamespace,
+					},
+					Data: map[string][]byte{
+						"ca-" + managedClusterName:      []byte("ca-cert-1"),
+						"ca-some-other-managed-cluster": []byte("ca-cert-2"),
+					},
+				},
 			).Build()
 			r := &VerrazzanoManagedClusterReconciler{
 				Client: cli,
@@ -174,8 +187,9 @@ func TestSyncThanosQuery(t *testing.T) {
 
 func makeThanosTestScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	_ = v1beta1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	v1beta1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+	appsv1.AddToScheme(scheme)
 	istioclinet.AddToScheme(scheme)
 	k8sapiext.AddToScheme(scheme)
 	return scheme
@@ -192,7 +206,7 @@ func makeThanosEnabledVerrazzano() *v1beta1.Verrazzano {
 	}
 }
 
-func makeThanosConfigMapWithExistingHosts(t *testing.T, hosts []string, useValidConfigMap bool) *v1.ConfigMap {
+func makeThanosConfigMapWithExistingHosts(t *testing.T, hosts []string, useValidConfigMap bool) *corev1.ConfigMap {
 	var yamlExistingHostInfo []byte
 	var err error
 	if useValidConfigMap {
@@ -206,7 +220,7 @@ func makeThanosConfigMapWithExistingHosts(t *testing.T, hosts []string, useValid
 	} else {
 		yamlExistingHostInfo = []byte("- targets: garbledTextHere")
 	}
-	return &v1.ConfigMap{
+	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Namespace: thanos.ComponentNamespace, Name: ThanosManagedClusterEndpointsConfigMap},
 		Data: map[string]string{
 			serviceDiscoveryKey: string(yamlExistingHostInfo),
@@ -215,7 +229,7 @@ func makeThanosConfigMapWithExistingHosts(t *testing.T, hosts []string, useValid
 }
 
 func assertThanosEndpointsConfigMap(ctx context.Context, t *testing.T, cli client.WithWatch, expectNumHosts int, host string, hostShoudExist bool) {
-	modifiedConfigMap := &v1.ConfigMap{}
+	modifiedConfigMap := &corev1.ConfigMap{}
 	err := cli.Get(ctx, types.NamespacedName{Namespace: thanos.ComponentNamespace, Name: ThanosManagedClusterEndpointsConfigMap}, modifiedConfigMap)
 	assert.NoError(t, err)
 	// make sure "targets" element is serialized in lower case in the config map
@@ -384,8 +398,9 @@ func TestCreateDestinationRule(t *testing.T) {
 		Client: cli,
 		log:    log,
 	}
+	vmc := &clustersv1alpha1.VerrazzanoManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: managedClusterName}}
 
-	err := r.createOrUpdateDestinationRule(managedClusterName, host, port)
+	err := r.createOrUpdateDestinationRule(vmc, host, port)
 	assert.NoError(t, err)
 
 	dr := &istioclinet.DestinationRule{}
@@ -408,7 +423,7 @@ func TestCreateDestinationRule(t *testing.T) {
 		log:    log,
 	}
 
-	err = r.createOrUpdateDestinationRule(managedClusterName, host, port)
+	err = r.createOrUpdateDestinationRule(vmc, host, port)
 	assert.NoError(t, err)
 
 	assertThanosDestinationRule(t, r, managedClusterName, host, port)
@@ -425,8 +440,9 @@ func TestUpdateDestinationRule(t *testing.T) {
 	// GIVEN the DestinationRule exists
 	// WHEN  the createOrUpdateDestinationRule function is called
 	// THEN  the call does not return an error and the DestinationRule is updated
+	vmc := &clustersv1alpha1.VerrazzanoManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: managedClusterName}}
 	dr := &istioclinet.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: managedClusterName, Namespace: constants.VerrazzanoMonitoringNamespace}}
-	populateDestinationRule(dr, "bad-bad-host", port, managedClusterName)
+	populateDestinationRule(dr, "bad-bad-host", port, vmc)
 
 	cli := fake.NewClientBuilder().WithScheme(makeThanosTestScheme()).WithRuntimeObjects(
 		&k8sapiext.CustomResourceDefinition{
@@ -441,7 +457,7 @@ func TestUpdateDestinationRule(t *testing.T) {
 		log:    log,
 	}
 
-	err := r.createOrUpdateDestinationRule(managedClusterName, host, port)
+	err := r.createOrUpdateDestinationRule(vmc, host, port)
 	assert.NoError(t, err)
 
 	assertThanosDestinationRule(t, r, managedClusterName, host, port)
@@ -470,8 +486,9 @@ func TestDeleteDestinationRule(t *testing.T) {
 	// GIVEN the DestinationRule exists
 	// WHEN  the deleteDestinationRule function is called
 	// THEN  the call does not return an error and the DestinationRule is deleted
+	vmc := &clustersv1alpha1.VerrazzanoManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: managedClusterName}}
 	dr := &istioclinet.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: managedClusterName, Namespace: constants.VerrazzanoMonitoringNamespace}}
-	populateDestinationRule(dr, host, port, managedClusterName)
+	populateDestinationRule(dr, host, port, vmc)
 
 	cli = fake.NewClientBuilder().WithScheme(makeThanosTestScheme()).WithRuntimeObjects(
 		&k8sapiext.CustomResourceDefinition{

--- a/cluster-operator/controllers/vmc/sync_thanos_test.go
+++ b/cluster-operator/controllers/vmc/sync_thanos_test.go
@@ -426,7 +426,7 @@ func TestUpdateDestinationRule(t *testing.T) {
 	// WHEN  the createOrUpdateDestinationRule function is called
 	// THEN  the call does not return an error and the DestinationRule is updated
 	dr := &istioclinet.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: managedClusterName, Namespace: constants.VerrazzanoMonitoringNamespace}}
-	populateDestinationRule(dr, "bad-bad-host", port)
+	populateDestinationRule(dr, "bad-bad-host", port, managedClusterName)
 
 	cli := fake.NewClientBuilder().WithScheme(makeThanosTestScheme()).WithRuntimeObjects(
 		&k8sapiext.CustomResourceDefinition{
@@ -471,7 +471,7 @@ func TestDeleteDestinationRule(t *testing.T) {
 	// WHEN  the deleteDestinationRule function is called
 	// THEN  the call does not return an error and the DestinationRule is deleted
 	dr := &istioclinet.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: managedClusterName, Namespace: constants.VerrazzanoMonitoringNamespace}}
-	populateDestinationRule(dr, host, port)
+	populateDestinationRule(dr, host, port, managedClusterName)
 
 	cli = fake.NewClientBuilder().WithScheme(makeThanosTestScheme()).WithRuntimeObjects(
 		&k8sapiext.CustomResourceDefinition{

--- a/cluster-operator/controllers/vmc/sync_thanos_test.go
+++ b/cluster-operator/controllers/vmc/sync_thanos_test.go
@@ -240,13 +240,6 @@ func TestDeleteClusterThanosEndpoint(t *testing.T) {
 	dr := &istioclinet.DestinationRule{}
 	err = r.Client.Get(context.TODO(), client.ObjectKey{Namespace: constants.VerrazzanoMonitoringNamespace, Name: managedClusterName}, dr)
 	assert.True(t, k8serrors.IsNotFound(err))
-
-	// istio volume and mount annotations should be gone
-	deployment := &appsv1.Deployment{}
-	err = r.Client.Get(context.TODO(), client.ObjectKey{Namespace: constants.VerrazzanoMonitoringNamespace, Name: thanosQueryDeployName}, deployment)
-	assert.NoError(t, err)
-	assert.NotContains(t, deployment.Spec.Template.ObjectMeta.Annotations, istioVolumeAnnotation)
-	assert.NotContains(t, deployment.Spec.Template.ObjectMeta.Annotations, istioVolumeMountAnnotation)
 }
 
 func makeThanosTestScheme() *runtime.Scheme {

--- a/pkg/rancherutil/rancher_config.go
+++ b/pkg/rancherutil/rancher_config.go
@@ -41,7 +41,7 @@ const (
 	tokensPath = "/v3/tokens" //nolint:gosec
 
 	// this host resolves to the cluster IP
-	nginxIngressHostName = "ingress-controller-ingress-nginx-controller.ingress-nginx"
+	nginxIngressHostName = "rancher.default.172.18.0.231.nip.io"
 )
 
 type RancherConfig struct {

--- a/pkg/rancherutil/rancher_config.go
+++ b/pkg/rancherutil/rancher_config.go
@@ -41,7 +41,7 @@ const (
 	tokensPath = "/v3/tokens" //nolint:gosec
 
 	// this host resolves to the cluster IP
-	nginxIngressHostName = "rancher.default.172.18.0.231.nip.io"
+	nginxIngressHostName = "ingress-controller-ingress-nginx-controller.ingress-nginx"
 )
 
 type RancherConfig struct {

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
@@ -72,6 +72,15 @@ rules:
       - watch
       - delete
   - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses


### PR DESCRIPTION
This PR enables CA cert checking for Thanos running on managed clusters. The Istio proxy running in the Thanos Query pod handles outbound TLS connections to managed clusters. The existing secret containing CA certs for managed clusters is mounted in the Istio sidecar container and the DestinationRule now references the CA cert for the managed cluster.

Tested by creating an MC environment, verifying Thanos Query on the admin cluster can talk to Thanos on the managed cluster. Destroyed the managed cluster, created a new managed cluster, verified that the new Thanos endpoint was added and that Thanos Query could talk to the managed cluster.