### PR TITLE
VZ-9282 Check for Grafana datasource in VMI test

### DIFF
--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -379,7 +379,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 					}
 				})
 
-				t.It("Grafana should have a datasource present", func() {
+				t.It("Grafana should have a default datasource present", func() {
 					vz, err := pkg.GetVerrazzanoInstallResourceInCluster(kubeconfigPath)
 					if err != nil {
 						t.Logs.Errorf("Error getting Verrazzano resource: %v", err)

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -697,7 +697,7 @@ func verrazzanoSecretRequired(vz *vzalpha1.Verrazzano) bool {
 		vzcr.IsComponentStatusEnabled(vz, kiali.ComponentName)
 }
 
-func grafanaDatasourceExists(vz *vzalpha1.Verrazzano, name, kubeconfigPath string) (bool, error) {
+func grafanaDefaultDatasourceExists(vz *vzalpha1.Verrazzano, name, kubeconfigPath string) (bool, error) {
 	password, err := pkg.GetVerrazzanoPasswordInCluster(kubeconfigPath)
 	if err != nil {
 		t.Logs.Error("Failed to get the Verrazzano password from the cluster")
@@ -732,9 +732,21 @@ func grafanaDatasourceExists(vz *vzalpha1.Verrazzano, name, kubeconfigPath strin
 			t.Logs.Errorf("Failed to convert name field to string")
 			continue
 		}
-		if nameStr == name {
-			return true, nil
+		if nameStr != name {
+			continue
 		}
+
+		sourceDefault, ok := source["isDefault"]
+		if !ok {
+			t.Logs.Errorf("Failed to verify the datasource was the default")
+			continue
+		}
+		defaultBool, ok := sourceDefault.(bool)
+		if !ok {
+			t.Logs.Errorf("Failed to convert default to bool")
+			continue
+		}
+		return defaultBool, nil
 	}
 
 	t.Logs.Errorf("Failed to find Grafana datasource %s", name)

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -390,7 +390,7 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 						name = "Thanos"
 					}
 					Eventually(func() (bool, error) {
-						return grafanaDatasourceExists(vz, name, kubeconfigPath)
+						return grafanaDefaultDatasourceExists(vz, name, kubeconfigPath)
 					}).WithTimeout(waitTimeout).WithPolling(pollingInterval).Should(BeTrue())
 				})
 			}

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -701,7 +701,7 @@ func grafanaDatasourceExists(vz *vzalpha1.Verrazzano, name, kubeconfigPath strin
 		t.Logs.Error("Failed to get the Verrazzano password from the cluster")
 		return false, err
 	}
-	if vz.Status.VerrazzanoInstance == nil || vz.Status.VerrazzanoInstance.GrafanaURL == nil {
+	if vz == nil || vz.Status.VerrazzanoInstance == nil || vz.Status.VerrazzanoInstance.GrafanaURL == nil {
 		t.Logs.Error("Grafana URL in the Verrazzano status is empty")
 		return false, nil
 	}

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -389,7 +389,9 @@ var _ = t.Describe("VMI", Label("f:infra-lcm"), func() {
 					if vzcr.IsThanosEnabled(vz) {
 						name = "Thanos"
 					}
-					Eventually(grafanaDatasourceExists(vz, name, kubeconfigPath)).WithTimeout(waitTimeout).WithPolling(pollingInterval).Should(BeTrue())
+					Eventually(func() (bool, error) {
+						return grafanaDatasourceExists(vz, name, kubeconfigPath)
+					}).WithTimeout(waitTimeout).WithPolling(pollingInterval).Should(BeTrue())
 				})
 			}
 

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -725,7 +725,12 @@ func grafanaDatasourceExists(vz *vzalpha1.Verrazzano, name, kubeconfigPath strin
 			continue
 		}
 
-		if nameStr, ok := sourceName.(string); ok && nameStr == name {
+		nameStr, ok := sourceName.(string)
+		if !ok {
+			t.Logs.Errorf("Failed to convert name field to string")
+			continue
+		}
+		if nameStr == name {
 			return true, nil
 		}
 	}

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -710,7 +710,7 @@ func grafanaDatasourceExists(vz *vzalpha1.Verrazzano, name, kubeconfigPath strin
 		return false, err
 	}
 
-	var datasources []map[string]string
+	var datasources []map[string]interface{}
 	err = json.Unmarshal(resp.Body, &datasources)
 	if err != nil {
 		t.Logs.Errorf("Failed to unmarshal Grafana datasources: %v", err)
@@ -718,7 +718,13 @@ func grafanaDatasourceExists(vz *vzalpha1.Verrazzano, name, kubeconfigPath strin
 	}
 
 	for _, source := range datasources {
-		if sourceName, ok := source["name"]; ok && sourceName == name {
+		sourceName, ok := source["name"]
+		if !ok {
+			t.Logs.Errorf("Failed to find name for Grafana datasource")
+			continue
+		}
+
+		if nameStr, ok := sourceName.(string); ok && nameStr == name {
 			return true, nil
 		}
 	}

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -698,9 +698,10 @@ func verrazzanoSecretRequired(vz *vzalpha1.Verrazzano) bool {
 func grafanaDatasourceExists(vz *vzalpha1.Verrazzano, name, kubeconfigPath string) (bool, error) {
 	password, err := pkg.GetVerrazzanoPasswordInCluster(kubeconfigPath)
 	if err != nil {
+		t.Logs.Error("Failed to get the Verrazzano password from the cluster")
 		return false, err
 	}
-	if vz.Status.VerrazzanoInstance.GrafanaURL == nil {
+	if vz.Status.VerrazzanoInstance == nil || vz.Status.VerrazzanoInstance.GrafanaURL == nil {
 		t.Logs.Error("Grafana URL in the Verrazzano status is empty")
 		return false, nil
 	}


### PR DESCRIPTION
Adds a test to ensure that the proper datasource is enabled in Grafana using the API.