### PR TITLE
VZ-9366 VZ CLI should not automatically call bug report and analyze upon certain failures 

### DIFF
--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -246,6 +246,20 @@ func CallVzBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) e
 	return err
 }
 
+// AutoBugReport checks that AutoBugReportFlag is set and then kicks off vz bugreport CLI command. It returns the same error that is passed in
+func AutoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) error {
+	autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
+	if errFlag != nil {
+		fmt.Fprintf(vzHelper.GetOutputStream(), "Error fetching flags: %s", errFlag.Error())
+		return err
+	}
+	if autoBugReportFlag {
+		//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from either installVerrazzano() or waitForInstallToComplete()
+		err = CallVzBugReport(cmd, vzHelper, err)
+	}
+	return err
+}
+
 func setUpFlags(cmd *cobra.Command, newCmd *cobra.Command) error {
 	kubeconfigFlag, errFlag := cmd.Flags().GetString(constants.GlobalFlagKubeConfig)
 	if errFlag != nil {

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -188,7 +188,7 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 		}
 		err = installVerrazzano(cmd, vzHelper, vz, client, version, vpoTimeout)
 		if err != nil {
-			return autoBugReport(cmd, vzHelper, err)
+			return bugreport.AutoBugReport(cmd, vzHelper, err)
 		}
 		vzNamespace = vz.GetNamespace()
 		vzName = vz.GetName()
@@ -197,23 +197,9 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 	// Wait for the Verrazzano install to complete
 	err = waitForInstallToComplete(client, kubeClient, vzHelper, types.NamespacedName{Namespace: vzNamespace, Name: vzName}, timeout, vpoTimeout, logFormat)
 	if err != nil {
-		return autoBugReport(cmd, vzHelper, err)
+		return bugreport.AutoBugReport(cmd, vzHelper, err)
 	}
 	return nil
-}
-
-// autoBugReport checks that AutoBugReportFlag is set and then kicks off vz bugreport CLI command. It returns the same error that is passed in
-func autoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) error {
-	autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
-	if errFlag != nil {
-		fmt.Fprintf(vzHelper.GetOutputStream(), "Error fetching flags: %s", errFlag.Error())
-		return err
-	}
-	if autoBugReportFlag {
-		//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from either installVerrazzano() or waitForInstallToComplete()
-		err = bugreport.CallVzBugReport(cmd, vzHelper, err)
-	}
-	return err
 }
 
 func installVerrazzano(cmd *cobra.Command, vzHelper helpers.VZHelper, vz clipkg.Object, client clipkg.Client, version string, vpoTimeout time.Duration) error {

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -181,6 +181,11 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 		if err != nil {
 			return err
 		}
+		// Apply the Verrazzano operator.yaml.
+		err = cmdhelpers.ApplyPlatformOperatorYaml(cmd, client, vzHelper, version)
+		if err != nil {
+			return err
+		}
 		err = installVerrazzano(cmd, vzHelper, vz, client, version, vpoTimeout)
 		if err != nil {
 			return autoBugReport(cmd, vzHelper, err)
@@ -212,14 +217,8 @@ func autoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) err
 }
 
 func installVerrazzano(cmd *cobra.Command, vzHelper helpers.VZHelper, vz clipkg.Object, client clipkg.Client, version string, vpoTimeout time.Duration) error {
-	// Apply the Verrazzano operator.yaml.
-	err := cmdhelpers.ApplyPlatformOperatorYaml(cmd, client, vzHelper, version)
-	if err != nil {
-		return err
-	}
-
 	// Wait for the platform operator to be ready before we create the Verrazzano resource.
-	_, err = cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondInstallComplete, vpoTimeout)
+	_, err := cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondInstallComplete, vpoTimeout)
 	if err != nil {
 		return err
 	}

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -197,6 +197,7 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 	return nil
 }
 
+// autoBugReport checks that AutoBugReportFlag is set and then kicks off vz bugreport CLI command. It returns the same error that is passed in
 func autoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) error {
 	autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
 	if errFlag != nil {

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -91,23 +91,6 @@ func NewCmdInstall(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) error {
-	err := installVerrazzano(cmd, vzHelper)
-	if err != nil {
-		autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
-		if errFlag != nil {
-			fmt.Fprintf(vzHelper.GetOutputStream(), "Error fetching flags: %s", errFlag.Error())
-			return err
-		}
-		if autoBugReportFlag {
-			//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from installVerrazzano
-			err = bugreport.CallVzBugReport(cmd, vzHelper, err)
-		}
-		return err
-	}
-	return nil
-}
-
-func installVerrazzano(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 	// Validate the command options
 	err := validateCmd(cmd)
 	if err != nil {
@@ -198,48 +181,71 @@ func installVerrazzano(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 		if err != nil {
 			return err
 		}
-
-		// Apply the Verrazzano operator.yaml.
-		err = cmdhelpers.ApplyPlatformOperatorYaml(cmd, client, vzHelper, version)
+		err = installVerrazzano(cmd, vzHelper, vz, client, version, vpoTimeout)
 		if err != nil {
-			return err
+			return autoBugReport(cmd, vzHelper, err)
 		}
-
-		// Wait for the platform operator to be ready before we create the Verrazzano resource.
-		_, err = cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondInstallComplete, vpoTimeout)
-		if err != nil {
-			return err
-		}
-
-		err = kubectlutil.SetLastAppliedConfigurationAnnotation(vz)
-		if err != nil {
-			return err
-		}
-
-		// Create the Verrazzano install resource, if need be.
-		// We will retry up to 5 times if there is an error.
-		// Sometimes we see intermittent webhook errors due to timeouts.
-		retry := 0
-		for {
-			err = client.Create(context.TODO(), vz)
-			if err != nil {
-				if retry == 5 {
-					return fmt.Errorf("Failed to create the verrazzano install resource: %s", err.Error())
-				}
-				time.Sleep(time.Second)
-				retry++
-				fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Retrying after failing to create the verrazzano install resource: %s\n", err.Error()))
-				continue
-			}
-			break
-		}
-
 		vzNamespace = vz.GetNamespace()
 		vzName = vz.GetName()
 	}
 
 	// Wait for the Verrazzano install to complete
-	return waitForInstallToComplete(client, kubeClient, vzHelper, types.NamespacedName{Namespace: vzNamespace, Name: vzName}, timeout, vpoTimeout, logFormat)
+	err = waitForInstallToComplete(client, kubeClient, vzHelper, types.NamespacedName{Namespace: vzNamespace, Name: vzName}, timeout, vpoTimeout, logFormat)
+	if err != nil {
+		return autoBugReport(cmd, vzHelper, err)
+	}
+	return nil
+}
+
+func autoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) error {
+	autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
+	if errFlag != nil {
+		fmt.Fprintf(vzHelper.GetOutputStream(), "Error fetching flags: %s", errFlag.Error())
+		return err
+	}
+	if autoBugReportFlag {
+		//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from either installVerrazzano() or waitForInstallToComplete()
+		err = bugreport.CallVzBugReport(cmd, vzHelper, err)
+	}
+	return err
+}
+
+func installVerrazzano(cmd *cobra.Command, vzHelper helpers.VZHelper, vz clipkg.Object, client clipkg.Client, version string, vpoTimeout time.Duration) error {
+	// Apply the Verrazzano operator.yaml.
+	err := cmdhelpers.ApplyPlatformOperatorYaml(cmd, client, vzHelper, version)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the platform operator to be ready before we create the Verrazzano resource.
+	_, err = cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondInstallComplete, vpoTimeout)
+	if err != nil {
+		return err
+	}
+
+	err = kubectlutil.SetLastAppliedConfigurationAnnotation(vz)
+	if err != nil {
+		return err
+	}
+
+	// Create the Verrazzano install resource, if need be.
+	// We will retry up to 5 times if there is an error.
+	// Sometimes we see intermittent webhook errors due to timeouts.
+	retry := 0
+	for {
+		err = client.Create(context.TODO(), vz)
+		if err != nil {
+			if retry == 5 {
+				return fmt.Errorf("Failed to create the verrazzano install resource: %s", err.Error())
+			}
+			time.Sleep(time.Second)
+			retry++
+			fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Retrying after failing to create the verrazzano install resource: %s\n", err.Error()))
+			continue
+		}
+		break
+	}
+	return nil
 }
 
 // getVerrazzanoYAML returns the verrazzano install resource to be created

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -198,7 +198,7 @@ func TestInstallCmdJsonLogFormat(t *testing.T) {
 // GIVEN a CLI install command with defaults and --wait=false and --filename specified and multiple group versions in the filenames
 //
 //	WHEN I call cmd.Execute for install
-//	THEN the CLI install command is unsuccessful and a bug report should be generated
+//	THEN the CLI install command is unsuccessful but a bug report should not be generated
 func TestInstallCmdMultipleGroupVersions(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(testhelpers.CreateTestVPOObjects()...).Build()
 	cmd, _, _, _ := createNewTestCommandAndBuffers(t, c)
@@ -213,7 +213,7 @@ func TestInstallCmdMultipleGroupVersions(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot merge objects with different group versions")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -404,7 +404,7 @@ func TestInstallCmdOperatorFile(t *testing.T) {
 // GIVEN an install command
 //
 //	WHEN invalid command options exist
-//	THEN expect an error and a bug report should be generated
+//	THEN expect an error but a bug report should not be generated
 func TestInstallValidations(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).WithObjects(testhelpers.CreateTestVPOObjects()...).Build()
 	cmd, _, _, _ := createNewTestCommandAndBuffers(t, c)
@@ -416,7 +416,7 @@ func TestInstallValidations(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("--%s and --%s cannot both be specified", constants.VersionFlag, constants.OperatorFileFlag))
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -578,7 +578,7 @@ func TestInstallCmdInProgress(t *testing.T) {
 // GIVEN a CLI install command when an install already happened
 //
 //	WHEN I call cmd.Execute for install
-//	THEN the CLI install command is unsuccessful and a bug report is generated
+//	THEN the CLI install command is unsuccessful but a bug report is not generated
 func TestInstallCmdAlreadyInstalled(t *testing.T) {
 	vz := &v1beta1.Verrazzano{
 		TypeMeta: metav1.TypeMeta{},
@@ -604,7 +604,7 @@ func TestInstallCmdAlreadyInstalled(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Only one install of Verrazzano is allowed")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -613,7 +613,7 @@ func TestInstallCmdAlreadyInstalled(t *testing.T) {
 // GIVEN a CLI install command when an install is in progress for a different version
 //
 //	WHEN I call cmd.Execute for install
-//	THEN the CLI install command is unsuccessful and a bug report is generated
+//	THEN the CLI install command is unsuccessful but a bug report is not generated
 func TestInstallCmdDifferentVersion(t *testing.T) {
 	vz := &v1beta1.Verrazzano{
 		TypeMeta: metav1.TypeMeta{},
@@ -639,7 +639,7 @@ func TestInstallCmdDifferentVersion(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Unable to install version v1.3.1, install of version v1.3.2 is in progress")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -163,7 +163,7 @@ func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 				return failedToUninstallErr(err)
 			}
 		} else {
-			return autoBugReport(cmd, vzHelper, err)
+			return bugreport.AutoBugReport(cmd, vzHelper, err)
 		}
 	}
 	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "Uninstalling Verrazzano\n")
@@ -171,23 +171,9 @@ func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	// Wait for the Verrazzano uninstall to complete.
 	err = waitForUninstallToComplete(client, kubeClient, vzHelper, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name}, timeout, vpoTimeout, logFormat, useUninstallJob)
 	if err != nil {
-		return autoBugReport(cmd, vzHelper, err)
+		return bugreport.AutoBugReport(cmd, vzHelper, err)
 	}
 	return nil
-}
-
-// autoBugReport checks that AutoBugReportFlag is set and then kicks off vz bugreport CLI command. It returns the same error that is passed in
-func autoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) error {
-	autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
-	if errFlag != nil {
-		fmt.Fprintf(vzHelper.GetOutputStream(), "Error fetching flags: %s", errFlag.Error())
-		return err
-	}
-	if autoBugReportFlag {
-		//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from uninstallVerrazzanoFn
-		err = bugreport.CallVzBugReport(cmd, vzHelper, err)
-	}
-	return failedToUninstallErr(err)
 }
 
 // cleanupResources deletes remaining resources that remain after the Verrazzano resource in uninstalled

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -61,19 +61,6 @@ var propagationPolicy = metav1.DeletePropagationBackground
 var deleteOptions = &client.DeleteOptions{PropagationPolicy: &propagationPolicy}
 
 var logsEnum = cmdhelpers.LogFormatSimple
-var uninstallVerrazzanoFn = uninstallVerrazzano
-
-type UninstallVerrazzanoFnType = func(cmd *cobra.Command, vzHelper helpers.VZHelper) error
-
-// SetUninstallVerrazzanoFn Allows overriding the uninstallVerrazzanoFn for testing purposes
-func SetUninstallVerrazzanoFn(fnType UninstallVerrazzanoFnType) {
-	uninstallVerrazzanoFn = fnType
-}
-
-// ResetUninstallVerrazzanoFn Restores the uninstallVerrazzanoFn implementation to the default if it's been overridden for testing
-func ResetUninstallVerrazzanoFn() {
-	uninstallVerrazzanoFn = uninstallVerrazzano
-}
 
 func NewCmdUninstall(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd := cmdhelpers.NewCommand(vzHelper, CommandName, helpShort, helpLong)
@@ -105,23 +92,6 @@ func NewCmdUninstall(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) error {
-	err := uninstallVerrazzanoFn(cmd, vzHelper)
-	if err != nil {
-		autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
-		if errFlag != nil {
-			fmt.Fprintf(vzHelper.GetOutputStream(), "Error fetching flags: %s", errFlag.Error())
-			return err
-		}
-		if autoBugReportFlag {
-			//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from uninstallVerrazzanoFn
-			err = bugreport.CallVzBugReport(cmd, vzHelper, err)
-		}
-		return fmt.Errorf("Failed to uninstall Verrazzano: %s", err.Error())
-	}
-	return nil
-}
-
-func uninstallVerrazzano(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 	// Get the controller runtime client.
 	client, err := vzHelper.GetClient(cmd)
 	if err != nil {
@@ -193,13 +163,31 @@ func uninstallVerrazzano(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 				return failedToUninstallErr(err)
 			}
 		} else {
-			return failedToUninstallErr(err)
+			return autoBugReport(cmd, vzHelper, err)
 		}
 	}
 	_, _ = fmt.Fprintf(vzHelper.GetOutputStream(), "Uninstalling Verrazzano\n")
 
 	// Wait for the Verrazzano uninstall to complete.
-	return waitForUninstallToComplete(client, kubeClient, vzHelper, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name}, timeout, vpoTimeout, logFormat, useUninstallJob)
+	err = waitForUninstallToComplete(client, kubeClient, vzHelper, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name}, timeout, vpoTimeout, logFormat, useUninstallJob)
+	if err != nil {
+		return autoBugReport(cmd, vzHelper, err)
+	}
+	return nil
+}
+
+// autoBugReport checks that AutoBugReportFlag is set and then kicks off vz bugreport CLI command. It returns the same error that is passed in
+func autoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) error {
+	autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
+	if errFlag != nil {
+		fmt.Fprintf(vzHelper.GetOutputStream(), "Error fetching flags: %s", errFlag.Error())
+		return err
+	}
+	if autoBugReportFlag {
+		//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from uninstallVerrazzanoFn
+		err = bugreport.CallVzBugReport(cmd, vzHelper, err)
+	}
+	return failedToUninstallErr(err)
 }
 
 // cleanupResources deletes remaining resources that remain after the Verrazzano resource in uninstalled

--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -159,7 +159,7 @@ func TestUninstallCmdDefaultTimeout(t *testing.T) {
 	assert.Error(t, err)
 	// This must be less than the 1 second polling delay to pass
 	// since the Verrazzano resource gets deleted almost instantaneously
-	assert.Equal(t, "Error: Failed to uninstall Verrazzano: Timeout 2ms exceeded waiting for uninstall to complete\n", errBuf.String())
+	assert.Equal(t, "Error: Timeout 2ms exceeded waiting for uninstall to complete\n", errBuf.String())
 	ensureResourcesNotDeleted(t, c)
 	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
 		t.Fatal(BugReportNotExist)
@@ -199,7 +199,7 @@ func TestUninstallCmdDefaultTimeoutNoBugReport(t *testing.T) {
 	assert.Error(t, err)
 	// This must be less than the 1 second polling delay to pass
 	// since the Verrazzano resource gets deleted almost instantaneously
-	assert.Equal(t, "Error: Failed to uninstall Verrazzano: Timeout 2ms exceeded waiting for uninstall to complete\n", errBuf.String())
+	assert.Equal(t, "Error: Timeout 2ms exceeded waiting for uninstall to complete\n", errBuf.String())
 	ensureResourcesNotDeleted(t, c)
 	// Bug Report must not exist
 	if helpers.CheckAndRemoveBugReportExistsInDir("") {

--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -6,8 +6,6 @@ package uninstall
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -145,11 +143,6 @@ func TestUninstallCmdDefaultTimeout(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
-	uninstallFunc := func(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
-		return fmt.Errorf("Timeout 2ms exceeded waiting for uninstall to complete")
-	}
-	SetUninstallVerrazzanoFn(uninstallFunc)
-	defer ResetUninstallVerrazzanoFn()
 	cmd := NewCmdUninstall(rc)
 	assert.NotNil(t, cmd)
 	tempKubeConfigPath, _ := os.CreateTemp(os.TempDir(), testKubeConfig)
@@ -193,11 +186,6 @@ func TestUninstallCmdDefaultTimeoutNoBugReport(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
-	uninstallFunc := func(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
-		return fmt.Errorf("Timeout 2ms exceeded waiting for uninstall to complete")
-	}
-	SetUninstallVerrazzanoFn(uninstallFunc)
-	defer ResetUninstallVerrazzanoFn()
 	cmd := NewCmdUninstall(rc)
 	assert.NotNil(t, cmd)
 	_ = cmd.PersistentFlags().Set(constants.TimeoutFlag, "2ms")
@@ -299,11 +287,6 @@ func TestUninstallCmdDefaultNoVPO(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
-	uninstallFunc := func(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
-		return fmt.Errorf(VzVpoFailureError)
-	}
-	SetUninstallVerrazzanoFn(uninstallFunc)
-	defer ResetUninstallVerrazzanoFn()
 	cmd := NewCmdUninstall(rc)
 	assert.NotNil(t, cmd)
 	tempKubeConfigPath, _ := os.CreateTemp(os.TempDir(), testKubeConfig)
@@ -339,11 +322,6 @@ func TestUninstallCmdDefaultNoUninstallJob(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
-	uninstallFunc := func(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
-		return fmt.Errorf(PodNotFoundError)
-	}
-	SetUninstallVerrazzanoFn(uninstallFunc)
-	defer ResetUninstallVerrazzanoFn()
 	cmd := NewCmdUninstall(rc)
 	assert.NotNil(t, cmd)
 	cmd.PersistentFlags().Set(constants.LogFormatFlag, "simple")
@@ -372,7 +350,7 @@ func TestUninstallCmdDefaultNoUninstallJob(t *testing.T) {
 // GIVEN a CLI uninstall command with all defaults and no vz resource found
 //
 //	WHEN I call cmd.Execute for uninstall
-//	THEN the CLI uninstall command fails and bug report should be generated
+//	THEN the CLI uninstall command fails and bug report should not be generated
 func TestUninstallCmdDefaultNoVzResource(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(helpers.NewScheme()).Build()
 
@@ -395,7 +373,7 @@ func TestUninstallCmdDefaultNoVzResource(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Verrazzano is not installed: Failed to find any Verrazzano resources")
 	assert.Contains(t, errBuf.String(), "Verrazzano is not installed: Failed to find any Verrazzano resources")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -156,53 +156,15 @@ func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 			return err
 		}
 
-		// Wait for the platform operator to be ready before we update the verrazzano install resource
-		_, err = cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondUpgradeComplete, vpoTimeout)
+		err = upgradeVerrazzano(vzHelper, vz, client, version, vpoTimeout)
 		if err != nil {
-			return err
-		}
-
-		err = kubectlutil.SetLastAppliedConfigurationAnnotation(vz)
-		if err != nil {
-			return err
-		}
-
-		// Update the version in the verrazzano install resource.  This will initiate the Verrazzano upgrade.
-		// We will retry up to 5 times if there is an error.
-		// Sometimes we see intermittent webhook errors due to timeouts.
-		retry := 0
-		for {
-			// Get the verrazzano install resource each iteration, in case of resource conflicts
-			vz, err = helpers.GetVerrazzanoResource(client, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name})
-			if err == nil {
-				vz.Spec.Version = version
-				err = helpers.UpdateVerrazzanoResource(client, vz)
-			}
-			if err != nil {
-				if retry == 5 {
-					return fmt.Errorf("Failed to set the upgrade version in the verrazzano install resource: %s", err.Error())
-				}
-				time.Sleep(time.Second)
-				retry++
-				fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Retrying after failing to set the upgrade version in the verrazzano install resource: %s\n", err.Error()))
-				continue
-			}
-			break
+			return autoBugReport(cmd, vzHelper, err)
 		}
 
 		// Wait for the Verrazzano upgrade to complete
 		err = waitForUpgradeToComplete(client, kubeClient, vzHelper, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name}, timeout, vpoTimeout, logFormat)
 		if err != nil {
-			autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
-			if errFlag != nil {
-				fmt.Fprintf(vzHelper.GetOutputStream(), "Error fetching flags: %s", errFlag.Error())
-				return err
-			}
-			if autoBugReportFlag {
-				//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from waitForUpgradeToComplete
-				return bugreport.CallVzBugReport(cmd, vzHelper, err)
-			}
-			return err
+			return autoBugReport(cmd, vzHelper, err)
 		}
 		return nil
 	}
@@ -213,16 +175,7 @@ func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 	if !vzStatusVersion.IsEqualTo(vzSpecVersion) {
 		err = waitForUpgradeToComplete(client, kubeClient, vzHelper, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name}, timeout, vpoTimeout, logFormat)
 		if err != nil {
-			autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
-			if errFlag != nil {
-				fmt.Fprintf(vzHelper.GetOutputStream(), "Error fetching flags: %s", errFlag.Error())
-				return err
-			}
-			if autoBugReportFlag {
-				//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from waitForUpgradeToComplete
-				return bugreport.CallVzBugReport(cmd, vzHelper, err)
-			}
-			return err
+			return autoBugReport(cmd, vzHelper, err)
 		}
 		return nil
 	}
@@ -230,7 +183,58 @@ func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 	return nil
 }
 
+func upgradeVerrazzano(vzHelper helpers.VZHelper, vz *v1beta1.Verrazzano, client clipkg.Client, version string, vpoTimeout time.Duration) error {
+	// Wait for the platform operator to be ready before we update the verrazzano install resource
+	_, err := cmdhelpers.WaitForPlatformOperator(client, vzHelper, v1beta1.CondUpgradeComplete, vpoTimeout)
+	if err != nil {
+		return err
+	}
+
+	err = kubectlutil.SetLastAppliedConfigurationAnnotation(vz)
+	if err != nil {
+		return err
+	}
+
+	// Update the version in the verrazzano install resource.  This will initiate the Verrazzano upgrade.
+	// We will retry up to 5 times if there is an error.
+	// Sometimes we see intermittent webhook errors due to timeouts.
+	retry := 0
+	for {
+		// Get the verrazzano install resource each iteration, in case of resource conflicts
+		vz, err = helpers.GetVerrazzanoResource(client, types.NamespacedName{Namespace: vz.Namespace, Name: vz.Name})
+		if err == nil {
+			vz.Spec.Version = version
+			err = helpers.UpdateVerrazzanoResource(client, vz)
+		}
+		if err != nil {
+			if retry == 5 {
+				return fmt.Errorf("Failed to set the upgrade version in the verrazzano install resource: %s", err.Error())
+			}
+			time.Sleep(time.Second)
+			retry++
+			fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Retrying after failing to set the upgrade version in the verrazzano install resource: %s\n", err.Error()))
+			continue
+		}
+		break
+	}
+	return nil
+}
+
 // Wait for the upgrade operation to complete
 func waitForUpgradeToComplete(client clipkg.Client, kubeClient kubernetes.Interface, vzHelper helpers.VZHelper, namespacedName types.NamespacedName, timeout time.Duration, vpoTimeout time.Duration, logFormat cmdhelpers.LogFormat) error {
 	return cmdhelpers.WaitForOperationToComplete(client, kubeClient, vzHelper, namespacedName, timeout, vpoTimeout, logFormat, v1beta1.CondUpgradeComplete)
+}
+
+// autoBugReport checks that AutoBugReportFlag is set and then kicks off vz bugreport CLI command. It returns the same error that is passed in
+func autoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) error {
+	autoBugReportFlag, errFlag := cmd.Flags().GetBool(constants.AutoBugReportFlag)
+	if errFlag != nil {
+		fmt.Fprintf(vzHelper.GetOutputStream(), "Error fetching flags: %s", errFlag.Error())
+		return err
+	}
+	if autoBugReportFlag {
+		//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from uninstallVerrazzanoFn
+		err = bugreport.CallVzBugReport(cmd, vzHelper, err)
+	}
+	return err
 }

--- a/tools/vz/cmd/upgrade/upgrade_test.go
+++ b/tools/vz/cmd/upgrade/upgrade_test.go
@@ -147,6 +147,9 @@ func TestUpgradeCmdDefaultNoVPO(t *testing.T) {
 	cmd := NewCmdUpgrade(rc)
 	assert.NotNil(t, cmd)
 	cmd.PersistentFlags().Set(constants.VersionFlag, "v1.4.0")
+	tempKubeConfigPath, _ := os.CreateTemp(os.TempDir(), testKubeConfig)
+	cmd.Flags().String(constants.GlobalFlagKubeConfig, tempKubeConfigPath.Name(), "")
+	cmd.Flags().String(constants.GlobalFlagContext, testK8sContext, "")
 
 	// Run upgrade command
 	cmd.PersistentFlags().Set(constants.VPOTimeoutFlag, "1s")
@@ -154,6 +157,9 @@ func TestUpgradeCmdDefaultNoVPO(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Waiting for verrazzano-platform-operator pod in namespace verrazzano-install")
 	assert.Contains(t, errBuf.String(), "Error: Waiting for verrazzano-platform-operator pod in namespace verrazzano-install")
+	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+		t.Fatal("found bug report file in current directory")
+	}
 }
 
 // TestUpgradeCmdDefaultMultipleVPO
@@ -173,6 +179,9 @@ func TestUpgradeCmdDefaultMultipleVPO(t *testing.T) {
 	cmd := NewCmdUpgrade(rc)
 	assert.NotNil(t, cmd)
 	cmd.PersistentFlags().Set(constants.VersionFlag, "v1.4.0")
+	tempKubeConfigPath, _ := os.CreateTemp(os.TempDir(), testKubeConfig)
+	cmd.Flags().String(constants.GlobalFlagKubeConfig, tempKubeConfigPath.Name(), "")
+	cmd.Flags().String(constants.GlobalFlagContext, testK8sContext, "")
 	cmdHelpers.SetDeleteFunc(cmdHelpers.FakeDeleteFunc)
 	defer cmdHelpers.SetDefaultDeleteFunc()
 
@@ -182,6 +191,9 @@ func TestUpgradeCmdDefaultMultipleVPO(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Waiting for verrazzano-platform-operator, more than one verrazzano-platform-operator pod was found in namespace verrazzano-install")
 	assert.Contains(t, errBuf.String(), "Error: Waiting for verrazzano-platform-operator, more than one verrazzano-platform-operator pod was found in namespace verrazzano-install")
+	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+		t.Fatal("found bug report file in current directory")
+	}
 }
 
 // TestUpgradeCmdJsonLogFormat


### PR DESCRIPTION
Example cases that should not automatically run analyze or bug report 
- Invoking vz uninstall when vz is not installed 
- Invoking vz install, uninstall, upgrade with incorrect CLI arguments 
- Invoking vz install with multiple versions 
- Invoking vz install when an install has already started 

Example cases that SHOULD automatically run analyze or bug report 
- timeout after waiting for install, uninstall, upgrade to complete 
- timeout after waiting for platform operator 
- failing to create the vz install resource 




