### PR TITLE
Add CRD capability check to Thanos ServiceMonitor and PrometheusRule Helm templates

### DIFF
--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
@@ -15,6 +15,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
+	promoperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -52,7 +53,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorUninstall: true,
 			ImagePullSecretKeyname:    "image.pullSecrets[0]",
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "thanos-values.yaml"),
-			Dependencies:              []string{networkpolicies.ComponentName, nginx.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, nginx.ComponentName, promoperator.ComponentName},
 			AppendOverridesFunc:       AppendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
 			AvailabilityObjects: &ready.AvailabilityObjects{

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/absent_rules.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/absent_rules.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.absent_rules ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.absent_rules ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/compaction.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/compaction.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.compaction ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.compaction ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/query.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/query.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.query ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.query ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/receive.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/receive.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.receive ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.receive ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/replicate.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/replicate.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.replicate ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.replicate ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/ruler.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/ruler.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.ruler ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.ruler ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/sidecar.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/sidecar.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.sidecar ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.sidecar ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/store_gateway.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/store_gateway.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.store_gateway ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.store_gateway ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/bucketweb/servicemonitor.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/bucketweb/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.bucketweb.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.bucketweb.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/compactor/servicemonitor.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/compactor/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.compactor.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.compactor.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/prometheusrule.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled .Values.metrics.prometheusRule.groups }}
+{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled .Values.metrics.prometheusRule.groups ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/query-frontend/servicemonitor.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/query-frontend/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.queryFrontend.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.queryFrontend.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/query/servicemonitor.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/query/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.query.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.query.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/receive-distributor/servicemonitor.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/receive-distributor/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.receiveDistributor.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.receiveDistributor.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/receive/servicemonitor.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/receive/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.receive.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.receive.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/ruler/servicemonitor.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/ruler/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ruler.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.ruler.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/storegateway/servicemonitor.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/storegateway/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.storegateway.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.storegateway.enabled .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
This PR adds a capabilities check for the monitoring CRD so that the Thanos install or call to get computed Helm values from the Thanos component do not fail if the CRD does not exist in the cluster. This avoids errors in the VPO log during install time. As long as the Prometheus Operator is enabled the errors are benign and would eventually resolve, but this cleans things up so the error condition is avoided.

I also added a dependency to the Thanos component on the Prometheus Operator component so that, if the Prometheus Operator is enabled, it will be installed first and thus install the monitoring CRD.