### PR TITLE
Add the exception capability for the Thanos sidecar in pod security

### DIFF
--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -85,6 +85,19 @@ var exceptionPods = map[string]podExceptions{
 			},
 		},
 	},
+	// Up to and including Prometheus Operator 0.59.1
+	// the thanos sidecar will get this capability from the Operator when object storage is enabled.
+	// This bug is fixed in the next patch version and this check should be removed once the
+	// Prometheus Operator is upgraded.
+	"prometheus-prometheus-operator-kube-p-prometheus": {
+		containers: map[string]containerException{
+			"thanos-sidecar": {
+				allowedCapabilities: map[string]bool{
+					capNetBindService: true,
+				},
+			},
+		},
+	},
 }
 
 var (


### PR DESCRIPTION
The Thanos sidecar security check is failing due to a bug in the Prometheus operator that is fixed in the next patch version:
fixed here: https://github.com/prometheus-operator/prometheus-operator/pull/5030

This change ignores that check for the Thanos sidecar for now. An upgrade to the Prometheus Operator should fix this issue.