### PR TITLE
Add the replica label for deduplication in Thanos

### DIFF
--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -33,7 +33,7 @@ query:
   # Adds the Prometheus Thanos sidecar as a Store API endpoint to Query
   stores:
     - dnssrv+_grpc._tcp.prometheus-operator-kube-p-prometheus
-  replicaLabel: verrazzano_cluster
+  replicaLabel: prometheus_replica
 
   # ConfigMap containing Verrazzano managed cluster Thanos endpoints that the admin cluster Thanos Query should use
   # This configmap is managed by the VMC controller

--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -33,6 +33,7 @@ query:
   # Adds the Prometheus Thanos sidecar as a Store API endpoint to Query
   stores:
     - dnssrv+_grpc._tcp.prometheus-operator-kube-p-prometheus
+  replicaLabel: verrazzano_cluster
 
   # ConfigMap containing Verrazzano managed cluster Thanos endpoints that the admin cluster Thanos Query should use
   # This configmap is managed by the VMC controller


### PR DESCRIPTION
Causes deduplication in Thanos based on the verrazzano_cluster label. 

**Testing**

Install multicluster Thanos and make sure that deduplication acts on the verrazzano_cluster label on the admin cluster.
