### PR TITLE
Prometheus a la carte doc changes and postuninstall bug fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 ### v1.6.0
 Features:
 
-- Prometheus stack is now able to be dynamically enabled or disabled at any point during the Verrazzano installation lifecycle
+- The Prometheus components can now be enabled or disabled at any point in the Verrazzano lifecycle
+- Added a None profile that comes with all components disabled by default
 
 Component version updates:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 ### v1.6.0
+Features:
+
+- Prometheus stack is now able to be dynamically enabled or disabled at any point during the Verrazzano installation lifecycle
+
 Component version updates:
 
 - Rancher v2.7.1

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -244,6 +244,7 @@ func (c prometheusComponent) PostUninstall(ctx spi.ComponentContext) error {
 	err := ctx.Client().Delete(context.TODO(), ingress)
 	if err != nil && !errors.IsNotFound(err) {
 		ctx.Log().Errorf("Error deleting legacy Prometheus ingress %s, %v", constants.PrometheusIngress, err)
+		return err
 	}
-	return err
+	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -6,6 +6,7 @@ package operator
 import (
 	"context"
 	networkv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"path/filepath"
 
@@ -241,7 +242,7 @@ func (c prometheusComponent) PostUninstall(ctx spi.ComponentContext) error {
 		},
 	}
 	err := ctx.Client().Delete(context.TODO(), ingress)
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		ctx.Log().Errorf("Error deleting legacy Prometheus ingress %s, %v", constants.PrometheusIngress, err)
 	}
 	return err


### PR DESCRIPTION
This change adds the Prometheus a la carte CHANGES.md entry, and also fixes a bug in the postuninstall hook that deletes the legacy ingress