### PR TITLE
VZ-9275: Update Keycloak image with SnakeYAML upgraded to v2.0

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -448,8 +448,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak",
-              "tag": "v20.0.1-20230301104410-055767339d",
+              "image": "keycloak-jenkins",
+              "tag": "v20.0.1-20230405142533-cdbc0b8282",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -449,7 +449,7 @@
           "images": [
             {
               "image": "keycloak-jenkins",
-              "tag": "v20.0.1-20230405142533-cdbc0b8282",
+              "tag": "v20.0.1-20230406071742-4f21cce126",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -448,8 +448,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak-jenkins",
-              "tag": "v20.0.1-20230406071742-4f21cce126",
+              "image": "keycloak",
+              "tag": "v20.0.1-20230406163645-080e314b71",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Refreshes the Keycloak 20.0.1 image built with SnakeYAML v2.0 in https://github.com/verrazzano/keycloak/pull/10