### PR TITLE
Update the Thanos Query Store Ingress name

### DIFF
--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -37,7 +37,7 @@ var validSecret = corev1.Secret{
 }
 
 const testManagedPrometheusHost = "prometheus"
-const testManagedThanosQueryStoreAPIHost = "thanos-grpc.example.com"
+const testManagedThanosQueryStoreAPIHost = "thanos-query-store.example.com"
 
 // TestProcessAgentThreadNoProjects tests agent thread when no projects exist
 // GIVEN a request to process the agent loop

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -204,4 +204,4 @@ const (
 const ThanosQueryIngress = "thanos-query-frontend"
 
 // ThanosQueryStoreIngress is the name of the ingress for the Thanos Query Store API
-const ThanosQueryStoreIngress = "thanos-grpc"
+const ThanosQueryStoreIngress = "thanos-query-store"

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak.go
@@ -552,8 +552,8 @@ const pkceClientUrisTemplate = `
 	  "https://osd.vmi.system.{{.DNSSubDomain}}/_authentication_callback",
 	  "https://kiali.vmi.system.{{.DNSSubDomain}}/*",
 	  "https://kiali.vmi.system.{{.DNSSubDomain}}/_authentication_callback",
-	  "https://query-store.{{.DNSSubDomain}}/*",
-	  "https://query-store.{{.DNSSubDomain}}/_authentication_callback",
+	  "https://thanos-query-store.{{.DNSSubDomain}}/*",
+	  "https://thanos-query-store.{{.DNSSubDomain}}/_authentication_callback",
 	  "https://thanos-query.{{.DNSSubDomain}}/*",
 	  "https://thanos-query.{{.DNSSubDomain}}/_authentication_callback",
 	  "https://jaeger.{{.DNSSubDomain}}/*"{{ if .OSHostExists}},
@@ -569,7 +569,7 @@ const pkceClientUrisTemplate = `
 	  "https://grafana.vmi.system.{{.DNSSubDomain}}",
 	  "https://osd.vmi.system.{{.DNSSubDomain}}",
 	  "https://kiali.vmi.system.{{.DNSSubDomain}}",
-	  "https://query-store.{{.DNSSubDomain}}",
+	  "https://thanos-query-store.{{.DNSSubDomain}}",
 	  "https://thanos-query.{{.DNSSubDomain}}",
 	  "https://jaeger.{{.DNSSubDomain}}"{{ if .OSHostExists}},
       "https://elasticsearch.vmi.system.{{.DNSSubDomain}}",
@@ -581,14 +581,14 @@ const ManagedClusterClientUrisTemplate = `
 	"redirectUris": [
 	  "https://prometheus.vmi.system.{{.DNSSubDomain}}/*",
 	  "https://prometheus.vmi.system.{{.DNSSubDomain}}/_authentication_callback",
-	  "https://query-store.{{.DNSSubDomain}}/*",
-	  "https://query-store.{{.DNSSubDomain}}/_authentication_callback",
+	  "https://thanos-query-store.{{.DNSSubDomain}}/*",
+	  "https://thanos-query-store.{{.DNSSubDomain}}/_authentication_callback",
 	  "https://thanos-query.{{.DNSSubDomain}}/*",
 	  "https://thanos-query.{{.DNSSubDomain}}/_authentication_callback"
 	],
 	"webOrigins": [
 	  "https://prometheus.vmi.system.{{.DNSSubDomain}}",
-	  "https://query-store.{{.DNSSubDomain}}",
+	  "https://thanos-query-store.{{.DNSSubDomain}}",
 	  "https://thanos-query.{{.DNSSubDomain}}"
 	]
 `

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos.go
@@ -26,7 +26,7 @@ const (
 	queryCertificateName = "system-tls-thanos-query"
 
 	// Thanos Query StoreAPI constants
-	queryStoreHostName        = "query-store"
+	queryStoreHostName        = "thanos-query-store"
 	queryStoreCertificateName = "system-tls-query-store"
 )
 

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
@@ -135,19 +135,19 @@ func TestAppendOverrides(t *testing.T) {
 		`queryFrontend.ingress.annotations.nginx\.ingress\.kubernetes\.io/session-cookie-name`: queryHostName,
 		"query.ingress.grpc.namespace":                                                         constants.VerrazzanoSystemNamespace,
 		"query.ingress.grpc.ingressClassName":                                                  "verrazzano-nginx",
-		"query.ingress.grpc.extraRules[0].host":                                                "query-store.default.11.22.33.44.nip.io",
+		"query.ingress.grpc.extraRules[0].host":                                                "thanos-query-store.default.11.22.33.44.nip.io",
 		"query.ingress.grpc.extraRules[0].http.paths[0].backend.service.name":                  constants.VerrazzanoAuthProxyServiceName,
 		"query.ingress.grpc.extraRules[0].http.paths[0].backend.service.port.number":           strconv.Itoa(constants.VerrazzanoAuthProxyGRPCServicePort),
 		"query.ingress.grpc.extraRules[0].http.paths[0].path":                                  "/",
 		"query.ingress.grpc.extraRules[0].http.paths[0].pathType":                              string(netv1.PathTypeImplementationSpecific),
-		"query.ingress.grpc.extraTls[0].hosts[0]":                                              "query-store.default.11.22.33.44.nip.io",
+		"query.ingress.grpc.extraTls[0].hosts[0]":                                              "thanos-query-store.default.11.22.33.44.nip.io",
 		"query.ingress.grpc.extraTls[0].secretName":                                            queryStoreCertificateName,
 	}
 	sslipioKVs := map[string]string{
 		"queryFrontend.ingress.extraRules[0].host":   "thanos-query.default.11.22.33.44.sslip.io",
 		"queryFrontend.ingress.extraTls[0].hosts[0]": "thanos-query.default.11.22.33.44.sslip.io",
-		"query.ingress.grpc.extraRules[0].host":      "query-store.default.11.22.33.44.sslip.io",
-		"query.ingress.grpc.extraTls[0].hosts[0]":    "query-store.default.11.22.33.44.sslip.io",
+		"query.ingress.grpc.extraRules[0].host":      "thanos-query-store.default.11.22.33.44.sslip.io",
+		"query.ingress.grpc.extraTls[0].hosts[0]":    "thanos-query-store.default.11.22.33.44.sslip.io",
 	}
 	istioEnabledKV := map[string]string{
 		"verrazzano.isIstioEnabled": "true",
@@ -162,8 +162,8 @@ func TestAppendOverrides(t *testing.T) {
 		"queryFrontend.ingress.extraTls[0].hosts[0]":                                   "thanos-query.default.mydomain.com",
 		`queryFrontend.ingress.annotations.external-dns\.alpha\.kubernetes\.io/target`: "verrazzano-ingress.default.mydomain.com",
 		`queryFrontend.ingress.annotations.external-dns\.alpha\.kubernetes\.io/ttl`:    "60",
-		"query.ingress.grpc.extraRules[0].host":                                        "query-store.default.mydomain.com",
-		"query.ingress.grpc.extraTls[0].hosts[0]":                                      "query-store.default.mydomain.com",
+		"query.ingress.grpc.extraRules[0].host":                                        "thanos-query-store.default.mydomain.com",
+		"query.ingress.grpc.extraTls[0].hosts[0]":                                      "thanos-query-store.default.mydomain.com",
 		`query.ingress.grpc.annotations.external-dns\.alpha\.kubernetes\.io/target`:    "verrazzano-ingress.default.mydomain.com",
 		`query.ingress.grpc.annotations.external-dns\.alpha\.kubernetes\.io/ttl`:       "60",
 	}

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy-configmap.yaml
@@ -430,7 +430,7 @@ data:
                 check_host = backend..me.hostSuffix
             elseif backend == 'thanos-query' then
                 check_host = backend..me.hostSuffix
-            elseif backend == 'query-store' then
+            elseif backend == 'thanos-query-store' then
                 check_host = backend..me.hostSuffix
             else
                 check_host = backend..vmi_system..me.hostSuffix
@@ -520,7 +520,7 @@ data:
             serverUrl = me.makeMonitoringComponentBackendUrl('http', 'prometheus-operator-kube-p-prometheus', '9090')
         elseif backend == 'thanos-query' then
             serverUrl = me.makeMonitoringComponentBackendUrl('http', 'thanos-query-frontend', '9090')
-        elseif backend == 'query-store' then
+        elseif backend == 'thanos-query-store' then
             serverUrl = me.makeMonitoringComponentBackendUrl('grpc', 'thanos-query-grpc', '10901')
         elseif backend == 'kibana' then
             serverUrl = me.makeVmiBackendUrl('osd', '5601')
@@ -1211,7 +1211,7 @@ data:
             allowedOrigins = os.getenv("VZ_PROMETHEUS_ALLOWED_ORIGINS")
         elseif backend == 'thanos-query' then
             allowedOrigins = os.getenv("VZ_THANOS_QUERY_ALLOWED_ORIGINS")
-        elseif backend == 'query-store' then
+        elseif backend == 'thanos-query-store' then
             allowedOrigins = os.getenv("VZ_QUERY_STORE_ALLOWED_ORIGINS")
         elseif backend == 'kibana' then
             allowedOrigins = os.getenv("VZ_KIBANA_ALLOWED_ORIGINS")

--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -12,6 +12,7 @@ query:
         - ALL
   ingress:
     grpc:
+      name: thanos-query-store
       enabled: true
       annotations:
         kubernetes.io/tls-acme: "true"

--- a/platform-operator/thirdparty/charts/thanos/templates/query/ingress-grpc.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/query/ingress-grpc.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ include "common.names.fullname" . }}-grpc
+  name: {{ .Values.query.ingress.grpc.name }}
   namespace: {{ .Values.query.ingress.grpc.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query

--- a/platform-operator/thirdparty/charts/thanos/templates/query/ingress-grpc.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/query/ingress-grpc.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ .Values.query.ingress.grpc.name }}
+  name: {{ .Values.query.ingress.grpc.name | quote }}
   namespace: {{ .Values.query.ingress.grpc.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -128,9 +128,9 @@ func GetQueryStoreIngressHost(kubeconfigPath string) string {
 		Log(Error, fmt.Sprintf("Failed to get clientset for cluster %v", err))
 		return ""
 	}
-	ingress, err := clientset.NetworkingV1().Ingresses("verrazzano-system").Get(context.TODO(), "thanos-grpc", metav1.GetOptions{})
+	ingress, err := clientset.NetworkingV1().Ingresses("verrazzano-system").Get(context.TODO(), "thanos-query-store", metav1.GetOptions{})
 	if err != nil {
-		Log(Error, fmt.Sprintf("Failed to get Ingress thanos-grpc from the cluster: %v", err))
+		Log(Error, fmt.Sprintf("Failed to get Ingress thanos-query-store from the cluster: %v", err))
 	}
 	return ingress.Spec.Rules[0].Host
 }

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -134,7 +134,7 @@ func getExpectedConsoleURLs(kubeConfig string) ([]string, error) {
 		// The Thanos Store API endpoints are not stored in the Verrazzano instance and can be ignored
 		if strings.HasPrefix(ingressHost, "elasticsearch") ||
 			strings.HasPrefix(ingressHost, "kibana") ||
-			strings.HasPrefix(ingressHost, "query-store") {
+			strings.HasPrefix(ingressHost, "thanos-query-store") {
 			continue
 		}
 		// Any verrazzano-managed ingresses in the Rancher namespace are created for managed clusters to be

--- a/tests/e2e/verify-install/thanos/thanos_test.go
+++ b/tests/e2e/verify-install/thanos/thanos_test.go
@@ -88,7 +88,7 @@ var _ = t.Describe("Thanos", Label("f:platform-lcm.install"), func() {
 		// THEN we successfully find the ingresses in the cluster
 		WhenThanosInstalledIt("query store and query frontend ingresses exist", func() {
 			Eventually(func() (bool, error) {
-				ingresses := []string{"thanos-query-frontend", "thanos-grpc"}
+				ingresses := []string{"thanos-query-frontend", "thanos-query-store"}
 				return pkg.IngressesExist(inClusterVZ, constants.VerrazzanoSystemNamespace, ingresses)
 			}, waitTimeout, pollingInterval).Should(BeTrue(), "Expected Thanos Ingresses should exist")
 		})


### PR DESCRIPTION
This is an alteration to the Thanos Query store Ingress name

**Testing**

Install multicluster verrazzano and verify that the ingress is updated and the managed cluster is scraped from the new ingress name.