### PR TITLE
VZ-9292: Update Keycloak image with SnakeYAML upgraded to v2.0 in release-1.3

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -410,8 +410,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak",
-              "tag": "v15.0.2-20221214054602-c01654ffed",
+              "image": "keycloak-jenkins",
+              "tag": "v15.0.2-20230410070629-88f8f1e509",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -410,8 +410,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak-jenkins",
-              "tag": "v15.0.2-20230410070629-88f8f1e509",
+              "image": "keycloak",
+              "tag": "v15.0.2-20230410125340-baa238fecb",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Refreshes the Keycloak 15.0.2 image built with SnakeYAML v2.0 in https://github.com/verrazzano/keycloak/pull/11