### PR TITLE
VZ-9280: E2E test for Thanos Store Gateway

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -95,6 +95,7 @@ pipeline {
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
         VERRAZZANO_OPERATOR_IMAGE="${params.VERRAZZANO_OPERATOR_IMAGE}"
+        ENABLE_THANOS_STORE_GATEWAY = true
 
         WEBLOGIC_PSW = credentials('weblogic-example-domain-password') // required by WebLogic application and console ingress test
         DATABASE_PSW = credentials('todo-mysql-password') // required by console ingress test

--- a/ci/scripts/prepare_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_jenkins_at_environment.sh
@@ -27,6 +27,7 @@ KIND_NODE_COUNT=${KIND_NODE_COUNT:-1}
 TEST_OVERRIDE_CONFIGMAP_FILE="./tests/e2e/config/scripts/pre-install-overrides/test-overrides-configmap.yaml"
 TEST_OVERRIDE_SECRET_FILE="./tests/e2e/config/scripts/pre-install-overrides/test-overrides-secret.yaml"
 INSTALL_TIMEOUT_VALUE=${INSTALL_TIMEOUT:-30m}
+ENABLE_THANOS_STORE_GATEWAY=${ENABLE_THANOS_STORE_GATEWAY:-false}
 
 cd ${GO_REPO_PATH}/verrazzano
 echo "tests will execute" > ${TESTS_EXECUTED_FILE}
@@ -141,6 +142,12 @@ VZ_INSTALL_FILE=${VZ_INSTALL_FILE:-"${WORKSPACE}/acceptance-test-config.yaml"}
 if [ $USE_DB_FOR_GRAFANA == true ]; then
   ./tests/e2e/config/scripts/process_grafana_db_install_yaml.sh ${INSTALL_CONFIG_FILE_KIND}
 fi
+
+# If Thanos Store Gateway flag is set, create the storage provider secret and update the Thanos overrides in the VZ file
+if [ $ENABLE_THANOS_STORE_GATEWAY == true ]; then
+  ./tests/e2e/config/scripts/configure_thanos_storegateway_install.sh ${INSTALL_CONFIG_FILE_KIND}
+fi
+
 cp -v ${INSTALL_CONFIG_FILE_KIND} ${VZ_INSTALL_FILE}
 
 echo "Creating Override ConfigMap"

--- a/tests/e2e/config/scripts/configure_thanos_storegateway_install.sh
+++ b/tests/e2e/config/scripts/configure_thanos_storegateway_install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+INSTALL_CONFIG_TO_EDIT=$1
+
+# Thanos storage provider config that uses local filesystem
+STORAGE_PROVIDER_CONFIG='type: FILESYSTEM
+config:
+  directory: "/tmp"
+'
+
+# Create the verrazzano-monitoring namespace if it does not exist and create a secret with the storage provider config
+kubectl create ns verrazzano-monitoring 2>/dev/null || true
+kubectl create secret generic -n verrazzano-monitoring objstore-config --from-literal=objstore.yml="${STORAGE_PROVIDER_CONFIG}"
+
+# Modify the VZ CR to enable Thanos Store Gateway and to reference the storage provider secret
+echo "Editing install config file for Thanos Store Gateway ${INSTALL_CONFIG_TO_EDIT}"
+  yq -i eval ".spec.components.thanos.overrides.[0].values.existingObjstoreSecret = \"objstore-config\"" ${INSTALL_CONFIG_TO_EDIT}
+  yq -i eval ".spec.components.thanos.overrides.[0].values.storegateway.enabled = true" ${INSTALL_CONFIG_TO_EDIT}
+
+cat ${INSTALL_CONFIG_TO_EDIT}

--- a/tests/e2e/verify-install/thanos/thanos_test.go
+++ b/tests/e2e/verify-install/thanos/thanos_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Jeffail/gabs/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -25,9 +26,10 @@ const (
 var t = framework.NewTestFramework("thanos")
 
 var (
-	isThanosSupported bool
-	isThanosInstalled bool
-	inClusterVZ       *v1alpha1.Verrazzano
+	isThanosSupported     bool
+	isThanosInstalled     bool
+	isStoreGatewayEnabled bool
+	inClusterVZ           *v1alpha1.Verrazzano
 )
 
 func getKubeConfigOrAbort() string {
@@ -51,7 +53,32 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 		AbortSuite(fmt.Sprintf("Failed to get Verrazzano from the cluster: %v", err))
 	}
 	isThanosInstalled = vzcr.IsThanosEnabled(inClusterVZ)
+
+	if isThanosInstalled {
+		isStoreGatewayEnabled, err = isStoreGatewayEnabledInOverrides(inClusterVZ.Spec.Components.Thanos.InstallOverrides.ValueOverrides)
+		if err != nil {
+			AbortSuite(fmt.Sprintf("Failed to process VZ CR Thanos overrides: %v", err))
+		}
+	}
 })
+
+// isStoreGatewayEnabledInOverrides returns true if the Thanos Store Gateway is enabled in the VZ CR overrides
+func isStoreGatewayEnabledInOverrides(overrides []v1alpha1.Overrides) (bool, error) {
+	for _, override := range inClusterVZ.Spec.Components.Thanos.InstallOverrides.ValueOverrides {
+		if override.Values != nil {
+			jsonString, err := gabs.ParseJSON(override.Values.Raw)
+			if err != nil {
+				return false, err
+			}
+			if container := jsonString.Path("storegateway.enabled"); container != nil {
+				if enabled, ok := container.Data().(bool); ok {
+					return enabled, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
 
 var _ = BeforeSuite(beforeSuite)
 
@@ -64,7 +91,6 @@ func WhenThanosInstalledIt(description string, f func()) {
 			t.Logs.Infof("Skipping check '%v', Thanos is not installed on this cluster", description)
 		}
 	})
-
 }
 
 var _ = t.Describe("Thanos", Label("f:platform-lcm.install"), func() {
@@ -72,9 +98,13 @@ var _ = t.Describe("Thanos", Label("f:platform-lcm.install"), func() {
 		// GIVEN the Thanos is installed
 		// WHEN we check to make sure the pods exist
 		// THEN we successfully find the pods in the cluster
-		WhenThanosInstalledIt("query and query frontend pods are running", func() {
+		WhenThanosInstalledIt("expected pods are running", func() {
+			pods := []string{"thanos-query", "thanos-query-frontend"}
+			if isStoreGatewayEnabled {
+				pods = append(pods, "thanos-storegateway")
+			}
+
 			Eventually(func() (bool, error) {
-				pods := []string{"thanos-query", "thanos-query-frontend"}
 				result, err := pkg.PodsRunning(constants.VerrazzanoMonitoringNamespace, pods)
 				if err != nil {
 					t.Logs.Errorf("Pods %v are not running in the namespace: %v, error: %v", pods, constants.VerrazzanoMonitoringNamespace, err)


### PR DESCRIPTION
This PR adds an end-to-end test for the Thanos Store Gateway to the Kind acceptance tests. If an environment variable to enable the test is set, the script creates a secret with the Thanos storage provider configuration and updates the VZ CR to enable the Store Gateway and point to the config secret. I enabled the flag in the main Kind AT pipeline.

I tested by running the test against a cluster with and without the Thanos Store Gateway enabled and confirmed that it checked for the running Store Gateway pod as needed.

Note that if the Store Gateway cannot mount the secret or if the secret contents don't pass minimal validation, the Store Gateway pod will go into CrashLoopBackoff and the test will fail, so the check for running (and ready) Store Gateway pod seems sufficient.