### PR TITLE
Fix e2e test script that configures Thanos long-term storage

### DIFF
--- a/tests/e2e/config/scripts/configure_thanos_storegateway_install.sh
+++ b/tests/e2e/config/scripts/configure_thanos_storegateway_install.sh
@@ -5,6 +5,12 @@
 
 INSTALL_CONFIG_TO_EDIT=$1
 
+THANOS_ENABLED=$(yq ".spec.components.thanos.enabled" ${INSTALL_CONFIG_TO_EDIT})
+if [[ $THANOS_ENABLED != "true" ]]; then
+  echo "Thanos component disabled, skipping editing of ${INSTALL_CONFIG_TO_EDIT}"
+  exit
+fi
+
 # Thanos storage provider config that uses local filesystem
 STORAGE_PROVIDER_CONFIG='type: FILESYSTEM
 config:
@@ -17,7 +23,12 @@ kubectl create secret generic -n verrazzano-monitoring objstore-config --from-li
 
 # Modify the VZ CR to enable Thanos Store Gateway and to reference the storage provider secret
 echo "Editing install config file for Thanos Store Gateway ${INSTALL_CONFIG_TO_EDIT}"
-  yq -i eval ".spec.components.thanos.overrides.[0].values.existingObjstoreSecret = \"objstore-config\"" ${INSTALL_CONFIG_TO_EDIT}
-  yq -i eval ".spec.components.thanos.overrides.[0].values.storegateway.enabled = true" ${INSTALL_CONFIG_TO_EDIT}
+yq -i eval ".spec.components.thanos.overrides.[0].values.existingObjstoreSecret = \"objstore-config\"" ${INSTALL_CONFIG_TO_EDIT}
+yq -i eval ".spec.components.thanos.overrides.[0].values.storegateway.enabled = true" ${INSTALL_CONFIG_TO_EDIT}
+
+# Modify the VZ CR to enable storage on the Prometheus Thanos Sidecar
+# This yq magic adds the Sidecar object storage config overrides to the correct override array element, but only if there is an existing prometheus override
+echo "Editing install config file to enable long-term storage on the Prometheus Thanos Sidecar ${INSTALL_CONFIG_TO_EDIT}"
+yq -i eval '(.spec.components.prometheusOperator.overrides.[].values | select(has("prometheus")).prometheus) += {"prometheusSpec":{"thanos":{"objectStorageConfig":{"key": "objstore.yml","name":"objstore-config"}}}}' ${INSTALL_CONFIG_TO_EDIT}
 
 cat ${INSTALL_CONFIG_TO_EDIT}


### PR DESCRIPTION
This PR re-introduces a chunk of reverted script that configured the VZ CR to use long-term storage for the Prometheus Thanos Sidecar. The previous version of this script resulted in a malformed VZ CR in a Kind pipeline with HA and Grafana DB enabled because the VZ CR Prometheus Operator Helm overrides were configured slightly differently from other tests. The length of the Prometheus Operator Helm overrides was different and the script assumed a certain length. The result was that the `yq` command used a bad index into the overrides array.

I fixed this by adding an enabled check for the Thanos component (the script just exits if it is disabled) and also modified the `yq` command so that it does not have to know the index of the overrides to modify.

I ran the previously failing pipeline with this change and verified that the VZ CR is valid.