### PR TITLE
Restart Grafana pod to pick up changes to datasources configmap

### DIFF
--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
@@ -177,7 +177,10 @@ func (g grafanaComponent) Install(ctx spi.ComponentContext) error {
 
 // PostInstall checks post install conditions
 func (g grafanaComponent) PostInstall(ctx spi.ComponentContext) error {
-	return common.CheckIngressesAndCerts(ctx, g)
+	if err := common.CheckIngressesAndCerts(ctx, g); err != nil {
+		return err
+	}
+	return restartGrafanaPod(ctx)
 }
 
 func (g grafanaComponent) IsOperatorUninstallSupported() bool {
@@ -216,9 +219,13 @@ func (g grafanaComponent) Upgrade(ctx spi.ComponentContext) error {
 	return common.CreateOrUpdateVMI(ctx, updateFunc)
 }
 
-// PostUpgrade checks post upgrade conditions
+// PostUpgrade checks post upgrade conditions and restarts the Grafana pod to ensure that any changes
+// to the datasources configmap are picked up
 func (g grafanaComponent) PostUpgrade(ctx spi.ComponentContext) error {
-	return common.CheckIngressesAndCerts(ctx, g)
+	if err := common.CheckIngressesAndCerts(ctx, g); err != nil {
+		return err
+	}
+	return restartGrafanaPod(ctx)
 }
 
 // ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated


### PR DESCRIPTION
During update or upgrade, the Grafana datasources configmap may be updated, depending on whether Thanos and/or Prometheus are enabled. Grafana does not automatically pick up changes to the datasources configmap so these changes set an annotation on the Grafana deployment to cause the Grafana pod to restart.

I tested this in a local cluster by first installing with Thanos disabled, then enabled Thanos in the VZ CR and confirmed that the datasources configmap was updated and the Grafana pod restarted. I logged into Grafana and confirmed the datasources list was correct.

I then disabled Thanos in the VZ CR and again confirmed that Grafana was restarted. I logged into Grafana and viewed the datasources and confirmed they were correct.