### PR TITLE
Disable Thanos in VZ CR used for upgrade tests, and separate out CR for MC tests

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -149,7 +149,7 @@ pipeline {
 
         OPERATOR_YAML_FILE = "${WORKSPACE}/acceptance-test-operator.yaml"
 
-        INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1beta1/install-vz-prod-kind-upgrade.yaml"
+        INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1beta1/install-vz-prod-kind-multicluster.yaml"
         INSTALL_CONFIG_FILE_OCIDNS = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1beta1/install-verrazzano-ocidns.yaml"
         INSTALL_CONFIG_FILE_NIPIO = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1beta1/install-verrazzano-nipio.yaml"
         OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"
@@ -1489,7 +1489,7 @@ def verifyExamples() {
 
 def setVZCRDVersionForInstallation(){
     if(params.CRD_API_VERSION == "v1alpha1"){
-        INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1alpha1/install-vz-prod-kind-upgrade.yaml"
+        INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1alpha1/install-vz-prod-kind-multicluster.yaml"
         INSTALL_CONFIG_FILE_OCIDNS = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1alpha1/install-verrazzano-ocidns.yaml"
         INSTALL_CONFIG_FILE_NIPIO = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1alpha1/install-verrazzano-nipio.yaml"
     }

--- a/tests/e2e/config/scripts/v1alpha1/install-vz-prod-kind-multicluster.yaml
+++ b/tests/e2e/config/scripts/v1alpha1/install-vz-prod-kind-multicluster.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-apiVersion: install.verrazzano.io/v1beta1
+apiVersion: install.verrazzano.io/v1alpha1
 kind: Verrazzano
 metadata:
   name: my-verrazzano
@@ -16,18 +16,15 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
-    clusterOperator:
+    prometheusOperator:
+      enabled: true
       overrides:
         - values:
-            syncClusters:
-              enabled: true
-              clusterSelector:
-                matchExpressions:
-                  - key: rancher-sync
-                    operator: In
-                    values: [ enabled ]
-    # Prometheus Operator and Thanos components are not included to account for upgrade tests since this file is used
-    # for installing older versions as well
+            prometheus:
+              thanos:
+                integration: sidecar
+    thanos:
+      enabled: true
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql

--- a/tests/e2e/config/scripts/v1alpha1/install-vz-prod-kind-upgrade.yaml
+++ b/tests/e2e/config/scripts/v1alpha1/install-vz-prod-kind-upgrade.yaml
@@ -16,16 +16,8 @@ spec:
         volumeSource:
           persistentVolumeClaim:
             claimName: mysql  # set storage for keycloak's MySql instance
-    prometheusOperator:
-      enabled: true
-      overrides:
-        - values:
-            prometheus:
-              thanos:
-                integration: sidecar
-    thanos:
-      enabled: true
-    # Prometheus Operator components are not included to account for upgrade tests
+    # Prometheus Operator and Thanos components are not included to account for upgrade tests since this file is used
+    # for installing older versions as well
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql

--- a/tests/e2e/config/scripts/v1beta1/install-vz-prod-kind-multicluster.yaml
+++ b/tests/e2e/config/scripts/v1beta1/install-vz-prod-kind-multicluster.yaml
@@ -26,8 +26,15 @@ spec:
                   - key: rancher-sync
                     operator: In
                     values: [ enabled ]
-    # Prometheus Operator and Thanos components are not included to account for upgrade tests since this file is used
-    # for installing older versions as well
+    prometheusOperator:
+      enabled: true
+      overrides:
+        - values:
+            prometheus:
+              thanos:
+                integration: sidecar
+    thanos:
+      enabled: true
   volumeClaimSpecTemplates:
     - metadata:
         name: mysql


### PR DESCRIPTION
Disabling Thanos in upgrade-tests since the CR is used for installing older VZ versions that don't have Thanos. Separated out the CRs used in MC tests so that we have MC Thanos coverage.
