### PR TITLE
VZ-9232: Fix Jaeger configuration in Fluentd

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-fluentd/templates/fluentd-config-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-fluentd/templates/fluentd-config-configmap.yaml
@@ -761,6 +761,9 @@ data:
           time_key logtime
           time_format %Y-%m-%dT%H:%M:%S.%NZ
         </pattern>
+        <pattern>
+          format none
+        </pattern>
       </parse>
     </filter>
 


### PR DESCRIPTION
Added `format none` as catch-all for jaeger. (Note: All our components each have `format none` pattern as catch-all mechanism in order to avoid fluentd parsing errors)