### PR TITLE
No Bug.  Make verify-upgrade-required tests more resilient

### DIFF
--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -1050,6 +1050,7 @@ def upgradePlatformOperatorOnCluster(count) {
 
                 # ensure operator pod is up
                 kubectl --kubeconfig=${kubeClusterConfig} -n verrazzano-install rollout status deployment/verrazzano-platform-operator
+                kubectl --kubeconfig=${kubeClusterConfig} -n verrazzano-install rollout status deployment/verrazzano-platform-operator-webhook
             """
         }
     }

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -77,14 +77,11 @@ var _ = t.Describe("Verify upgrade required when new version is available", Labe
 			}
 
 			var vz *vzalpha1.Verrazzano
-			Eventually(func() error {
+			Eventually(func() (*vzalpha1.Verrazzano, error) {
 				vz, err = pkg.GetVerrazzano()
-				return err
-			}, waitTimeout, pollingInterval).Should(BeNil())
-			if vz == nil {
-				t.Fail("Unable to get Verrazzano instance")
-				return
-			}
+				return vz, err
+			}).WithPolling(pollingInterval).WithTimeout(waitTimeout).
+				ShouldNot(BeNil(), "Unable to get Verrazzano instance")
 
 			if vz.Spec.Components.Istio == nil {
 				vz.Spec.Components.Istio = &vzalpha1.IstioComponent{}

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package verify
@@ -82,7 +82,7 @@ var _ = t.Describe("Verify upgrade required when new version is available", Labe
 				return err
 			}, waitTimeout, pollingInterval).Should(BeNil())
 			if vz == nil {
-				t.Fail(fmt.Sprintf("Unable to get Verrazzano instance"))
+				t.Fail("Unable to get Verrazzano instance")
 				return
 			}
 

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -24,6 +24,9 @@ import (
 
 var t = framework.NewTestFramework("verify-upgrade-required")
 
+var waitTimeout = 3 * time.Minute
+var pollingInterval = 10 * time.Second
+
 var beforeSuite = t.BeforeSuiteFunc(func() {
 	start := time.Now()
 	beforeSuitePassed = true
@@ -73,9 +76,13 @@ var _ = t.Describe("Verify upgrade required when new version is available", Labe
 				return
 			}
 
-			vz, err := pkg.GetVerrazzano()
-			if err != nil {
-				t.Fail(fmt.Sprintf("Error getting Verrazzano instance: %s", err.Error()))
+			var vz *vzalpha1.Verrazzano
+			Eventually(func() error {
+				vz, err = pkg.GetVerrazzano()
+				return err
+			}, waitTimeout, pollingInterval).Should(BeNil())
+			if vz == nil {
+				t.Fail(fmt.Sprintf("Unable to get Verrazzano instance"))
 				return
 			}
 


### PR DESCRIPTION
Attempt to resolve a timing issue in the upgrade-paths tests in the `verify-upgrade-required` stage
- Add a `rollout-status` check on the webhook deployment
- Wrap the code to get the VZ instance in an `Eventually` assertion
