### PR TITLE
VZ-9210: Backport PR update vmo image to fix the bug by adding annotation to OS/OSD pods to add hooks to delay application startup to release 1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -223,7 +223,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "v1.5.3-20230320145557-f8a3f5d",
+              "tag": "v1.5.3-20230410114615-9f5efc3",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
Added annotations proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }' to OS/OSD pods.
This annotation adds hooks to delay application startup until the pod proxy is ready to accept traffic, mitigating some startup race conditions