### PR TITLE
VZ-8892 Update the Thanos VMC sync to remove Prometheus federation

### DIFF
--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -176,9 +176,9 @@ func (s *Syncer) updateVMCStatus() error {
 	if err != nil {
 		return fmt.Errorf("Failed to get Thanos query URL to update VMC %s: %v", vmcName, err)
 	}
-	if thanosAPIHost != "" {
-		vmc.Status.ThanosQueryStore = thanosAPIHost
-	}
+
+	// If Thanos is disabled, we want to empty the host so Prometheus federation returns
+	vmc.Status.ThanosQueryStore = thanosAPIHost
 
 	// update status of VMC
 	return s.AdminClient.Status().Update(s.Context, &vmc)

--- a/cluster-operator/controllers/vmc/argocd.go
+++ b/cluster-operator/controllers/vmc/argocd.go
@@ -79,7 +79,7 @@ func (r *VerrazzanoManagedClusterReconciler) registerManagedClusterWithArgoCD(vm
 	var rancherURL = *(vz.Status.VerrazzanoInstance.RancherURL) + k8sClustersPath + clusterID
 
 	// If the managed cluster is not active, we should not attempt to register in Argo CD
-	rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.log)
+	rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.RancherIngressHost, r.log)
 	if err != nil {
 		msg := "Could not create rancher config that authenticates with the admin user"
 		return newArgoCDRegistration(clusterapi.MCRegistrationFailed, msg), err
@@ -117,7 +117,7 @@ func (r *VerrazzanoManagedClusterReconciler) createArgoCDClusterSecret(vmc *clus
 	if err != nil {
 		return err
 	}
-	rc, err := rancherutil.NewRancherConfigForUser(r.Client, vzconst.ArgoCDClusterRancherUsername, secret, r.log)
+	rc, err := rancherutil.NewRancherConfigForUser(r.Client, vzconst.ArgoCDClusterRancherUsername, secret, r.RancherIngressHost, r.log)
 	if err != nil {
 		return err
 	}

--- a/cluster-operator/controllers/vmc/argocd_test.go
+++ b/cluster-operator/controllers/vmc/argocd_test.go
@@ -96,7 +96,7 @@ func TestMutateArgoCDClusterSecretWithoutRefresh(t *testing.T) {
 
 	caData := []byte("ca")
 
-	rc, err := rancherutil.NewRancherConfigForUser(cli, constants.ArgoCDClusterRancherUsername, "foobar", log)
+	rc, err := rancherutil.NewRancherConfigForUser(cli, constants.ArgoCDClusterRancherUsername, "foobar", constants.DefaultRancherIngressHost, log)
 	assert.NoError(t, err)
 
 	err = r.mutateArgoCDClusterSecret(secret, rc, vmc.Name, clusterID, rancherURL, caData)
@@ -169,7 +169,7 @@ func TestMutateArgoCDClusterSecretWithRefresh(t *testing.T) {
 
 	caData := []byte("ca")
 
-	rc, err := rancherutil.NewRancherConfigForUser(cli, constants.ArgoCDClusterRancherUsername, "foobar", log)
+	rc, err := rancherutil.NewRancherConfigForUser(cli, constants.ArgoCDClusterRancherUsername, "foobar", constants.DefaultRancherIngressHost, log)
 	assert.NoError(t, err)
 
 	err = r.mutateArgoCDClusterSecret(secret, rc, vmc.Name, clusterID, rancherURL, caData)
@@ -337,7 +337,7 @@ func TestUpdateArgoCDClusterRoleBindingTemplate(t *testing.T) {
 				Client: cli,
 				log:    vzlog.DefaultLogger(),
 			}
-			rc, err := rancherutil.NewAdminRancherConfig(cli, vzlog.DefaultLogger())
+			rc, err := rancherutil.NewAdminRancherConfig(cli, constants.DefaultRancherIngressHost, vzlog.DefaultLogger())
 			assert.NoError(t, err)
 
 			err = r.updateArgoCDClusterRoleBindingTemplate(rc, tt.vmc)

--- a/cluster-operator/controllers/vmc/push_manifest_objects.go
+++ b/cluster-operator/controllers/vmc/push_manifest_objects.go
@@ -19,7 +19,7 @@ func (r *VerrazzanoManagedClusterReconciler) pushManifestObjects(vmc *clusterapi
 		r.log.Progressf("Waiting to push manifest objects, Rancher ClusterID not found in the VMC %s/%s status", vmc.GetNamespace(), vmc.GetName())
 		return false, nil
 	}
-	rc, err := rancherutil.NewVerrazzanoClusterRancherConfig(r.Client, r.log)
+	rc, err := rancherutil.NewVerrazzanoClusterRancherConfig(r.Client, r.RancherIngressHost, r.log)
 	if err != nil || rc == nil {
 		return false, err
 	}

--- a/cluster-operator/controllers/vmc/sync_manifest_secret.go
+++ b/cluster-operator/controllers/vmc/sync_manifest_secret.go
@@ -68,7 +68,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 		// Rancher YAML is applied on the managed cluster
 		// NOTE: If this errors we log it and do not fail the reconcile
 		var clusterID string
-		rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.log)
+		rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.RancherIngressHost, r.log)
 		if err != nil {
 			msg := "Failed to create Rancher API client"
 			r.log.Infof("Unable to connect to Rancher API on admin cluster, manifest secret will not contain Rancher YAML: %v", err)
@@ -128,7 +128,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncCACertSecret(vmc *clusterapi.Ve
 	if len(vmc.Spec.CASecret) > 0 {
 		return false, nil
 	}
-	rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.log)
+	rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.RancherIngressHost, r.log)
 	if err != nil {
 		return false, err
 	}

--- a/cluster-operator/controllers/vmc/sync_prometheus.go
+++ b/cluster-operator/controllers/vmc/sync_prometheus.go
@@ -5,7 +5,6 @@ package vmc
 
 import (
 	"context"
-	"fmt"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
 
@@ -18,7 +17,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/yaml"
 )
@@ -58,34 +56,10 @@ basic_auth:
 
 // syncPrometheusScraper will create a scrape configuration for the cluster and update the prometheus config map.  There will also be an
 // entry for the cluster's CA cert added to the prometheus config map to allow for lookup of the CA cert by the scraper's HTTP client.
-func (r *VerrazzanoManagedClusterReconciler) syncPrometheusScraper(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
-	var secret corev1.Secret
-
-	// read the configuration secret specified if it exists
-	if len(vmc.Spec.CASecret) > 0 {
-		secretNsn := types.NamespacedName{
-			Namespace: vmc.Namespace,
-			Name:      vmc.Spec.CASecret,
-		}
-
-		// validate secret if it exists
-		if err := r.Get(context.TODO(), secretNsn, &secret); err != nil {
-			return fmt.Errorf("failed to fetch the managed cluster CA secret %s/%s, %v", vmc.Namespace, vmc.Spec.CASecret, err)
-		}
-	}
-
+func (r *VerrazzanoManagedClusterReconciler) syncPrometheusScraper(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, secret *corev1.Secret) error {
 	// The additional scrape configs and managed cluster TLS secrets are needed by the Prometheus Operator Prometheus
 	// because the federated scrape config can't be represented in a PodMonitor, ServiceMonitor, etc.
-	err := r.mutateManagedClusterCACertsSecret(ctx, vmc, &secret)
-	if err != nil {
-		return err
-	}
-	err = r.mutateAdditionalScrapeConfigs(ctx, vmc, &secret)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return r.mutateAdditionalScrapeConfigs(ctx, vmc, secret)
 }
 
 // newScrapeConfig will return a prometheus scraper configuration based on the entries in the prometheus info structure provided
@@ -124,16 +98,7 @@ func (r *VerrazzanoManagedClusterReconciler) newScrapeConfig(cacrtSecret *corev1
 // deleteClusterPrometheusConfiguration deletes the managed cluster configuration from the prometheus configuration and updates the prometheus config
 // map
 func (r *VerrazzanoManagedClusterReconciler) deleteClusterPrometheusConfiguration(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
-	err := r.mutateAdditionalScrapeConfigs(ctx, vmc, nil)
-	if err != nil {
-		return err
-	}
-	err = r.mutateManagedClusterCACertsSecret(ctx, vmc, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return r.mutateAdditionalScrapeConfigs(ctx, vmc, nil)
 }
 
 // parsePrometheusConfig returns an editable representation of the prometheus configuration
@@ -209,32 +174,6 @@ func (r *VerrazzanoManagedClusterReconciler) mutateAdditionalScrapeConfigs(ctx c
 	}
 	if result != controllerutil.OperationResultNone {
 		r.log.Infof("The Prometheus additional scrape config Secret %s has been modified for VMC %s", secret.Name, vmc.Name)
-	}
-
-	return nil
-}
-
-// mutateManagedClusterCACertsSecret adds and removes managed cluster CA certs to/from the managed cluster CA certs secret
-func (r *VerrazzanoManagedClusterReconciler) mutateManagedClusterCACertsSecret(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster, cacrtSecret *corev1.Secret) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vpoconst.PromManagedClusterCACertsSecretName,
-			Namespace: vpoconst.VerrazzanoMonitoringNamespace,
-		},
-	}
-
-	if _, err := controllerruntime.CreateOrUpdate(ctx, r.Client, secret, func() error {
-		if secret.Data == nil {
-			secret.Data = make(map[string][]byte)
-		}
-		if cacrtSecret != nil && cacrtSecret.Data != nil && len(cacrtSecret.Data["cacrt"]) > 0 {
-			secret.Data[getCAKey(vmc)] = cacrtSecret.Data["cacrt"]
-		} else {
-			delete(secret.Data, getCAKey(vmc))
-		}
-		return nil
-	}); err != nil {
-		return err
 	}
 
 	return nil

--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -30,6 +31,7 @@ const (
 	serviceEntryCRDName    = "serviceentries.networking.istio.io"
 	destinationRuleCRDName = "destinationrules.networking.istio.io"
 	thanosQueryDeployName  = "thanos-query"
+	verrazzanoManagedLabel = "verrazzano_cluster"
 	thanosGrpcIngressPort  = 443
 
 	istioVolumeAnnotation      = "sidecar.istio.io/userVolume"
@@ -40,8 +42,10 @@ const (
 
 // thanosServiceDiscovery represents one element in the Thanos service discovery YAML. The YAML
 // format contains a list of thanosServiceDiscovery elements
+// The format of this object is outlined here https://github.com/thanos-io/thanos/blob/main/docs/service-discovery.md#file-service-discovery
 type thanosServiceDiscovery struct {
-	Targets []string `json:"targets"`
+	Targets []string          `json:"targets"`
+	Labels  map[string]string `json:"labels"`
 }
 
 const ThanosManagedClusterEndpointsConfigMap = "verrazzano-thanos-endpoints"
@@ -54,11 +58,6 @@ const serviceDiscoveryKey = "servicediscovery.yml"
 func (r *VerrazzanoManagedClusterReconciler) syncThanosQuery(ctx context.Context,
 	vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
 
-	if vmc.Status.ThanosQueryStore == "" {
-		r.log.Oncef("Managed cluster Thanos Query Store not found in VMC Status for VMC %s. Not updating Thanos endpoints", vmc.Name)
-		return nil
-	}
-
 	if err := r.syncThanosQueryEndpoint(ctx, vmc); err != nil {
 		return err
 	}
@@ -68,37 +67,18 @@ func (r *VerrazzanoManagedClusterReconciler) syncThanosQuery(ctx context.Context
 	if err := r.createOrUpdateServiceEntry(vmc.Name, vmc.Status.ThanosQueryStore, thanosGrpcIngressPort); err != nil {
 		return err
 	}
-	if err := r.createOrUpdateDestinationRule(vmc, vmc.Status.ThanosQueryStore, thanosGrpcIngressPort); err != nil {
-		return err
-	}
-	return nil
+	return r.createOrUpdateDestinationRule(vmc, vmc.Status.ThanosQueryStore, thanosGrpcIngressPort)
 }
 
 // syncThanosQueryEndpoint will update the config map used by Thanos Query with the managed cluster
 // Thanos store API endpoint.
 func (r *VerrazzanoManagedClusterReconciler) syncThanosQueryEndpoint(ctx context.Context,
 	vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
-
-	if thanosEnabled, err := r.isThanosEnabled(); err != nil || !thanosEnabled {
-		r.log.Oncef("Thanos is not enabled on this cluster. Not updating Thanos endpoints for VMC %s", vmc.Name)
-		return nil
-	}
-
-	return r.addThanosHostIfNotPresent(ctx, vmc.Status.ThanosQueryStore)
+	return r.addThanosHostIfNotPresent(ctx, vmc.Status.ThanosQueryStore, vmc.Name)
 }
 
-func (r *VerrazzanoManagedClusterReconciler) deleteClusterThanosEndpoint(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
-	if vmc.Status.ThanosQueryStore == "" {
-		r.log.Oncef("Managed cluster Thanos Query Store not found in VMC Status for VMC %s. No Thanos endpoint to be deleted", vmc.Name)
-		return nil
-	}
-
-	if thanosEnabled, err := r.isThanosEnabled(); err != nil || !thanosEnabled {
-		r.log.Oncef("Thanos is not enabled on this cluster. Not updating Thanos endpoints for VMC %s", vmc.Name)
-		return nil
-	}
-
-	if err := r.removeThanosHostFromConfigMap(ctx, vmc.Status.ThanosQueryStore, r.log); err != nil {
+func (r *VerrazzanoManagedClusterReconciler) syncThanosQueryEndpointDelete(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
+	if err := r.removeThanosHostFromConfigMap(ctx, vmc.Name, r.log); err != nil {
 		return err
 	}
 	if err := r.deleteDestinationRule(vmc.Name); err != nil {
@@ -110,7 +90,13 @@ func (r *VerrazzanoManagedClusterReconciler) deleteClusterThanosEndpoint(ctx con
 	return nil
 }
 
-func (r *VerrazzanoManagedClusterReconciler) removeThanosHostFromConfigMap(ctx context.Context, host string, log vzlog.VerrazzanoLogger) error {
+func (r *VerrazzanoManagedClusterReconciler) removeThanosHostFromConfigMap(ctx context.Context, vmcName string, log vzlog.VerrazzanoLogger) error {
+	// Check if Thanos is enabled before getting the endpoints ConfigMap
+	// to avoid repeating error message when Thanos is disabled
+	thanosEnabled, err := r.isThanosEnabled()
+	if err != nil || !thanosEnabled {
+		return err
+	}
 	configMap, err := r.getThanosEndpointsConfigMap(ctx)
 	if err != nil {
 		return err
@@ -121,34 +107,35 @@ func (r *VerrazzanoManagedClusterReconciler) removeThanosHostFromConfigMap(ctx c
 		// we will try to automatically resolve the issue
 		return nil
 	}
-	hostEndpoint := toGrpcTarget(host)
 
-	for _, serviceDiscovery := range serviceDiscoveryList {
-		foundTargetIndex := findHost(serviceDiscovery, hostEndpoint)
-		if foundTargetIndex > -1 {
-			serviceDiscovery.Targets = append(serviceDiscovery.Targets[:foundTargetIndex], serviceDiscovery.Targets[foundTargetIndex+1:]...)
-			return r.createOrUpdateThanosEndpointConfigMap(ctx, serviceDiscoveryList, hostEndpoint, configMap)
+	for i, serviceDiscovery := range serviceDiscoveryList {
+		if findLabelName(serviceDiscovery, vmcName) {
+			serviceDiscoveryList = append(serviceDiscoveryList[:i], serviceDiscoveryList[i+1:]...)
+			return r.createOrUpdateThanosEndpointConfigMap(ctx, serviceDiscoveryList, vmcName, configMap)
 		}
 	}
 	return nil
 }
 
-func (r *VerrazzanoManagedClusterReconciler) createOrUpdateThanosEndpointConfigMap(ctx context.Context, serviceDiscoveryList []*thanosServiceDiscovery, hostEndpoint string, configMap *v1.ConfigMap) error {
+func (r *VerrazzanoManagedClusterReconciler) createOrUpdateThanosEndpointConfigMap(ctx context.Context, serviceDiscoveryList []*thanosServiceDiscovery, vmcName string, configMap *v1.ConfigMap) error {
 	newServiceDiscoveryYaml, err := yaml.Marshal(serviceDiscoveryList)
 	if err != nil {
-		return r.log.ErrorfNewErr("Failed to serialize Thanos endpoints config map content for host %s: %v", hostEndpoint, err)
+		return r.log.ErrorfNewErr("Failed to serialize Thanos endpoints config map content for VMC %s: %v", vmcName, err)
 	}
-	_, err = controllerruntime.CreateOrUpdate(ctx, r.Client, configMap, func() error {
+	result, err := controllerruntime.CreateOrUpdate(ctx, r.Client, configMap, func() error {
 		configMap.Data[serviceDiscoveryKey] = string(newServiceDiscoveryYaml)
 		return nil
 	})
 	if err != nil {
-		return r.log.ErrorfNewErr("Failed to update Thanos endpoints config map after removing endpoint %s: %v", hostEndpoint, err)
+		return r.log.ErrorfNewErr("Failed to update Thanos endpoints config map after removing endpoint for VMC %s: %v", vmcName, err)
+	}
+	if result != controllerutil.OperationResultNone {
+		r.log.Infof("The Thanos endpoint Configmap %s has been modified for VMC %s", configMap.Name, vmcName)
 	}
 	return nil
 }
 
-func (r *VerrazzanoManagedClusterReconciler) addThanosHostIfNotPresent(ctx context.Context, host string) error {
+func (r *VerrazzanoManagedClusterReconciler) addThanosHostIfNotPresent(ctx context.Context, host, vmcName string) error {
 	configMap, err := r.getThanosEndpointsConfigMap(ctx)
 	if err != nil {
 		return err
@@ -157,49 +144,63 @@ func (r *VerrazzanoManagedClusterReconciler) addThanosHostIfNotPresent(ctx conte
 	if err != nil {
 		// We will wipe out and repopulate the config map if it could not be parsed
 		r.log.Info("Clearing and repopulating Thanos endpoints ConfigMap due to parse error")
-		serviceDiscoveryList = []*thanosServiceDiscovery{
-			{Targets: []string{}},
-		}
+		serviceDiscoveryList = []*thanosServiceDiscovery{}
 	}
 	hostEndpoint := toGrpcTarget(host)
 
-	if len(serviceDiscoveryList) == 0 {
-		// empty list found, add a placeholder item so that the loop below will populate it
-		serviceDiscoveryList = append(serviceDiscoveryList, &thanosServiceDiscovery{})
-	}
-	for _, serviceDiscovery := range serviceDiscoveryList {
-		if serviceDiscovery.Targets == nil {
-			serviceDiscovery.Targets = []string{}
-		}
-		foundIndex := findHost(serviceDiscovery, hostEndpoint)
-		if foundIndex > -1 {
+	for i, serviceDiscovery := range serviceDiscoveryList {
+		if findLabelAndHost(serviceDiscovery, hostEndpoint, vmcName) {
 			// already exists, nothing to be added
 			r.log.Debugf("Managed cluster endpoint %s is already present in the Thanos endpoints config map", hostEndpoint)
 			return nil
 		}
+		if findLabelName(serviceDiscovery, vmcName) {
+			// label exists, but host has changed
+			r.log.Debugf("Modifying managed cluster endpoint %s to Thanos endpoints for VMC %s", hostEndpoint, vmcName)
+			serviceDiscoveryList[i] = &thanosServiceDiscovery{
+				Targets: []string{hostEndpoint},
+				Labels:  serviceDiscovery.Labels,
+			}
+			return r.createOrUpdateThanosEndpointConfigMap(ctx, serviceDiscoveryList, vmcName, configMap)
+		}
 	}
 	// not found, add this host endpoint and update the config map
 	r.log.Debugf("Adding managed cluster endpoint %s to Thanos endpoints config map", hostEndpoint)
-	serviceDiscoveryList[0].Targets = append(serviceDiscoveryList[0].Targets, hostEndpoint)
-	return r.createOrUpdateThanosEndpointConfigMap(ctx, serviceDiscoveryList, hostEndpoint, configMap)
+	serviceDiscoveryList = append(serviceDiscoveryList, &thanosServiceDiscovery{
+		Targets: []string{hostEndpoint},
+		Labels: map[string]string{
+			verrazzanoManagedLabel: vmcName,
+		},
+	})
+	return r.createOrUpdateThanosEndpointConfigMap(ctx, serviceDiscoveryList, vmcName, configMap)
 }
 
-func findHost(serviceDiscovery *thanosServiceDiscovery, host string) int {
-	foundIndex := -1
-	for i, target := range serviceDiscovery.Targets {
+func findLabelAndHost(serviceDiscovery *thanosServiceDiscovery, host, name string) bool {
+	if val, ok := serviceDiscovery.Labels[verrazzanoManagedLabel]; !ok || val != name {
+		return false
+	}
+	for _, target := range serviceDiscovery.Targets {
 		if target == host {
-			foundIndex = i
-			break
+			return true
 		}
 	}
-	return foundIndex
+	return false
+}
+
+// findLabelName parses the service discovery labels and matches it with a given name
+func findLabelName(serviceDiscovery *thanosServiceDiscovery, name string) bool {
+	val, ok := serviceDiscovery.Labels[verrazzanoManagedLabel]
+	return ok && val == name
 }
 
 func parseThanosEndpointsConfigMap(configMap *v1.ConfigMap, log vzlog.VerrazzanoLogger) ([]*thanosServiceDiscovery, error) {
 	// ConfigMap format for Thanos endpoints is
 	// servicediscovery.yml: |
-	//  - Targets:
+	//  - targets:
 	//    - example.com:443
+	//    labels:
+	//      verrazzano_cluster: managed
+	// The format is outlined here: https://github.com/thanos-io/thanos/blob/main/docs/service-discovery.md#file-service-discovery
 	serviceDiscoveryYaml, exists := configMap.Data[serviceDiscoveryKey]
 	serviceDiscoveryArray := []*thanosServiceDiscovery{}
 	var err error
@@ -220,7 +221,8 @@ func (r *VerrazzanoManagedClusterReconciler) getThanosEndpointsConfigMap(ctx con
 	}
 	configMap := v1.ConfigMap{}
 	if err := r.Get(ctx, configMapNsn, &configMap); err != nil {
-		return nil, r.log.ErrorfNewErr("failed to fetch the Thanos endpoints ConfigMap %s/%s, %v", configMapNsn.Namespace, configMapNsn.Name, err)
+		r.log.Errorf("failed to fetch the Thanos endpoints ConfigMap %s/%s, %v", configMapNsn.Namespace, configMapNsn.Name, err)
+		return nil, err
 	}
 	return &configMap, nil
 }

--- a/cluster-operator/controllers/vmc/sync_thanos_test.go
+++ b/cluster-operator/controllers/vmc/sync_thanos_test.go
@@ -5,11 +5,14 @@ package vmc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/metricsutils"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/thanos"
@@ -28,76 +31,81 @@ import (
 )
 
 type addRemoveSyncThanosTestType struct {
-	name           string
-	host           string
-	existingHosts  []string
-	expectError    bool
-	expectNumHosts int
-	useValidCM     bool
+	name              string
+	clusterNumToCheck int
+	numClusters       int
+	expectError       bool
+	expectNumHosts    int
+	changedHost       *string
+	useValidCM        bool
 }
 
 func TestAddThanosHostIfNotPresent(t *testing.T) {
-	newHostName := "newhostname"
-	otherHost1 := toGrpcTarget("otherhost1")
-	otherHost2 := toGrpcTarget("otherhost2")
-	newHost := toGrpcTarget(newHostName)
+	vmcPrefix := "cluster"
+	host := "test-host"
+	newHost := "altered-host"
 	tests := []addRemoveSyncThanosTestType{
-		{"no existing hosts", newHostName, []string{}, false, 1, true},
-		{"host already exists", newHostName, []string{otherHost1, newHost}, false, 2, true},
-		{"host does not exist", newHostName, []string{otherHost1, otherHost2}, false, 3, true},
-		{"existing ConfigMap is malformed", newHostName, []string{}, false, 1, false},
+		{"no existing VMC", 1, 0, false, 1, nil, true},
+		{"VMC already exists", 2, 2, false, 2, nil, true},
+		{"VMC already exists host changed", 2, 2, false, 2, &newHost, true},
+		{"VMC does not exist", 3, 2, false, 3, nil, true},
+		{"existing ConfigMap is malformed", 1, 0, false, 1, nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			log := vzlog.DefaultLogger()
 			ctx := context.TODO()
+			effectiveHost := host
 			cli := fake.NewClientBuilder().WithScheme(makeThanosTestScheme()).WithRuntimeObjects(
-				makeThanosConfigMapWithExistingHosts(t, tt.existingHosts, tt.useValidCM),
+				makeThanosConfigMapWithExistingHosts(t, tt.useValidCM, tt.numClusters, toGrpcTarget(effectiveHost), vmcPrefix),
 				makeThanosEnabledVerrazzano(),
 			).Build()
 			r := &VerrazzanoManagedClusterReconciler{
 				Client: cli,
 				log:    log,
 			}
-			err := r.addThanosHostIfNotPresent(ctx, tt.host)
+			vmcName := fmt.Sprintf("%s%d", vmcPrefix, tt.clusterNumToCheck)
+			if tt.changedHost != nil {
+				effectiveHost = *tt.changedHost
+			}
+			err := r.addThanosHostIfNotPresent(ctx, effectiveHost, vmcName)
 			if tt.expectError {
 				assert.Error(t, err, "Expected error")
 			} else {
-				hostShouldExist := true
-				assertThanosEndpointsConfigMap(ctx, t, cli, tt.expectNumHosts, tt.host, hostShouldExist)
+				clusterShouldExist := true
+				assertThanosEndpointsConfigMap(ctx, t, cli, tt.expectNumHosts, toGrpcTarget(effectiveHost), vmcName, clusterShouldExist)
 			}
 		})
 	}
 }
 
 func TestRemoveThanosHostFromConfigMap(t *testing.T) {
-	newHostName := "newhostname"
-	otherHost1 := toGrpcTarget("otherhost1")
-	otherHost2 := toGrpcTarget("otherhost2")
-	newHost := toGrpcTarget(newHostName)
+	vmcPrefix := "cluster"
+	hostName := toGrpcTarget("test-host")
 	tests := []addRemoveSyncThanosTestType{
-		{"no existing hosts", newHostName, []string{}, false, 0, true},
-		{"host already exists", newHostName, []string{otherHost1, newHost}, false, 1, true},
-		{"host does not exist", newHostName, []string{otherHost1, otherHost2}, false, 2, true},
+		{"no existing hosts", 0, 0, false, 0, nil, true},
+		{"host already exists", 2, 2, false, 1, nil, true},
+		{"host does not exist", 3, 2, false, 2, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			log := vzlog.DefaultLogger()
 			ctx := context.TODO()
 			cli := fake.NewClientBuilder().WithScheme(makeThanosTestScheme()).WithRuntimeObjects(
-				makeThanosConfigMapWithExistingHosts(t, tt.existingHosts, tt.useValidCM),
+				makeThanosConfigMapWithExistingHosts(t, tt.useValidCM, tt.numClusters, hostName, vmcPrefix),
 				makeThanosEnabledVerrazzano(),
 			).Build()
 			r := &VerrazzanoManagedClusterReconciler{
 				Client: cli,
 				log:    log,
 			}
-			err := r.removeThanosHostFromConfigMap(ctx, tt.host, log)
+			vmcName := fmt.Sprintf("%s%d", vmcPrefix, tt.clusterNumToCheck)
+			err := r.removeThanosHostFromConfigMap(ctx, vmcName, log)
 			if tt.expectError {
 				assert.Error(t, err, "Expected error")
 			} else {
-				hostShouldExist := false
-				assertThanosEndpointsConfigMap(ctx, t, cli, tt.expectNumHosts, tt.host, hostShouldExist)
+				clusterShouldExist := false
+				assertThanosEndpointsConfigMap(ctx, t, cli, tt.expectNumHosts, hostName, vmcName, clusterShouldExist)
 			}
 		})
 	}
@@ -105,41 +113,41 @@ func TestRemoveThanosHostFromConfigMap(t *testing.T) {
 
 // TestSyncThanosQuery tests the syncThanosQuery function which is the top level entry point
 func TestSyncThanosQuery(t *testing.T) {
-	newHostName := "newhostname"
-	otherHost1 := toGrpcTarget("otherhost1")
-	otherHost2 := toGrpcTarget("otherhost2")
-	newHost := toGrpcTarget(newHostName)
-	managedClusterName := "somename"
-
+	hostName := "test-host"
+	vmcPrefix := "cluster"
 	tests := []struct {
 		name                   string
 		vmcStatus              *clustersv1alpha1.VerrazzanoManagedClusterStatus
 		expectedConfigMapHosts int
-		hostname               string
-		configMapExistingHosts []string
-		hostShouldExistInCM    bool
+		numClusters            int
+		clusterToSync          int
+		clusterShouldExistInCM bool
+		prometheusConfig       *corev1.Secret
 	}{
-		{"VMC status empty", nil, 1, "", []string{otherHost1}, false},
-		{"VMC status has no Thanos Query Store",
+		{"VMC status empty", nil, 1, 1, 1, false, nil},
+		{"VMC status has no Thanos host",
 			&clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl"},
 			1,
-			"",
-			[]string{otherHost1},
+			1,
+			1,
 			false,
+			nil,
 		},
-		{"VMC status has existing Thanos Query Store",
-			&clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl", ThanosQueryStore: newHostName},
+		{"VMC status has existing VMC",
+			&clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl", ThanosQueryStore: hostName},
 			2,
-			newHostName,
-			[]string{newHost, otherHost1},
+			2,
+			1,
 			true, // new host already exists in query endpoints configmap, should still exist
+			nil,
 		},
-		{"VMC status has non-existing Thanos Query Store",
-			&clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl", ThanosQueryStore: newHostName},
+		{"VMC status has non-existing Thanos host",
+			&clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl", ThanosQueryStore: hostName},
 			3,
-			newHostName,
-			[]string{otherHost1, otherHost2},
+			2,
+			3,
 			true, // new host should be added to query endpoints configmap
+			nil,
 		},
 	}
 	for _, tt := range tests {
@@ -147,39 +155,38 @@ func TestSyncThanosQuery(t *testing.T) {
 			log := vzlog.DefaultLogger()
 			ctx := context.TODO()
 			var vmcStatus clustersv1alpha1.VerrazzanoManagedClusterStatus
+			thanosHost := ""
 			if tt.vmcStatus != nil {
 				vmcStatus = *tt.vmcStatus
+				thanosHost = vmcStatus.ThanosQueryStore
 			}
 			vmc := &clustersv1alpha1.VerrazzanoManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: managedClusterName, Namespace: constants.VerrazzanoMultiClusterNamespace},
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s%d", vmcPrefix, tt.clusterToSync), Namespace: constants.VerrazzanoMultiClusterNamespace},
 				Status:     vmcStatus,
 			}
-			cli := fake.NewClientBuilder().WithScheme(makeThanosTestScheme()).WithRuntimeObjects(
-				makeThanosConfigMapWithExistingHosts(t, tt.configMapExistingHosts, true),
+			cliBuilder := fake.NewClientBuilder().WithScheme(makeThanosTestScheme()).WithRuntimeObjects(
+				makeThanosConfigMapWithExistingHosts(t, true, tt.numClusters, thanosHost, vmcPrefix),
 				makeThanosEnabledVerrazzano(),
 				&k8sapiext.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: serviceEntryCRDName}},
 				&k8sapiext.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: destinationRuleCRDName}},
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      constants.PromManagedClusterCACertsSecretName,
-						Namespace: constants.VerrazzanoMonitoringNamespace,
-					},
-					Data: map[string][]byte{
-						"ca-" + managedClusterName:      []byte("ca-cert-1"),
-						"ca-some-other-managed-cluster": []byte("ca-cert-2"),
-					},
-				},
-			).Build()
+			)
+			if tt.prometheusConfig != nil {
+				cliBuilder = cliBuilder.WithObjects(tt.prometheusConfig)
+			}
+			cli := cliBuilder.Build()
 			r := &VerrazzanoManagedClusterReconciler{
 				Client: cli,
 				log:    log,
 			}
 			err := r.syncThanosQuery(ctx, vmc)
 			assert.NoError(t, err)
-			assertThanosEndpointsConfigMap(ctx, t, cli, tt.expectedConfigMapHosts, tt.hostname, tt.hostShouldExistInCM)
-			if tt.hostShouldExistInCM {
-				assertThanosServiceEntry(t, r, vmc.Name, tt.hostname, thanosGrpcIngressPort)
-				assertThanosDestinationRule(t, r, vmc.Name, tt.hostname, thanosGrpcIngressPort)
+			assertThanosEndpointsConfigMap(ctx, t, cli, tt.expectedConfigMapHosts, toGrpcTarget(thanosHost), vmc.Name, tt.clusterShouldExistInCM)
+			if tt.clusterShouldExistInCM {
+				assertThanosServiceEntry(t, r, vmc.Name, hostName, thanosGrpcIngressPort)
+				assertThanosDestinationRule(t, r, vmc.Name, hostName, thanosGrpcIngressPort)
+			}
+			if tt.prometheusConfig != nil {
+				assertAdditionalScrapeConfigRemoved(t, r, vmc.Name)
 			}
 		})
 	}
@@ -187,6 +194,7 @@ func TestSyncThanosQuery(t *testing.T) {
 
 // TestDeleteClusterThanosEndpoint tests the deleteClusterThanosEndpoint function.
 func TestDeleteClusterThanosEndpoint(t *testing.T) {
+	vmcPrefix := "managed"
 	const managedClusterName = "managed1"
 	const hostName = "thanos-query.example.com"
 	host := toGrpcTarget(hostName)
@@ -197,7 +205,7 @@ func TestDeleteClusterThanosEndpoint(t *testing.T) {
 		Status:     vmcStatus,
 	}
 	cli := fake.NewClientBuilder().WithScheme(makeThanosTestScheme()).WithRuntimeObjects(
-		makeThanosConfigMapWithExistingHosts(t, []string{host}, true),
+		makeThanosConfigMapWithExistingHosts(t, true, 1, host, vmcPrefix),
 		makeThanosEnabledVerrazzano(),
 		&k8sapiext.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: serviceEntryCRDName}},
 		&k8sapiext.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: destinationRuleCRDName}},
@@ -237,7 +245,7 @@ func TestDeleteClusterThanosEndpoint(t *testing.T) {
 	// GIVEN we have sync'ed a managed cluster Thanos endpoint
 	// WHEN we call deleteClusterThanosEndpoint
 	// THEN the resources we created during sync are cleaned up
-	err = r.deleteClusterThanosEndpoint(context.TODO(), vmc)
+	err = r.syncThanosQueryEndpointDelete(context.TODO(), vmc)
 	assert.NoError(t, err)
 
 	// ServiceEntry and DestinationRule should be gone
@@ -271,14 +279,18 @@ func makeThanosEnabledVerrazzano() *v1beta1.Verrazzano {
 	}
 }
 
-func makeThanosConfigMapWithExistingHosts(t *testing.T, hosts []string, useValidConfigMap bool) *corev1.ConfigMap {
+func makeThanosConfigMapWithExistingHosts(t *testing.T, useValidConfigMap bool, numClusters int, host, vmcPrefix string) *corev1.ConfigMap {
 	var yamlExistingHostInfo []byte
 	var err error
 	if useValidConfigMap {
-		existingHostInfo := []*thanosServiceDiscovery{
-			{
-				Targets: hosts,
-			},
+		existingHostInfo := []*thanosServiceDiscovery{}
+		for i := 1; i <= numClusters; i++ {
+			existingHostInfo = append(existingHostInfo, &thanosServiceDiscovery{
+				Targets: []string{host},
+				Labels: map[string]string{
+					verrazzanoManagedLabel: fmt.Sprintf("%s%d", vmcPrefix, i),
+				},
+			})
 		}
 		yamlExistingHostInfo, err = yaml.Marshal(existingHostInfo)
 		assert.NoError(t, err)
@@ -293,20 +305,22 @@ func makeThanosConfigMapWithExistingHosts(t *testing.T, hosts []string, useValid
 	}
 }
 
-func assertThanosEndpointsConfigMap(ctx context.Context, t *testing.T, cli client.WithWatch, expectNumHosts int, host string, hostShoudExist bool) {
+func assertThanosEndpointsConfigMap(ctx context.Context, t *testing.T, cli client.WithWatch, expectNumHosts int, host, vmcName string, vmcShoudExist bool) {
 	modifiedConfigMap := &corev1.ConfigMap{}
 	err := cli.Get(ctx, types.NamespacedName{Namespace: thanos.ComponentNamespace, Name: ThanosManagedClusterEndpointsConfigMap}, modifiedConfigMap)
 	assert.NoError(t, err)
-	// make sure "targets" element is serialized in lower case in the config map
-	assert.Contains(t, modifiedConfigMap.Data[serviceDiscoveryKey], "targets")
-	modifiedContent := []*thanosServiceDiscovery{}
+	var modifiedContent []*thanosServiceDiscovery
 	err = yaml.Unmarshal([]byte(modifiedConfigMap.Data[serviceDiscoveryKey]), &modifiedContent)
 	assert.NoError(t, err)
-	// for now we are only testing with a single service discovery entry with zero or more Targets
-	assert.Len(t, modifiedContent, 1)
-	assert.Equalf(t, expectNumHosts, len(modifiedContent[0].Targets), "Expected %d hosts in modified config map", expectNumHosts)
-	if hostShoudExist {
-		assert.Contains(t, modifiedContent[0].Targets, toGrpcTarget(host))
+	assert.Len(t, modifiedContent, expectNumHosts, "Expected %d service discovery entries", expectNumHosts)
+	if vmcShoudExist {
+		for _, sd := range modifiedContent {
+			if val, ok := sd.Labels[verrazzanoManagedLabel]; ok && val == vmcName {
+				assert.Equal(t, host, sd.Targets[0])
+				return
+			}
+		}
+		assert.Fail(t, fmt.Sprintf("Failed to find Service Discovery for VMC %s", vmcName))
 	}
 }
 
@@ -600,4 +614,16 @@ func assertThanosDestinationRule(t *testing.T, r *VerrazzanoManagedClusterReconc
 	assert.Equal(t, dr.Spec.TrafficPolicy.PortLevelSettings[0].Port.Number, portNum)
 	assert.Equal(t, dr.Spec.TrafficPolicy.PortLevelSettings[0].Tls.Mode, istionet.ClientTLSSettings_SIMPLE)
 	assert.Equal(t, dr.Spec.TrafficPolicy.PortLevelSettings[0].Tls.Sni, hostName)
+}
+
+func assertAdditionalScrapeConfigRemoved(t *testing.T, r *VerrazzanoManagedClusterReconciler, vmcName string) {
+	sec := &corev1.Secret{}
+	err := r.Client.Get(context.TODO(), client.ObjectKey{Namespace: constants.VerrazzanoMonitoringNamespace, Name: vzconst.PromAdditionalScrapeConfigsSecretName}, sec)
+	assert.NoError(t, err)
+	data, ok := sec.Data[vzconst.PromAdditionalScrapeConfigsSecretKey]
+	assert.True(t, ok, "Additional scrape configs key not found in secret")
+	assert.NotEmpty(t, data)
+	scrapeConfigContainer, err := metricsutils.ParseScrapeConfig(string(data))
+	assert.NoError(t, err)
+	assert.Negative(t, metricsutils.FindScrapeJob(scrapeConfigContainer, vmcName))
 }

--- a/cluster-operator/controllers/vmc/vmc_controller.go
+++ b/cluster-operator/controllers/vmc/vmc_controller.go
@@ -419,6 +419,9 @@ func (r *VerrazzanoManagedClusterReconciler) mutateManagedClusterCACertsSecret(c
 func (r *VerrazzanoManagedClusterReconciler) syncManagedMetrics(ctx context.Context, log vzlog.VerrazzanoLogger, vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
 	// We need to sync the multicluster CA secret for Prometheus and Thanos
 	caSecret, err := r.syncMultiClusterCASecret(ctx, log, vmc)
+	if err != nil {
+		r.handleError(ctx, vmc, "Failed to sync the multicluster CA secret", err, log)
+	}
 
 	thanosEnabled, err := r.isThanosEnabled()
 	if err != nil {

--- a/cluster-operator/controllers/vmc/vmc_controller.go
+++ b/cluster-operator/controllers/vmc/vmc_controller.go
@@ -43,8 +43,9 @@ const finalizerName = "managedcluster.verrazzano.io"
 // contains the kubeconfig to be used by the Multi-Cluster Agent to access the admin cluster.
 type VerrazzanoManagedClusterReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	log    vzlog.VerrazzanoLogger
+	Scheme             *runtime.Scheme
+	RancherIngressHost string
+	log                vzlog.VerrazzanoLogger
 }
 
 // bindingParams used to mutate the RoleBinding
@@ -260,20 +261,7 @@ func (r *VerrazzanoManagedClusterReconciler) doReconcile(ctx context.Context, lo
 		log.Errorf("Failed to update status to ready for VMC %s: %v", vmc.Name, err)
 	}
 
-	if vmc.Status.PrometheusHost == "" {
-		log.Oncef("Managed cluster Prometheus Host not found in VMC Status for VMC %s. Waiting for VMC to be registered...", vmc.Name)
-	} else {
-		log.Debugf("Syncing the prometheus scraper for VMC %s", vmc.Name)
-		err = r.syncPrometheusScraper(ctx, vmc)
-		if err != nil {
-			r.handleError(ctx, vmc, "Failed to setup the prometheus scraper for managed cluster", err, log)
-			return newRequeueWithDelay(), err
-		}
-	}
-
-	err = r.syncThanosQuery(ctx, vmc)
-	if err != nil {
-		r.handleError(ctx, vmc, "Failed to update Thanos Query endpoint managed cluster", err, log)
+	if err := r.syncManagedMetrics(ctx, log, vmc); err != nil {
 		return newRequeueWithDelay(), err
 	}
 
@@ -369,6 +357,65 @@ func (r *VerrazzanoManagedClusterReconciler) syncManagedRoleBinding(vmc *cluster
 	})
 }
 
+// syncManagedMetrics syncs the metrics federation for managed clusters
+// There are currently two ways of federating metrics from managed clusters:
+// 1. Creating a Scrape config for the managed cluster on the admin cluster Prometheus
+// 2. Creating a Store in Thanos so that managed cluster metrics can be accessed by the admin cluster Query
+// These scenarios are mutually exclusive and the Thanos Query method takes precedence
+// There are two conditions that enable the Thanos query method
+//  1. Thanos is enabled on the managed cluster
+//     a. This manifests as the ThanosHost field in the VMC being populated
+//  2. Thanos is enabled on the managed cluster
+//
+// If these two conditions are not met, the Prometheus federation will be enabled
+func (r *VerrazzanoManagedClusterReconciler) syncManagedMetrics(ctx context.Context, log vzlog.VerrazzanoLogger, vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
+	thanosEnabled, err := r.isThanosEnabled()
+	if err != nil {
+		r.handleError(ctx, vmc, "Failed to verify if Thanos is enabled", err, log)
+		return err
+	}
+	// If the Thanos multicluster requirements are met, set up the Thanos Query store
+	if vmc.Status.ThanosQueryStore != "" && thanosEnabled {
+		err = r.syncThanosQuery(ctx, vmc)
+		if err != nil {
+			r.handleError(ctx, vmc, "Failed to update Thanos Query endpoint managed cluster", err, log)
+			return err
+		}
+
+		// If we successfully sync the managed cluster Thanos Query store, we should remove the federated Prometheus to avoid duplication
+		r.log.Oncef("Thanos Query synced for VMC %s. Removing the Prometheus scraper", vmc.Name)
+		err = r.deleteClusterPrometheusConfiguration(ctx, vmc)
+		if err != nil {
+			r.handleError(ctx, vmc, "Failed to remove the Prometheus scrape config", err, log)
+			return err
+		}
+		return nil
+	}
+
+	// If Thanos multicluster is disabled, attempt to delete left over resources
+	err = r.syncThanosQueryEndpointDelete(ctx, vmc)
+	if err != nil {
+		r.handleError(ctx, vmc, "Failed to delete Thanos Query endpoint managed cluster", err, log)
+		return err
+	}
+
+	// If the Prometheus host is not populated, skip federation and do nothing
+	if vmc.Status.PrometheusHost == "" {
+		log.Oncef("Managed cluster Prometheus Host not found in VMC Status for VMC %s. Waiting for VMC to be registered...", vmc.Name)
+		return nil
+	}
+
+	// Sync the Prometheus Scraper if Thanos multicluster is disabled and the host is populated
+	log.Debugf("Syncing the prometheus scraper for VMC %s", vmc.Name)
+	err = r.syncPrometheusScraper(ctx, vmc)
+	if err != nil {
+		r.handleError(ctx, vmc, "Failed to setup the prometheus scraper for managed cluster", err, log)
+		return err
+	}
+
+	return nil
+}
+
 // mutateBinding mutates the RoleBinding to ensure it has the valid params
 func mutateBinding(binding *rbacv1.RoleBinding, p bindingParams) {
 	binding.Name = generateManagedResourceName(p.vmc.Name)
@@ -409,7 +456,7 @@ func (r *VerrazzanoManagedClusterReconciler) reconcileManagedClusterDelete(ctx c
 	if err := r.unregisterClusterFromArgoCD(ctx, vmc); err != nil {
 		return err
 	}
-	if err := r.deleteClusterThanosEndpoint(ctx, vmc); err != nil {
+	if err := r.syncThanosQueryEndpointDelete(ctx, vmc); err != nil {
 		return err
 	}
 	return r.deleteClusterFromRancher(ctx, vmc)
@@ -423,7 +470,7 @@ func (r *VerrazzanoManagedClusterReconciler) deleteClusterFromRancher(ctx contex
 		return nil
 	}
 
-	rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.log)
+	rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.RancherIngressHost, r.log)
 	if err != nil {
 		msg := "Failed to create Rancher API client"
 		r.updateRancherStatus(ctx, vmc, clustersv1alpha1.DeleteFailed, clusterID, msg)

--- a/cluster-operator/internal/operatorinit/run_operator.go
+++ b/cluster-operator/internal/operatorinit/run_operator.go
@@ -31,7 +31,7 @@ const (
 )
 
 // StartClusterOperator Cluster operator execution entry point
-func StartClusterOperator(metricsAddr string, enableLeaderElection bool, probeAddr string, log *zap.SugaredLogger, scheme *runtime.Scheme) error {
+func StartClusterOperator(metricsAddr string, enableLeaderElection bool, probeAddr string, ingressHost string, log *zap.SugaredLogger, scheme *runtime.Scheme) error {
 	options := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
@@ -76,8 +76,9 @@ func StartClusterOperator(metricsAddr string, enableLeaderElection bool, probeAd
 
 	// Set up the reconciler for VerrazzanoManagedCluster objects
 	if err = (&vmc.VerrazzanoManagedClusterReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		RancherIngressHost: ingressHost,
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "Failed to setup controller VerrazzanoManagedCluster")
 		os.Exit(1)

--- a/cluster-operator/main.go
+++ b/cluster-operator/main.go
@@ -9,6 +9,7 @@ import (
 
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/cluster-operator/internal/operatorinit"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"go.uber.org/zap"
@@ -32,6 +33,7 @@ var (
 	runWebhooks          bool
 	runWebhookInit       bool
 	certDir              string
+	ingressHost          string
 )
 
 func init() {
@@ -59,7 +61,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		err := operatorinit.StartClusterOperator(metricsAddr, enableLeaderElection, probeAddr, log, scheme)
+		err := operatorinit.StartClusterOperator(metricsAddr, enableLeaderElection, probeAddr, ingressHost, log, scheme)
 		if err != nil {
 			os.Exit(1)
 		}
@@ -78,6 +80,7 @@ func handleFlags() {
 	flag.BoolVar(&runWebhookInit, "run-webhook-init", false,
 		"Runs the webhook initialization code")
 	flag.StringVar(&certDir, "cert-dir", "/etc/certs/", "The directory containing tls.crt and tls.key.")
+	flag.StringVar(&ingressHost, "ingress-host", constants.DefaultRancherIngressHost, "The host used for Rancher API requests.")
 
 	opts := kzap.Options{}
 	opts.BindFlags(flag.CommandLine)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -181,6 +181,9 @@ const ArgoCDClusterRancherSecretName = "verrazzano-argocd-secret"
 // ArgoCDClusterRancherUsername is the username in Rancher used to identify the Verrazzano Argo CD cluster user
 const ArgoCDClusterRancherUsername = "vz-argoCD-reg"
 
+// DefaultRancherIngressHost is the default host used for Rancher API requests
+const DefaultRancherIngressHost = "ingress-controller-ingress-nginx-controller.ingress-nginx"
+
 // Components Names
 const (
 	Istio                 = "istio"

--- a/pkg/rancherutil/rancher_config.go
+++ b/pkg/rancherutil/rancher_config.go
@@ -39,9 +39,6 @@ const (
 
 	loginPath  = "/v3-public/localProviders/local?action=login"
 	tokensPath = "/v3/tokens" //nolint:gosec
-
-	// this host resolves to the cluster IP
-	nginxIngressHostName = "ingress-controller-ingress-nginx-controller.ingress-nginx"
 )
 
 type RancherConfig struct {
@@ -76,26 +73,26 @@ func (*HTTPRequestSender) Do(httpClient *http.Client, req *http.Request) (*http.
 }
 
 // NewAdminRancherConfig creates A rancher config that authenticates with the admin user
-func NewAdminRancherConfig(rdr client.Reader, log vzlog.VerrazzanoLogger) (*RancherConfig, error) {
+func NewAdminRancherConfig(rdr client.Reader, host string, log vzlog.VerrazzanoLogger) (*RancherConfig, error) {
 	secret, err := GetAdminSecret(rdr)
 	if err != nil {
 		return nil, log.ErrorfNewErr("Failed to get the admin secret from the cluster: %v", err)
 	}
-	return NewRancherConfigForUser(rdr, rancherAdminUsername, secret, log)
+	return NewRancherConfigForUser(rdr, rancherAdminUsername, secret, host, log)
 }
 
 // NewVerrazzanoClusterRancherConfig creates A rancher config that authenticates with the Verrazzano cluster user
-func NewVerrazzanoClusterRancherConfig(rdr client.Reader, log vzlog.VerrazzanoLogger) (*RancherConfig, error) {
+func NewVerrazzanoClusterRancherConfig(rdr client.Reader, host string, log vzlog.VerrazzanoLogger) (*RancherConfig, error) {
 	secret, err := GetVerrazzanoClusterUserSecret(rdr)
 	if err != nil {
 		return nil, log.ErrorfNewErr("Failed to get the Verrazzano cluster secret from the cluster: %v", err)
 	}
-	return NewRancherConfigForUser(rdr, cons.VerrazzanoClusterRancherUsername, secret, log)
+	return NewRancherConfigForUser(rdr, cons.VerrazzanoClusterRancherUsername, secret, host, log)
 }
 
 // NewRancherConfigForUser returns a populated RancherConfig struct that can be used to make calls to the Rancher API
-func NewRancherConfigForUser(rdr client.Reader, username, password string, log vzlog.VerrazzanoLogger) (*RancherConfig, error) {
-	rc := &RancherConfig{BaseURL: "https://" + nginxIngressHostName}
+func NewRancherConfigForUser(rdr client.Reader, username, password, host string, log vzlog.VerrazzanoLogger) (*RancherConfig, error) {
+	rc := &RancherConfig{BaseURL: "https://" + host}
 
 	// Rancher host name is needed for TLS
 	log.Debug("Getting Rancher ingress host name")

--- a/pkg/rancherutil/rancher_config_test.go
+++ b/pkg/rancherutil/rancher_config_test.go
@@ -62,7 +62,7 @@ func TestCreateRancherRequest(t *testing.T) {
 	RancherHTTPClient = httpMock
 
 	// Test with the Verrazzano cluster user
-	rc, err := NewVerrazzanoClusterRancherConfig(cli, log)
+	rc, err := NewVerrazzanoClusterRancherConfig(cli, pkgconst.DefaultRancherIngressHost, log)
 	assert.NoError(t, err)
 
 	response, body, err := SendRequest(http.MethodGet, testPath, map[string]string{}, "", rc, log)
@@ -71,7 +71,7 @@ func TestCreateRancherRequest(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 
 	// Test with the admin user
-	rc, err = NewAdminRancherConfig(cli, log)
+	rc, err = NewAdminRancherConfig(cli, pkgconst.DefaultRancherIngressHost, log)
 	assert.NoError(t, err)
 
 	response, body, err = SendRequest(http.MethodGet, testPath, map[string]string{}, "", rc, log)

--- a/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator.go
+++ b/platform-operator/controllers/verrazzano/component/clusteroperator/cluster_operator.go
@@ -97,7 +97,7 @@ func (c clusterOperatorComponent) postInstallUpgrade(ctx spi.ComponentContext) e
 
 // createVZClusterUser creates the Verrazzano cluster user in Rancher using the Rancher API
 func createVZUser(userName, regName, userDescription, secretName string, ctx spi.ComponentContext) error {
-	rc, err := rancherutil.NewAdminRancherConfig(ctx.Client(), ctx.Log())
+	rc, err := rancherutil.NewAdminRancherConfig(ctx.Client(), vzconst.DefaultRancherIngressHost, ctx.Log())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Changes**

- Add a cluster label to the managed cluster store targets for selection
- Change the update and create process to factor in labels
- Add an ingress host flag to override the Rancher API calls for running in IDE
- Update and add unit tests to test new update and delete process

**Testing**

- Run a multicluster setup in kind
- Turn on and off the Thanos component on the managed cluster
- Turn on and off the Thanos component on the admin cluster
- Make sure that the Thanos query store configmap gets modified correctly
- Make sure that the Prometheus additional configs get modified correctly
- Deregister and make sure both Thanos and Prometheus targets get cleaned up


