### PR TITLE
Rename Thanos Query Store host field in VMC status

### DIFF
--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -177,7 +177,7 @@ func (s *Syncer) updateVMCStatus() error {
 		return fmt.Errorf("Failed to get Thanos query URL to update VMC %s: %v", vmcName, err)
 	}
 	if thanosAPIHost != "" {
-		vmc.Status.ThanosHost = thanosAPIHost
+		vmc.Status.ThanosQueryStore = thanosAPIHost
 	}
 
 	// update status of VMC

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -323,7 +323,7 @@ func expectAdminVMCStatusUpdateSuccess(adminMock *mocks.MockClient, vmcName type
 			assert.NotNil(vmc.Status.LastAgentConnectTime)
 			assert.NotNil(vmc.Status.APIUrl)
 			assert.Equal(testManagedPrometheusHost, vmc.Status.PrometheusHost)
-			assert.Equal(testManagedThanosQueryStoreAPIHost, vmc.Status.ThanosHost)
+			assert.Equal(testManagedThanosQueryStoreAPIHost, vmc.Status.ThanosQueryStore)
 			return nil
 		})
 }

--- a/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
+++ b/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
@@ -126,8 +126,8 @@ type VerrazzanoManagedClusterStatus struct {
 	LastAgentConnectTime *metav1.Time `json:"lastAgentConnectTime,omitempty"`
 	// The Prometheus host for this managed cluster.
 	PrometheusHost string `json:"prometheusHost,omitempty"`
-	// The Thanos API host name for this managed cluster.
-	ThanosHost string `json:"thanosHost,omitempty"`
+	// The Thanos Query Store API host name for this managed cluster.
+	ThanosQueryStore string `json:"thanosQueryStore,omitempty"`
 	// The state of Rancher registration for this managed cluster.
 	RancherRegistration RancherRegistration `json:"rancherRegistration,omitempty"`
 	// The state of ArgoCD registration for this managed cluster.

--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -54,8 +54,8 @@ const serviceDiscoveryKey = "servicediscovery.yml"
 func (r *VerrazzanoManagedClusterReconciler) syncThanosQuery(ctx context.Context,
 	vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
 
-	if vmc.Status.ThanosHost == "" {
-		r.log.Oncef("Managed cluster Thanos Host not found in VMC Status for VMC %s. Not updating Thanos endpoints", vmc.Name)
+	if vmc.Status.ThanosQueryStore == "" {
+		r.log.Oncef("Managed cluster Thanos Query Store not found in VMC Status for VMC %s. Not updating Thanos endpoints", vmc.Name)
 		return nil
 	}
 
@@ -65,10 +65,10 @@ func (r *VerrazzanoManagedClusterReconciler) syncThanosQuery(ctx context.Context
 	if err := r.createOrUpdateCACertVolume(vmc, r.addCACertToDeployment); err != nil {
 		return err
 	}
-	if err := r.createOrUpdateServiceEntry(vmc.Name, vmc.Status.ThanosHost, thanosGrpcIngressPort); err != nil {
+	if err := r.createOrUpdateServiceEntry(vmc.Name, vmc.Status.ThanosQueryStore, thanosGrpcIngressPort); err != nil {
 		return err
 	}
-	if err := r.createOrUpdateDestinationRule(vmc, vmc.Status.ThanosHost, thanosGrpcIngressPort); err != nil {
+	if err := r.createOrUpdateDestinationRule(vmc, vmc.Status.ThanosQueryStore, thanosGrpcIngressPort); err != nil {
 		return err
 	}
 	return nil
@@ -84,12 +84,12 @@ func (r *VerrazzanoManagedClusterReconciler) syncThanosQueryEndpoint(ctx context
 		return nil
 	}
 
-	return r.addThanosHostIfNotPresent(ctx, vmc.Status.ThanosHost)
+	return r.addThanosHostIfNotPresent(ctx, vmc.Status.ThanosQueryStore)
 }
 
 func (r *VerrazzanoManagedClusterReconciler) deleteClusterThanosEndpoint(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
-	if vmc.Status.ThanosHost == "" {
-		r.log.Oncef("Managed cluster Thanos Host not found in VMC Status for VMC %s. No Thanos endpoint to be deleted", vmc.Name)
+	if vmc.Status.ThanosQueryStore == "" {
+		r.log.Oncef("Managed cluster Thanos Query Store not found in VMC Status for VMC %s. No Thanos endpoint to be deleted", vmc.Name)
 		return nil
 	}
 
@@ -98,7 +98,7 @@ func (r *VerrazzanoManagedClusterReconciler) deleteClusterThanosEndpoint(ctx con
 		return nil
 	}
 
-	if err := r.removeThanosHostFromConfigMap(ctx, vmc.Status.ThanosHost, r.log); err != nil {
+	if err := r.removeThanosHostFromConfigMap(ctx, vmc.Status.ThanosQueryStore, r.log); err != nil {
 		return err
 	}
 	if err := r.deleteDestinationRule(vmc.Name); err != nil {

--- a/cluster-operator/controllers/vmc/sync_thanos_test.go
+++ b/cluster-operator/controllers/vmc/sync_thanos_test.go
@@ -120,22 +120,22 @@ func TestSyncThanosQuery(t *testing.T) {
 		hostShouldExistInCM    bool
 	}{
 		{"VMC status empty", nil, 1, "", []string{otherHost1}, false},
-		{"VMC status has no Thanos host",
+		{"VMC status has no Thanos Query Store",
 			&clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl"},
 			1,
 			"",
 			[]string{otherHost1},
 			false,
 		},
-		{"VMC status has existing Thanos host",
-			&clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl", ThanosHost: newHostName},
+		{"VMC status has existing Thanos Query Store",
+			&clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl", ThanosQueryStore: newHostName},
 			2,
 			newHostName,
 			[]string{newHost, otherHost1},
 			true, // new host already exists in query endpoints configmap, should still exist
 		},
-		{"VMC status has non-existing Thanos host",
-			&clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl", ThanosHost: newHostName},
+		{"VMC status has non-existing Thanos Query Store",
+			&clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl", ThanosQueryStore: newHostName},
 			3,
 			newHostName,
 			[]string{otherHost1, otherHost2},
@@ -191,7 +191,7 @@ func TestDeleteClusterThanosEndpoint(t *testing.T) {
 	const hostName = "thanos-query.example.com"
 	host := toGrpcTarget(hostName)
 
-	vmcStatus := clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl", ThanosHost: hostName}
+	vmcStatus := clustersv1alpha1.VerrazzanoManagedClusterStatus{APIUrl: "someurl", ThanosQueryStore: hostName}
 	vmc := &clustersv1alpha1.VerrazzanoManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: managedClusterName, Namespace: constants.VerrazzanoMultiClusterNamespace},
 		Status:     vmcStatus,

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
@@ -142,8 +142,9 @@ spec:
               state:
                 description: The state of this managed cluster.
                 type: string
-              thanosHost:
-                description: The Thanos API host name for this managed cluster.
+              thanosQueryStore:
+                description: The Thanos Query Store API host name for this managed
+                  cluster.
                 type: string
             required:
             - state


### PR DESCRIPTION
Per API Review, updating the Thanos Query Store field in the VMC status.

I tested locally in a multicluster environment and verified that the Thanos host gets set in the VMC status and that the endpoint shows as healthy in the Thanos Query store list on the admin cluster.

Example VMC status snippet:
```
  Prometheus Host:          prometheus.vmi.system.default...
  Rancher Registration:
    Cluster ID:        c-cqb45
    Message:           Registration of managed cluster completed successfully for cluster managed1 with ID c-cqb45
    Status:            Completed
  State:               Active
  Thanos Query Store:  query-store.default...
```