### PR TITLE
VZ-9275: Update Keycloak image with SnakeYAML upgraded to v2.0, release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -449,7 +449,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "v20.0.1-20230301104410-055767339d",
+              "tag": "v20.0.1-20230406163645-080e314b71",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Refreshes the Keycloak 20.0.1 image built with SnakeYAML v2.0 in https://github.com/verrazzano/keycloak/pull/10