### PR TITLE
Make the Thanos authorization policies more specific

### DIFF
--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
@@ -32,6 +32,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}
+      app.kubernetes.io/component: query-frontend
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
@@ -87,4 +88,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}
+      app.kubernetes.io/component: query
 {{end}}


### PR DESCRIPTION
This makes the Authorization Policies specifically select the correct pods for Thanos. These values are derived from the helm chart and are hard coded into the deployments.

**Testing**

Deploy Thanos and expect that the authorization policies allow traffic from all sources to the correct pods.