### PR TITLE
VZ-9371: CAPI experimental component updates

### DIFF
--- a/platform-operator/capi/.cluster-api/clusterctl.yaml
+++ b/platform-operator/capi/.cluster-api/clusterctl.yaml
@@ -1,13 +1,23 @@
 # Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
+# TODO: image overrides should come from the BOM
 images:
-  control-plane-ocne:
-    # TODO: these should come from the BOM
+  cluster-api:
+    repository: ghcr.io/verrazzano
+    tag: amd64-v1.3.3-20230324202819-5e71a53d9
+
+  bootstrap-kubeadm:
+    repository: ghcr.io/verrazzano
+    tag: amd64-v1.3.3-20230324202819-5e71a53d9
+  control-plane-kubeadm:
+    repository: ghcr.io/verrazzano
+    tag: amd64-v1.3.3-20230324202819-5e71a53d9
+
+  bootstrap-ocne:
     repository: ghcr.io/verrazzano
     tag: v0.1.0-20230406225237-9bd77d2
-  bootstrap-ocne:
-    # TODO: these should come from the BOM
+  control-plane-ocne:
     repository: ghcr.io/verrazzano
     tag: v0.1.0-20230406225237-9bd77d2
 

--- a/platform-operator/capi/.cluster-api/clusterctl.yaml
+++ b/platform-operator/capi/.cluster-api/clusterctl.yaml
@@ -7,13 +7,6 @@ images:
     repository: ghcr.io/verrazzano
     tag: amd64-v1.3.3-20230324202819-5e71a53d9
 
-  bootstrap-kubeadm:
-    repository: ghcr.io/verrazzano
-    tag: amd64-v1.3.3-20230324202819-5e71a53d9
-  control-plane-kubeadm:
-    repository: ghcr.io/verrazzano
-    tag: amd64-v1.3.3-20230324202819-5e71a53d9
-
   infrastructure-oci:
     repository: ghcr.io/oracle
     tag: v0.8.0

--- a/platform-operator/capi/.cluster-api/clusterctl.yaml
+++ b/platform-operator/capi/.cluster-api/clusterctl.yaml
@@ -14,12 +14,17 @@ images:
     repository: ghcr.io/verrazzano
     tag: amd64-v1.3.3-20230324202819-5e71a53d9
 
+  infrastructure-oci:
+    repository: ghcr.io/oracle
+    tag: v0.8.0
+
   bootstrap-ocne:
     repository: ghcr.io/verrazzano
     tag: v0.1.0-20230406225237-9bd77d2
   control-plane-ocne:
     repository: ghcr.io/verrazzano
     tag: v0.1.0-20230406225237-9bd77d2
+
 
 providers:
   - name: "ocne"

--- a/platform-operator/controllers/verrazzano/component/capi/capi_component.go
+++ b/platform-operator/controllers/verrazzano/component/capi/capi_component.go
@@ -203,8 +203,9 @@ func (c capiComponent) Install(_ spi.ComponentContext) error {
 	// TODO: version of providers should come from the BOM. Is kubeadm optional?
 	// Set up the init options for the CAPI init.
 	initOptions := clusterapi.InitOptions{
-		BootstrapProviders:      []string{"ocne:v0.1.0", "kubeadm"},
-		ControlPlaneProviders:   []string{"ocne:v0.1.0", "kubeadm"},
+		CoreProvider:            "cluster-api:v1.3.3",
+		BootstrapProviders:      []string{"ocne:v0.1.0", "kubeadm:v1.3.3"},
+		ControlPlaneProviders:   []string{"ocne:v0.1.0", "kubeadm:v1.3.3"},
 		InfrastructureProviders: []string{"oci:v0.8.0"},
 		TargetNamespace:         ComponentNamespace,
 	}

--- a/platform-operator/controllers/verrazzano/component/capi/capi_component.go
+++ b/platform-operator/controllers/verrazzano/component/capi/capi_component.go
@@ -204,8 +204,8 @@ func (c capiComponent) Install(_ spi.ComponentContext) error {
 	// Set up the init options for the CAPI init.
 	initOptions := clusterapi.InitOptions{
 		CoreProvider:            "cluster-api:v1.3.3",
-		BootstrapProviders:      []string{"ocne:v0.1.0", "kubeadm:v1.3.3"},
-		ControlPlaneProviders:   []string{"ocne:v0.1.0", "kubeadm:v1.3.3"},
+		BootstrapProviders:      []string{"ocne:v0.1.0"},
+		ControlPlaneProviders:   []string{"ocne:v0.1.0"},
 		InfrastructureProviders: []string{"oci:v0.8.0"},
 	}
 

--- a/platform-operator/controllers/verrazzano/component/capi/capi_component.go
+++ b/platform-operator/controllers/verrazzano/component/capi/capi_component.go
@@ -207,7 +207,6 @@ func (c capiComponent) Install(_ spi.ComponentContext) error {
 		BootstrapProviders:      []string{"ocne:v0.1.0", "kubeadm:v1.3.3"},
 		ControlPlaneProviders:   []string{"ocne:v0.1.0", "kubeadm:v1.3.3"},
 		InfrastructureProviders: []string{"oci:v0.8.0"},
-		TargetNamespace:         ComponentNamespace,
 	}
 
 	_, err = capiClient.Init(initOptions)


### PR DESCRIPTION
This pull request includes the following changes to the experimental CAPI component:
1. Include image overrides for the oci infra provider and core provider
2. Use provider default namespaces
3. Don't install the kubeadm providers by default