### PR TITLE
VZ-7914: a la carte pipeline updates with ginkgo

### DIFF
--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -184,8 +184,6 @@ pipeline {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
-                REALM_USER_PASSWORD = credentials('todo-mysql-password')
-                REALM_NAME = 'test-realm'
             }
             steps {
                 sh """
@@ -211,8 +209,6 @@ pipeline {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
-                REALM_USER_PASSWORD = credentials('todo-mysql-password')
-                REALM_NAME = 'test-realm'
             }
             steps {
                 runGinkgoUpdate('update/a-la-carte', 'prom-edge-stack')
@@ -263,8 +259,6 @@ pipeline {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
-                REALM_USER_PASSWORD = credentials('todo-mysql-password')
-                REALM_NAME = 'test-realm'
             }
             steps {
                 runGinkgoUpdate('update/a-la-carte', 'app-stack')
@@ -318,45 +312,135 @@ pipeline {
             }
         }
 
+        stage('Install Istio App stack') {
+            environment {
+                KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
+                OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
+            }
+            steps {
+                runGinkgoUpdate('update/a-la-carte', 'istio-app-stack')
+            }
+
+            post {
+                failure {
+                    archiveArtifacts artifacts: "**/kind-logs/**", allowEmptyArchive: true
+                    dumpK8sCluster('install-prom-app-istio-stack-dump')
+                }
+                always {
+                    archiveArtifacts artifacts: "acceptance-test-operator.yaml,downloaded-operator.yaml,$INSTALL_CONFIG_FILE_KIND", allowEmptyArchive: true
+                }
+            }
+        }
+
+        stage('Verify Istio App Stack') {
+            parallel {
+                stage('examples helidon') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-helidon"
+                    }
+                    steps {
+                        runGinkgo('examples/helidon')
+                    }
+                }
+                stage('verify-install/promstack') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-install/promstack"
+                    }
+                    steps {
+                        runGinkgoRandomize('verify-install/promstack')
+                    }
+                }
+                stage('verify-infra/vmi') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-infra/vmi"
+                    }
+                    steps {
+                        runGinkgoRandomize('verify-infra/vmi')
+                    }
+                }
+            }
+            post {
+                failure {
+                    dumpK8sCluster('verify-prom-app-istio-stack-dump')
+                }
+                always {
+                    archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**,**/*cluster-snapshot*/**', allowEmptyArchive: true
+                    junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                }
+                success {
+                    script {
+                        if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
+                            dumpK8sCluster('istio-prom-app-istio-installation-cluster-snapshot')
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Install Cluster Management stack') {
+            environment {
+                KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
+                OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
+            }
+            steps {
+                runGinkgoUpdate('update/a-la-carte', 'cluster-management-stack')
+            }
+
+            post {
+                failure {
+                    archiveArtifacts artifacts: "**/kind-logs/**", allowEmptyArchive: true
+                    dumpK8sCluster('install-cluster-management-stack-dump')
+                }
+                always {
+                    archiveArtifacts artifacts: "acceptance-test-operator.yaml,downloaded-operator.yaml,$INSTALL_CONFIG_FILE_KIND", allowEmptyArchive: true
+                }
+            }
+        }
+
+        stage('Verify Cluster Management Stack') {
+            parallel {
+                stage('verify-install/promstack') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-install/promstack"
+                    }
+                    steps {
+                        runGinkgoRandomize('verify-install/promstack')
+                    }
+                }
+                stage('verify-infra/vmi') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-infra/vmi"
+                    }
+                    steps {
+                        runGinkgoRandomize('verify-infra/vmi')
+                    }
+                }
+            }
+            post {
+                failure {
+                    dumpK8sCluster('verify-cluster-management-stack-dump')
+                }
+                always {
+                    archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**,**/*cluster-snapshot*/**', allowEmptyArchive: true
+                    junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                }
+                success {
+                    script {
+                        if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
+                            dumpK8sCluster('verify-cluster-management-stack-dump')
+                        }
+                    }
+                }
+            }
+        }
+
         stage('Reinstall None') {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
-                REALM_USER_PASSWORD = credentials('todo-mysql-password')
-                REALM_NAME = 'test-realm'
             }
             steps {
-                sh """
-                    cp ${env.INSTALL_CONFIG_FILE_KIND_TESTS} ${env.INSTALL_CONFIG_FILE_KIND}
-                    cp ${INSTALL_CONFIG_FILE_KIND} ${WORKSPACE}/none.yaml
-                    cd ${GO_REPO_PATH}/verrazzano
-                    yq -i eval '.spec.components.kubeStateMetrics.enabled = false' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.prometheus.enabled = false' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.prometheusOperator.enabled = false' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.prometheusAdapter.enabled = false' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.prometheusNodeExporter.enabled = false' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.prometheusPushgateway.enabled = false' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.applicationOperator.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.authProxy.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.certManager.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.fluentd.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.grafana.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.ingressNGINX.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.keycloak.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.mySQLOperator.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.opensearch.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.opensearchDashboards.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.oam.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.verrazzano.enabled = true' ${WORKSPACE}/none.yaml
-                    yq -i eval '.spec.components.jaegerOperator.enabled = true' ${WORKSPACE}/none.yaml
-                    kubectl apply -f ${WORKSPACE}/none.yaml
-
-                    # wait for Verrazzano install to complete
-                    ${WORKSPACE}/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
-
-                    # Log the vz status to get the URLs
-                    ${GO_REPO_PATH}/vz status
-                """
+                runGinkgoUpdate('update/a-la-carte', 'cluster-management-stack')
             }
 
             post {
@@ -585,6 +669,15 @@ def runGinkgoRandomize(testSuitePath, kubeConfig = '') {
             if [ -d "${testSuitePath}" ]; then
                 ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file=".*" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
             fi
+        """
+    }
+}
+
+def runGinkgo(testSuitePath) {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+        sh """
+            cd ${GO_REPO_PATH}/verrazzano/tests/e2e
+            ginkgo -v -keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
         """
     }
 }

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -440,7 +440,7 @@ pipeline {
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
             }
             steps {
-                runGinkgoUpdate('update/a-la-carte', 'cluster-management-stack')
+                runGinkgoUpdate('update/a-la-carte', 'none-profile')
             }
 
             post {

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -215,24 +215,7 @@ pipeline {
                 REALM_NAME = 'test-realm'
             }
             steps {
-                sh """
-                    cp ${env.INSTALL_CONFIG_FILE_KIND_TESTS} ${env.INSTALL_CONFIG_FILE_KIND}
-                    cp ${INSTALL_CONFIG_FILE_KIND} ${WORKSPACE}/edgestack.yaml
-                    cd ${GO_REPO_PATH}/verrazzano
-                    yq -i eval '.spec.components.kubeStateMetrics.enabled = true' ${WORKSPACE}/edgestack.yaml
-                    yq -i eval '.spec.components.prometheus.enabled = true' ${WORKSPACE}/edgestack.yaml
-                    yq -i eval '.spec.components.prometheusOperator.enabled = true' ${WORKSPACE}/edgestack.yaml
-                    yq -i eval '.spec.components.prometheusAdapter.enabled = true' ${WORKSPACE}/edgestack.yaml
-                    yq -i eval '.spec.components.prometheusNodeExporter.enabled = true' ${WORKSPACE}/edgestack.yaml
-                    yq -i eval '.spec.components.prometheusPushgateway.enabled = true' ${WORKSPACE}/edgestack.yaml
-                    kubectl apply -f ${WORKSPACE}/edgestack.yaml
-
-                    # wait for Verrazzano install to complete
-                    ${WORKSPACE}/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
-
-                    # Log the vz status to get the URLs
-                    ${GO_REPO_PATH}/vz status
-                """
+                runGinkgoUpdate('update/a-la-carte', 'prom-edge-stack')
             }
 
             post {
@@ -284,41 +267,7 @@ pipeline {
                 REALM_NAME = 'test-realm'
             }
             steps {
-                sh """
-                    cp ${env.INSTALL_CONFIG_FILE_KIND_TESTS} ${env.INSTALL_CONFIG_FILE_KIND}
-                    cp ${INSTALL_CONFIG_FILE_KIND} ${WORKSPACE}/appstack.yaml
-                    cd ${GO_REPO_PATH}/verrazzano
-                    yq -i eval '.spec.components.kubeStateMetrics.enabled = false' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.prometheus.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.prometheusOperator.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.prometheusAdapter.enabled = false' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.prometheusNodeExporter.enabled = false' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.prometheusPushgateway.enabled = false' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.applicationOperator.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.authProxy.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.certManager.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.fluentd.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.grafana.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.ingressNGINX.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.keycloak.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.mySQLOperator.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.opensearch.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.opensearchDashboards.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.oam.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.verrazzano.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.jaegerOperator.enabled = true' ${WORKSPACE}/appstack.yaml
-
-                    kubectl apply -f ${WORKSPACE}/appstack.yaml
-
-                    # wait for Verrazzano install to start reconciling
-                    ${WORKSPACE}/tests/e2e/config/scripts/wait-for-verrazzano-reconciling.sh
-
-                    # wait for Verrazzano install to complete
-                    ${WORKSPACE}/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
-
-                    # Log the vz status to get the URLs
-                    ${GO_REPO_PATH}/vz status
-                """
+                runGinkgoUpdate('update/a-la-carte', 'app-stack')
             }
 
             post {
@@ -369,92 +318,6 @@ pipeline {
             }
         }
 
-
-        stage('Install Istio App stack') {
-            environment {
-                KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
-                OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
-                REALM_USER_PASSWORD = credentials('todo-mysql-password')
-                REALM_NAME = 'test-realm'
-            }
-            steps {
-                sh """
-                    cp ${env.INSTALL_CONFIG_FILE_KIND_TESTS} ${env.INSTALL_CONFIG_FILE_KIND}
-                    cp ${INSTALL_CONFIG_FILE_KIND} ${WORKSPACE}/appstack.yaml
-                    cd ${GO_REPO_PATH}/verrazzano
-                    yq -i eval '.spec.components.istio.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.kubeStateMetrics.enabled = false' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.prometheus.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.prometheusOperator.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.prometheusAdapter.enabled = false' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.prometheusNodeExporter.enabled = false' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.prometheusPushgateway.enabled = false' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.applicationOperator.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.authProxy.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.certManager.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.fluentd.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.grafana.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.ingressNGINX.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.keycloak.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.mySQLOperator.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.opensearch.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.opensearchDashboards.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.oam.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.verrazzano.enabled = true' ${WORKSPACE}/appstack.yaml
-                    yq -i eval '.spec.components.jaegerOperator.enabled = true' ${WORKSPACE}/appstack.yaml
-                    kubectl apply -f ${WORKSPACE}/appstack.yaml
-
-                    # wait for Verrazzano install to start reconciling
-                    ${WORKSPACE}/tests/e2e/config/scripts/wait-for-verrazzano-reconciling.sh
-
-                    # wait for Verrazzano install to complete
-                    ${WORKSPACE}/tests/e2e/config/scripts/wait-for-verrazzano-install.sh
-
-                    # Log the vz status to get the URLs
-                    ${GO_REPO_PATH}/vz status
-                """
-            }
-
-            post {
-                failure {
-                    archiveArtifacts artifacts: "**/kind-logs/**", allowEmptyArchive: true
-                    dumpK8sCluster('install-prom-app-istio-stack-dump')
-                }
-                always {
-                    archiveArtifacts artifacts: "acceptance-test-operator.yaml,downloaded-operator.yaml,$INSTALL_CONFIG_FILE_KIND", allowEmptyArchive: true
-                }
-            }
-        }
-
-        stage('Verify Istio App Stack') {
-            parallel {
-                stage('examples helidon') {
-                    environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-helidon"
-                    }
-                    steps {
-                        runGinkgo('examples/helidon')
-                    }
-                }
-            }
-            post {
-                failure {
-                    dumpK8sCluster('verify-prom-app-istio-stack-dump')
-                }
-                always {
-                    archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**,**/*cluster-snapshot*/**', allowEmptyArchive: true
-                    junit testResults: '**/*test-result.xml', allowEmptyResults: true
-                }
-                success {
-                    script {
-                        if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true && fileExists(env.TESTS_EXECUTED_FILE) ) {
-                            dumpK8sCluster('istio-prom-app-istio-installation-cluster-snapshot')
-                        }
-                    }
-                }
-            }
-        }
-
         stage('Reinstall None') {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
@@ -467,7 +330,6 @@ pipeline {
                     cp ${env.INSTALL_CONFIG_FILE_KIND_TESTS} ${env.INSTALL_CONFIG_FILE_KIND}
                     cp ${INSTALL_CONFIG_FILE_KIND} ${WORKSPACE}/none.yaml
                     cd ${GO_REPO_PATH}/verrazzano
-                    yq -i eval '.spec.components.istio.enabled = true' ${WORKSPACE}/none.yaml
                     yq -i eval '.spec.components.kubeStateMetrics.enabled = false' ${WORKSPACE}/none.yaml
                     yq -i eval '.spec.components.prometheus.enabled = false' ${WORKSPACE}/none.yaml
                     yq -i eval '.spec.components.prometheusOperator.enabled = false' ${WORKSPACE}/none.yaml
@@ -727,12 +589,13 @@ def runGinkgoRandomize(testSuitePath, kubeConfig = '') {
     }
 }
 
-def runGinkgo(testSuitePath) {
+def runGinkgoUpdate(testSuitePath, updateTypeVal = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v -keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+            if [ -d "${testSuitePath}" ]; then
+                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file=".*" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --updateType="${updateTypeVal}"
+            fi
         """
     }
 }
-

--- a/tests/e2e/update/a-la-carte/a_la_carte_suite_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package alacarte

--- a/tests/e2e/update/a-la-carte/a_la_carte_suite_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_suite_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package alacarte
+
+import (
+	"flag"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var updateType string
+
+func init() {
+	flag.StringVar(&updateType, "updateType", "", "updateType is the type of update to perform")
+}
+func TestALaCarte(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "A-La-Carte Suite")
+}

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package alacarte

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package alacarte
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/update"
+)
+
+const (
+	waitTimeout     = 10 * time.Minute
+	pollingInterval = 5 * time.Second
+)
+
+const (
+	promEdgeStack          = "prom-edge-stack"
+	appStack               = "app-stack"
+	istioAppStack          = "istio-app-stack"
+	clusterManagementStack = "cluster-management-stack"
+	noneProfile            = "none-profile"
+)
+
+var (
+	t        = framework.NewTestFramework("a_la_carte")
+	trueVal  = true
+	falseVal = false
+)
+
+var failed = false
+var _ = t.AfterEach(func() {
+	failed = failed || CurrentSpecReport().Failed()
+})
+
+type prometheusEdgeStackModifier struct {
+}
+
+type appStackModifier struct {
+}
+
+type istioAppStackModifier struct {
+}
+
+type clusterManagementStackModifier struct {
+}
+
+type noneModifier struct {
+}
+
+func (m prometheusEdgeStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
+	cr.Spec.Components.PrometheusOperator = &vzapi.PrometheusOperatorComponent{Enabled: &trueVal}
+	cr.Spec.Components.Prometheus = &vzapi.PrometheusComponent{Enabled: &trueVal}
+	cr.Spec.Components.PrometheusNodeExporter = &vzapi.PrometheusNodeExporterComponent{Enabled: &trueVal}
+	cr.Spec.Components.PrometheusAdapter = &vzapi.PrometheusAdapterComponent{Enabled: &trueVal}
+	cr.Spec.Components.PrometheusPushgateway = &vzapi.PrometheusPushgatewayComponent{Enabled: &trueVal}
+	cr.Spec.Components.KubeStateMetrics = &vzapi.KubeStateMetricsComponent{Enabled: &trueVal}
+}
+
+func (m appStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
+	cr.Spec.Components.PrometheusNodeExporter = &vzapi.PrometheusNodeExporterComponent{Enabled: &falseVal}
+	cr.Spec.Components.PrometheusAdapter = &vzapi.PrometheusAdapterComponent{Enabled: &falseVal}
+	cr.Spec.Components.PrometheusPushgateway = &vzapi.PrometheusPushgatewayComponent{Enabled: &falseVal}
+	cr.Spec.Components.KubeStateMetrics = &vzapi.KubeStateMetricsComponent{Enabled: &falseVal}
+
+	cr.Spec.Components.ApplicationOperator = &vzapi.ApplicationOperatorComponent{Enabled: &trueVal}
+	cr.Spec.Components.AuthProxy = &vzapi.AuthProxyComponent{Enabled: &trueVal}
+	cr.Spec.Components.CertManager = &vzapi.CertManagerComponent{Enabled: &trueVal}
+	cr.Spec.Components.Fluentd = &vzapi.FluentdComponent{Enabled: &trueVal}
+	cr.Spec.Components.Grafana = &vzapi.GrafanaComponent{Enabled: &trueVal}
+	cr.Spec.Components.Ingress = &vzapi.IngressNginxComponent{Enabled: &trueVal}
+	cr.Spec.Components.Keycloak = &vzapi.KeycloakComponent{Enabled: &trueVal}
+	cr.Spec.Components.MySQLOperator = &vzapi.MySQLOperatorComponent{Enabled: &trueVal}
+	cr.Spec.Components.Elasticsearch = &vzapi.ElasticsearchComponent{Enabled: &trueVal}
+	cr.Spec.Components.Kibana = &vzapi.KibanaComponent{Enabled: &trueVal}
+	cr.Spec.Components.OAM = &vzapi.OAMComponent{Enabled: &trueVal}
+	cr.Spec.Components.Verrazzano = &vzapi.VerrazzanoComponent{Enabled: &trueVal}
+	cr.Spec.Components.JaegerOperator = &vzapi.JaegerOperatorComponent{Enabled: &trueVal}
+}
+
+func (m istioAppStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
+	cr.Spec.Components.Istio = &vzapi.IstioComponent{Enabled: &trueVal}
+	cr.Spec.Components.Kiali = &vzapi.KialiComponent{Enabled: &trueVal}
+}
+
+func (m clusterManagementStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
+	cr.Spec.Components.ArgoCD = &vzapi.ArgoCDComponent{Enabled: &trueVal}
+	cr.Spec.Components.CoherenceOperator = &vzapi.CoherenceOperatorComponent{Enabled: &trueVal}
+	cr.Spec.Components.ClusterOperator = &vzapi.ClusterOperatorComponent{Enabled: &trueVal}
+	cr.Spec.Components.Console = &vzapi.ConsoleComponent{Enabled: &trueVal}
+	cr.Spec.Components.Rancher = &vzapi.RancherComponent{Enabled: &trueVal}
+	cr.Spec.Components.RancherBackup = &vzapi.RancherBackupComponent{Enabled: &trueVal}
+	cr.Spec.Components.Velero = &vzapi.VeleroComponent{Enabled: &trueVal}
+	cr.Spec.Components.WebLogicOperator = &vzapi.WebLogicOperatorComponent{Enabled: &trueVal}
+}
+
+func (m noneModifier) ModifyCR(cr *vzapi.Verrazzano) {
+	cr.Spec.Components.PrometheusOperator = &vzapi.PrometheusOperatorComponent{Enabled: &falseVal}
+	cr.Spec.Components.Prometheus = &vzapi.PrometheusComponent{Enabled: &falseVal}
+}
+
+var beforeSuite = t.BeforeSuiteFunc(func() {
+	Expect(getModifer(updateType)).ToNot(BeNil(), fmt.Sprintf("Provided update type %s was not a supported update type", updateType))
+})
+
+var _ = BeforeSuite(beforeSuite)
+
+var _ = t.Describe("Update a la carte configuration", func() {
+	t.Context(fmt.Sprintf("to the %s", updateType), func() {
+		t.It("Peforming update and waiting for Verrazzano to become ready", func() {
+			modifier := getModifer(updateType)
+			if modifier == nil {
+				AbortSuite(fmt.Sprintf("Unsupported modifier %s", updateType))
+			}
+			update.UpdateCRWithRetries(modifier, pollingInterval, waitTimeout)
+		})
+	})
+})
+
+func getModifer(updateType string) update.CRModifier {
+	switch updateType {
+	case promEdgeStack:
+		return prometheusEdgeStackModifier{}
+	case appStack:
+		return appStackModifier{}
+	case istioAppStack:
+		return istioAppStackModifier{}
+	case clusterManagementStack:
+		return clusterManagementStackModifier{}
+	case noneProfile:
+		return noneModifier{}
+	default:
+		return nil
+	}
+}

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -110,15 +110,13 @@ var beforeSuite = t.BeforeSuiteFunc(func() {
 
 var _ = BeforeSuite(beforeSuite)
 
-var _ = t.Describe("Update a la carte configuration", func() {
-	t.Context(fmt.Sprintf("to the %s", updateType), func() {
-		t.It("Peforming update and waiting for Verrazzano to become ready", func() {
-			modifier := getModifer(updateType)
-			if modifier == nil {
-				AbortSuite(fmt.Sprintf("Unsupported modifier %s", updateType))
-			}
-			update.UpdateCRWithRetries(modifier, pollingInterval, waitTimeout)
-		})
+var _ = t.Describe("Updating a la carte configuration", func() {
+	t.It(fmt.Sprintf("to the %s and waiting for Verrazzano to become ready", updateType), func() {
+		modifier := getModifer(updateType)
+		if modifier == nil {
+			AbortSuite(fmt.Sprintf("Unsupported modifier %s", updateType))
+		}
+		update.UpdateCRWithRetries(modifier, pollingInterval, waitTimeout)
 	})
 })
 


### PR DESCRIPTION
This change updates the a la carte pipeline to use ginkgo to perform updates instead of the Jenkinsfile. It also adds the cluster management stage.