### PR TITLE
Update metrics test function to accept extra kubeconfigs

### DIFF
--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -127,7 +127,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/examples/helidon/helidon_example_test.go
@@ -117,7 +117,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/examples/helidonconfig/helidon_config_test.go
+++ b/tests/e2e/examples/helidonconfig/helidon_config_test.go
@@ -117,7 +117,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/examples/helidonmetrics/helidon_metrics_test.go
+++ b/tests/e2e/examples/helidonmetrics/helidon_metrics_test.go
@@ -107,7 +107,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/examples/socks/sock_shop_example_test.go
+++ b/tests/e2e/examples/socks/sock_shop_example_test.go
@@ -151,7 +151,7 @@ var beforeSuite = clusterDump.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/examples/springboot/springboot_test.go
+++ b/tests/e2e/examples/springboot/springboot_test.go
@@ -93,7 +93,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/examples/todo/todo_list_test.go
+++ b/tests/e2e/examples/todo/todo_list_test.go
@@ -108,7 +108,7 @@ var beforeSuite = clusterDump.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/jaeger/system/jaeger_system_test.go
+++ b/tests/e2e/jaeger/system/jaeger_system_test.go
@@ -37,7 +37,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to find Kubeconfig location: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfigPath, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/jwt/helidon-svc/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon-svc/helidon_example_test.go
@@ -68,7 +68,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/jwt/helidon/helidon_example_test.go
+++ b/tests/e2e/jwt/helidon/helidon_example_test.go
@@ -61,7 +61,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to get the Kubeconfig location for the cluster: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
+++ b/tests/e2e/metrics/deploymetrics/deploymetrics_test.go
@@ -93,7 +93,7 @@ var beforeSuite = clusterDump.BeforeSuiteFunc(func() {
 		}, waitTimeout, pollingInterval).Should(BeNil(), "Expected to be able to create the metrics service")
 	}
 
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/metrics/syscomponents/metrics_test.go
+++ b/tests/e2e/metrics/syscomponents/metrics_test.go
@@ -128,7 +128,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if clusterLabelVal := getClusterNameForPromQuery(); clusterLabelVal != "" {
 		defaultLabels[getClusterNameMetricLabel()] = clusterLabelVal
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeConfig}, adminKubeConfig, defaultLabels)
+	metricsTest, err = pkg.NewMetricsTest(adminKubeConfig, defaultLabels)
 	if err != nil {
 		Fail(err.Error())
 	}

--- a/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon-deprecated/helidon_example_test.go
@@ -87,7 +87,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
 	var err error
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeconfig, managedKubeconfig}, adminKubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(adminKubeconfig, map[string]string{}, managedKubeconfig)
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
+++ b/tests/e2e/multicluster/examples/helidon/helidon_example_test.go
@@ -67,9 +67,9 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 		}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 		metrics.Emit(t.Metrics.With("deployment_elapsed_time", time.Since(start).Milliseconds()))
 	}
-	
+
 	var err error
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeconfig, managedKubeconfig}, adminKubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(adminKubeconfig, map[string]string{}, managedKubeconfig)
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
+++ b/tests/e2e/multicluster/examples/sock-shop/sock_shop_example_test.go
@@ -66,7 +66,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
 	var err error
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeconfig, managedKubeconfig}, adminKubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(adminKubeconfig, map[string]string{}, managedKubeconfig)
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
+++ b/tests/e2e/multicluster/examples/todo-list/todo_list_example_test.go
@@ -88,7 +88,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
 	var err error
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeconfig, managedKubeconfig}, adminKubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(adminKubeconfig, map[string]string{}, managedKubeconfig)
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/multicluster/verify-jaeger/system/jaeger_system_test.go
+++ b/tests/e2e/multicluster/verify-jaeger/system/jaeger_system_test.go
@@ -51,7 +51,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 
 	m := make(map[string]string)
 	m[clusterNameLabel] = getClusterName()
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeConfigPath}, adminKubeConfigPath, m)
+	metricsTest, err = pkg.NewMetricsTest(adminKubeConfigPath, m)
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/multicluster/verify-register/verify_register_test.go
+++ b/tests/e2e/multicluster/verify-register/verify_register_test.go
@@ -50,7 +50,7 @@ var afterSuite = t.AfterSuiteFunc(func() {})
 var _ = AfterSuite(afterSuite)
 var beforeSuite = t.BeforeSuiteFunc(func() {
 	var err error
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeconfig, managedKubeconfig}, adminKubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(adminKubeconfig, map[string]string{}, managedKubeconfig)
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/multicluster/workloads/mccoherence/coherence_workload_mc_test.go
+++ b/tests/e2e/multicluster/workloads/mccoherence/coherence_workload_mc_test.go
@@ -114,7 +114,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	}
 
 	var err error
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeconfig, managedKubeconfig}, adminKubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(adminKubeconfig, map[string]string{}, managedKubeconfig)
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/multicluster/workloads/mcweblogic/weblogic_workload_mc_test.go
+++ b/tests/e2e/multicluster/workloads/mcweblogic/weblogic_workload_mc_test.go
@@ -128,7 +128,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	}, waitTimeout, pollingInterval).ShouldNot(HaveOccurred())
 
 	var err error
-	metricsTest, err = pkg.NewMetricsTest([]string{adminKubeconfig, managedKubeconfig}, adminKubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(adminKubeconfig, map[string]string{}, managedKubeconfig)
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/pkg/metrics.go
+++ b/tests/e2e/pkg/metrics.go
@@ -30,12 +30,12 @@ type MetricsTest struct {
 // kubeconfigs 		a list of kubeconfigs from all clusters
 // kubeconfigPath 	this is the kubeconfigPath for the cluster we want to search metrics from
 // defaultLabels    the default labels will be added to the test metric when the query begins
-func NewMetricsTest(kubeconfigs []string, kubeconfigPath string, defaultLabels map[string]string) (MetricsTest, error) {
+func NewMetricsTest(kubeconfigPath string, defaultLabels map[string]string, extraKubeconfigs ...string) (MetricsTest, error) {
 	mt := MetricsTest{
 		DefaultLabels: defaultLabels,
 	}
 
-	for _, kc := range kubeconfigs {
+	for _, kc := range append(extraKubeconfigs, kubeconfigPath) {
 		vz, err := GetVerrazzanoInstallResourceInCluster(kc)
 		if err != nil {
 			return MetricsTest{}, err

--- a/tests/e2e/update/certmc/certmc_test.go
+++ b/tests/e2e/update/certmc/certmc_test.go
@@ -140,7 +140,7 @@ func verifyCaSync() {
 func verifyThanosStore() {
 	for _, managedCluster := range managedClusters {
 		gomega.Eventually(func() (bool, error) {
-			metricsTest, err := pkg.NewMetricsTest([]string{adminCluster.KubeConfigPath, managedCluster.KubeConfigPath}, adminCluster.KubeConfigPath, map[string]string{})
+			metricsTest, err := pkg.NewMetricsTest(adminCluster.KubeConfigPath, map[string]string{}, managedCluster.KubeConfigPath)
 			if err != nil {
 				t.Logs.Errorf("Failed to create metrics test object for cluster: %v", err)
 				return false, err

--- a/tests/e2e/update/dnsmc/dnsmc_test.go
+++ b/tests/e2e/update/dnsmc/dnsmc_test.go
@@ -103,7 +103,7 @@ func verifyThanosIngress() {
 func verifyThanosStore() {
 	for _, managedCluster := range managedClusters {
 		gomega.Eventually(func() (bool, error) {
-			metricsTest, err := pkg.NewMetricsTest([]string{adminCluster.KubeConfigPath, managedCluster.KubeConfigPath}, adminCluster.KubeConfigPath, map[string]string{})
+			metricsTest, err := pkg.NewMetricsTest(adminCluster.KubeConfigPath, map[string]string{}, managedCluster.KubeConfigPath)
 			if err != nil {
 				t.Logs.Errorf("Failed to create metrics test object for cluster: %v", err)
 				return false, err

--- a/tests/e2e/update/jaeger/jaeger_update_test.go
+++ b/tests/e2e/update/jaeger/jaeger_update_test.go
@@ -50,7 +50,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to find Kubeconfig location: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfigPath, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/workloads/coherence/coherence_workload_test.go
+++ b/tests/e2e/workloads/coherence/coherence_workload_test.go
@@ -111,7 +111,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to find Kubeconfig location: %v", err))
 	}
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfigPath, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/workloads/weblogic-cluster/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic-cluster/weblogic_workload_test.go
@@ -136,7 +136,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	metrics.Emit(t.Metrics.With("get_host_name_elapsed_time", time.Since(start).Milliseconds()))
 
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfigPath, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tests/e2e/workloads/weblogic/weblogic_workload_test.go
+++ b/tests/e2e/workloads/weblogic/weblogic_workload_test.go
@@ -108,7 +108,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	metrics.Emit(t.Metrics.With("get_host_name_elapsed_time", time.Since(start).Milliseconds()))
 
 	kubeconfigPath, err := k8sutil.GetKubeConfigLocation()
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfigPath}, kubeconfigPath, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfigPath, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tools/psr/tests/scenarios/opensearch/s1/opensearch_s1_test.go
+++ b/tools/psr/tests/scenarios/opensearch/s1/opensearch_s1_test.go
@@ -46,7 +46,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	httpClient = pkg.EventuallyVerrazzanoRetryableHTTPClient()
 	vmiCredentials = pkg.EventuallyGetSystemVMICredentials()
 
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}

--- a/tools/psr/tests/scenarios/opensearch/s2/opensearch_s2_test.go
+++ b/tools/psr/tests/scenarios/opensearch/s2/opensearch_s2_test.go
@@ -46,7 +46,7 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 	httpClient = pkg.EventuallyVerrazzanoRetryableHTTPClient()
 	vmiCredentials = pkg.EventuallyGetSystemVMICredentials()
 
-	metricsTest, err = pkg.NewMetricsTest([]string{kubeconfig}, kubeconfig, map[string]string{})
+	metricsTest, err = pkg.NewMetricsTest(kubeconfig, map[string]string{})
 	if err != nil {
 		AbortSuite(fmt.Sprintf("Failed to create the Metrics test object: %v", err))
 	}


### PR DESCRIPTION
Update to a function call. This prevents the annoyance of adding the metrics kubeconfig to the kubeconfig list and makes the default a lot simpler. It also extends the list to add as many extra kubeconfigs as needed.