### PR TITLE
Enable storage on Prometheus Thanos Sidecar when enabling Store Gateway for testing

### DIFF
--- a/tests/e2e/config/scripts/configure_thanos_storegateway_install.sh
+++ b/tests/e2e/config/scripts/configure_thanos_storegateway_install.sh
@@ -20,4 +20,9 @@ echo "Editing install config file for Thanos Store Gateway ${INSTALL_CONFIG_TO_E
   yq -i eval ".spec.components.thanos.overrides.[0].values.existingObjstoreSecret = \"objstore-config\"" ${INSTALL_CONFIG_TO_EDIT}
   yq -i eval ".spec.components.thanos.overrides.[0].values.storegateway.enabled = true" ${INSTALL_CONFIG_TO_EDIT}
 
+# Modify the VZ CR to enable storage on the Prometheus Thanos Sidecar
+echo "Editing install config file to enable long-term storage on the Prometheus Thanos Sidecar ${INSTALL_CONFIG_TO_EDIT}"
+  yq -i eval ".spec.components.prometheusOperator.overrides.[2].values.prometheus.prometheusSpec.thanos.objectStorageConfig.key = \"objstore.yml\"" ${INSTALL_CONFIG_TO_EDIT}
+  yq -i eval ".spec.components.prometheusOperator.overrides.[2].values.prometheus.prometheusSpec.thanos.objectStorageConfig.name = \"objstore-config\"" ${INSTALL_CONFIG_TO_EDIT}
+
 cat ${INSTALL_CONFIG_TO_EDIT}


### PR DESCRIPTION
The e2e security tests failed in the dev LRE environment because the LRE has long-term storage enabled on the Prometheus Thanos Sidecar. The test for long-term storage only enabled storage on the Store Gateway, which is why we didn't catch the LRE issue in our e2e testing.

This PR enables storage on the Thanos Sidecar so we catch any future problems related to Sidecar storage.