### PR TITLE
VZ-9456: Embed the providers manifests/metadat installed by the CAPI in the VPO image

### DIFF
--- a/ignore_copyright_check.txt
+++ b/ignore_copyright_check.txt
@@ -10,8 +10,6 @@ platform-operator/helm_config/charts/verrazzano-fluentd/NOTES.txt
 platform-operator/helm_config/charts/verrazzano-platform-operator/NOTES.txt
 platform-operator/helm_config/charts/verrazzano-monitoring-operator/NOTES.txt
 platform-operator/helm_config/charts/verrazzano-network-policies/NOTES.txt
-platform-operator/capi/bootstrap-ocne
-platform-operator/capi/control-plane-ocne
 
 tools/psr/manifests/charts/worker/NOTES.txt
 tools/psr/manifests/charts/worker/charts/http/NOTES.txt

--- a/platform-operator/Dockerfile
+++ b/platform-operator/Dockerfile
@@ -48,6 +48,7 @@ COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/ver
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/out/generated-verrazzano-bom.json ./platform-operator/verrazzano-bom.json
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/bootstrap-ocne ./capi/bootstrap-ocne
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/control-plane-ocne ./capi/control-plane-ocne
+COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/infrastructure-oci ./capi/infrastructure-oci
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/.cluster-api ./.cluster-api
 
 COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano/platform-operator/THIRD_PARTY_LICENSES.txt /licenses/

--- a/platform-operator/Dockerfile
+++ b/platform-operator/Dockerfile
@@ -49,6 +49,7 @@ COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/ver
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/bootstrap-ocne ./capi/bootstrap-ocne
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/control-plane-ocne ./capi/control-plane-ocne
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/infrastructure-oci ./capi/infrastructure-oci
+COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/cluster-api ./capi/cluster-api
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/.cluster-api ./.cluster-api
 
 COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano/platform-operator/THIRD_PARTY_LICENSES.txt /licenses/

--- a/platform-operator/capi/.cluster-api/clusterctl.yaml
+++ b/platform-operator/capi/.cluster-api/clusterctl.yaml
@@ -19,6 +19,9 @@ images:
     tag: v0.1.0-20230417200213-babd8e5
 
 providers:
+  - name: "cluster-api"
+    url: "/verrazzano/capi/cluster-api/v1.3.3/core-components.yaml"
+    type: "CoreProvider"
   - name: "oci"
     url: "/verrazzano/capi/infrastructure-oci/v0.8.1/infrastructure-components.yaml"
     type: "InfrastructureProvider"

--- a/platform-operator/capi/.cluster-api/clusterctl.yaml
+++ b/platform-operator/capi/.cluster-api/clusterctl.yaml
@@ -18,8 +18,10 @@ images:
     repository: ghcr.io/verrazzano
     tag: v0.1.0-20230417200213-babd8e5
 
-
 providers:
+  - name: "oci"
+    url: "/verrazzano/capi/infrastructure-oci/v0.8.1/infrastructure-components.yaml"
+    type: "InfrastructureProvider"
   - name: "ocne"
     url: "/verrazzano/capi/bootstrap-ocne/v0.1.0/bootstrap-components.yaml"
     type: "BootstrapProvider"

--- a/platform-operator/capi/bootstrap-ocne/v0.1.0/bootstrap-components.yaml
+++ b/platform-operator/capi/bootstrap-ocne/v0.1.0/bootstrap-components.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/platform-operator/capi/bootstrap-ocne/v0.1.0/metadata.yaml
+++ b/platform-operator/capi/bootstrap-ocne/v0.1.0/metadata.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 # maps release series of major.minor to cluster-api contract version
 # the contract version may change between minor or major versions, but *not*
 # between patch versions.

--- a/platform-operator/capi/cluster-api/v1.3.3/core-components.yaml
+++ b/platform-operator/capi/cluster-api/v1.3.3/core-components.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/platform-operator/capi/cluster-api/v1.3.3/core-components.yaml
+++ b/platform-operator/capi/cluster-api/v1.3.3/core-components.yaml
@@ -1,0 +1,11400 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    control-plane: controller-manager
+  name: capi-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusterclasses.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterClass
+    listKind: ClusterClassList
+    plural: clusterclasses
+    shortNames:
+    - cc
+    singular: clusterclass
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterClass
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: ClusterClass is a template which can be used to create managed
+          topologies.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterClassSpec describes the desired state of the ClusterClass.
+            properties:
+              controlPlane:
+                description: ControlPlane is a reference to a local struct that holds
+                  the details for provisioning the Control Plane for the Cluster.
+                properties:
+                  machineInfrastructure:
+                    description: "MachineTemplate defines the metadata and infrastructure
+                      information for control plane machines. \n This field is supported
+                      if and only if the control plane provider template referenced
+                      above is Machine based and supports setting replicas."
+                    properties:
+                      ref:
+                        description: Ref is a required reference to a custom resource
+                          offered by a provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - ref
+                    type: object
+                  metadata:
+                    description: "Metadata is the metadata applied to the machines
+                      of the ControlPlane. At runtime this metadata is merged with
+                      the corresponding metadata from the topology. \n This field
+                      is supported if and only if the control plane provider template
+                      referenced is Machine based."
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  ref:
+                    description: Ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              infrastructure:
+                description: Infrastructure is a reference to a provider-specific
+                  template that holds the details for provisioning infrastructure
+                  specific cluster for the underlying provider. The underlying provider
+                  is responsible for the implementation of the template to an infrastructure
+                  cluster.
+                properties:
+                  ref:
+                    description: Ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              workers:
+                description: Workers describes the worker nodes for the cluster. It
+                  is a collection of node types which can be used to create the worker
+                  nodes of the cluster.
+                properties:
+                  machineDeployments:
+                    description: MachineDeployments is a list of machine deployment
+                      classes that can be used to create a set of worker nodes.
+                    items:
+                      description: MachineDeploymentClass serves as a template to
+                        define a set of worker nodes of the cluster provisioned using
+                        the `ClusterClass`.
+                      properties:
+                        class:
+                          description: Class denotes a type of worker node present
+                            in the cluster, this name MUST be unique within a ClusterClass
+                            and can be referenced in the Cluster to create a managed
+                            MachineDeployment.
+                          type: string
+                        template:
+                          description: Template is a local struct containing a collection
+                            of templates for creation of MachineDeployment objects
+                            representing a set of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: Bootstrap contains the bootstrap template
+                                reference to be used for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: Ref is a required reference to a custom
+                                    resource offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an
+                                        object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access
+                                        statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to
+                                        a container within a pod, this would take
+                                        on a value like: "spec.containers{name}" (where
+                                        "name" refers to the name of the container
+                                        that triggered the event) or if no container
+                                        name is specified "spec.containers[2]" (container
+                                        with index 2 in this pod). This syntax is
+                                        chosen only to have some well-defined way
+                                        of referencing a part of an object. TODO:
+                                        this design is not final and this field is
+                                        subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More
+                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which
+                                        this reference is made, if any. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: Infrastructure contains the infrastructure
+                                template reference to be used for the creation of
+                                worker Machines.
+                              properties:
+                                ref:
+                                  description: Ref is a required reference to a custom
+                                    resource offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an
+                                        object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access
+                                        statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to
+                                        a container within a pod, this would take
+                                        on a value like: "spec.containers{name}" (where
+                                        "name" refers to the name of the container
+                                        that triggered the event) or if no container
+                                        name is specified "spec.containers[2]" (container
+                                        with index 2 in this pod). This syntax is
+                                        chosen only to have some well-defined way
+                                        of referencing a part of an object. TODO:
+                                        this design is not final and this field is
+                                        subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More
+                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which
+                                        this reference is made, if any. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: Metadata is the metadata applied to the
+                                machines of the MachineDeployment. At runtime this
+                                metadata is merged with the corresponding metadata
+                                from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key
+                                    value map stored with a resource that may be set
+                                    by external tools to store and retrieve arbitrary
+                                    metadata. They are not queryable and should be
+                                    preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that
+                                    can be used to organize and categorize (scope
+                                    and select) objects. May match selectors of replication
+                                    controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterClass
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterClass is a template which can be used to create managed
+          topologies.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterClassSpec describes the desired state of the ClusterClass.
+            properties:
+              controlPlane:
+                description: ControlPlane is a reference to a local struct that holds
+                  the details for provisioning the Control Plane for the Cluster.
+                properties:
+                  machineHealthCheck:
+                    description: MachineHealthCheck defines a MachineHealthCheck for
+                      this ControlPlaneClass. This field is supported if and only
+                      if the ControlPlane provider template referenced above is Machine
+                      based and supports setting replicas.
+                    properties:
+                      maxUnhealthy:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Any further remediation is only allowed if at
+                          most "MaxUnhealthy" machines selected by "selector" are
+                          not healthy.
+                        x-kubernetes-int-or-string: true
+                      nodeStartupTimeout:
+                        description: Machines older than this duration without a node
+                          will be considered to have failed and will be remediated.
+                          If you wish to disable this feature, set the value explicitly
+                          to 0.
+                        type: string
+                      remediationTemplate:
+                        description: "RemediationTemplate is a reference to a remediation
+                          template provided by an infrastructure provider. \n This
+                          field is completely optional, when filled, the MachineHealthCheck
+                          controller creates a new object from the template referenced
+                          and hands off remediation of the machine to a controller
+                          that lives outside of Cluster API."
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      unhealthyConditions:
+                        description: UnhealthyConditions contains a list of the conditions
+                          that determine whether a node is considered unhealthy. The
+                          conditions are combined in a logical OR, i.e. if any of
+                          the conditions is met, the node is unhealthy.
+                        items:
+                          description: UnhealthyCondition represents a Node condition
+                            type and value with a timeout specified as a duration.  When
+                            the named condition has been in the given status for at
+                            least the timeout value, a node is considered unhealthy.
+                          properties:
+                            status:
+                              minLength: 1
+                              type: string
+                            timeout:
+                              type: string
+                            type:
+                              minLength: 1
+                              type: string
+                          required:
+                          - status
+                          - timeout
+                          - type
+                          type: object
+                        type: array
+                      unhealthyRange:
+                        description: 'Any further remediation is only allowed if the
+                          number of machines selected by "selector" as not healthy
+                          is within the range of "UnhealthyRange". Takes precedence
+                          over MaxUnhealthy. Eg. "[3-5]" - This means that remediation
+                          will be allowed only when: (a) there are at least 3 unhealthy
+                          machines (and) (b) there are at most 5 unhealthy machines'
+                        pattern: ^\[[0-9]+-[0-9]+\]$
+                        type: string
+                    type: object
+                  machineInfrastructure:
+                    description: "MachineInfrastructure defines the metadata and infrastructure
+                      information for control plane machines. \n This field is supported
+                      if and only if the control plane provider template referenced
+                      above is Machine based and supports setting replicas."
+                    properties:
+                      ref:
+                        description: Ref is a required reference to a custom resource
+                          offered by a provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - ref
+                    type: object
+                  metadata:
+                    description: "Metadata is the metadata applied to the machines
+                      of the ControlPlane. At runtime this metadata is merged with
+                      the corresponding metadata from the topology. \n This field
+                      is supported if and only if the control plane provider template
+                      referenced is Machine based."
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  nodeDeletionTimeout:
+                    description: 'NodeDeletionTimeout defines how long the controller
+                      will attempt to delete the Node that the Machine hosts after
+                      the Machine is marked for deletion. A duration of 0 will retry
+                      deletion indefinitely. Defaults to 10 seconds. NOTE: This value
+                      can be overridden while defining a Cluster.Topology.'
+                    type: string
+                  nodeDrainTimeout:
+                    description: 'NodeDrainTimeout is the total amount of time that
+                      the controller will spend on draining a node. The default value
+                      is 0, meaning that the node can be drained without any time
+                      limitations. NOTE: NodeDrainTimeout is different from `kubectl
+                      drain --timeout` NOTE: This value can be overridden while defining
+                      a Cluster.Topology.'
+                    type: string
+                  nodeVolumeDetachTimeout:
+                    description: 'NodeVolumeDetachTimeout is the total amount of time
+                      that the controller will spend on waiting for all volumes to
+                      be detached. The default value is 0, meaning that the volumes
+                      can be detached without any time limitations. NOTE: This value
+                      can be overridden while defining a Cluster.Topology.'
+                    type: string
+                  ref:
+                    description: Ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              infrastructure:
+                description: Infrastructure is a reference to a provider-specific
+                  template that holds the details for provisioning infrastructure
+                  specific cluster for the underlying provider. The underlying provider
+                  is responsible for the implementation of the template to an infrastructure
+                  cluster.
+                properties:
+                  ref:
+                    description: Ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              patches:
+                description: 'Patches defines the patches which are applied to customize
+                  referenced templates of a ClusterClass. Note: Patches will be applied
+                  in the order of the array.'
+                items:
+                  description: ClusterClassPatch defines a patch which is applied
+                    to customize the referenced templates.
+                  properties:
+                    definitions:
+                      description: 'Definitions define inline patches. Note: Patches
+                        will be applied in the order of the array. Note: Exactly one
+                        of Definitions or External must be set.'
+                      items:
+                        description: PatchDefinition defines a patch which is applied
+                          to customize the referenced templates.
+                        properties:
+                          jsonPatches:
+                            description: 'JSONPatches defines the patches which should
+                              be applied on the templates matching the selector. Note:
+                              Patches will be applied in the order of the array.'
+                            items:
+                              description: JSONPatch defines a JSON patch.
+                              properties:
+                                op:
+                                  description: 'Op defines the operation of the patch.
+                                    Note: Only `add`, `replace` and `remove` are supported.'
+                                  type: string
+                                path:
+                                  description: 'Path defines the path of the patch.
+                                    Note: Only the spec of a template can be patched,
+                                    thus the path has to start with /spec/. Note:
+                                    For now the only allowed array modifications are
+                                    `append` and `prepend`, i.e.: * for op: `add`:
+                                    only index 0 (prepend) and - (append) are allowed
+                                    * for op: `replace` or `remove`: no indexes are
+                                    allowed'
+                                  type: string
+                                value:
+                                  description: 'Value defines the value of the patch.
+                                    Note: Either Value or ValueFrom is required for
+                                    add and replace operations. Only one of them is
+                                    allowed to be set at the same time. Note: We have
+                                    to use apiextensionsv1.JSON instead of our JSON
+                                    type, because controller-tools has a hard-coded
+                                    schema for apiextensionsv1.JSON which cannot be
+                                    produced by another type (unset type field). Ref:
+                                    https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111'
+                                  x-kubernetes-preserve-unknown-fields: true
+                                valueFrom:
+                                  description: 'ValueFrom defines the value of the
+                                    patch. Note: Either Value or ValueFrom is required
+                                    for add and replace operations. Only one of them
+                                    is allowed to be set at the same time.'
+                                  properties:
+                                    template:
+                                      description: 'Template is the Go template to
+                                        be used to calculate the value. A template
+                                        can reference variables defined in .spec.variables
+                                        and builtin variables. Note: The template
+                                        must evaluate to a valid YAML or JSON value.'
+                                      type: string
+                                    variable:
+                                      description: Variable is the variable to be
+                                        used as value. Variable can be one of the
+                                        variables defined in .spec.variables or a
+                                        builtin variable.
+                                      type: string
+                                  type: object
+                              required:
+                              - op
+                              - path
+                              type: object
+                            type: array
+                          selector:
+                            description: Selector defines on which templates the patch
+                              should be applied.
+                            properties:
+                              apiVersion:
+                                description: APIVersion filters templates by apiVersion.
+                                type: string
+                              kind:
+                                description: Kind filters templates by kind.
+                                type: string
+                              matchResources:
+                                description: MatchResources selects templates based
+                                  on where they are referenced.
+                                properties:
+                                  controlPlane:
+                                    description: 'ControlPlane selects templates referenced
+                                      in .spec.ControlPlane. Note: this will match
+                                      the controlPlane and also the controlPlane machineInfrastructure
+                                      (depending on the kind and apiVersion).'
+                                    type: boolean
+                                  infrastructureCluster:
+                                    description: InfrastructureCluster selects templates
+                                      referenced in .spec.infrastructure.
+                                    type: boolean
+                                  machineDeploymentClass:
+                                    description: MachineDeploymentClass selects templates
+                                      referenced in specific MachineDeploymentClasses
+                                      in .spec.workers.machineDeployments.
+                                    properties:
+                                      names:
+                                        description: Names selects templates by class
+                                          names.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                            required:
+                            - apiVersion
+                            - kind
+                            - matchResources
+                            type: object
+                        required:
+                        - jsonPatches
+                        - selector
+                        type: object
+                      type: array
+                    description:
+                      description: Description is a human-readable description of
+                        this patch.
+                      type: string
+                    enabledIf:
+                      description: EnabledIf is a Go template to be used to calculate
+                        if a patch should be enabled. It can reference variables defined
+                        in .spec.variables and builtin variables. The patch will be
+                        enabled if the template evaluates to `true`, otherwise it
+                        will be disabled. If EnabledIf is not set, the patch will
+                        be enabled per default.
+                      type: string
+                    external:
+                      description: 'External defines an external patch. Note: Exactly
+                        one of Definitions or External must be set.'
+                      properties:
+                        generateExtension:
+                          description: GenerateExtension references an extension which
+                            is called to generate patches.
+                          type: string
+                        validateExtension:
+                          description: ValidateExtension references an extension which
+                            is called to validate the topology.
+                          type: string
+                      type: object
+                    name:
+                      description: Name of the patch.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              variables:
+                description: Variables defines the variables which can be configured
+                  in the Cluster topology and are then used in patches.
+                items:
+                  description: ClusterClassVariable defines a variable which can be
+                    configured in the Cluster topology and used in patches.
+                  properties:
+                    name:
+                      description: Name of the variable.
+                      type: string
+                    required:
+                      description: 'Required specifies if the variable is required.
+                        Note: this applies to the variable as a whole and thus the
+                        top-level object defined in the schema. If nested fields are
+                        required, this will be specified inside the schema.'
+                      type: boolean
+                    schema:
+                      description: Schema defines the schema of the variable.
+                      properties:
+                        openAPIV3Schema:
+                          description: OpenAPIV3Schema defines the schema of a variable
+                            via OpenAPI v3 schema. The schema is a subset of the schema
+                            used in Kubernetes CRDs.
+                          properties:
+                            additionalProperties:
+                              description: 'AdditionalProperties specifies the schema
+                                of values in a map (keys are always strings). NOTE:
+                                Can only be set if type is object. NOTE: AdditionalProperties
+                                is mutually exclusive with Properties. NOTE: This
+                                field uses PreserveUnknownFields and Schemaless, because
+                                recursive validation is not possible.'
+                              x-kubernetes-preserve-unknown-fields: true
+                            default:
+                              description: 'Default is the default value of the variable.
+                                NOTE: Can be set for all types.'
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: Description is a human-readable description
+                                of this variable.
+                              type: string
+                            enum:
+                              description: 'Enum is the list of valid values of the
+                                variable. NOTE: Can be set for all types.'
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            example:
+                              description: Example is an example for this variable.
+                              x-kubernetes-preserve-unknown-fields: true
+                            exclusiveMaximum:
+                              description: 'ExclusiveMaximum specifies if the Maximum
+                                is exclusive. NOTE: Can only be set if type is integer
+                                or number.'
+                              type: boolean
+                            exclusiveMinimum:
+                              description: 'ExclusiveMinimum specifies if the Minimum
+                                is exclusive. NOTE: Can only be set if type is integer
+                                or number.'
+                              type: boolean
+                            format:
+                              description: 'Format is an OpenAPI v3 format string.
+                                Unknown formats are ignored. For a list of supported
+                                formats please see: (of the k8s.io/apiextensions-apiserver
+                                version we''re currently using) https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go
+                                NOTE: Can only be set if type is string.'
+                              type: string
+                            items:
+                              description: 'Items specifies fields of an array. NOTE:
+                                Can only be set if type is array. NOTE: This field
+                                uses PreserveUnknownFields and Schemaless, because
+                                recursive validation is not possible.'
+                              x-kubernetes-preserve-unknown-fields: true
+                            maxItems:
+                              description: 'MaxItems is the max length of an array
+                                variable. NOTE: Can only be set if type is array.'
+                              format: int64
+                              type: integer
+                            maxLength:
+                              description: 'MaxLength is the max length of a string
+                                variable. NOTE: Can only be set if type is string.'
+                              format: int64
+                              type: integer
+                            maximum:
+                              description: 'Maximum is the maximum of an integer or
+                                number variable. If ExclusiveMaximum is false, the
+                                variable is valid if it is lower than, or equal to,
+                                the value of Maximum. If ExclusiveMaximum is true,
+                                the variable is valid if it is strictly lower than
+                                the value of Maximum. NOTE: Can only be set if type
+                                is integer or number.'
+                              format: int64
+                              type: integer
+                            minItems:
+                              description: 'MinItems is the min length of an array
+                                variable. NOTE: Can only be set if type is array.'
+                              format: int64
+                              type: integer
+                            minLength:
+                              description: 'MinLength is the min length of a string
+                                variable. NOTE: Can only be set if type is string.'
+                              format: int64
+                              type: integer
+                            minimum:
+                              description: 'Minimum is the minimum of an integer or
+                                number variable. If ExclusiveMinimum is false, the
+                                variable is valid if it is greater than, or equal
+                                to, the value of Minimum. If ExclusiveMinimum is true,
+                                the variable is valid if it is strictly greater than
+                                the value of Minimum. NOTE: Can only be set if type
+                                is integer or number.'
+                              format: int64
+                              type: integer
+                            pattern:
+                              description: 'Pattern is the regex which a string variable
+                                must match. NOTE: Can only be set if type is string.'
+                              type: string
+                            properties:
+                              description: 'Properties specifies fields of an object.
+                                NOTE: Can only be set if type is object. NOTE: Properties
+                                is mutually exclusive with AdditionalProperties. NOTE:
+                                This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.'
+                              x-kubernetes-preserve-unknown-fields: true
+                            required:
+                              description: 'Required specifies which fields of an
+                                object are required. NOTE: Can only be set if type
+                                is object.'
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              description: 'Type is the type of the variable. Valid
+                                values are: object, array, string, integer, number
+                                or boolean.'
+                              type: string
+                            uniqueItems:
+                              description: 'UniqueItems specifies if items in an array
+                                must be unique. NOTE: Can only be set if type is array.'
+                              type: boolean
+                            x-kubernetes-preserve-unknown-fields:
+                              description: XPreserveUnknownFields allows setting fields
+                                in a variable object which are not defined in the
+                                variable schema. This affects fields recursively,
+                                except if nested properties or additionalProperties
+                                are specified in the schema.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - openAPIV3Schema
+                      type: object
+                  required:
+                  - name
+                  - required
+                  - schema
+                  type: object
+                type: array
+              workers:
+                description: Workers describes the worker nodes for the cluster. It
+                  is a collection of node types which can be used to create the worker
+                  nodes of the cluster.
+                properties:
+                  machineDeployments:
+                    description: MachineDeployments is a list of machine deployment
+                      classes that can be used to create a set of worker nodes.
+                    items:
+                      description: MachineDeploymentClass serves as a template to
+                        define a set of worker nodes of the cluster provisioned using
+                        the `ClusterClass`.
+                      properties:
+                        class:
+                          description: Class denotes a type of worker node present
+                            in the cluster, this name MUST be unique within a ClusterClass
+                            and can be referenced in the Cluster to create a managed
+                            MachineDeployment.
+                          type: string
+                        failureDomain:
+                          description: 'FailureDomain is the failure domain the machines
+                            will be created in. Must match a key in the FailureDomains
+                            map stored on the cluster object. NOTE: This value can
+                            be overridden while defining a Cluster.Topology using
+                            this MachineDeploymentClass.'
+                          type: string
+                        machineHealthCheck:
+                          description: MachineHealthCheck defines a MachineHealthCheck
+                            for this MachineDeploymentClass.
+                          properties:
+                            maxUnhealthy:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Any further remediation is only allowed
+                                if at most "MaxUnhealthy" machines selected by "selector"
+                                are not healthy.
+                              x-kubernetes-int-or-string: true
+                            nodeStartupTimeout:
+                              description: Machines older than this duration without
+                                a node will be considered to have failed and will
+                                be remediated. If you wish to disable this feature,
+                                set the value explicitly to 0.
+                              type: string
+                            remediationTemplate:
+                              description: "RemediationTemplate is a reference to
+                                a remediation template provided by an infrastructure
+                                provider. \n This field is completely optional, when
+                                filled, the MachineHealthCheck controller creates
+                                a new object from the template referenced and hands
+                                off remediation of the machine to a controller that
+                                lives outside of Cluster API."
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: 'If referring to a piece of an object
+                                    instead of an entire object, this string should
+                                    contain a valid JSON/Go field access statement,
+                                    such as desiredState.manifest.containers[2]. For
+                                    example, if the object reference is to a container
+                                    within a pod, this would take on a value like:
+                                    "spec.containers{name}" (where "name" refers to
+                                    the name of the container that triggered the event)
+                                    or if no container name is specified "spec.containers[2]"
+                                    (container with index 2 in this pod). This syntax
+                                    is chosen only to have some well-defined way of
+                                    referencing a part of an object. TODO: this design
+                                    is not final and this field is subject to change
+                                    in the future.'
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                                resourceVersion:
+                                  description: 'Specific resourceVersion to which
+                                    this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                  type: string
+                                uid:
+                                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            unhealthyConditions:
+                              description: UnhealthyConditions contains a list of
+                                the conditions that determine whether a node is considered
+                                unhealthy. The conditions are combined in a logical
+                                OR, i.e. if any of the conditions is met, the node
+                                is unhealthy.
+                              items:
+                                description: UnhealthyCondition represents a Node
+                                  condition type and value with a timeout specified
+                                  as a duration.  When the named condition has been
+                                  in the given status for at least the timeout value,
+                                  a node is considered unhealthy.
+                                properties:
+                                  status:
+                                    minLength: 1
+                                    type: string
+                                  timeout:
+                                    type: string
+                                  type:
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - status
+                                - timeout
+                                - type
+                                type: object
+                              type: array
+                            unhealthyRange:
+                              description: 'Any further remediation is only allowed
+                                if the number of machines selected by "selector" as
+                                not healthy is within the range of "UnhealthyRange".
+                                Takes precedence over MaxUnhealthy. Eg. "[3-5]" -
+                                This means that remediation will be allowed only when:
+                                (a) there are at least 3 unhealthy machines (and)
+                                (b) there are at most 5 unhealthy machines'
+                              pattern: ^\[[0-9]+-[0-9]+\]$
+                              type: string
+                          type: object
+                        minReadySeconds:
+                          description: 'Minimum number of seconds for which a newly
+                            created machine should be ready. Defaults to 0 (machine
+                            will be considered available as soon as it is ready) NOTE:
+                            This value can be overridden while defining a Cluster.Topology
+                            using this MachineDeploymentClass.'
+                          format: int32
+                          type: integer
+                        nodeDeletionTimeout:
+                          description: 'NodeDeletionTimeout defines how long the controller
+                            will attempt to delete the Node that the Machine hosts
+                            after the Machine is marked for deletion. A duration of
+                            0 will retry deletion indefinitely. Defaults to 10 seconds.
+                            NOTE: This value can be overridden while defining a Cluster.Topology
+                            using this MachineDeploymentClass.'
+                          type: string
+                        nodeDrainTimeout:
+                          description: 'NodeDrainTimeout is the total amount of time
+                            that the controller will spend on draining a node. The
+                            default value is 0, meaning that the node can be drained
+                            without any time limitations. NOTE: NodeDrainTimeout is
+                            different from `kubectl drain --timeout` NOTE: This value
+                            can be overridden while defining a Cluster.Topology using
+                            this MachineDeploymentClass.'
+                          type: string
+                        nodeVolumeDetachTimeout:
+                          description: 'NodeVolumeDetachTimeout is the total amount
+                            of time that the controller will spend on waiting for
+                            all volumes to be detached. The default value is 0, meaning
+                            that the volumes can be detached without any time limitations.
+                            NOTE: This value can be overridden while defining a Cluster.Topology
+                            using this MachineDeploymentClass.'
+                          type: string
+                        strategy:
+                          description: 'The deployment strategy to use to replace
+                            existing machines with new ones. NOTE: This value can
+                            be overridden while defining a Cluster.Topology using
+                            this MachineDeploymentClass.'
+                          properties:
+                            rollingUpdate:
+                              description: Rolling update config params. Present only
+                                if MachineDeploymentStrategyType = RollingUpdate.
+                              properties:
+                                deletePolicy:
+                                  description: DeletePolicy defines the policy used
+                                    by the MachineDeployment to identify nodes to
+                                    delete when downscaling. Valid values are "Random,
+                                    "Newest", "Oldest" When no value is supplied,
+                                    the default DeletePolicy of MachineSet is used
+                                  enum:
+                                  - Random
+                                  - Newest
+                                  - Oldest
+                                  type: string
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of machines that
+                                    can be scheduled above the desired number of machines.
+                                    Value can be an absolute number (ex: 5) or a percentage
+                                    of desired machines (ex: 10%). This can not be
+                                    0 if MaxUnavailable is 0. Absolute number is calculated
+                                    from percentage by rounding up. Defaults to 1.
+                                    Example: when this is set to 30%, the new MachineSet
+                                    can be scaled up immediately when the rolling
+                                    update starts, such that the total number of old
+                                    and new machines do not exceed 130% of desired
+                                    machines. Once old machines have been killed,
+                                    new MachineSet can be scaled up further, ensuring
+                                    that total number of machines running at any time
+                                    during the update is at most 130% of desired machines.'
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'The maximum number of machines that
+                                    can be unavailable during the update. Value can
+                                    be an absolute number (ex: 5) or a percentage
+                                    of desired machines (ex: 10%). Absolute number
+                                    is calculated from percentage by rounding down.
+                                    This can not be 0 if MaxSurge is 0. Defaults to
+                                    0. Example: when this is set to 30%, the old MachineSet
+                                    can be scaled down to 70% of desired machines
+                                    immediately when the rolling update starts. Once
+                                    new machines are ready, old MachineSet can be
+                                    scaled down further, followed by scaling up the
+                                    new MachineSet, ensuring that the total number
+                                    of machines available at all times during the
+                                    update is at least 70% of desired machines.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Default is RollingUpdate.
+                              enum:
+                              - RollingUpdate
+                              - OnDelete
+                              type: string
+                          type: object
+                        template:
+                          description: Template is a local struct containing a collection
+                            of templates for creation of MachineDeployment objects
+                            representing a set of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: Bootstrap contains the bootstrap template
+                                reference to be used for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: Ref is a required reference to a custom
+                                    resource offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an
+                                        object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access
+                                        statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to
+                                        a container within a pod, this would take
+                                        on a value like: "spec.containers{name}" (where
+                                        "name" refers to the name of the container
+                                        that triggered the event) or if no container
+                                        name is specified "spec.containers[2]" (container
+                                        with index 2 in this pod). This syntax is
+                                        chosen only to have some well-defined way
+                                        of referencing a part of an object. TODO:
+                                        this design is not final and this field is
+                                        subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More
+                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which
+                                        this reference is made, if any. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: Infrastructure contains the infrastructure
+                                template reference to be used for the creation of
+                                worker Machines.
+                              properties:
+                                ref:
+                                  description: Ref is a required reference to a custom
+                                    resource offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an
+                                        object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access
+                                        statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to
+                                        a container within a pod, this would take
+                                        on a value like: "spec.containers{name}" (where
+                                        "name" refers to the name of the container
+                                        that triggered the event) or if no container
+                                        name is specified "spec.containers[2]" (container
+                                        with index 2 in this pod). This syntax is
+                                        chosen only to have some well-defined way
+                                        of referencing a part of an object. TODO:
+                                        this design is not final and this field is
+                                        subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More
+                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which
+                                        this reference is made, if any. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: Metadata is the metadata applied to the
+                                machines of the MachineDeployment. At runtime this
+                                metadata is merged with the corresponding metadata
+                                from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key
+                                    value map stored with a resource that may be set
+                                    by external tools to store and retrieve arbitrary
+                                    metadata. They are not queryable and should be
+                                    preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that
+                                    can be used to organize and categorize (scope
+                                    and select) objects. May match selectors of replication
+                                    controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: ClusterClassStatus defines the observed state of the ClusterClass.
+            properties:
+              conditions:
+                description: Conditions defines current observed state of the ClusterClass.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusterresourcesetbindings.addons.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSetBinding
+    listKind: ClusterResourceSetBindingList
+    plural: clusterresourcesetbindings
+    singular: clusterresourcesetbinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets
+          with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of
+              ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: Bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources
+                    in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: ClusterResourceSetName is the name of the ClusterResourceSet
+                        that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: Resources is a list of resources that the ClusterResourceSet
+                        has.
+                      items:
+                        description: ResourceBinding shows the status of a resource
+                          that belongs to a ClusterResourceSet matched by the owner
+                          cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: Applied is to track if a resource is applied
+                              to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: Hash is the hash of a resource's data. This
+                              can be used to decide if a resource is changed. For
+                              "ApplyOnce" ClusterResourceSet.spec.strategy, this is
+                              no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'Kind of the resource. Supported kinds are:
+                              Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: LastAppliedTime identifies when this resource
+                              was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: Name of the resource that is in the same
+                              namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSetBinding
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets
+          with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of
+              ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: Bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources
+                    in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: ClusterResourceSetName is the name of the ClusterResourceSet
+                        that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: Resources is a list of resources that the ClusterResourceSet
+                        has.
+                      items:
+                        description: ResourceBinding shows the status of a resource
+                          that belongs to a ClusterResourceSet matched by the owner
+                          cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: Applied is to track if a resource is applied
+                              to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: Hash is the hash of a resource's data. This
+                              can be used to decide if a resource is changed. For
+                              "ApplyOnce" ClusterResourceSet.spec.strategy, this is
+                              no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'Kind of the resource. Supported kinds are:
+                              Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: LastAppliedTime identifies when this resource
+                              was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: Name of the resource that is in the same
+                              namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSetBinding
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets
+          with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of
+              ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: Bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources
+                    in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: ClusterResourceSetName is the name of the ClusterResourceSet
+                        that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: Resources is a list of resources that the ClusterResourceSet
+                        has.
+                      items:
+                        description: ResourceBinding shows the status of a resource
+                          that belongs to a ClusterResourceSet matched by the owner
+                          cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: Applied is to track if a resource is applied
+                              to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: Hash is the hash of a resource's data. This
+                              can be used to decide if a resource is changed. For
+                              "ApplyOnce" ClusterResourceSet.spec.strategy, this is
+                              no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'Kind of the resource. Supported kinds are:
+                              Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: LastAppliedTime identifies when this resource
+                              was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: Name of the resource that is in the same
+                              namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusterresourcesets.addons.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSet
+    listKind: ClusterResourceSetList
+    plural: clusterresourcesets
+    singular: clusterresourceset
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSet is the Schema for the clusterresourcesets
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: Label selector for Clusters. The Clusters that are selected
+                  by this will be the ones affected by this ClusterResourceSet. It
+                  must match the Cluster labels. This field is immutable.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              resources:
+                description: Resources is a list of Secrets/ConfigMaps where each
+                  contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'Kind of the resource. Supported kinds are: Secrets
+                        and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: Name of the resource that is in the same namespace
+                        with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: Strategy is the strategy to be used during applying resources.
+                  Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: Conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSet is the Schema for the clusterresourcesets
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: Label selector for Clusters. The Clusters that are selected
+                  by this will be the ones affected by this ClusterResourceSet. It
+                  must match the Cluster labels. This field is immutable. Label selector
+                  cannot be empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              resources:
+                description: Resources is a list of Secrets/ConfigMaps where each
+                  contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'Kind of the resource. Supported kinds are: Secrets
+                        and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: Name of the resource that is in the same namespace
+                        with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: Strategy is the strategy to be used during applying resources.
+                  Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: Conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSet is the Schema for the clusterresourcesets
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: Label selector for Clusters. The Clusters that are selected
+                  by this will be the ones affected by this ClusterResourceSet. It
+                  must match the Cluster labels. This field is immutable. Label selector
+                  cannot be empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              resources:
+                description: Resources is a list of Secrets/ConfigMaps where each
+                  contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'Kind of the resource. Supported kinds are: Secrets
+                        and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: Name of the resource that is in the same namespace
+                        with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: Strategy is the strategy to be used during applying resources.
+                  Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: Conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: clusters.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    shortNames:
+    - cl
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: APIServerPort specifies the port the API Server should
+                      bind to. Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: ControlPlaneRef is an optional reference to a provider-specific
+                  resource that holds the details for provisioning the Control Plane
+                  for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              infrastructureRef:
+                description: InfrastructureRef is a reference to a provider-specific
+                  resource that holds the details for provisioning infrastructure
+                  for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: Paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneInitialized:
+                description: ControlPlaneInitialized defines if the control plane
+                  has been initialized.
+                type: boolean
+              controlPlaneReady:
+                description: ControlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: FailureMessage indicates that there is a fatal problem
+                  reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a fatal problem
+                  reconciling the state, and will be set to a token value suitable
+                  for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: APIServerPort specifies the port the API Server should
+                      bind to. Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: ControlPlaneRef is an optional reference to a provider-specific
+                  resource that holds the details for provisioning the Control Plane
+                  for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              infrastructureRef:
+                description: InfrastructureRef is a reference to a provider-specific
+                  resource that holds the details for provisioning infrastructure
+                  for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: Paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
+              topology:
+                description: 'This encapsulates the topology for the cluster. NOTE:
+                  It is required to enable the ClusterTopology feature gate flag to
+                  activate managed topologies support; this feature is highly experimental,
+                  and parts of it might still be not implemented.'
+                properties:
+                  class:
+                    description: The name of the ClusterClass object to create the
+                      topology.
+                    type: string
+                  controlPlane:
+                    description: ControlPlane describes the cluster control plane.
+                    properties:
+                      metadata:
+                        description: "Metadata is the metadata applied to the machines
+                          of the ControlPlane. At runtime this metadata is merged
+                          with the corresponding metadata from the ClusterClass. \n
+                          This field is supported if and only if the control plane
+                          provider template referenced in the ClusterClass is Machine
+                          based."
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'Annotations is an unstructured key value
+                              map stored with a resource that may be set by external
+                              tools to store and retrieve arbitrary metadata. They
+                              are not queryable and should be preserved when modifying
+                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: 'Map of string keys and values that can be
+                              used to organize and categorize (scope and select) objects.
+                              May match selectors of replication controllers and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels'
+                            type: object
+                        type: object
+                      replicas:
+                        description: Replicas is the number of control plane nodes.
+                          If the value is nil, the ControlPlane object is created
+                          without the number of Replicas and it's assumed that the
+                          control plane controller does not implement support for
+                          this field. When specified against a control plane provider
+                          that lacks support for this field, this value will be ignored.
+                        format: int32
+                        type: integer
+                    type: object
+                  rolloutAfter:
+                    description: RolloutAfter performs a rollout of the entire cluster
+                      one component at a time, control plane first and then machine
+                      deployments.
+                    format: date-time
+                    type: string
+                  version:
+                    description: The Kubernetes version of the cluster.
+                    type: string
+                  workers:
+                    description: Workers encapsulates the different constructs that
+                      form the worker nodes for the cluster.
+                    properties:
+                      machineDeployments:
+                        description: MachineDeployments is a list of machine deployments
+                          in the cluster.
+                        items:
+                          description: MachineDeploymentTopology specifies the different
+                            parameters for a set of worker nodes in the topology.
+                            This set of nodes is managed by a MachineDeployment object
+                            whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: Class is the name of the MachineDeploymentClass
+                                used to create the set of worker nodes. This should
+                                match one of the deployment classes defined in the
+                                ClusterClass object mentioned in the `Cluster.Spec.Class`
+                                field.
+                              type: string
+                            metadata:
+                              description: Metadata is the metadata applied to the
+                                machines of the MachineDeployment. At runtime this
+                                metadata is merged with the corresponding metadata
+                                from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key
+                                    value map stored with a resource that may be set
+                                    by external tools to store and retrieve arbitrary
+                                    metadata. They are not queryable and should be
+                                    preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that
+                                    can be used to organize and categorize (scope
+                                    and select) objects. May match selectors of replication
+                                    controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                            name:
+                              description: Name is the unique identifier for this
+                                MachineDeploymentTopology. The value is used with
+                                other unique identifiers to create a MachineDeployment's
+                                Name (e.g. cluster's name, etc). In case the name
+                                is greater than the allowed maximum length, the values
+                                are hashed together.
+                              type: string
+                            replicas:
+                              description: Replicas is the number of worker nodes
+                                belonging to this set. If the value is nil, the MachineDeployment
+                                is created without the number of Replicas (defaulting
+                                to zero) and it's assumed that an external entity
+                                (like cluster autoscaler) is responsible for the management
+                                of this value.
+                              format: int32
+                              type: integer
+                          required:
+                          - class
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - class
+                - version
+                type: object
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneReady:
+                description: ControlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: FailureMessage indicates that there is a fatal problem
+                  reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a fatal problem
+                  reconciling the state, and will be set to a token value suitable
+                  for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Cluster
+      jsonPath: .spec.topology.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: APIServerPort specifies the port the API Server should
+                      bind to. Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: ControlPlaneRef is an optional reference to a provider-specific
+                  resource that holds the details for provisioning the Control Plane
+                  for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              infrastructureRef:
+                description: InfrastructureRef is a reference to a provider-specific
+                  resource that holds the details for provisioning infrastructure
+                  for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: Paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
+              topology:
+                description: 'This encapsulates the topology for the cluster. NOTE:
+                  It is required to enable the ClusterTopology feature gate flag to
+                  activate managed topologies support; this feature is highly experimental,
+                  and parts of it might still be not implemented.'
+                properties:
+                  class:
+                    description: The name of the ClusterClass object to create the
+                      topology.
+                    type: string
+                  controlPlane:
+                    description: ControlPlane describes the cluster control plane.
+                    properties:
+                      machineHealthCheck:
+                        description: MachineHealthCheck allows to enable, disable
+                          and override the MachineHealthCheck configuration in the
+                          ClusterClass for this control plane.
+                        properties:
+                          enable:
+                            description: "Enable controls if a MachineHealthCheck
+                              should be created for the target machines. \n If false:
+                              No MachineHealthCheck will be created. \n If not set(default):
+                              A MachineHealthCheck will be created if it is defined
+                              here or in the associated ClusterClass. If no MachineHealthCheck
+                              is defined then none will be created. \n If true: A
+                              MachineHealthCheck is guaranteed to be created. Cluster
+                              validation will block if `enable` is true and no MachineHealthCheck
+                              definition is available."
+                            type: boolean
+                          maxUnhealthy:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Any further remediation is only allowed if
+                              at most "MaxUnhealthy" machines selected by "selector"
+                              are not healthy.
+                            x-kubernetes-int-or-string: true
+                          nodeStartupTimeout:
+                            description: Machines older than this duration without
+                              a node will be considered to have failed and will be
+                              remediated. If you wish to disable this feature, set
+                              the value explicitly to 0.
+                            type: string
+                          remediationTemplate:
+                            description: "RemediationTemplate is a reference to a
+                              remediation template provided by an infrastructure provider.
+                              \n This field is completely optional, when filled, the
+                              MachineHealthCheck controller creates a new object from
+                              the template referenced and hands off remediation of
+                              the machine to a controller that lives outside of Cluster
+                              API."
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          unhealthyConditions:
+                            description: UnhealthyConditions contains a list of the
+                              conditions that determine whether a node is considered
+                              unhealthy. The conditions are combined in a logical
+                              OR, i.e. if any of the conditions is met, the node is
+                              unhealthy.
+                            items:
+                              description: UnhealthyCondition represents a Node condition
+                                type and value with a timeout specified as a duration.  When
+                                the named condition has been in the given status for
+                                at least the timeout value, a node is considered unhealthy.
+                              properties:
+                                status:
+                                  minLength: 1
+                                  type: string
+                                timeout:
+                                  type: string
+                                type:
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - status
+                              - timeout
+                              - type
+                              type: object
+                            type: array
+                          unhealthyRange:
+                            description: 'Any further remediation is only allowed
+                              if the number of machines selected by "selector" as
+                              not healthy is within the range of "UnhealthyRange".
+                              Takes precedence over MaxUnhealthy. Eg. "[3-5]" - This
+                              means that remediation will be allowed only when: (a)
+                              there are at least 3 unhealthy machines (and) (b) there
+                              are at most 5 unhealthy machines'
+                            pattern: ^\[[0-9]+-[0-9]+\]$
+                            type: string
+                        type: object
+                      metadata:
+                        description: "Metadata is the metadata applied to the machines
+                          of the ControlPlane. At runtime this metadata is merged
+                          with the corresponding metadata from the ClusterClass. \n
+                          This field is supported if and only if the control plane
+                          provider template referenced in the ClusterClass is Machine
+                          based."
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'Annotations is an unstructured key value
+                              map stored with a resource that may be set by external
+                              tools to store and retrieve arbitrary metadata. They
+                              are not queryable and should be preserved when modifying
+                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: 'Map of string keys and values that can be
+                              used to organize and categorize (scope and select) objects.
+                              May match selectors of replication controllers and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels'
+                            type: object
+                        type: object
+                      nodeDeletionTimeout:
+                        description: NodeDeletionTimeout defines how long the controller
+                          will attempt to delete the Node that the Machine hosts after
+                          the Machine is marked for deletion. A duration of 0 will
+                          retry deletion indefinitely. Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: NodeVolumeDetachTimeout is the total amount of
+                          time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the
+                          volumes can be detached without any time limitations.
+                        type: string
+                      replicas:
+                        description: Replicas is the number of control plane nodes.
+                          If the value is nil, the ControlPlane object is created
+                          without the number of Replicas and it's assumed that the
+                          control plane controller does not implement support for
+                          this field. When specified against a control plane provider
+                          that lacks support for this field, this value will be ignored.
+                        format: int32
+                        type: integer
+                    type: object
+                  rolloutAfter:
+                    description: RolloutAfter performs a rollout of the entire cluster
+                      one component at a time, control plane first and then machine
+                      deployments.
+                    format: date-time
+                    type: string
+                  variables:
+                    description: Variables can be used to customize the Cluster through
+                      patches. They must comply to the corresponding VariableClasses
+                      defined in the ClusterClass.
+                    items:
+                      description: ClusterVariable can be used to customize the Cluster
+                        through patches. It must comply to the corresponding ClusterClassVariable
+                        defined in the ClusterClass.
+                      properties:
+                        name:
+                          description: Name of the variable.
+                          type: string
+                        value:
+                          description: 'Value of the variable. Note: the value will
+                            be validated against the schema of the corresponding ClusterClassVariable
+                            from the ClusterClass. Note: We have to use apiextensionsv1.JSON
+                            instead of a custom JSON type, because controller-tools
+                            has a hard-coded schema for apiextensionsv1.JSON which
+                            cannot be produced by another type via controller-tools,
+                            i.e. it is not possible to have no type field. Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111'
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  version:
+                    description: The Kubernetes version of the cluster.
+                    type: string
+                  workers:
+                    description: Workers encapsulates the different constructs that
+                      form the worker nodes for the cluster.
+                    properties:
+                      machineDeployments:
+                        description: MachineDeployments is a list of machine deployments
+                          in the cluster.
+                        items:
+                          description: MachineDeploymentTopology specifies the different
+                            parameters for a set of worker nodes in the topology.
+                            This set of nodes is managed by a MachineDeployment object
+                            whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: Class is the name of the MachineDeploymentClass
+                                used to create the set of worker nodes. This should
+                                match one of the deployment classes defined in the
+                                ClusterClass object mentioned in the `Cluster.Spec.Class`
+                                field.
+                              type: string
+                            failureDomain:
+                              description: FailureDomain is the failure domain the
+                                machines will be created in. Must match a key in the
+                                FailureDomains map stored on the cluster object.
+                              type: string
+                            machineHealthCheck:
+                              description: MachineHealthCheck allows to enable, disable
+                                and override the MachineHealthCheck configuration
+                                in the ClusterClass for this MachineDeployment.
+                              properties:
+                                enable:
+                                  description: "Enable controls if a MachineHealthCheck
+                                    should be created for the target machines. \n
+                                    If false: No MachineHealthCheck will be created.
+                                    \n If not set(default): A MachineHealthCheck will
+                                    be created if it is defined here or in the associated
+                                    ClusterClass. If no MachineHealthCheck is defined
+                                    then none will be created. \n If true: A MachineHealthCheck
+                                    is guaranteed to be created. Cluster validation
+                                    will block if `enable` is true and no MachineHealthCheck
+                                    definition is available."
+                                  type: boolean
+                                maxUnhealthy:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Any further remediation is only allowed
+                                    if at most "MaxUnhealthy" machines selected by
+                                    "selector" are not healthy.
+                                  x-kubernetes-int-or-string: true
+                                nodeStartupTimeout:
+                                  description: Machines older than this duration without
+                                    a node will be considered to have failed and will
+                                    be remediated. If you wish to disable this feature,
+                                    set the value explicitly to 0.
+                                  type: string
+                                remediationTemplate:
+                                  description: "RemediationTemplate is a reference
+                                    to a remediation template provided by an infrastructure
+                                    provider. \n This field is completely optional,
+                                    when filled, the MachineHealthCheck controller
+                                    creates a new object from the template referenced
+                                    and hands off remediation of the machine to a
+                                    controller that lives outside of Cluster API."
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an
+                                        object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access
+                                        statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to
+                                        a container within a pod, this would take
+                                        on a value like: "spec.containers{name}" (where
+                                        "name" refers to the name of the container
+                                        that triggered the event) or if no container
+                                        name is specified "spec.containers[2]" (container
+                                        with index 2 in this pod). This syntax is
+                                        chosen only to have some well-defined way
+                                        of referencing a part of an object. TODO:
+                                        this design is not final and this field is
+                                        subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More
+                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which
+                                        this reference is made, if any. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                unhealthyConditions:
+                                  description: UnhealthyConditions contains a list
+                                    of the conditions that determine whether a node
+                                    is considered unhealthy. The conditions are combined
+                                    in a logical OR, i.e. if any of the conditions
+                                    is met, the node is unhealthy.
+                                  items:
+                                    description: UnhealthyCondition represents a Node
+                                      condition type and value with a timeout specified
+                                      as a duration.  When the named condition has
+                                      been in the given status for at least the timeout
+                                      value, a node is considered unhealthy.
+                                    properties:
+                                      status:
+                                        minLength: 1
+                                        type: string
+                                      timeout:
+                                        type: string
+                                      type:
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - status
+                                    - timeout
+                                    - type
+                                    type: object
+                                  type: array
+                                unhealthyRange:
+                                  description: 'Any further remediation is only allowed
+                                    if the number of machines selected by "selector"
+                                    as not healthy is within the range of "UnhealthyRange".
+                                    Takes precedence over MaxUnhealthy. Eg. "[3-5]"
+                                    - This means that remediation will be allowed
+                                    only when: (a) there are at least 3 unhealthy
+                                    machines (and) (b) there are at most 5 unhealthy
+                                    machines'
+                                  pattern: ^\[[0-9]+-[0-9]+\]$
+                                  type: string
+                              type: object
+                            metadata:
+                              description: Metadata is the metadata applied to the
+                                machines of the MachineDeployment. At runtime this
+                                metadata is merged with the corresponding metadata
+                                from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key
+                                    value map stored with a resource that may be set
+                                    by external tools to store and retrieve arbitrary
+                                    metadata. They are not queryable and should be
+                                    preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that
+                                    can be used to organize and categorize (scope
+                                    and select) objects. May match selectors of replication
+                                    controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                            minReadySeconds:
+                              description: Minimum number of seconds for which a newly
+                                created machine should be ready. Defaults to 0 (machine
+                                will be considered available as soon as it is ready)
+                              format: int32
+                              type: integer
+                            name:
+                              description: Name is the unique identifier for this
+                                MachineDeploymentTopology. The value is used with
+                                other unique identifiers to create a MachineDeployment's
+                                Name (e.g. cluster's name, etc). In case the name
+                                is greater than the allowed maximum length, the values
+                                are hashed together.
+                              type: string
+                            nodeDeletionTimeout:
+                              description: NodeDeletionTimeout defines how long the
+                                controller will attempt to delete the Node that the
+                                Machine hosts after the Machine is marked for deletion.
+                                A duration of 0 will retry deletion indefinitely.
+                                Defaults to 10 seconds.
+                              type: string
+                            nodeDrainTimeout:
+                              description: 'NodeDrainTimeout is the total amount of
+                                time that the controller will spend on draining a
+                                node. The default value is 0, meaning that the node
+                                can be drained without any time limitations. NOTE:
+                                NodeDrainTimeout is different from `kubectl drain
+                                --timeout`'
+                              type: string
+                            nodeVolumeDetachTimeout:
+                              description: NodeVolumeDetachTimeout is the total amount
+                                of time that the controller will spend on waiting
+                                for all volumes to be detached. The default value
+                                is 0, meaning that the volumes can be detached without
+                                any time limitations.
+                              type: string
+                            replicas:
+                              description: Replicas is the number of worker nodes
+                                belonging to this set. If the value is nil, the MachineDeployment
+                                is created without the number of Replicas (defaulting
+                                to zero) and it's assumed that an external entity
+                                (like cluster autoscaler) is responsible for the management
+                                of this value.
+                              format: int32
+                              type: integer
+                            strategy:
+                              description: The deployment strategy to use to replace
+                                existing machines with new ones.
+                              properties:
+                                rollingUpdate:
+                                  description: Rolling update config params. Present
+                                    only if MachineDeploymentStrategyType = RollingUpdate.
+                                  properties:
+                                    deletePolicy:
+                                      description: DeletePolicy defines the policy
+                                        used by the MachineDeployment to identify
+                                        nodes to delete when downscaling. Valid values
+                                        are "Random, "Newest", "Oldest" When no value
+                                        is supplied, the default DeletePolicy of MachineSet
+                                        is used
+                                      enum:
+                                      - Random
+                                      - Newest
+                                      - Oldest
+                                      type: string
+                                    maxSurge:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: 'The maximum number of machines
+                                        that can be scheduled above the desired number
+                                        of machines. Value can be an absolute number
+                                        (ex: 5) or a percentage of desired machines
+                                        (ex: 10%). This can not be 0 if MaxUnavailable
+                                        is 0. Absolute number is calculated from percentage
+                                        by rounding up. Defaults to 1. Example: when
+                                        this is set to 30%, the new MachineSet can
+                                        be scaled up immediately when the rolling
+                                        update starts, such that the total number
+                                        of old and new machines do not exceed 130%
+                                        of desired machines. Once old machines have
+                                        been killed, new MachineSet can be scaled
+                                        up further, ensuring that total number of
+                                        machines running at any time during the update
+                                        is at most 130% of desired machines.'
+                                      x-kubernetes-int-or-string: true
+                                    maxUnavailable:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: 'The maximum number of machines
+                                        that can be unavailable during the update.
+                                        Value can be an absolute number (ex: 5) or
+                                        a percentage of desired machines (ex: 10%).
+                                        Absolute number is calculated from percentage
+                                        by rounding down. This can not be 0 if MaxSurge
+                                        is 0. Defaults to 0. Example: when this is
+                                        set to 30%, the old MachineSet can be scaled
+                                        down to 70% of desired machines immediately
+                                        when the rolling update starts. Once new machines
+                                        are ready, old MachineSet can be scaled down
+                                        further, followed by scaling up the new MachineSet,
+                                        ensuring that the total number of machines
+                                        available at all times during the update is
+                                        at least 70% of desired machines.'
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                type:
+                                  description: Type of deployment. Default is RollingUpdate.
+                                  enum:
+                                  - RollingUpdate
+                                  - OnDelete
+                                  type: string
+                              type: object
+                            variables:
+                              description: Variables can be used to customize the
+                                MachineDeployment through patches.
+                              properties:
+                                overrides:
+                                  description: Overrides can be used to override Cluster
+                                    level variables.
+                                  items:
+                                    description: ClusterVariable can be used to customize
+                                      the Cluster through patches. It must comply
+                                      to the corresponding ClusterClassVariable defined
+                                      in the ClusterClass.
+                                    properties:
+                                      name:
+                                        description: Name of the variable.
+                                        type: string
+                                      value:
+                                        description: 'Value of the variable. Note:
+                                          the value will be validated against the
+                                          schema of the corresponding ClusterClassVariable
+                                          from the ClusterClass. Note: We have to
+                                          use apiextensionsv1.JSON instead of a custom
+                                          JSON type, because controller-tools has
+                                          a hard-coded schema for apiextensionsv1.JSON
+                                          which cannot be produced by another type
+                                          via controller-tools, i.e. it is not possible
+                                          to have no type field. Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111'
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                              type: object
+                          required:
+                          - class
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - class
+                - version
+                type: object
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneReady:
+                description: ControlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: FailureMessage indicates that there is a fatal problem
+                  reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a fatal problem
+                  reconciling the state, and will be set to a token value suitable
+                  for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: extensionconfigs.runtime.cluster.x-k8s.io
+spec:
+  group: runtime.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ExtensionConfig
+    listKind: ExtensionConfigList
+    plural: extensionconfigs
+    shortNames:
+    - ext
+    singular: extensionconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ExtensionConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ExtensionConfig is the Schema for the ExtensionConfig API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ExtensionConfigSpec is the desired state of the ExtensionConfig
+            properties:
+              clientConfig:
+                description: ClientConfig defines how to communicate with the Extension
+                  server.
+                properties:
+                  caBundle:
+                    description: CABundle is a PEM encoded CA bundle which will be
+                      used to validate the Extension server's server certificate.
+                    format: byte
+                    type: string
+                  service:
+                    description: "Service is a reference to the Kubernetes service
+                      for the Extension server. Note: Exactly one of `url` or `service`
+                      must be specified. \n If the Extension server is running within
+                      a cluster, then you should use `service`."
+                    properties:
+                      name:
+                        description: Name is the name of the service.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the service.
+                        type: string
+                      path:
+                        description: Path is an optional URL path and if present may
+                          be any string permissible in a URL. If a path is set it
+                          will be used as prefix to the hook-specific path.
+                        type: string
+                      port:
+                        description: Port is the port on the service that's hosting
+                          the Extension server. Defaults to 443. Port should be a
+                          valid port number (1-65535, inclusive).
+                        format: int32
+                        type: integer
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  url:
+                    description: "URL gives the location of the Extension server,
+                      in standard URL form (`scheme://host:port/path`). Note: Exactly
+                      one of `url` or `service` must be specified. \n The scheme must
+                      be \"https\". \n The `host` should not refer to a service running
+                      in the cluster; use the `service` field instead. \n A path is
+                      optional, and if present may be any string permissible in a
+                      URL. If a path is set it will be used as prefix to the hook-specific
+                      path. \n Attempting to use a user or basic auth e.g. \"user:password@\"
+                      is not allowed. Fragments (\"#...\") and query parameters (\"?...\")
+                      are not allowed either."
+                    type: string
+                type: object
+              namespaceSelector:
+                description: NamespaceSelector decides whether to call the hook for
+                  an object based on whether the namespace for that object matches
+                  the selector. Defaults to the empty LabelSelector, which matches
+                  all objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+            required:
+            - clientConfig
+            type: object
+          status:
+            description: ExtensionConfigStatus is the current state of the ExtensionConfig
+            properties:
+              conditions:
+                description: Conditions define the current service state of the ExtensionConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              handlers:
+                description: Handlers defines the current ExtensionHandlers supported
+                  by an Extension.
+                items:
+                  description: ExtensionHandler specifies the details of a handler
+                    for a particular runtime hook registered by an Extension server.
+                  properties:
+                    failurePolicy:
+                      description: FailurePolicy defines how failures in calls to
+                        the ExtensionHandler should be handled by a client. Defaults
+                        to Fail if not set.
+                      type: string
+                    name:
+                      description: Name is the unique name of the ExtensionHandler.
+                      type: string
+                    requestHook:
+                      description: RequestHook defines the versioned runtime hook
+                        which this ExtensionHandler serves.
+                      properties:
+                        apiVersion:
+                          description: APIVersion is the group and version of the
+                            Hook.
+                          type: string
+                        hook:
+                          description: Hook is the name of the hook.
+                          type: string
+                      required:
+                      - apiVersion
+                      - hook
+                      type: object
+                    timeoutSeconds:
+                      description: TimeoutSeconds defines the timeout duration for
+                        client calls to the ExtensionHandler. Defaults to 10 is not
+                        set.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - requestHook
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: ipaddressclaims.ipam.cluster.x-k8s.io
+spec:
+  group: ipam.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: IPAddressClaim
+    listKind: IPAddressClaimList
+    plural: ipaddressclaims
+    singular: ipaddressclaim
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the pool to allocate an address from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool to allocate an address from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAddressClaim is the Schema for the ipaddressclaim API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAddressClaimSpec is the desired state of an IPAddressClaim.
+            properties:
+              poolRef:
+                description: PoolRef is a reference to the pool from which an IP address
+                  should be created.
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - apiGroup
+                - kind
+                - name
+                type: object
+            required:
+            - poolRef
+            type: object
+          status:
+            description: IPAddressClaimStatus is the observed status of a IPAddressClaim.
+            properties:
+              addressRef:
+                description: AddressRef is a reference to the address that was created
+                  for this claim.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              conditions:
+                description: Conditions summarises the current state of the IPAddressClaim
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - addressRef
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: ipaddresses.ipam.cluster.x-k8s.io
+spec:
+  group: ipam.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: IPAddress
+    listKind: IPAddressList
+    plural: ipaddresses
+    singular: ipaddress
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    - description: Name of the pool the address is from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool the address is from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAddress is the Schema for the ipaddress API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAddressSpec is the desired state of an IPAddress.
+            properties:
+              address:
+                description: Address is the IP address.
+                type: string
+              claimRef:
+                description: ClaimRef is a reference to the claim this IPAddress was
+                  created for.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              gateway:
+                description: Gateway is the network gateway of the network the address
+                  is from.
+                type: string
+              poolRef:
+                description: PoolRef is a reference to the pool that this IPAddress
+                  was created from.
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - apiGroup
+                - kind
+                - name
+                type: object
+              prefix:
+                description: Prefix is the prefix of the address.
+                type: integer
+            required:
+            - address
+            - claimRef
+            - gateway
+            - poolRef
+            - prefix
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinedeployments.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineDeployment
+    listKind: MachineDeploymentList
+    plural: machinedeployments
+    shortNames:
+    - md
+    singular: machinedeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  should be ready. Defaults to 0 (machine will be considered available
+                  as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make
+                  progress before it is considered to be failed. The deployment controller
+                  will continue to process failed deployments and a condition with
+                  a ProgressDeadlineExceeded reason will be surfaced in the deployment
+                  status. Note that progress will not be estimated during the time
+                  a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for machines. Existing MachineSets whose
+                  machines are selected by this will be the ones affected by this
+                  deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: The deployment strategy to use to replace existing machines
+                  with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType
+                      = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled
+                          above the desired number of machines. Value can be an absolute
+                          number (ex: 5) or a percentage of desired machines (ex:
+                          10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                          number is calculated from percentage by rounding up. Defaults
+                          to 1. Example: when this is set to 30%, the new MachineSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new machines do not
+                          exceed 130% of desired machines. Once old machines have
+                          been killed, new MachineSet can be scaled up further, ensuring
+                          that total number of machines running at any time during
+                          the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired machines (ex: 10%). Absolute
+                          number is calculated from percentage by rounding down. This
+                          can not be 0 if MaxSurge is 0. Defaults to 0. Example: when
+                          this is set to 30%, the old MachineSet can be scaled down
+                          to 70% of desired machines immediately when the rolling
+                          update starts. Once new machines are ready, old MachineSet
+                          can be scaled down further, followed by scaling up the new
+                          MachineSet, ensuring that the total number of machines available
+                          at all times during the update is at least 70% of desired
+                          machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Currently the only supported
+                      strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by
+                          the server, to generate a unique name ONLY IF the Name field
+                          has not been provided. If this field is used, the name returned
+                          to the client will be different than the name passed. This
+                          value will also be combined with a unique suffix. The provided
+                          value has the same validation rules as the Name field, and
+                          may be truncated by the length of the suffix required to
+                          make the value unique on the server. \n If this field is
+                          specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created
+                          or 500 with Reason ServerTimeout indicating a unique name
+                          could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the
+                          Retry-After header). \n Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names \n
+                          Deprecated: This field has no function and is going to be
+                          removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name
+                          must be unique. An empty namespace is equivalent to the
+                          \"default\" namespace, but \"default\" is the canonical
+                          representation. Not all objects are required to be scoped
+                          to a namespace - the value of this field for those objects
+                          will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If
+                          ALL objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller. \n Deprecated: This field
+                          has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information
+                            to let you identify an owning object. An owning object
+                            must be in the same namespace as the dependent, or be
+                            cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the
+                                key-value store until this reference is removed. See
+                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this
+                                field and enforces the foreground deletion. Defaults
+                                to false. To set this field, a user needs "delete"
+                                permission of the owner, otherwise 422 (Unprocessable
+                                Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.Data
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: "Data contains the bootstrap data, such as
+                              cloud-init details scripts. If nil, the Machine should
+                              remain in the Pending state. \n Deprecated: Switch to
+                              DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least
+                  minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the
+                  string format to avoid introspection by clients. The string will
+                  be in the same format as the query-param syntax. More info about
+                  label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this
+                  deployment. This is the total number of machines that are still
+                  required for the deployment to have 100% available capacity. They
+                  may either be machines that are running but not yet available or
+                  machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  should be ready. Defaults to 0 (machine will be considered available
+                  as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make
+                  progress before it is considered to be failed. The deployment controller
+                  will continue to process failed deployments and a condition with
+                  a ProgressDeadlineExceeded reason will be surfaced in the deployment
+                  status. Note that progress will not be estimated during the time
+                  a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for machines. Existing MachineSets whose
+                  machines are selected by this will be the ones affected by this
+                  deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: The deployment strategy to use to replace existing machines
+                  with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType
+                      = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: DeletePolicy defines the policy used by the MachineDeployment
+                          to identify nodes to delete when downscaling. Valid values
+                          are "Random, "Newest", "Oldest" When no value is supplied,
+                          the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled
+                          above the desired number of machines. Value can be an absolute
+                          number (ex: 5) or a percentage of desired machines (ex:
+                          10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                          number is calculated from percentage by rounding up. Defaults
+                          to 1. Example: when this is set to 30%, the new MachineSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new machines do not
+                          exceed 130% of desired machines. Once old machines have
+                          been killed, new MachineSet can be scaled up further, ensuring
+                          that total number of machines running at any time during
+                          the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired machines (ex: 10%). Absolute
+                          number is calculated from percentage by rounding down. This
+                          can not be 0 if MaxSurge is 0. Defaults to 0. Example: when
+                          this is set to 30%, the old MachineSet can be scaled down
+                          to 70% of desired machines immediately when the rolling
+                          update starts. Once new machines are ready, old MachineSet
+                          can be scaled down further, followed by scaling up the new
+                          MachineSet, ensuring that the total number of machines available
+                          at all times during the update is at least 70% of desired
+                          machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.DataSecretName
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least
+                  minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the
+                  string format to avoid introspection by clients. The string will
+                  be in the same format as the query-param syntax. More info about
+                  label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this
+                  deployment. This is the total number of machines that are still
+                  required for the deployment to have 100% available capacity. They
+                  may either be machines that are running but not yet available or
+                  machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this MachineDeployment
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineDeployment
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  should be ready. Defaults to 0 (machine will be considered available
+                  as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make
+                  progress before it is considered to be failed. The deployment controller
+                  will continue to process failed deployments and a condition with
+                  a ProgressDeadlineExceeded reason will be surfaced in the deployment
+                  status. Note that progress will not be estimated during the time
+                  a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for machines. Existing MachineSets whose
+                  machines are selected by this will be the ones affected by this
+                  deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: The deployment strategy to use to replace existing machines
+                  with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType
+                      = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: DeletePolicy defines the policy used by the MachineDeployment
+                          to identify nodes to delete when downscaling. Valid values
+                          are "Random, "Newest", "Oldest" When no value is supplied,
+                          the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled
+                          above the desired number of machines. Value can be an absolute
+                          number (ex: 5) or a percentage of desired machines (ex:
+                          10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                          number is calculated from percentage by rounding up. Defaults
+                          to 1. Example: when this is set to 30%, the new MachineSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new machines do not
+                          exceed 130% of desired machines. Once old machines have
+                          been killed, new MachineSet can be scaled up further, ensuring
+                          that total number of machines running at any time during
+                          the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired machines (ex: 10%). Absolute
+                          number is calculated from percentage by rounding down. This
+                          can not be 0 if MaxSurge is 0. Defaults to 0. Example: when
+                          this is set to 30%, the old MachineSet can be scaled down
+                          to 70% of desired machines immediately when the rolling
+                          update starts. Once new machines are ready, old MachineSet
+                          can be scaled down further, followed by scaling up the new
+                          MachineSet, ensuring that the total number of machines available
+                          at all times during the update is at least 70% of desired
+                          machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.DataSecretName
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: NodeDeletionTimeout defines how long the controller
+                          will attempt to delete the Node that the Machine hosts after
+                          the Machine is marked for deletion. A duration of 0 will
+                          retry deletion indefinitely. Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: NodeVolumeDetachTimeout is the total amount of
+                          time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the
+                          volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least
+                  minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the
+                  string format to avoid introspection by clients. The string will
+                  be in the same format as the query-param syntax. More info about
+                  label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this
+                  deployment. This is the total number of machines that are still
+                  required for the deployment to have 100% available capacity. They
+                  may either be machines that are running but not yet available or
+                  machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinehealthchecks.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineHealthCheck
+    listKind: MachineHealthCheckList
+    plural: machinehealthchecks
+    shortNames:
+    - mhc
+    - mhcs
+    singular: machinehealthcheck
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Any further remediation is only allowed if at most "MaxUnhealthy"
+                  machines selected by "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: Machines older than this duration without a node will
+                  be considered to have failed and will be remediated.
+                type: string
+              remediationTemplate:
+                description: "RemediationTemplate is a reference to a remediation
+                  template provided by an infrastructure provider. \n This field is
+                  completely optional, when filled, the MachineHealthCheck controller
+                  creates a new object from the template referenced and hands off
+                  remediation of the machine to a controller that lives outside of
+                  Cluster API."
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: Label selector to match machines whose health will be
+                  exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              unhealthyConditions:
+                description: UnhealthyConditions contains a list of the conditions
+                  that determine whether a node is considered unhealthy.  The conditions
+                  are combined in a logical OR, i.e. if any of the conditions is met,
+                  the node is unhealthy.
+                items:
+                  description: UnhealthyCondition represents a Node condition type
+                    and value with a timeout specified as a duration.  When the named
+                    condition has been in the given status for at least the timeout
+                    value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: Conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine
+                  health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health
+                  check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: RemediationsAllowed is the number of further remediations
+                  allowed by this machine health check before maxUnhealthy short circuiting
+                  will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: Targets shows the current list of machines the machine
+                  health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineHealthCheck
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Any further remediation is only allowed if at most "MaxUnhealthy"
+                  machines selected by "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: Machines older than this duration without a node will
+                  be considered to have failed and will be remediated. If not set,
+                  this value is defaulted to 10 minutes. If you wish to disable this
+                  feature, set the value explicitly to 0.
+                type: string
+              remediationTemplate:
+                description: "RemediationTemplate is a reference to a remediation
+                  template provided by an infrastructure provider. \n This field is
+                  completely optional, when filled, the MachineHealthCheck controller
+                  creates a new object from the template referenced and hands off
+                  remediation of the machine to a controller that lives outside of
+                  Cluster API."
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: Label selector to match machines whose health will be
+                  exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              unhealthyConditions:
+                description: UnhealthyConditions contains a list of the conditions
+                  that determine whether a node is considered unhealthy.  The conditions
+                  are combined in a logical OR, i.e. if any of the conditions is met,
+                  the node is unhealthy.
+                items:
+                  description: UnhealthyCondition represents a Node condition type
+                    and value with a timeout specified as a duration.  When the named
+                    condition has been in the given status for at least the timeout
+                    value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+              unhealthyRange:
+                description: 'Any further remediation is only allowed if the number
+                  of machines selected by "selector" as not healthy is within the
+                  range of "UnhealthyRange". Takes precedence over MaxUnhealthy. Eg.
+                  "[3-5]" - This means that remediation will be allowed only when:
+                  (a) there are at least 3 unhealthy machines (and) (b) there are
+                  at most 5 unhealthy machines'
+                pattern: ^\[[0-9]+-[0-9]+\]$
+                type: string
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: Conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine
+                  health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health
+                  check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: RemediationsAllowed is the number of further remediations
+                  allowed by this machine health check before maxUnhealthy short circuiting
+                  will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: Targets shows the current list of machines the machine
+                  health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    - description: Time duration since creation of MachineHealthCheck
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Any further remediation is only allowed if at most "MaxUnhealthy"
+                  machines selected by "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: Machines older than this duration without a node will
+                  be considered to have failed and will be remediated. If not set,
+                  this value is defaulted to 10 minutes. If you wish to disable this
+                  feature, set the value explicitly to 0.
+                type: string
+              remediationTemplate:
+                description: "RemediationTemplate is a reference to a remediation
+                  template provided by an infrastructure provider. \n This field is
+                  completely optional, when filled, the MachineHealthCheck controller
+                  creates a new object from the template referenced and hands off
+                  remediation of the machine to a controller that lives outside of
+                  Cluster API."
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: Label selector to match machines whose health will be
+                  exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              unhealthyConditions:
+                description: UnhealthyConditions contains a list of the conditions
+                  that determine whether a node is considered unhealthy.  The conditions
+                  are combined in a logical OR, i.e. if any of the conditions is met,
+                  the node is unhealthy.
+                items:
+                  description: UnhealthyCondition represents a Node condition type
+                    and value with a timeout specified as a duration.  When the named
+                    condition has been in the given status for at least the timeout
+                    value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+              unhealthyRange:
+                description: 'Any further remediation is only allowed if the number
+                  of machines selected by "selector" as not healthy is within the
+                  range of "UnhealthyRange". Takes precedence over MaxUnhealthy. Eg.
+                  "[3-5]" - This means that remediation will be allowed only when:
+                  (a) there are at least 3 unhealthy machines (and) (b) there are
+                  at most 5 unhealthy machines'
+                pattern: ^\[[0-9]+-[0-9]+\]$
+                type: string
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: Conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine
+                  health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health
+                  check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: RemediationsAllowed is the number of further remediations
+                  allowed by this machine health check before maxUnhealthy short circuiting
+                  will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: Targets shows the current list of machines the machine
+                  health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinepools.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachinePool
+    listKind: MachinePoolList
+    plural: machinepools
+    shortNames:
+    - mp
+    singular: machinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  instances should be ready. Defaults to 0 (machine instance will
+                  be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              strategy:
+                description: The deployment strategy to use to replace existing machine
+                  instances with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType
+                      = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled
+                          above the desired number of machines. Value can be an absolute
+                          number (ex: 5) or a percentage of desired machines (ex:
+                          10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                          number is calculated from percentage by rounding up. Defaults
+                          to 1. Example: when this is set to 30%, the new MachineSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new machines do not
+                          exceed 130% of desired machines. Once old machines have
+                          been killed, new MachineSet can be scaled up further, ensuring
+                          that total number of machines running at any time during
+                          the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired machines (ex: 10%). Absolute
+                          number is calculated from percentage by rounding down. This
+                          can not be 0 if MaxSurge is 0. Defaults to 0. Example: when
+                          this is set to 30%, the old MachineSet can be scaled down
+                          to 70% of desired machines immediately when the rolling
+                          update starts. Once new machines are ready, old MachineSet
+                          can be scaled down further, followed by scaling up the new
+                          MachineSet, ensuring that the total number of machines available
+                          at all times during the update is at least 70% of desired
+                          machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Currently the only supported
+                      strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by
+                          the server, to generate a unique name ONLY IF the Name field
+                          has not been provided. If this field is used, the name returned
+                          to the client will be different than the name passed. This
+                          value will also be combined with a unique suffix. The provided
+                          value has the same validation rules as the Name field, and
+                          may be truncated by the length of the suffix required to
+                          make the value unique on the server. \n If this field is
+                          specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created
+                          or 500 with Reason ServerTimeout indicating a unique name
+                          could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the
+                          Retry-After header). \n Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names \n
+                          Deprecated: This field has no function and is going to be
+                          removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name
+                          must be unique. An empty namespace is equivalent to the
+                          \"default\" namespace, but \"default\" is the canonical
+                          representation. Not all objects are required to be scoped
+                          to a namespace - the value of this field for those objects
+                          will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If
+                          ALL objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller. \n Deprecated: This field
+                          has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information
+                            to let you identify an owning object. An owning object
+                            must be in the same namespace as the dependent, or be
+                            cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the
+                                key-value store until this reference is removed. See
+                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this
+                                field and enforces the foreground deletion. Defaults
+                                to false. To set this field, a user needs "delete"
+                                permission of the owner, otherwise 422 (Unprocessable
+                                Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.Data
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: "Data contains the bootstrap data, such as
+                              cloud-init details scripts. If nil, the Machine should
+                              remain in the Pending state. \n Deprecated: Switch to
+                              DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling
+                  the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling
+                  the state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted
+                  by this machine pool. This is the total number of machine instances
+                  that are still required for the machine pool to have 100% available
+                  capacity. They may either be machine instances that are running
+                  but not yet available or machine instances that still have not been
+                  created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  instances should be ready. Defaults to 0 (machine instance will
+                  be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.DataSecretName
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling
+                  the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling
+                  the state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted
+                  by this machine pool. This is the total number of machine instances
+                  that are still required for the machine pool to have 100% available
+                  capacity. They may either be machine instances that are running
+                  but not yet available or machine instances that still have not been
+                  created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this MachinePool
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  instances should be ready. Defaults to 0 (machine instance will
+                  be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a
+                  pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.DataSecretName
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: NodeDeletionTimeout defines how long the controller
+                          will attempt to delete the Node that the Machine hosts after
+                          the Machine is marked for deletion. A duration of 0 will
+                          retry deletion indefinitely. Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: NodeVolumeDetachTimeout is the total amount of
+                          time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the
+                          volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling
+                  the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling
+                  the state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it
+                  they exist.
+                items:
+                  description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A
+                  machine is considered ready when the node has been created and is
+                  "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted
+                  by this machine pool. This is the total number of machine instances
+                  that are still required for the machine pool to have 100% available
+                  capacity. They may either be machine instances that are running
+                  but not yet available or machine instances that still have not been
+                  created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machines.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Machine
+    listKind: MachineList
+    plural: machines
+    shortNames:
+    - ma
+    singular: machine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      priority: 1
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: Bootstrap is a reference to a local struct which encapsulates
+                  fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: ConfigRef is a reference to a bootstrap provider-specific
+                      resource that holds configuration details. The reference is
+                      optional to allow users/operators to specify Bootstrap.Data
+                      without the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  data:
+                    description: "Data contains the bootstrap data, such as cloud-init
+                      details scripts. If nil, the Machine should remain in the Pending
+                      state. \n Deprecated: Switch to DataSecretName."
+                    type: string
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores
+                      the bootstrap data script. If nil, the Machine should remain
+                      in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: FailureDomain is the failure domain the machine will
+                  be created in. Must match a key in the FailureDomains map stored
+                  on the cluster object.
+                type: string
+              infrastructureRef:
+                description: InfrastructureRef is a required reference to a custom
+                  resource offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the
+                  controller will spend on draining a node. The default value is 0,
+                  meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                type: string
+              providerID:
+                description: ProviderID is the identification ID of the machine provided
+                  by the provider. This field must match the provider ID as seen on
+                  the node object corresponding to this machine. This field is required
+                  by higher level consumers of cluster-api. Example use case is cluster
+                  autoscaler with cluster-api as provider. Clean-up logic in the autoscaler
+                  compares machines to nodes to find out machines at provider which
+                  could not get registered as Kubernetes nodes. With cluster-api as
+                  a generic out-of-tree provider for autoscaler, this field is required
+                  by autoscaler to be able to have a provider view of the list of
+                  machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines
+                  and are marked for delete. This field will be set by the actuators
+                  and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. This
+                  field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: Addresses is a list of addresses assigned to the machine.
+                  This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              lastUpdated:
+                description: LastUpdated identifies when the phase of the Machine
+                  last transitioned.
+                format: date-time
+                type: string
+              nodeRef:
+                description: NodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of machine actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              version:
+                description: Version specifies the current version of Kubernetes running
+                  on the corresponding Node. This is meant to be a means of bubbling
+                  up status from the Node to the Machine. It is entirely optional,
+                  but useful for end-user UX if it’s present.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      priority: 1
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: Bootstrap is a reference to a local struct which encapsulates
+                  fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: ConfigRef is a reference to a bootstrap provider-specific
+                      resource that holds configuration details. The reference is
+                      optional to allow users/operators to specify Bootstrap.DataSecretName
+                      without the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores
+                      the bootstrap data script. If nil, the Machine should remain
+                      in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: FailureDomain is the failure domain the machine will
+                  be created in. Must match a key in the FailureDomains map stored
+                  on the cluster object.
+                type: string
+              infrastructureRef:
+                description: InfrastructureRef is a required reference to a custom
+                  resource offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the
+                  controller will spend on draining a node. The default value is 0,
+                  meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                type: string
+              providerID:
+                description: ProviderID is the identification ID of the machine provided
+                  by the provider. This field must match the provider ID as seen on
+                  the node object corresponding to this machine. This field is required
+                  by higher level consumers of cluster-api. Example use case is cluster
+                  autoscaler with cluster-api as provider. Clean-up logic in the autoscaler
+                  compares machines to nodes to find out machines at provider which
+                  could not get registered as Kubernetes nodes. With cluster-api as
+                  a generic out-of-tree provider for autoscaler, this field is required
+                  by autoscaler to be able to have a provider view of the list of
+                  machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines
+                  and are marked for delete. This field will be set by the actuators
+                  and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. This
+                  field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: Addresses is a list of addresses assigned to the machine.
+                  This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              lastUpdated:
+                description: LastUpdated identifies when the phase of the Machine
+                  last transitioned.
+                format: date-time
+                type: string
+              nodeInfo:
+                description: 'NodeInfo is a set of ids/uuids to uniquely identify
+                  the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info'
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through
+                      runtime remote API (e.g. containerd://1.4.2).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r'
+                      (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: KubeProxy Version reported by the node.
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: 'MachineID reported by the node. For unique machine
+                      identification in the cluster this field is preferred. Learn
+                      more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html'
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release
+                      (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: SystemUUID reported by the node. For unique machine
+                      identification MachineID is preferred. This field is specific
+                      to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: NodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of machine actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              version:
+                description: Version specifies the current version of Kubernetes running
+                  on the corresponding Node. This is meant to be a means of bubbling
+                  up status from the Node to the Machine. It is entirely optional,
+                  but useful for end-user UX if it’s present.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: Bootstrap is a reference to a local struct which encapsulates
+                  fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: ConfigRef is a reference to a bootstrap provider-specific
+                      resource that holds configuration details. The reference is
+                      optional to allow users/operators to specify Bootstrap.DataSecretName
+                      without the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores
+                      the bootstrap data script. If nil, the Machine should remain
+                      in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: FailureDomain is the failure domain the machine will
+                  be created in. Must match a key in the FailureDomains map stored
+                  on the cluster object.
+                type: string
+              infrastructureRef:
+                description: InfrastructureRef is a required reference to a custom
+                  resource offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeDeletionTimeout:
+                description: NodeDeletionTimeout defines how long the controller will
+                  attempt to delete the Node that the Machine hosts after the Machine
+                  is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                  Defaults to 10 seconds.
+                type: string
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the
+                  controller will spend on draining a node. The default value is 0,
+                  meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                type: string
+              nodeVolumeDetachTimeout:
+                description: NodeVolumeDetachTimeout is the total amount of time that
+                  the controller will spend on waiting for all volumes to be detached.
+                  The default value is 0, meaning that the volumes can be detached
+                  without any time limitations.
+                type: string
+              providerID:
+                description: ProviderID is the identification ID of the machine provided
+                  by the provider. This field must match the provider ID as seen on
+                  the node object corresponding to this machine. This field is required
+                  by higher level consumers of cluster-api. Example use case is cluster
+                  autoscaler with cluster-api as provider. Clean-up logic in the autoscaler
+                  compares machines to nodes to find out machines at provider which
+                  could not get registered as Kubernetes nodes. With cluster-api as
+                  a generic out-of-tree provider for autoscaler, this field is required
+                  by autoscaler to be able to have a provider view of the list of
+                  machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines
+                  and are marked for delete. This field will be set by the actuators
+                  and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. This
+                  field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: Addresses is a list of addresses assigned to the machine.
+                  This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              certificatesExpiryDate:
+                description: CertificatesExpiryDate is the expiry date of the machine
+                  certificates. This value is only set for control plane machines.
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              lastUpdated:
+                description: LastUpdated identifies when the phase of the Machine
+                  last transitioned.
+                format: date-time
+                type: string
+              nodeInfo:
+                description: 'NodeInfo is a set of ids/uuids to uniquely identify
+                  the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info'
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through
+                      runtime remote API (e.g. containerd://1.4.2).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r'
+                      (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: KubeProxy Version reported by the node.
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: 'MachineID reported by the node. For unique machine
+                      identification in the cluster this field is preferred. Learn
+                      more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html'
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release
+                      (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: SystemUUID reported by the node. For unique machine
+                      identification MachineID is preferred. This field is specific
+                      to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: NodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of machine actuation.
+                  E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: machinesets.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineSet
+    listKind: MachineSetList
+    plural: machinesets
+    shortNames:
+    - ms
+    singular: machineset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: DeletePolicy defines the policy used to identify nodes
+                  to delete when downscaling. Defaults to "Random".  Valid values
+                  are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: MinReadySeconds is the minimum number of seconds for
+                  which a newly created machine should be ready. Defaults to 0 (machine
+                  will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the number of desired replicas. This is a
+                  pointer to distinguish between explicit zero and unspecified. Defaults
+                  to 1.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is a label query over machines that should
+                  match the replica count. Label keys and values that must match in
+                  order to be controlled by this MachineSet. It must match the machine
+                  template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: Template is the object that describes the machine that
+                  will be created if insufficient replicas are detected. Object references
+                  to custom resources are treated as templates.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by
+                          the server, to generate a unique name ONLY IF the Name field
+                          has not been provided. If this field is used, the name returned
+                          to the client will be different than the name passed. This
+                          value will also be combined with a unique suffix. The provided
+                          value has the same validation rules as the Name field, and
+                          may be truncated by the length of the suffix required to
+                          make the value unique on the server. \n If this field is
+                          specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created
+                          or 500 with Reason ServerTimeout indicating a unique name
+                          could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the
+                          Retry-After header). \n Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names \n
+                          Deprecated: This field has no function and is going to be
+                          removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name
+                          must be unique. An empty namespace is equivalent to the
+                          \"default\" namespace, but \"default\" is the canonical
+                          representation. Not all objects are required to be scoped
+                          to a namespace - the value of this field for those objects
+                          will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+                          \n Deprecated: This field has no function and is going to
+                          be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If
+                          ALL objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller. \n Deprecated: This field
+                          has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information
+                            to let you identify an owning object. An owning object
+                            must be in the same namespace as the dependent, or be
+                            cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the
+                                key-value store until this reference is removed. See
+                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this
+                                field and enforces the foreground deletion. Defaults
+                                to false. To set this field, a user needs "delete"
+                                permission of the owner, otherwise 422 (Unprocessable
+                                Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.Data
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          data:
+                            description: "Data contains the bootstrap data, such as
+                              cloud-init details scripts. If nil, the Machine should
+                              remain in the Pending state. \n Deprecated: Switch to
+                              DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              failureMessage:
+                type: string
+              failureReason:
+                description: "In the event that there is a terminal problem reconciling
+                  the replicas, both FailureReason and FailureMessage will be set.
+                  FailureReason will be populated with a succinct value suitable for
+                  machine interpretation, while FailureMessage will contain a more
+                  verbose string suitable for logging and human consumption. \n These
+                  fields should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the MachineTemplate's spec or the configuration of the
+                  machine controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in
+                  the spec, values that are unsupported by the machine controller,
+                  or the responsible machine controller itself being critically misconfigured.
+                  \n Any transient errors that occur during the reconciliation of
+                  Machines can be added as events to the MachineSet object and/or
+                  logged in the controller's output."
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the
+                  labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine
+                  is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the
+                  string format to avoid introspection by clients. The string will
+                  be in the same format as the query-param syntax. More info about
+                  label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: DeletePolicy defines the policy used to identify nodes
+                  to delete when downscaling. Defaults to "Random".  Valid values
+                  are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: MinReadySeconds is the minimum number of seconds for
+                  which a newly created machine should be ready. Defaults to 0 (machine
+                  will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Replicas is the number of desired replicas. This is a
+                  pointer to distinguish between explicit zero and unspecified. Defaults
+                  to 1.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is a label query over machines that should
+                  match the replica count. Label keys and values that must match in
+                  order to be controlled by this MachineSet. It must match the machine
+                  template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: Template is the object that describes the machine that
+                  will be created if insufficient replicas are detected. Object references
+                  to custom resources are treated as templates.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.DataSecretName
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                type: string
+              failureReason:
+                description: "In the event that there is a terminal problem reconciling
+                  the replicas, both FailureReason and FailureMessage will be set.
+                  FailureReason will be populated with a succinct value suitable for
+                  machine interpretation, while FailureMessage will contain a more
+                  verbose string suitable for logging and human consumption. \n These
+                  fields should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the MachineTemplate's spec or the configuration of the
+                  machine controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in
+                  the spec, values that are unsupported by the machine controller,
+                  or the responsible machine controller itself being critically misconfigured.
+                  \n Any transient errors that occur during the reconciliation of
+                  Machines can be added as events to the MachineSet object and/or
+                  logged in the controller's output."
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the
+                  labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine
+                  is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the
+                  string format to avoid introspection by clients. The string will
+                  be in the same format as the query-param syntax. More info about
+                  label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this machineset
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Time duration since creation of MachineSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineSet
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs
+                  to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: DeletePolicy defines the policy used to identify nodes
+                  to delete when downscaling. Defaults to "Random".  Valid values
+                  are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: MinReadySeconds is the minimum number of seconds for
+                  which a newly created machine should be ready. Defaults to 0 (machine
+                  will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Replicas is the number of desired replicas. This is a
+                  pointer to distinguish between explicit zero and unspecified. Defaults
+                  to 1.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is a label query over machines that should
+                  match the replica count. Label keys and values that must match in
+                  order to be controlled by this MachineSet. It must match the machine
+                  template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: Template is the object that describes the machine that
+                  will be created if insufficient replicas are detected. Object references
+                  to custom resources are treated as templates.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which
+                          encapsulates fields to configure the Machine’s bootstrapping
+                          mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific
+                              resource that holds configuration details. The reference
+                              is optional to allow users/operators to specify Bootstrap.DataSecretName
+                              without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object. TODO: this design is not final and
+                                  this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret
+                              that stores the bootstrap data script. If nil, the Machine
+                              should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object
+                          belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to
+                          a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: NodeDeletionTimeout defines how long the controller
+                          will attempt to delete the Node that the Machine hosts after
+                          the Machine is marked for deletion. A duration of 0 will
+                          retry deletion indefinitely. Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time
+                          that the controller will spend on draining a node. The default
+                          value is 0, meaning that the node can be drained without
+                          any time limitations. NOTE: NodeDrainTimeout is different
+                          from `kubectl drain --timeout`'
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: NodeVolumeDetachTimeout is the total amount of
+                          time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the
+                          volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                type: string
+              failureReason:
+                description: "In the event that there is a terminal problem reconciling
+                  the replicas, both FailureReason and FailureMessage will be set.
+                  FailureReason will be populated with a succinct value suitable for
+                  machine interpretation, while FailureMessage will contain a more
+                  verbose string suitable for logging and human consumption. \n These
+                  fields should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the MachineTemplate's spec or the configuration of the
+                  machine controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in
+                  the spec, values that are unsupported by the machine controller,
+                  or the responsible machine controller itself being critically misconfigured.
+                  \n Any transient errors that occur during the reconciliation of
+                  Machines can be added as events to the MachineSet object and/or
+                  logged in the controller's output."
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the
+                  labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine
+                  is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the
+                  string format to avoid introspection by clients. The string will
+                  be in the same format as the query-param syntax. More info about
+                  label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-leader-election-role
+  namespace: capi-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      cluster.x-k8s.io/aggregate-to-manager: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-aggregated-manager-role
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: "true"
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  resources:
+  - clusterresourcesets/finalizers
+  - clusterresourcesets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusterclasses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusterclasses
+  - clusterclasses/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/finalizers
+  - clusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/finalizers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/finalizers
+  - machinedeployments/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinehealthchecks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinehealthchecks
+  - machinehealthchecks/finalizers
+  - machinehealthchecks/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/finalizers
+  - machinepools/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/finalizers
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  - machinesets/finalizers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  - machinesets/finalizers
+  - machinesets/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ipam.cluster.x-k8s.io
+  resources:
+  - ipaddressclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - runtime.cluster.x-k8s.io
+  resources:
+  - extensionconfigs
+  - extensionconfigs/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-leader-election-rolebinding
+  namespace: capi-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-aggregated-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-webhook-service
+  namespace: capi-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: cluster-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    control-plane: controller-manager
+  name: capi-controller-manager
+  namespace: capi-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: cluster-api
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: cluster-api
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --metrics-bind-addr=localhost:8080
+        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=false},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false}
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        image: registry.k8s.io/cluster-api/cluster-api-controller:v1.3.3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: capi-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capi-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-serving-cert
+  namespace: capi-system
+spec:
+  dnsNames:
+  - capi-webhook-service.capi-system.svc
+  - capi-webhook-service.capi-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capi-selfsigned-issuer
+  secretName: capi-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-selfsigned-issuer
+  namespace: capi-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinehealthcheck
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinehealthcheck.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinehealthchecks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machineset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-runtime-cluster-x-k8s-io-v1alpha1-extensionconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.extensionconfig.runtime.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - runtime.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - extensionconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinepool.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: capi-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinehealthcheck
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinehealthcheck.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinehealthchecks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machineset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-runtime-cluster-x-k8s-io-v1alpha1-extensionconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.extensionconfig.runtime.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - runtime.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - extensionconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinepool.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-ipam-cluster-x-k8s-io-v1alpha1-ipaddress
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ipaddress.ipam.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - ipam.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - ipaddresses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-ipam-cluster-x-k8s-io-v1alpha1-ipaddressclaim
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ipaddressclaim.ipam.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - ipam.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - ipaddressclaims
+  sideEffects: None

--- a/platform-operator/capi/cluster-api/v1.3.3/metadata.yaml
+++ b/platform-operator/capi/cluster-api/v1.3.3/metadata.yaml
@@ -1,0 +1,26 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 1
+    minor: 3
+    contract: v1beta1
+  - major: 1
+    minor: 2
+    contract: v1beta1
+  - major: 1
+    minor: 1
+    contract: v1beta1
+  - major: 1
+    minor: 0
+    contract: v1beta1
+  - major: 0
+    minor: 4
+    contract: v1alpha4
+  - major: 0
+    minor: 3
+    contract: v1alpha3

--- a/platform-operator/capi/cluster-api/v1.3.3/metadata.yaml
+++ b/platform-operator/capi/cluster-api/v1.3.3/metadata.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 # maps release series of major.minor to cluster-api contract version
 # the contract version may change between minor or major versions, but *not*
 # between patch versions.

--- a/platform-operator/capi/control-plane-ocne/v0.1.0/control-plane-components.yaml
+++ b/platform-operator/capi/control-plane-ocne/v0.1.0/control-plane-components.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/platform-operator/capi/control-plane-ocne/v0.1.0/metadata.yaml
+++ b/platform-operator/capi/control-plane-ocne/v0.1.0/metadata.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 # maps release series of major.minor to cluster-api contract version
 # the contract version may change between minor or major versions, but *not*
 # between patch versions.

--- a/platform-operator/capi/infrastructure-oci/v0.8.1/infrastructure-components.yaml
+++ b/platform-operator/capi/infrastructure-oci/v0.8.1/infrastructure-components.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/platform-operator/capi/infrastructure-oci/v0.8.1/infrastructure-components.yaml
+++ b/platform-operator/capi/infrastructure-oci/v0.8.1/infrastructure-components.yaml
@@ -1,0 +1,7047 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    control-plane: controller-manager
+  name: cluster-api-provider-oci-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: ociclusteridentities.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: OCIClusterIdentity
+    listKind: OCIClusterIdentityList
+    plural: ociclusteridentities
+    singular: ociclusteridentity
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OCIClusterIdentity is the Schema for the OCI Cluster Identity
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIClusterIdentitySpec defines the parameters that are used
+              to create an OCIClusterIdentity.
+            properties:
+              allowedNamespaces:
+                description: AllowedNamespaces is used to identify the namespaces
+                  the clusters are allowed to use the identity from. Namespaces can
+                  be selected either using an array of namespaces or with label selector.
+                  An empty allowedNamespaces object indicates that OCIClusters can
+                  use this identity from any namespace. If this object is nil, no
+                  namespaces will be allowed (default behaviour, if this field is
+                  not provided) A namespace should be either in the NamespaceList
+                  or match with Selector to use the identity.
+                nullable: true
+                properties:
+                  list:
+                    description: A nil or empty list indicates that OCICluster cannot
+                      use the identity from any namespace. NamespaceList takes precedence
+                      over the Selector.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  selector:
+                    description: "Selector is a selector of namespaces that OCICluster
+                      can use this Identity from. This is a standard Kubernetes LabelSelector,
+                      a label query over a set of resources. The result of matchLabels
+                      and matchExpressions are ANDed. \n A nil or empty selector indicates
+                      that OCICluster cannot use this OCIClusterIdentity from any
+                      namespace."
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              principalSecret:
+                description: PrincipalSecret is a secret reference which contains
+                  the authentication credentials for the principal.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              type:
+                description: Type is the type of OCI Principal used. UserPrincipal
+                  is the only supported value
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: OCIClusterIdentityStatus defines the observed state of OCIClusterIdentity.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the OCIClusterIdentity.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: cluster-api-provider-oci-system/capoci-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: ociclusters.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capoci-webhook-service
+          namespace: cluster-api-provider-oci-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: OCICluster
+    listKind: OCIClusterList
+    plural: ociclusters
+    singular: ocicluster
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OCICluster is the Schema for the ociclusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIClusterSpec defines the desired state of OciCluster
+            properties:
+              compartmentId:
+                description: Compartment to create the cluster network.
+                type: string
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              definedTags:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                description: 'Defined tags for this resource. Each key is predefined
+                  and scoped to a namespace. For more information, see Resource Tags
+                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                  Example: `{"Operations": {"CostCenter": "42"}}`'
+                type: object
+              freeformTags:
+                additionalProperties:
+                  type: string
+                description: Free-form tags for this resource.
+                type: object
+              identityRef:
+                description: IdentityRef is a reference to an identity(principal)
+                  to be used when reconciling this cluster
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              networkSpec:
+                description: NetworkSpec encapsulates all things related to OCI network.
+                properties:
+                  apiServerLoadBalancer:
+                    description: API Server LB configuration.
+                    properties:
+                      loadBalancerId:
+                        description: ID of Load Balancer.
+                        type: string
+                      name:
+                        description: LoadBalancer Name.
+                        type: string
+                    type: object
+                  skipNetworkManagement:
+                    description: SkipNetworkManagement defines if the networking spec(VCN
+                      related) specified by the user needs to be reconciled(actioned-upon)
+                      or used as it is. APIServerLB will still be reconciled.
+                    type: boolean
+                  vcn:
+                    description: VCN configuration.
+                    properties:
+                      cidr:
+                        description: VCN CIDR.
+                        type: string
+                      id:
+                        description: VCN OCID.
+                        type: string
+                      internetGatewayId:
+                        description: ID of Internet Gateway.
+                        type: string
+                      name:
+                        description: VCN Name.
+                        type: string
+                      natGatewayId:
+                        description: ID of Nat Gateway.
+                        type: string
+                      networkSecurityGroups:
+                        description: NetworkSecurityGroups is the configuration for
+                          the Network Security Groups required in the VCN.
+                        items:
+                          description: NSG defines configuration for a Network Security
+                            Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                          properties:
+                            egressRules:
+                              description: EgressRules on the NSG.
+                              items:
+                                description: EgressSecurityRuleForNSG is EgressSecurityRule
+                                  for NSG.
+                                properties:
+                                  egressRule:
+                                    description: EgressSecurityRule A rule for allowing
+                                      outbound IP packets.
+                                    properties:
+                                      description:
+                                        description: An optional description of your
+                                          choice for the rule.
+                                        type: string
+                                      destination:
+                                        description: 'Conceptually, this is the range
+                                          of IP addresses that a packet originating
+                                          from the instance can go to. Allowed values:
+                                          * IP address range in CIDR notation. For
+                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                          Note that IPv6 addressing is currently supported
+                                          only in certain regions. See IPv6 Addresses
+                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                          * The `cidrBlock` value for a Service, if
+                                          you''re setting up a security list rule
+                                          for traffic destined for a particular `Service`
+                                          through a service gateway. For example:
+                                          `oci-phx-objectstorage`.'
+                                        type: string
+                                      destinationType:
+                                        description: 'Type of destination for the
+                                          rule. The default is `CIDR_BLOCK`. Allowed
+                                          values: * `CIDR_BLOCK`: If the rule''s `destination`
+                                          is an IP address range in CIDR notation.
+                                          * `SERVICE_CIDR_BLOCK`: If the rule''s `destination`
+                                          is the `cidrBlock` value for a Service (the
+                                          rule is for traffic destined for a particular
+                                          `Service` through a service gateway).'
+                                        type: string
+                                      icmpOptions:
+                                        description: 'IcmpOptions Optional and valid
+                                          only for ICMP and ICMPv6. Use to specify
+                                          a particular ICMP type and code as defined
+                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                          - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                          If you specify ICMP or ICMPv6 as the protocol
+                                          but omit this object, then all ICMP types
+                                          and codes are allowed. If you do provide
+                                          this object, the type is required and the
+                                          code is optional. To enable MTU negotiation
+                                          for ingress internet traffic via IPv4, make
+                                          sure to allow type 3 ("Destination Unreachable")
+                                          code 4 ("Fragmentation Needed and Don''t
+                                          Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create
+                                          a separate security list rule for each.'
+                                        properties:
+                                          code:
+                                            description: The ICMP code (optional).
+                                            type: integer
+                                          type:
+                                            description: The ICMP type.
+                                            type: integer
+                                        type: object
+                                      isStateless:
+                                        description: A stateless rule allows traffic
+                                          in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if
+                                          you need to support bidirectional traffic.
+                                          For example, if egress traffic allows TCP
+                                          destination port 80, there should be an
+                                          ingress rule to allow TCP source port 80.
+                                          Defaults to false, which means the rule
+                                          is stateful and a corresponding rule is
+                                          not necessary for bidirectional traffic.
+                                        type: boolean
+                                      protocol:
+                                        description: The transport protocol. Specify
+                                          either `all` or an IPv4 protocol number
+                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"),
+                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        type: string
+                                      tcpOptions:
+                                        description: TcpOptions Optional and valid
+                                          only for TCP. Use to specify particular
+                                          destination ports for TCP rules. If you
+                                          specify TCP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      udpOptions:
+                                        description: UdpOptions Optional and valid
+                                          only for UDP. Use to specify particular
+                                          destination ports for UDP rules. If you
+                                          specify UDP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                    type: object
+                                  id:
+                                    description: 'EgressSecurityRule ID for NSG. Deprecated:
+                                      this field is not populated and used during
+                                      reconciliation'
+                                    type: string
+                                type: object
+                              type: array
+                            id:
+                              description: NSG OCID.
+                              type: string
+                            ingressRules:
+                              description: IngressRules on the NSG.
+                              items:
+                                description: IngressSecurityRuleForNSG is IngressSecurityRule
+                                  for NSG
+                                properties:
+                                  id:
+                                    description: 'IngressSecurityRule ID for NSG.
+                                      Deprecated: this field is not populated and
+                                      used during reconciliation'
+                                    type: string
+                                  ingressRule:
+                                    description: IngressSecurityRule A rule for allowing
+                                      inbound IP packets.
+                                    properties:
+                                      description:
+                                        description: An optional description of your
+                                          choice for the rule.
+                                        type: string
+                                      icmpOptions:
+                                        description: 'IcmpOptions Optional and valid
+                                          only for ICMP and ICMPv6. Use to specify
+                                          a particular ICMP type and code as defined
+                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                          - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                          If you specify ICMP or ICMPv6 as the protocol
+                                          but omit this object, then all ICMP types
+                                          and codes are allowed. If you do provide
+                                          this object, the type is required and the
+                                          code is optional. To enable MTU negotiation
+                                          for ingress internet traffic via IPv4, make
+                                          sure to allow type 3 ("Destination Unreachable")
+                                          code 4 ("Fragmentation Needed and Don''t
+                                          Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create
+                                          a separate security list rule for each.'
+                                        properties:
+                                          code:
+                                            description: The ICMP code (optional).
+                                            type: integer
+                                          type:
+                                            description: The ICMP type.
+                                            type: integer
+                                        type: object
+                                      isStateless:
+                                        description: A stateless rule allows traffic
+                                          in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if
+                                          you need to support bidirectional traffic.
+                                          For example, if ingress traffic allows TCP
+                                          destination port 80, there should be an
+                                          egress rule to allow TCP source port 80.
+                                          Defaults to false, which means the rule
+                                          is stateful and a corresponding rule is
+                                          not necessary for bidirectional traffic.
+                                        type: boolean
+                                      protocol:
+                                        description: The transport protocol. Specify
+                                          either `all` or an IPv4 protocol number
+                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"),
+                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        type: string
+                                      source:
+                                        description: 'Conceptually, this is the range
+                                          of IP addresses that a packet coming into
+                                          the instance can come from. Allowed values:
+                                          * IP address range in CIDR notation. For
+                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                          IPv6 addressing is supported for all commercial
+                                          and government regions. See IPv6 Addresses
+                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                          * The `cidrBlock` value for a Service, if
+                                          you''re setting up a security list rule
+                                          for traffic coming from a particular `Service`
+                                          through a service gateway. For example:
+                                          `oci-phx-objectstorage`.'
+                                        type: string
+                                      sourceType:
+                                        description: 'Type of source for the rule.
+                                          The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
+                                          If the rule''s `source` is an IP address
+                                          range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
+                                          If the rule''s `source` is the `cidrBlock`
+                                          value for a Service (the rule is for traffic
+                                          coming from a particular `Service` through
+                                          a service gateway).'
+                                        type: string
+                                      tcpOptions:
+                                        description: TcpOptions Optional and valid
+                                          only for TCP. Use to specify particular
+                                          destination ports for TCP rules. If you
+                                          specify TCP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      udpOptions:
+                                        description: UdpOptions Optional and valid
+                                          only for UDP. Use to specify particular
+                                          destination ports for UDP rules. If you
+                                          specify UDP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                            name:
+                              description: NSG Name.
+                              type: string
+                            role:
+                              description: Role defines the NSG role (eg. control-plane,
+                                control-plane-endpoint, service-lb, worker).
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      privateRouteTableId:
+                        description: ID of Private Route Table.
+                        type: string
+                      publicRouteTableId:
+                        description: ID of Public Route Table.
+                        type: string
+                      serviceGatewayId:
+                        description: ID of Service Gateway.
+                        type: string
+                      subnets:
+                        description: Subnets is the configuration for subnets required
+                          in the VCN.
+                        items:
+                          description: Subnet defines the configuration for a network's
+                            subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                          properties:
+                            cidr:
+                              description: Subnet CIDR.
+                              type: string
+                            id:
+                              description: Subnet OCID.
+                              type: string
+                            name:
+                              description: Subnet Name.
+                              type: string
+                            role:
+                              description: Role defines the subnet role (eg. control-plane,
+                                control-plane-endpoint, service-lb, worker).
+                              type: string
+                            securityList:
+                              description: The security list associated with Subnet.
+                              properties:
+                                egressRules:
+                                  description: EgressRules on the SecurityList.
+                                  items:
+                                    description: EgressSecurityRule A rule for allowing
+                                      outbound IP packets.
+                                    properties:
+                                      description:
+                                        description: An optional description of your
+                                          choice for the rule.
+                                        type: string
+                                      destination:
+                                        description: 'Conceptually, this is the range
+                                          of IP addresses that a packet originating
+                                          from the instance can go to. Allowed values:
+                                          * IP address range in CIDR notation. For
+                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                          Note that IPv6 addressing is currently supported
+                                          only in certain regions. See IPv6 Addresses
+                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                          * The `cidrBlock` value for a Service, if
+                                          you''re setting up a security list rule
+                                          for traffic destined for a particular `Service`
+                                          through a service gateway. For example:
+                                          `oci-phx-objectstorage`.'
+                                        type: string
+                                      destinationType:
+                                        description: 'Type of destination for the
+                                          rule. The default is `CIDR_BLOCK`. Allowed
+                                          values: * `CIDR_BLOCK`: If the rule''s `destination`
+                                          is an IP address range in CIDR notation.
+                                          * `SERVICE_CIDR_BLOCK`: If the rule''s `destination`
+                                          is the `cidrBlock` value for a Service (the
+                                          rule is for traffic destined for a particular
+                                          `Service` through a service gateway).'
+                                        type: string
+                                      icmpOptions:
+                                        description: 'IcmpOptions Optional and valid
+                                          only for ICMP and ICMPv6. Use to specify
+                                          a particular ICMP type and code as defined
+                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                          - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                          If you specify ICMP or ICMPv6 as the protocol
+                                          but omit this object, then all ICMP types
+                                          and codes are allowed. If you do provide
+                                          this object, the type is required and the
+                                          code is optional. To enable MTU negotiation
+                                          for ingress internet traffic via IPv4, make
+                                          sure to allow type 3 ("Destination Unreachable")
+                                          code 4 ("Fragmentation Needed and Don''t
+                                          Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create
+                                          a separate security list rule for each.'
+                                        properties:
+                                          code:
+                                            description: The ICMP code (optional).
+                                            type: integer
+                                          type:
+                                            description: The ICMP type.
+                                            type: integer
+                                        type: object
+                                      isStateless:
+                                        description: A stateless rule allows traffic
+                                          in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if
+                                          you need to support bidirectional traffic.
+                                          For example, if egress traffic allows TCP
+                                          destination port 80, there should be an
+                                          ingress rule to allow TCP source port 80.
+                                          Defaults to false, which means the rule
+                                          is stateful and a corresponding rule is
+                                          not necessary for bidirectional traffic.
+                                        type: boolean
+                                      protocol:
+                                        description: The transport protocol. Specify
+                                          either `all` or an IPv4 protocol number
+                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"),
+                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        type: string
+                                      tcpOptions:
+                                        description: TcpOptions Optional and valid
+                                          only for TCP. Use to specify particular
+                                          destination ports for TCP rules. If you
+                                          specify TCP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      udpOptions:
+                                        description: UdpOptions Optional and valid
+                                          only for UDP. Use to specify particular
+                                          destination ports for UDP rules. If you
+                                          specify UDP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                id:
+                                  description: ID of the SecurityList.
+                                  type: string
+                                ingressRules:
+                                  description: IngressRules on the SecurityList.
+                                  items:
+                                    description: IngressSecurityRule A rule for allowing
+                                      inbound IP packets.
+                                    properties:
+                                      description:
+                                        description: An optional description of your
+                                          choice for the rule.
+                                        type: string
+                                      icmpOptions:
+                                        description: 'IcmpOptions Optional and valid
+                                          only for ICMP and ICMPv6. Use to specify
+                                          a particular ICMP type and code as defined
+                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                          - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                          If you specify ICMP or ICMPv6 as the protocol
+                                          but omit this object, then all ICMP types
+                                          and codes are allowed. If you do provide
+                                          this object, the type is required and the
+                                          code is optional. To enable MTU negotiation
+                                          for ingress internet traffic via IPv4, make
+                                          sure to allow type 3 ("Destination Unreachable")
+                                          code 4 ("Fragmentation Needed and Don''t
+                                          Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create
+                                          a separate security list rule for each.'
+                                        properties:
+                                          code:
+                                            description: The ICMP code (optional).
+                                            type: integer
+                                          type:
+                                            description: The ICMP type.
+                                            type: integer
+                                        type: object
+                                      isStateless:
+                                        description: A stateless rule allows traffic
+                                          in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if
+                                          you need to support bidirectional traffic.
+                                          For example, if ingress traffic allows TCP
+                                          destination port 80, there should be an
+                                          egress rule to allow TCP source port 80.
+                                          Defaults to false, which means the rule
+                                          is stateful and a corresponding rule is
+                                          not necessary for bidirectional traffic.
+                                        type: boolean
+                                      protocol:
+                                        description: The transport protocol. Specify
+                                          either `all` or an IPv4 protocol number
+                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"),
+                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        type: string
+                                      source:
+                                        description: 'Conceptually, this is the range
+                                          of IP addresses that a packet coming into
+                                          the instance can come from. Allowed values:
+                                          * IP address range in CIDR notation. For
+                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                          IPv6 addressing is supported for all commercial
+                                          and government regions. See IPv6 Addresses
+                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                          * The `cidrBlock` value for a Service, if
+                                          you''re setting up a security list rule
+                                          for traffic coming from a particular `Service`
+                                          through a service gateway. For example:
+                                          `oci-phx-objectstorage`.'
+                                        type: string
+                                      sourceType:
+                                        description: 'Type of source for the rule.
+                                          The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
+                                          If the rule''s `source` is an IP address
+                                          range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
+                                          If the rule''s `source` is the `cidrBlock`
+                                          value for a Service (the rule is for traffic
+                                          coming from a particular `Service` through
+                                          a service gateway).'
+                                        type: string
+                                      tcpOptions:
+                                        description: TcpOptions Optional and valid
+                                          only for TCP. Use to specify particular
+                                          destination ports for TCP rules. If you
+                                          specify TCP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      udpOptions:
+                                        description: UdpOptions Optional and valid
+                                          only for UDP. Use to specify particular
+                                          destination ports for UDP rules. If you
+                                          specify UDP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                name:
+                                  description: SecurityList Name.
+                                  type: string
+                              type: object
+                            type:
+                              description: Type defines the subnet type (e.g. public,
+                                private).
+                              type: string
+                          required:
+                          - name
+                          - role
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  vcnPeering:
+                    description: VCNPeering configuration.
+                    properties:
+                      drg:
+                        description: DRG configuration refers to the DRG which has
+                          to be created if required. If management cluster and workload
+                          cluster shares the same DRG, this fields is not required
+                          to be specified.
+                        properties:
+                          id:
+                            description: ID is the OCID for the created DRG.
+                            type: string
+                          manage:
+                            description: Manage defines whether the DRG has to be
+                              managed(including create). If set to false(the default)
+                              the ID has to be specified by the user to a valid DRG
+                              ID to which the VCN has to be attached.
+                            type: boolean
+                          name:
+                            description: Name is the name of the created DRG.
+                            type: string
+                          vcnAttachmentId:
+                            description: VcnAttachmentId is the ID of the VCN attachment
+                              of the DRG. The workload cluster VCN can be attached
+                              to either the management cluster VCN if they are sharing
+                              the same DRG or to the workload cluster DRG.
+                            type: string
+                        type: object
+                      peerRouteRules:
+                        description: PeerRouteRules defines the routing rules which
+                          will be added to the private route tables of the workload
+                          cluster VCN. The routes defined here will be directed to
+                          DRG.
+                        items:
+                          description: PeerRouteRule defines a Route Rule to be routed
+                            via a DRG.
+                          properties:
+                            vcnCIDRRange:
+                              description: VCNCIDRRange is the CIDR Range of peer
+                                VCN to which the workload cluster VCN will be peered.
+                                The CIDR range is required to add the route rule in
+                                the workload cluster VCN, the route rule will forward
+                                any traffic to the CIDR to the DRG.
+                              type: string
+                          type: object
+                        type: array
+                      remotePeeringConnections:
+                        description: RemotePeeringConnections defines the RPC connections
+                          which be established with the workload cluster DRG.
+                        items:
+                          description: RemotePeeringConnection is used to peer VCNs
+                            residing in different regions(typically). Remote VCN Peering
+                            is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
+                          properties:
+                            managePeerRPC:
+                              description: ManagePeerRPC will define if the Peer VCN
+                                needs to be managed. If set to true a Remote Peering
+                                Connection will be created in the Peer DRG and the
+                                connection will be created between local and peer
+                                RPC.
+                              type: boolean
+                            peerDRGId:
+                              description: PeerDRGId defines the DRG ID of the peer.
+                              type: string
+                            peerRPCConnectionId:
+                              description: PeerRPCConnectionId defines the RPC ID
+                                of peer. If ManagePeerRPC is set to true this will
+                                be created by Cluster API Provider for OCI, otherwise
+                                this has be defined by the user.
+                              type: string
+                            peerRegionName:
+                              description: PeerRegionName defined the region name
+                                of Peer VCN.
+                              type: string
+                            rpcConnectionId:
+                              description: RPCConnectionId is the connection ID of
+                                the connection between peer and local RPC.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              ociResourceIdentifier:
+                description: The unique ID which will be used to tag all the resources
+                  created by this Cluster. The tag will be used to identify resources
+                  belonging to this cluster. this will be auto-generated and should
+                  not be set by the user.
+                type: string
+              region:
+                description: Region the cluster operates in. It must be one of available
+                  regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                type: string
+            type: object
+          status:
+            description: OCIClusterStatus defines the observed state of OCICluster
+            properties:
+              availabilityDomains:
+                additionalProperties:
+                  description: OCIAvailabilityDomain contains information about an
+                    Availability Domain (AD).
+                  properties:
+                    faultDomains:
+                      description: 'FaultDomains a list of fault domain (FD) names.
+                        Example: ["FAULT-DOMAIN-1"]'
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: 'Name is the AD''s full name. Example: Uocm:PHX-AD-1'
+                      type: string
+                  type: object
+                description: AvailabilityDomains encapsulates the clusters Availability
+                  Domain (AD) information in a map where the map key is the AD name
+                  and the struct is details about the AD.
+                type: object
+              conditions:
+                description: NetworkSpec encapsulates all things related to OCI network.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of FailureDomains.
+                type: object
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: ociclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OCIClusterTemplate
+    listKind: OCIClusterTemplateList
+    plural: ociclustertemplates
+    singular: ociclustertemplate
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OCIClusterTemplate is the Schema for the ociclustertemplates
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIClusterTemplateSpec defines the desired state of OCIClusterTemplate.
+            properties:
+              template:
+                description: OCIClusterTemplateResource describes the data needed
+                  to create an OCICluster from a template.
+                properties:
+                  spec:
+                    description: OCIClusterSpec defines the desired state of OciCluster
+                    properties:
+                      compartmentId:
+                        description: Compartment to create the cluster network.
+                        type: string
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint represents the endpoint
+                          used to communicate with the control plane.
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      definedTags:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: 'Defined tags for this resource. Each key is
+                          predefined and scoped to a namespace. For more information,
+                          see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                          Example: `{"Operations": {"CostCenter": "42"}}`'
+                        type: object
+                      freeformTags:
+                        additionalProperties:
+                          type: string
+                        description: Free-form tags for this resource.
+                        type: object
+                      identityRef:
+                        description: IdentityRef is a reference to an identity(principal)
+                          to be used when reconciling this cluster
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object. TODO: this design
+                              is not final and this field is subject to change in
+                              the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      networkSpec:
+                        description: NetworkSpec encapsulates all things related to
+                          OCI network.
+                        properties:
+                          apiServerLoadBalancer:
+                            description: API Server LB configuration.
+                            properties:
+                              loadBalancerId:
+                                description: ID of Load Balancer.
+                                type: string
+                              name:
+                                description: LoadBalancer Name.
+                                type: string
+                            type: object
+                          skipNetworkManagement:
+                            description: SkipNetworkManagement defines if the networking
+                              spec(VCN related) specified by the user needs to be
+                              reconciled(actioned-upon) or used as it is. APIServerLB
+                              will still be reconciled.
+                            type: boolean
+                          vcn:
+                            description: VCN configuration.
+                            properties:
+                              cidr:
+                                description: VCN CIDR.
+                                type: string
+                              id:
+                                description: VCN OCID.
+                                type: string
+                              internetGatewayId:
+                                description: ID of Internet Gateway.
+                                type: string
+                              name:
+                                description: VCN Name.
+                                type: string
+                              natGatewayId:
+                                description: ID of Nat Gateway.
+                                type: string
+                              networkSecurityGroups:
+                                description: NetworkSecurityGroups is the configuration
+                                  for the Network Security Groups required in the
+                                  VCN.
+                                items:
+                                  description: NSG defines configuration for a Network
+                                    Security Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                                  properties:
+                                    egressRules:
+                                      description: EgressRules on the NSG.
+                                      items:
+                                        description: EgressSecurityRuleForNSG is EgressSecurityRule
+                                          for NSG.
+                                        properties:
+                                          egressRule:
+                                            description: EgressSecurityRule A rule
+                                              for allowing outbound IP packets.
+                                            properties:
+                                              description:
+                                                description: An optional description
+                                                  of your choice for the rule.
+                                                type: string
+                                              destination:
+                                                description: 'Conceptually, this is
+                                                  the range of IP addresses that a
+                                                  packet originating from the instance
+                                                  can go to. Allowed values: * IP
+                                                  address range in CIDR notation.
+                                                  For example: `192.168.1.0/24` or
+                                                  `2001:0db8:0123:45::/56` Note that
+                                                  IPv6 addressing is currently supported
+                                                  only in certain regions. See IPv6
+                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                  * The `cidrBlock` value for a Service,
+                                                  if you''re setting up a security
+                                                  list rule for traffic destined for
+                                                  a particular `Service` through a
+                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                type: string
+                                              destinationType:
+                                                description: 'Type of destination
+                                                  for the rule. The default is `CIDR_BLOCK`.
+                                                  Allowed values: * `CIDR_BLOCK`:
+                                                  If the rule''s `destination` is
+                                                  an IP address range in CIDR notation.
+                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
+                                                  `destination` is the `cidrBlock`
+                                                  value for a Service (the rule is
+                                                  for traffic destined for a particular
+                                                  `Service` through a service gateway).'
+                                                type: string
+                                              icmpOptions:
+                                                description: 'IcmpOptions Optional
+                                                  and valid only for ICMP and ICMPv6.
+                                                  Use to specify a particular ICMP
+                                                  type and code as defined in: - ICMP
+                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                  - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                                  If you specify ICMP or ICMPv6 as
+                                                  the protocol but omit this object,
+                                                  then all ICMP types and codes are
+                                                  allowed. If you do provide this
+                                                  object, the type is required and
+                                                  the code is optional. To enable
+                                                  MTU negotiation for ingress internet
+                                                  traffic via IPv4, make sure to allow
+                                                  type 3 ("Destination Unreachable")
+                                                  code 4 ("Fragmentation Needed and
+                                                  Don''t Fragment was Set"). If you
+                                                  need to specify multiple codes for
+                                                  a single type, create a separate
+                                                  security list rule for each.'
+                                                properties:
+                                                  code:
+                                                    description: The ICMP code (optional).
+                                                    type: integer
+                                                  type:
+                                                    description: The ICMP type.
+                                                    type: integer
+                                                type: object
+                                              isStateless:
+                                                description: A stateless rule allows
+                                                  traffic in one direction. Remember
+                                                  to add a corresponding stateless
+                                                  rule in the other direction if you
+                                                  need to support bidirectional traffic.
+                                                  For example, if egress traffic allows
+                                                  TCP destination port 80, there should
+                                                  be an ingress rule to allow TCP
+                                                  source port 80. Defaults to false,
+                                                  which means the rule is stateful
+                                                  and a corresponding rule is not
+                                                  necessary for bidirectional traffic.
+                                                type: boolean
+                                              protocol:
+                                                description: The transport protocol.
+                                                  Specify either `all` or an IPv4
+                                                  protocol number as defined in Protocol
+                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP
+                                                  ("1"), TCP ("6"), UDP ("17"), and
+                                                  ICMPv6 ("58").
+                                                type: string
+                                              tcpOptions:
+                                                description: TcpOptions Optional and
+                                                  valid only for TCP. Use to specify
+                                                  particular destination ports for
+                                                  TCP rules. If you specify TCP as
+                                                  the protocol but omit this object,
+                                                  then all destination ports are allowed.
+                                                properties:
+                                                  destinationPortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                  sourcePortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                type: object
+                                              udpOptions:
+                                                description: UdpOptions Optional and
+                                                  valid only for UDP. Use to specify
+                                                  particular destination ports for
+                                                  UDP rules. If you specify UDP as
+                                                  the protocol but omit this object,
+                                                  then all destination ports are allowed.
+                                                properties:
+                                                  destinationPortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                  sourcePortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                type: object
+                                            type: object
+                                          id:
+                                            description: 'EgressSecurityRule ID for
+                                              NSG. Deprecated: this field is not populated
+                                              and used during reconciliation'
+                                            type: string
+                                        type: object
+                                      type: array
+                                    id:
+                                      description: NSG OCID.
+                                      type: string
+                                    ingressRules:
+                                      description: IngressRules on the NSG.
+                                      items:
+                                        description: IngressSecurityRuleForNSG is
+                                          IngressSecurityRule for NSG
+                                        properties:
+                                          id:
+                                            description: 'IngressSecurityRule ID for
+                                              NSG. Deprecated: this field is not populated
+                                              and used during reconciliation'
+                                            type: string
+                                          ingressRule:
+                                            description: IngressSecurityRule A rule
+                                              for allowing inbound IP packets.
+                                            properties:
+                                              description:
+                                                description: An optional description
+                                                  of your choice for the rule.
+                                                type: string
+                                              icmpOptions:
+                                                description: 'IcmpOptions Optional
+                                                  and valid only for ICMP and ICMPv6.
+                                                  Use to specify a particular ICMP
+                                                  type and code as defined in: - ICMP
+                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                  - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                                  If you specify ICMP or ICMPv6 as
+                                                  the protocol but omit this object,
+                                                  then all ICMP types and codes are
+                                                  allowed. If you do provide this
+                                                  object, the type is required and
+                                                  the code is optional. To enable
+                                                  MTU negotiation for ingress internet
+                                                  traffic via IPv4, make sure to allow
+                                                  type 3 ("Destination Unreachable")
+                                                  code 4 ("Fragmentation Needed and
+                                                  Don''t Fragment was Set"). If you
+                                                  need to specify multiple codes for
+                                                  a single type, create a separate
+                                                  security list rule for each.'
+                                                properties:
+                                                  code:
+                                                    description: The ICMP code (optional).
+                                                    type: integer
+                                                  type:
+                                                    description: The ICMP type.
+                                                    type: integer
+                                                type: object
+                                              isStateless:
+                                                description: A stateless rule allows
+                                                  traffic in one direction. Remember
+                                                  to add a corresponding stateless
+                                                  rule in the other direction if you
+                                                  need to support bidirectional traffic.
+                                                  For example, if ingress traffic
+                                                  allows TCP destination port 80,
+                                                  there should be an egress rule to
+                                                  allow TCP source port 80. Defaults
+                                                  to false, which means the rule is
+                                                  stateful and a corresponding rule
+                                                  is not necessary for bidirectional
+                                                  traffic.
+                                                type: boolean
+                                              protocol:
+                                                description: The transport protocol.
+                                                  Specify either `all` or an IPv4
+                                                  protocol number as defined in Protocol
+                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP
+                                                  ("1"), TCP ("6"), UDP ("17"), and
+                                                  ICMPv6 ("58").
+                                                type: string
+                                              source:
+                                                description: 'Conceptually, this is
+                                                  the range of IP addresses that a
+                                                  packet coming into the instance
+                                                  can come from. Allowed values: *
+                                                  IP address range in CIDR notation.
+                                                  For example: `192.168.1.0/24` or
+                                                  `2001:0db8:0123:45::/56`. IPv6 addressing
+                                                  is supported for all commercial
+                                                  and government regions. See IPv6
+                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                  * The `cidrBlock` value for a Service,
+                                                  if you''re setting up a security
+                                                  list rule for traffic coming from
+                                                  a particular `Service` through a
+                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                type: string
+                                              sourceType:
+                                                description: 'Type of source for the
+                                                  rule. The default is `CIDR_BLOCK`.
+                                                  * `CIDR_BLOCK`: If the rule''s `source`
+                                                  is an IP address range in CIDR notation.
+                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
+                                                  `source` is the `cidrBlock` value
+                                                  for a Service (the rule is for traffic
+                                                  coming from a particular `Service`
+                                                  through a service gateway).'
+                                                type: string
+                                              tcpOptions:
+                                                description: TcpOptions Optional and
+                                                  valid only for TCP. Use to specify
+                                                  particular destination ports for
+                                                  TCP rules. If you specify TCP as
+                                                  the protocol but omit this object,
+                                                  then all destination ports are allowed.
+                                                properties:
+                                                  destinationPortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                  sourcePortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                type: object
+                                              udpOptions:
+                                                description: UdpOptions Optional and
+                                                  valid only for UDP. Use to specify
+                                                  particular destination ports for
+                                                  UDP rules. If you specify UDP as
+                                                  the protocol but omit this object,
+                                                  then all destination ports are allowed.
+                                                properties:
+                                                  destinationPortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                  sourcePortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                type: object
+                                            type: object
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: NSG Name.
+                                      type: string
+                                    role:
+                                      description: Role defines the NSG role (eg.
+                                        control-plane, control-plane-endpoint, service-lb,
+                                        worker).
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              privateRouteTableId:
+                                description: ID of Private Route Table.
+                                type: string
+                              publicRouteTableId:
+                                description: ID of Public Route Table.
+                                type: string
+                              serviceGatewayId:
+                                description: ID of Service Gateway.
+                                type: string
+                              subnets:
+                                description: Subnets is the configuration for subnets
+                                  required in the VCN.
+                                items:
+                                  description: Subnet defines the configuration for
+                                    a network's subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                                  properties:
+                                    cidr:
+                                      description: Subnet CIDR.
+                                      type: string
+                                    id:
+                                      description: Subnet OCID.
+                                      type: string
+                                    name:
+                                      description: Subnet Name.
+                                      type: string
+                                    role:
+                                      description: Role defines the subnet role (eg.
+                                        control-plane, control-plane-endpoint, service-lb,
+                                        worker).
+                                      type: string
+                                    securityList:
+                                      description: The security list associated with
+                                        Subnet.
+                                      properties:
+                                        egressRules:
+                                          description: EgressRules on the SecurityList.
+                                          items:
+                                            description: EgressSecurityRule A rule
+                                              for allowing outbound IP packets.
+                                            properties:
+                                              description:
+                                                description: An optional description
+                                                  of your choice for the rule.
+                                                type: string
+                                              destination:
+                                                description: 'Conceptually, this is
+                                                  the range of IP addresses that a
+                                                  packet originating from the instance
+                                                  can go to. Allowed values: * IP
+                                                  address range in CIDR notation.
+                                                  For example: `192.168.1.0/24` or
+                                                  `2001:0db8:0123:45::/56` Note that
+                                                  IPv6 addressing is currently supported
+                                                  only in certain regions. See IPv6
+                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                  * The `cidrBlock` value for a Service,
+                                                  if you''re setting up a security
+                                                  list rule for traffic destined for
+                                                  a particular `Service` through a
+                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                type: string
+                                              destinationType:
+                                                description: 'Type of destination
+                                                  for the rule. The default is `CIDR_BLOCK`.
+                                                  Allowed values: * `CIDR_BLOCK`:
+                                                  If the rule''s `destination` is
+                                                  an IP address range in CIDR notation.
+                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
+                                                  `destination` is the `cidrBlock`
+                                                  value for a Service (the rule is
+                                                  for traffic destined for a particular
+                                                  `Service` through a service gateway).'
+                                                type: string
+                                              icmpOptions:
+                                                description: 'IcmpOptions Optional
+                                                  and valid only for ICMP and ICMPv6.
+                                                  Use to specify a particular ICMP
+                                                  type and code as defined in: - ICMP
+                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                  - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                                  If you specify ICMP or ICMPv6 as
+                                                  the protocol but omit this object,
+                                                  then all ICMP types and codes are
+                                                  allowed. If you do provide this
+                                                  object, the type is required and
+                                                  the code is optional. To enable
+                                                  MTU negotiation for ingress internet
+                                                  traffic via IPv4, make sure to allow
+                                                  type 3 ("Destination Unreachable")
+                                                  code 4 ("Fragmentation Needed and
+                                                  Don''t Fragment was Set"). If you
+                                                  need to specify multiple codes for
+                                                  a single type, create a separate
+                                                  security list rule for each.'
+                                                properties:
+                                                  code:
+                                                    description: The ICMP code (optional).
+                                                    type: integer
+                                                  type:
+                                                    description: The ICMP type.
+                                                    type: integer
+                                                type: object
+                                              isStateless:
+                                                description: A stateless rule allows
+                                                  traffic in one direction. Remember
+                                                  to add a corresponding stateless
+                                                  rule in the other direction if you
+                                                  need to support bidirectional traffic.
+                                                  For example, if egress traffic allows
+                                                  TCP destination port 80, there should
+                                                  be an ingress rule to allow TCP
+                                                  source port 80. Defaults to false,
+                                                  which means the rule is stateful
+                                                  and a corresponding rule is not
+                                                  necessary for bidirectional traffic.
+                                                type: boolean
+                                              protocol:
+                                                description: The transport protocol.
+                                                  Specify either `all` or an IPv4
+                                                  protocol number as defined in Protocol
+                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP
+                                                  ("1"), TCP ("6"), UDP ("17"), and
+                                                  ICMPv6 ("58").
+                                                type: string
+                                              tcpOptions:
+                                                description: TcpOptions Optional and
+                                                  valid only for TCP. Use to specify
+                                                  particular destination ports for
+                                                  TCP rules. If you specify TCP as
+                                                  the protocol but omit this object,
+                                                  then all destination ports are allowed.
+                                                properties:
+                                                  destinationPortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                  sourcePortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                type: object
+                                              udpOptions:
+                                                description: UdpOptions Optional and
+                                                  valid only for UDP. Use to specify
+                                                  particular destination ports for
+                                                  UDP rules. If you specify UDP as
+                                                  the protocol but omit this object,
+                                                  then all destination ports are allowed.
+                                                properties:
+                                                  destinationPortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                  sourcePortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                type: object
+                                            type: object
+                                          type: array
+                                        id:
+                                          description: ID of the SecurityList.
+                                          type: string
+                                        ingressRules:
+                                          description: IngressRules on the SecurityList.
+                                          items:
+                                            description: IngressSecurityRule A rule
+                                              for allowing inbound IP packets.
+                                            properties:
+                                              description:
+                                                description: An optional description
+                                                  of your choice for the rule.
+                                                type: string
+                                              icmpOptions:
+                                                description: 'IcmpOptions Optional
+                                                  and valid only for ICMP and ICMPv6.
+                                                  Use to specify a particular ICMP
+                                                  type and code as defined in: - ICMP
+                                                  Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                                  - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                                  If you specify ICMP or ICMPv6 as
+                                                  the protocol but omit this object,
+                                                  then all ICMP types and codes are
+                                                  allowed. If you do provide this
+                                                  object, the type is required and
+                                                  the code is optional. To enable
+                                                  MTU negotiation for ingress internet
+                                                  traffic via IPv4, make sure to allow
+                                                  type 3 ("Destination Unreachable")
+                                                  code 4 ("Fragmentation Needed and
+                                                  Don''t Fragment was Set"). If you
+                                                  need to specify multiple codes for
+                                                  a single type, create a separate
+                                                  security list rule for each.'
+                                                properties:
+                                                  code:
+                                                    description: The ICMP code (optional).
+                                                    type: integer
+                                                  type:
+                                                    description: The ICMP type.
+                                                    type: integer
+                                                type: object
+                                              isStateless:
+                                                description: A stateless rule allows
+                                                  traffic in one direction. Remember
+                                                  to add a corresponding stateless
+                                                  rule in the other direction if you
+                                                  need to support bidirectional traffic.
+                                                  For example, if ingress traffic
+                                                  allows TCP destination port 80,
+                                                  there should be an egress rule to
+                                                  allow TCP source port 80. Defaults
+                                                  to false, which means the rule is
+                                                  stateful and a corresponding rule
+                                                  is not necessary for bidirectional
+                                                  traffic.
+                                                type: boolean
+                                              protocol:
+                                                description: The transport protocol.
+                                                  Specify either `all` or an IPv4
+                                                  protocol number as defined in Protocol
+                                                  Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                                  Options are supported only for ICMP
+                                                  ("1"), TCP ("6"), UDP ("17"), and
+                                                  ICMPv6 ("58").
+                                                type: string
+                                              source:
+                                                description: 'Conceptually, this is
+                                                  the range of IP addresses that a
+                                                  packet coming into the instance
+                                                  can come from. Allowed values: *
+                                                  IP address range in CIDR notation.
+                                                  For example: `192.168.1.0/24` or
+                                                  `2001:0db8:0123:45::/56`. IPv6 addressing
+                                                  is supported for all commercial
+                                                  and government regions. See IPv6
+                                                  Addresses (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                                  * The `cidrBlock` value for a Service,
+                                                  if you''re setting up a security
+                                                  list rule for traffic coming from
+                                                  a particular `Service` through a
+                                                  service gateway. For example: `oci-phx-objectstorage`.'
+                                                type: string
+                                              sourceType:
+                                                description: 'Type of source for the
+                                                  rule. The default is `CIDR_BLOCK`.
+                                                  * `CIDR_BLOCK`: If the rule''s `source`
+                                                  is an IP address range in CIDR notation.
+                                                  * `SERVICE_CIDR_BLOCK`: If the rule''s
+                                                  `source` is the `cidrBlock` value
+                                                  for a Service (the rule is for traffic
+                                                  coming from a particular `Service`
+                                                  through a service gateway).'
+                                                type: string
+                                              tcpOptions:
+                                                description: TcpOptions Optional and
+                                                  valid only for TCP. Use to specify
+                                                  particular destination ports for
+                                                  TCP rules. If you specify TCP as
+                                                  the protocol but omit this object,
+                                                  then all destination ports are allowed.
+                                                properties:
+                                                  destinationPortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                  sourcePortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                type: object
+                                              udpOptions:
+                                                description: UdpOptions Optional and
+                                                  valid only for UDP. Use to specify
+                                                  particular destination ports for
+                                                  UDP rules. If you specify UDP as
+                                                  the protocol but omit this object,
+                                                  then all destination ports are allowed.
+                                                properties:
+                                                  destinationPortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                  sourcePortRange:
+                                                    description: PortRange The representation
+                                                      of PortRange.
+                                                    properties:
+                                                      max:
+                                                        description: The maximum port
+                                                          number, which must not be
+                                                          less than the minimum port
+                                                          number. To specify a single
+                                                          port number, set both the
+                                                          min and max to the same
+                                                          value.
+                                                        type: integer
+                                                      min:
+                                                        description: The minimum port
+                                                          number, which must not be
+                                                          greater than the maximum
+                                                          port number.
+                                                        type: integer
+                                                    type: object
+                                                type: object
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: SecurityList Name.
+                                          type: string
+                                      type: object
+                                    type:
+                                      description: Type defines the subnet type (e.g.
+                                        public, private).
+                                      type: string
+                                  required:
+                                  - name
+                                  - role
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          vcnPeering:
+                            description: VCNPeering configuration.
+                            properties:
+                              drg:
+                                description: DRG configuration refers to the DRG which
+                                  has to be created if required. If management cluster
+                                  and workload cluster shares the same DRG, this fields
+                                  is not required to be specified.
+                                properties:
+                                  id:
+                                    description: ID is the OCID for the created DRG.
+                                    type: string
+                                  manage:
+                                    description: Manage defines whether the DRG has
+                                      to be managed(including create). If set to false(the
+                                      default) the ID has to be specified by the user
+                                      to a valid DRG ID to which the VCN has to be
+                                      attached.
+                                    type: boolean
+                                  name:
+                                    description: Name is the name of the created DRG.
+                                    type: string
+                                  vcnAttachmentId:
+                                    description: VcnAttachmentId is the ID of the
+                                      VCN attachment of the DRG. The workload cluster
+                                      VCN can be attached to either the management
+                                      cluster VCN if they are sharing the same DRG
+                                      or to the workload cluster DRG.
+                                    type: string
+                                type: object
+                              peerRouteRules:
+                                description: PeerRouteRules defines the routing rules
+                                  which will be added to the private route tables
+                                  of the workload cluster VCN. The routes defined
+                                  here will be directed to DRG.
+                                items:
+                                  description: PeerRouteRule defines a Route Rule
+                                    to be routed via a DRG.
+                                  properties:
+                                    vcnCIDRRange:
+                                      description: VCNCIDRRange is the CIDR Range
+                                        of peer VCN to which the workload cluster
+                                        VCN will be peered. The CIDR range is required
+                                        to add the route rule in the workload cluster
+                                        VCN, the route rule will forward any traffic
+                                        to the CIDR to the DRG.
+                                      type: string
+                                  type: object
+                                type: array
+                              remotePeeringConnections:
+                                description: RemotePeeringConnections defines the
+                                  RPC connections which be established with the workload
+                                  cluster DRG.
+                                items:
+                                  description: RemotePeeringConnection is used to
+                                    peer VCNs residing in different regions(typically).
+                                    Remote VCN Peering is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
+                                  properties:
+                                    managePeerRPC:
+                                      description: ManagePeerRPC will define if the
+                                        Peer VCN needs to be managed. If set to true
+                                        a Remote Peering Connection will be created
+                                        in the Peer DRG and the connection will be
+                                        created between local and peer RPC.
+                                      type: boolean
+                                    peerDRGId:
+                                      description: PeerDRGId defines the DRG ID of
+                                        the peer.
+                                      type: string
+                                    peerRPCConnectionId:
+                                      description: PeerRPCConnectionId defines the
+                                        RPC ID of peer. If ManagePeerRPC is set to
+                                        true this will be created by Cluster API Provider
+                                        for OCI, otherwise this has be defined by
+                                        the user.
+                                      type: string
+                                    peerRegionName:
+                                      description: PeerRegionName defined the region
+                                        name of Peer VCN.
+                                      type: string
+                                    rpcConnectionId:
+                                      description: RPCConnectionId is the connection
+                                        ID of the connection between peer and local
+                                        RPC.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      ociResourceIdentifier:
+                        description: The unique ID which will be used to tag all the
+                          resources created by this Cluster. The tag will be used
+                          to identify resources belonging to this cluster. this will
+                          be auto-generated and should not be set by the user.
+                        type: string
+                      region:
+                        description: Region the cluster operates in. It must be one
+                          of available regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                        type: string
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: ocimachinepools.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: OCIMachinePool
+    listKind: OCIMachinePoolList
+    plural: ocimachinepools
+    singular: ocimachinepool
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIMachinePoolSpec defines the desired state of OCIMachinePool
+            properties:
+              instanceConfiguration:
+                description: InstanceConfiguration defines the configuration of the
+                  instance pool instances.
+                properties:
+                  agentConfig:
+                    description: AgentConfig defines the options for the Oracle Cloud
+                      Agent software running on the instance.
+                    properties:
+                      areAllPluginsDisabled:
+                        description: AreAllPluginsDisabled defines whether Oracle
+                          Cloud Agent can run all the available plugins. This includes
+                          the management and monitoring plugins. To get a list of
+                          available plugins, use the ListInstanceagentAvailablePlugins
+                          operation in the Oracle Cloud Agent API. For more information
+                          about the available plugins, see Managing Plugins with Oracle
+                          Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                        type: boolean
+                      isManagementDisabled:
+                        description: 'IsManagementDisabled defines whether Oracle
+                          Cloud Agent can run all the available management plugins.
+                          Default value is false (management plugins are enabled).
+                          These are the management plugins: OS Management Service
+                          Agent and Compute Instance Run Command. The management plugins
+                          are controlled by this parameter and by the per-plugin configuration
+                          in the `pluginsConfig` object. - If `isManagementDisabled`
+                          is true, all of the management plugins are disabled, regardless
+                          of the per-plugin configuration. - If `isManagementDisabled`
+                          is false, all of the management plugins are enabled. You
+                          can optionally disable individual management plugins by
+                          providing a value in the `pluginsConfig` object.'
+                        type: boolean
+                      isMonitoringDisabled:
+                        description: 'IsMonitoringDisabled defines whether Oracle
+                          Cloud Agent can gather performance metrics and monitor the
+                          instance using the monitoring plugins. Default value is
+                          false (monitoring plugins are enabled). These are the monitoring
+                          plugins: Compute Instance Monitoring and Custom Logs Monitoring.
+                          The monitoring plugins are controlled by this parameter
+                          and by the per-plugin configuration in the `pluginsConfig`
+                          object. - If `isMonitoringDisabled` is true, all of the
+                          monitoring plugins are disabled, regardless of the per-plugin
+                          configuration. - If `isMonitoringDisabled` is false, all
+                          of the monitoring plugins are enabled. You can optionally
+                          disable individual monitoring plugins by providing a value
+                          in the `pluginsConfig` object.'
+                        type: boolean
+                      pluginsConfigs:
+                        description: PluginsConfig defines the configuration of plugins
+                          associated with this instance.
+                        items:
+                          description: InstanceAgentPluginConfig defines the configuration
+                            of plugins associated with this instance.
+                          properties:
+                            desiredState:
+                              description: 'DesiredState defines whether the plugin
+                                should be enabled or disabled. To enable the monitoring
+                                and management plugins, the `isMonitoringDisabled`
+                                and `isManagementDisabled` attributes must also be
+                                set to false. The following values are supported:
+                                * `ENABLED` * `DISABLED`'
+                              type: string
+                            name:
+                              description: Name defines the name of the plugin. To
+                                get a list of available plugins, use the ListInstanceagentAvailablePlugins
+                                operation in the Oracle Cloud Agent API. For more
+                                information about the available plugins, see Managing
+                                Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  availabilityConfig:
+                    description: LaunchInstanceAvailabilityConfig defines the options
+                      for VM migration during infrastructure maintenance events and
+                      for defining the availability of a VM instance after a maintenance
+                      event that impacts the underlying hardware.
+                    properties:
+                      isLiveMigrationPreferred:
+                        description: IsLiveMigrationPreferred defines whether to live
+                          migrate supported VM instances to a healthy physical VM
+                          host without disrupting running instances during infrastructure
+                          maintenance events. If null, Oracle chooses the best option
+                          for migrating the VM during infrastructure maintenance events.
+                        type: boolean
+                      recoveryAction:
+                        description: RecoveryAction defines the lifecycle state for
+                          an instance when it is recovered after infrastructure maintenance.
+                          * `RESTORE_INSTANCE` - The instance is restored to the lifecycle
+                          state it was in before the maintenance event. If the instance
+                          was running, it is automatically rebooted. This is the default
+                          action when a value is not set. * `STOP_INSTANCE` - The
+                          instance is recovered in the stopped state.
+                        type: string
+                    type: object
+                  capacityReservationId:
+                    description: CapacityReservationId defines the OCID of the compute
+                      capacity reservation this instance is launched under. You can
+                      opt out of all default reservations by specifying an empty string
+                      as input for this field. For more information, see Capacity
+                      Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
+                    type: string
+                  dedicatedVmHostId:
+                    description: DedicatedVmHostId defines the OCID of the dedicated
+                      VM host.
+                    type: string
+                  instanceConfigurationId:
+                    type: string
+                  instanceOptions:
+                    description: InstanceOptions defines the instance options
+                    properties:
+                      areLegacyImdsEndpointsDisabled:
+                        description: Whether to disable the legacy (/v1) instance
+                          metadata service endpoints. Customers who have migrated
+                          to /v2 should set this to true for added security. Default
+                          is false.
+                        type: boolean
+                    type: object
+                  instanceSourceViaImageConfig:
+                    description: InstanceSourceViaImageConfig defines the options
+                      for booting up instances via images
+                    properties:
+                      bootVolumeSizeInGBs:
+                        description: The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
+                          to extend the boot volume size.
+                        format: int64
+                        type: integer
+                      bootVolumeVpusPerGB:
+                        description: 'BootVolumeVpusPerGB defines the number of volume
+                          performance units (VPUs) that will be applied to this volume
+                          per GB, representing the Block Volume service''s elastic
+                          performance options. See Block Volume Performance Levels
+                          (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
+                          for more information. Allowed values: * `10`: Represents
+                          Balanced option. * `20`: Represents Higher Performance option.
+                          * `30`-`120`: Represents the Ultra High Performance option.
+                          For volumes with the auto-tuned performance feature enabled,
+                          this is set to the default (minimum) VPUs/GB.'
+                        format: int64
+                        type: integer
+                      imageId:
+                        description: OCID of the image to be used to launch the instance.
+                        type: string
+                      kmsKeyId:
+                        description: KmsKeyId defines the OCID of the Key Management
+                          key to assign as the master encryption key for the boot
+                          volume.
+                        type: string
+                    type: object
+                  instanceVnicConfiguration:
+                    description: NetworkDetails defines the configuration options
+                      for the network
+                    properties:
+                      assignPrivateDnsRecord:
+                        description: AssignPrivateDnsRecord defines whether the VNIC
+                          should be assigned a DNS record.
+                        type: boolean
+                      assignPublicIp:
+                        description: AssignPublicIp defines whether the instance should
+                          have a public IP address
+                        type: boolean
+                      displayName:
+                        description: DisplayName defines a user-friendly name. Does
+                          not have to be unique, and it's changeable. Avoid entering
+                          confidential information.
+                        type: string
+                      hostnameLabel:
+                        description: HostnameLabel defines the hostname for the VNIC's
+                          primary private IP. Used for DNS.
+                        type: string
+                      nsgId:
+                        description: "Deprecated, use \tNsgNames parameter to define
+                          the NSGs"
+                        type: string
+                      nsgNames:
+                        description: NsgNames defines a list of the nsg names of the
+                          network security groups (NSGs) to add the VNIC to.
+                        items:
+                          type: string
+                        type: array
+                      skipSourceDestCheck:
+                        description: SkipSourceDestCheck defines whether the source/destination
+                          check is disabled on the VNIC.
+                        type: boolean
+                      subnetId:
+                        description: SubnetId defines the ID of the subnet to use.
+                          Deprecated, use SubnetName parameter
+                        type: string
+                      subnetName:
+                        description: SubnetName defines the subnet name to use for
+                          the VNIC
+                        type: string
+                    type: object
+                  isPvEncryptionInTransitEnabled:
+                    default: true
+                    description: Is in transit encryption of volumes required.
+                    type: boolean
+                  launchOptions:
+                    description: LaunchOptions defines the options for tuning the
+                      compatibility and performance of VM shapes
+                    properties:
+                      bootVolumeType:
+                        description: BootVolumeType defines Emulation type for the
+                          boot volume. * `ISCSI` - ISCSI attached block storage device.
+                          * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated IDE disk.
+                          * `VFIO` - Direct attached Virtual Function storage. This
+                          is the default option for local data volumes on platform
+                          images. * `PARAVIRTUALIZED` - Paravirtualized disk. This
+                          is the default for boot volumes and remote block storage
+                          volumes on platform images.
+                        type: string
+                      firmware:
+                        description: Firmware defines the firmware used to boot VM.
+                          Select the option that matches your operating system. *
+                          `BIOS` - Boot VM using BIOS style firmware. This is compatible
+                          with both 32 bit and 64 bit operating systems that boot
+                          using MBR style bootloaders. * `UEFI_64` - Boot VM using
+                          UEFI style firmware compatible with 64 bit operating systems.
+                          This is the default for platform images.
+                        type: string
+                      isConsistentVolumeNamingEnabled:
+                        description: IsConsistentVolumeNamingEnabled defines whether
+                          to enable consistent volume naming feature. Defaults to
+                          false.
+                        type: boolean
+                      networkType:
+                        description: NetworkType defines the emulation type for the
+                          physical network interface card (NIC). * `E1000` - Emulated
+                          Gigabit ethernet controller. Compatible with Linux e1000
+                          network driver. * `VFIO` - Direct attached Virtual Function
+                          network controller. This is the networking type when you
+                          launch an instance using hardware-assisted (SR-IOV) networking.
+                          * `PARAVIRTUALIZED` - VM instances launch with paravirtualized
+                          devices using VirtIO drivers.
+                        type: string
+                      remoteDataVolumeType:
+                        description: RemoteDataVolumeType defines the emulation type
+                          for volume. * `ISCSI` - ISCSI attached block storage device.
+                          * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated IDE disk.
+                          * `VFIO` - Direct attached Virtual Function storage. This
+                          is the default option for local data volumes on platform
+                          images. * `PARAVIRTUALIZED` - Paravirtualized disk. This
+                          is the default for boot volumes and remote block storage
+                          volumes on platform images.
+                        type: string
+                    type: object
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Custom metadata key/value pairs that you provide,
+                      such as the SSH public key required to connect to the instance.
+                    type: object
+                  platformConfig:
+                    description: PlatformConfig defines the platform config parameters
+                    properties:
+                      amdMilanBmPlatformConfig:
+                        description: AmdMilanBmPlatformConfig describe AMD Milan BM
+                          platform configuration
+                        properties:
+                          areVirtualInstructionsEnabled:
+                            description: Whether virtualization instructions are available.
+                              For example, Secure Virtual Machine for AMD shapes or
+                              VT-x for Intel shapes.
+                            type: boolean
+                          isAccessControlServiceEnabled:
+                            description: Whether the Access Control Service is enabled
+                              on the instance. When enabled, the platform can enforce
+                              PCIe device isolation, required for VFIO device pass-through.
+                            type: boolean
+                          isInputOutputMemoryManagementUnitEnabled:
+                            description: Whether the input-output memory management
+                              unit is enabled.
+                            type: boolean
+                          isMeasuredBootEnabled:
+                            description: Whether the Measured Boot feature is enabled
+                              on the instance.
+                            type: boolean
+                          isMemoryEncryptionEnabled:
+                            description: Whether the instance is a confidential instance.
+                              If this value is `true`, the instance is a confidential
+                              instance. The default value is `false`.
+                            type: boolean
+                          isSecureBootEnabled:
+                            description: Whether Secure Boot is enabled on the instance.
+                            type: boolean
+                          isSymmetricMultiThreadingEnabled:
+                            description: Whether symmetric multithreading is enabled
+                              on the instance. Symmetric multithreading is also called
+                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution
+                              threads per core (OCPU). SMT permits multiple independent
+                              threads of execution, to better use the resources and
+                              increase the efficiency of the CPU. When multithreading
+                              is disabled, only one thread is permitted to run on
+                              each core, which can provide higher or more predictable
+                              performance for some workloads.
+                            type: boolean
+                          isTrustedPlatformModuleEnabled:
+                            description: Whether the Trusted Platform Module (TPM)
+                              is enabled on the instance.
+                            type: boolean
+                          numaNodesPerSocket:
+                            description: 'The number of NUMA nodes per socket (NPS).
+                              The following values are supported: * `NPS0` * `NPS1`
+                              * `NPS2` * `NPS4`'
+                            type: string
+                          percentageOfCoresEnabled:
+                            description: The percentage of cores enabled. Value must
+                              be a multiple of 25%. If the requested percentage results
+                              in a fractional number of cores, the system rounds up
+                              the number of cores across processors and provisions
+                              an instance with a whole number of cores. If the applications
+                              that you run on the instance use a core-based licensing
+                              model and need fewer cores than the full size of the
+                              shape, you can disable cores to reduce your licensing
+                              costs. The instance itself is billed for the full shape,
+                              regardless of whether all cores are enabled.
+                            type: integer
+                        type: object
+                      amdRomeBmGpuPlatformConfig:
+                        description: AmdMilanBmPlatformConfig describe AMD Rome BM
+                          platform configuration
+                        properties:
+                          areVirtualInstructionsEnabled:
+                            description: Whether virtualization instructions are available.
+                              For example, Secure Virtual Machine for AMD shapes or
+                              VT-x for Intel shapes.
+                            type: boolean
+                          isAccessControlServiceEnabled:
+                            description: Whether the Access Control Service is enabled
+                              on the instance. When enabled, the platform can enforce
+                              PCIe device isolation, required for VFIO device pass-through.
+                            type: boolean
+                          isInputOutputMemoryManagementUnitEnabled:
+                            description: Whether the input-output memory management
+                              unit is enabled.
+                            type: boolean
+                          isMeasuredBootEnabled:
+                            description: Whether the Measured Boot feature is enabled
+                              on the instance.
+                            type: boolean
+                          isMemoryEncryptionEnabled:
+                            description: Whether the instance is a confidential instance.
+                              If this value is `true`, the instance is a confidential
+                              instance. The default value is `false`.
+                            type: boolean
+                          isSecureBootEnabled:
+                            description: Whether Secure Boot is enabled on the instance.
+                            type: boolean
+                          isSymmetricMultiThreadingEnabled:
+                            description: Whether symmetric multithreading is enabled
+                              on the instance. Symmetric multithreading is also called
+                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution
+                              threads per core (OCPU). SMT permits multiple independent
+                              threads of execution, to better use the resources and
+                              increase the efficiency of the CPU. When multithreading
+                              is disabled, only one thread is permitted to run on
+                              each core, which can provide higher or more predictable
+                              performance for some workloads.
+                            type: boolean
+                          isTrustedPlatformModuleEnabled:
+                            description: Whether the Trusted Platform Module (TPM)
+                              is enabled on the instance.
+                            type: boolean
+                          numaNodesPerSocket:
+                            description: 'The number of NUMA nodes per socket (NPS).
+                              The following values are supported: * `NPS0` * `NPS1`
+                              * `NPS2` * `NPS4`'
+                            type: string
+                        type: object
+                      amdRomeBmPlatformConfig:
+                        description: AmdMilanBmPlatformConfig describe AMD Rome BM
+                          platform configuration
+                        properties:
+                          areVirtualInstructionsEnabled:
+                            description: Whether virtualization instructions are available.
+                              For example, Secure Virtual Machine for AMD shapes or
+                              VT-x for Intel shapes.
+                            type: boolean
+                          isAccessControlServiceEnabled:
+                            description: Whether the Access Control Service is enabled
+                              on the instance. When enabled, the platform can enforce
+                              PCIe device isolation, required for VFIO device pass-through.
+                            type: boolean
+                          isInputOutputMemoryManagementUnitEnabled:
+                            description: Whether the input-output memory management
+                              unit is enabled.
+                            type: boolean
+                          isMeasuredBootEnabled:
+                            description: Whether the Measured Boot feature is enabled
+                              on the instance.
+                            type: boolean
+                          isMemoryEncryptionEnabled:
+                            description: Whether the instance is a confidential instance.
+                              If this value is `true`, the instance is a confidential
+                              instance. The default value is `false`.
+                            type: boolean
+                          isSecureBootEnabled:
+                            description: Whether Secure Boot is enabled on the instance.
+                            type: boolean
+                          isSymmetricMultiThreadingEnabled:
+                            description: Whether symmetric multithreading is enabled
+                              on the instance. Symmetric multithreading is also called
+                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution
+                              threads per core (OCPU). SMT permits multiple independent
+                              threads of execution, to better use the resources and
+                              increase the efficiency of the CPU. When multithreading
+                              is disabled, only one thread is permitted to run on
+                              each core, which can provide higher or more predictable
+                              performance for some workloads.
+                            type: boolean
+                          isTrustedPlatformModuleEnabled:
+                            description: Whether the Trusted Platform Module (TPM)
+                              is enabled on the instance.
+                            type: boolean
+                          numaNodesPerSocket:
+                            description: 'The number of NUMA nodes per socket (NPS).
+                              The following values are supported: * `NPS0` * `NPS1`
+                              * `NPS2` * `NPS4`'
+                            type: string
+                          percentageOfCoresEnabled:
+                            description: The percentage of cores enabled. Value must
+                              be a multiple of 25%. If the requested percentage results
+                              in a fractional number of cores, the system rounds up
+                              the number of cores across processors and provisions
+                              an instance with a whole number of cores. If the applications
+                              that you run on the instance use a core-based licensing
+                              model and need fewer cores than the full size of the
+                              shape, you can disable cores to reduce your licensing
+                              costs. The instance itself is billed for the full shape,
+                              regardless of whether all cores are enabled.
+                            type: integer
+                        type: object
+                      amdVmPlatformConfig:
+                        description: AmdMilanBmPlatformConfig describe AMD VM platform
+                          configuration
+                        properties:
+                          isMeasuredBootEnabled:
+                            description: Whether the Measured Boot feature is enabled
+                              on the instance.
+                            type: boolean
+                          isMemoryEncryptionEnabled:
+                            description: Whether the instance is a confidential instance.
+                              If this value is `true`, the instance is a confidential
+                              instance. The default value is `false`.
+                            type: boolean
+                          isSecureBootEnabled:
+                            description: Whether Secure Boot is enabled on the instance.
+                            type: boolean
+                          isTrustedPlatformModuleEnabled:
+                            description: Whether the Trusted Platform Module (TPM)
+                              is enabled on the instance.
+                            type: boolean
+                        type: object
+                      intelIcelakeBmPlatformConfig:
+                        description: AmdMilanBmPlatformConfig describe Intel Skylke
+                          BM platform configuration
+                        properties:
+                          isInputOutputMemoryManagementUnitEnabled:
+                            description: Whether the input-output memory management
+                              unit is enabled.
+                            type: boolean
+                          isMeasuredBootEnabled:
+                            description: Whether the Measured Boot feature is enabled
+                              on the instance.
+                            type: boolean
+                          isMemoryEncryptionEnabled:
+                            description: Whether the instance is a confidential instance.
+                              If this value is `true`, the instance is a confidential
+                              instance. The default value is `false`.
+                            type: boolean
+                          isSecureBootEnabled:
+                            description: Whether Secure Boot is enabled on the instance.
+                            type: boolean
+                          isSymmetricMultiThreadingEnabled:
+                            description: Whether symmetric multithreading is enabled
+                              on the instance. Symmetric multithreading is also called
+                              simultaneous multithreading (SMT) or Intel Hyper-Threading.
+                              Intel and AMD processors have two hardware execution
+                              threads per core (OCPU). SMT permits multiple independent
+                              threads of execution, to better use the resources and
+                              increase the efficiency of the CPU. When multithreading
+                              is disabled, only one thread is permitted to run on
+                              each core, which can provide higher or more predictable
+                              performance for some workloads.
+                            type: boolean
+                          isTrustedPlatformModuleEnabled:
+                            description: Whether the Trusted Platform Module (TPM)
+                              is enabled on the instance.
+                            type: boolean
+                          numaNodesPerSocket:
+                            description: 'The number of NUMA nodes per socket (NPS).
+                              The following values are supported: * `NPS1` * `NPS2`'
+                            type: string
+                          percentageOfCoresEnabled:
+                            description: The percentage of cores enabled. Value must
+                              be a multiple of 25%. If the requested percentage results
+                              in a fractional number of cores, the system rounds up
+                              the number of cores across processors and provisions
+                              an instance with a whole number of cores. If the applications
+                              that you run on the instance use a core-based licensing
+                              model and need fewer cores than the full size of the
+                              shape, you can disable cores to reduce your licensing
+                              costs. The instance itself is billed for the full shape,
+                              regardless of whether all cores are enabled.
+                            type: integer
+                        type: object
+                      intelSkylakeBmPlatformConfig:
+                        description: AmdMilanBmPlatformConfig describe Intel Skylke
+                          BM platform configuration
+                        properties:
+                          isMeasuredBootEnabled:
+                            description: Whether the Measured Boot feature is enabled
+                              on the instance.
+                            type: boolean
+                          isMemoryEncryptionEnabled:
+                            description: Whether the instance is a confidential instance.
+                              If this value is `true`, the instance is a confidential
+                              instance. The default value is `false`.
+                            type: boolean
+                          isSecureBootEnabled:
+                            description: Whether Secure Boot is enabled on the instance.
+                            type: boolean
+                          isTrustedPlatformModuleEnabled:
+                            description: Whether the Trusted Platform Module (TPM)
+                              is enabled on the instance.
+                            type: boolean
+                        type: object
+                      intelVmPlatformConfig:
+                        description: AmdMilanBmPlatformConfig describe Intel VM platform
+                          configuration
+                        properties:
+                          isMeasuredBootEnabled:
+                            description: Whether the Measured Boot feature is enabled
+                              on the instance.
+                            type: boolean
+                          isMemoryEncryptionEnabled:
+                            description: Whether the instance is a confidential instance.
+                              If this value is `true`, the instance is a confidential
+                              instance. The default value is `false`.
+                            type: boolean
+                          isSecureBootEnabled:
+                            description: Whether Secure Boot is enabled on the instance.
+                            type: boolean
+                          isTrustedPlatformModuleEnabled:
+                            description: Whether the Trusted Platform Module (TPM)
+                              is enabled on the instance.
+                            type: boolean
+                        type: object
+                      platformConfigType:
+                        description: The type of platform configuration. Valid values
+                          are * `AMD_ROME_BM_GPU` * `AMD_ROME_BM` * `INTEL_ICELAKE_BM`
+                          * `AMD_VM` * `INTEL_VM` * `INTEL_SKYLAKE_BM` * `AMD_MILAN_BM`
+                          Based on the enum, exactly one of the specific configuration
+                          types must be set
+                        type: string
+                    type: object
+                  preemptibleInstanceConfig:
+                    description: PreemptibleInstanceConfig Configuration options for
+                      preemptible instances.
+                    properties:
+                      terminatePreemptionAction:
+                        description: TerminatePreemptionAction terminates the preemptible
+                          instance when it is interrupted for eviction.
+                        properties:
+                          preserveBootVolume:
+                            description: PreserveBootVolume defines whether to preserve
+                              the boot volume that was used to launch the preemptible
+                              instance when the instance is terminated. Defaults to
+                              false if not specified.
+                            type: boolean
+                        type: object
+                    type: object
+                  shape:
+                    type: string
+                  shapeConfig:
+                    description: The shape configuration of the instance, applicable
+                      for flex instances.
+                    properties:
+                      baselineOcpuUtilization:
+                        description: 'The baseline OCPU utilization for a subcore
+                          burstable VM instance. Leave this attribute blank for a
+                          non-burstable instance, or explicitly specify non-burstable
+                          with `BASELINE_1_1`. The following values are supported:
+                          - `BASELINE_1_8` - baseline usage is 1/8 of an OCPU. - `BASELINE_1_2`
+                          - baseline usage is 1/2 of an OCPU. - `BASELINE_1_1` - baseline
+                          usage is an entire OCPU. This represents a non-burstable
+                          instance.'
+                        type: string
+                      memoryInGBs:
+                        description: The total amount of memory available to the instance,
+                          in gigabytes.
+                        type: string
+                      nvmes:
+                        description: Nvmes defines the number of NVMe drives to be
+                          used for storage. A single drive has 6.8 TB available.
+                        type: integer
+                      ocpus:
+                        description: The total number of OCPUs available to the instance.
+                        type: string
+                    type: object
+                type: object
+              ocid:
+                description: OCID is the OCID of the associated InstancePool
+                type: string
+              placementDetails:
+                description: PlacementDetails defines the placement details of the
+                  instance pool.
+                items:
+                  properties:
+                    availabilityDomain:
+                      description: The availability domain to place instances.
+                      type: integer
+                  required:
+                  - availabilityDomain
+                  type: object
+                type: array
+              providerID:
+                description: ProviderID is the OCID of the associated InstancePool
+                  in a provider format
+                type: string
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: OCIMachinePoolStatus defines the observed state of OCIMachinePool
+            properties:
+              conditions:
+                description: Conditions defines current service state of the OCIMachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                type: string
+              failureReason:
+                description: MachineStatusError defines errors states for Machine
+                  objects.
+                type: string
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: cluster-api-provider-oci-system/capoci-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: ocimachines.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capoci-webhook-service
+          namespace: cluster-api-provider-oci-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: OCIMachine
+    listKind: OCIMachineList
+    plural: ocimachines
+    singular: ocimachine
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OCIMachine is the Schema for the ocimachines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIMachineSpec defines the desired state of OCIMachine Please
+              read the API https://docs.oracle.com/en-us/iaas/api/#/en/iaas/20160918/Instance/LaunchInstance
+              for more information about the parameters below
+            properties:
+              agentConfig:
+                description: AgentConfig defines the options for the Oracle Cloud
+                  Agent software running on the instance.
+                properties:
+                  areAllPluginsDisabled:
+                    description: AreAllPluginsDisabled defines whether Oracle Cloud
+                      Agent can run all the available plugins. This includes the management
+                      and monitoring plugins. To get a list of available plugins,
+                      use the ListInstanceagentAvailablePlugins operation in the Oracle
+                      Cloud Agent API. For more information about the available plugins,
+                      see Managing Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                    type: boolean
+                  isManagementDisabled:
+                    description: 'IsManagementDisabled defines whether Oracle Cloud
+                      Agent can run all the available management plugins. Default
+                      value is false (management plugins are enabled). These are the
+                      management plugins: OS Management Service Agent and Compute
+                      Instance Run Command. The management plugins are controlled
+                      by this parameter and by the per-plugin configuration in the
+                      `pluginsConfig` object. - If `isManagementDisabled` is true,
+                      all of the management plugins are disabled, regardless of the
+                      per-plugin configuration. - If `isManagementDisabled` is false,
+                      all of the management plugins are enabled. You can optionally
+                      disable individual management plugins by providing a value in
+                      the `pluginsConfig` object.'
+                    type: boolean
+                  isMonitoringDisabled:
+                    description: 'IsMonitoringDisabled defines whether Oracle Cloud
+                      Agent can gather performance metrics and monitor the instance
+                      using the monitoring plugins. Default value is false (monitoring
+                      plugins are enabled). These are the monitoring plugins: Compute
+                      Instance Monitoring and Custom Logs Monitoring. The monitoring
+                      plugins are controlled by this parameter and by the per-plugin
+                      configuration in the `pluginsConfig` object. - If `isMonitoringDisabled`
+                      is true, all of the monitoring plugins are disabled, regardless
+                      of the per-plugin configuration. - If `isMonitoringDisabled`
+                      is false, all of the monitoring plugins are enabled. You can
+                      optionally disable individual monitoring plugins by providing
+                      a value in the `pluginsConfig` object.'
+                    type: boolean
+                  pluginsConfigs:
+                    description: PluginsConfig defines the configuration of plugins
+                      associated with this instance.
+                    items:
+                      description: InstanceAgentPluginConfig defines the configuration
+                        of plugins associated with this instance.
+                      properties:
+                        desiredState:
+                          description: 'DesiredState defines whether the plugin should
+                            be enabled or disabled. To enable the monitoring and management
+                            plugins, the `isMonitoringDisabled` and `isManagementDisabled`
+                            attributes must also be set to false. The following values
+                            are supported: * `ENABLED` * `DISABLED`'
+                          type: string
+                        name:
+                          description: Name defines the name of the plugin. To get
+                            a list of available plugins, use the ListInstanceagentAvailablePlugins
+                            operation in the Oracle Cloud Agent API. For more information
+                            about the available plugins, see Managing Plugins with
+                            Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              availabilityConfig:
+                description: LaunchInstanceAvailabilityConfig defines the options
+                  for VM migration during infrastructure maintenance events and for
+                  defining the availability of a VM instance after a maintenance event
+                  that impacts the underlying hardware.
+                properties:
+                  isLiveMigrationPreferred:
+                    description: IsLiveMigrationPreferred defines whether to live
+                      migrate supported VM instances to a healthy physical VM host
+                      without disrupting running instances during infrastructure maintenance
+                      events. If null, Oracle chooses the best option for migrating
+                      the VM during infrastructure maintenance events.
+                    type: boolean
+                  recoveryAction:
+                    description: RecoveryAction defines the lifecycle state for an
+                      instance when it is recovered after infrastructure maintenance.
+                      * `RESTORE_INSTANCE` - The instance is restored to the lifecycle
+                      state it was in before the maintenance event. If the instance
+                      was running, it is automatically rebooted. This is the default
+                      action when a value is not set. * `STOP_INSTANCE` - The instance
+                      is recovered in the stopped state.
+                    type: string
+                type: object
+              bootVolumeSizeInGBs:
+                description: The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
+                  to extend the boot volume size.
+                type: string
+              capacityReservationId:
+                description: CapacityReservationId defines the OCID of the compute
+                  capacity reservation this instance is launched under. You can opt
+                  out of all default reservations by specifying an empty string as
+                  input for this field. For more information, see Capacity Reservations
+                  (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
+                type: string
+              compartmentId:
+                description: Compartment to launch the instance in.
+                type: string
+              dedicatedVmHostId:
+                description: DedicatedVmHostId defines the OCID of the dedicated VM
+                  host.
+                type: string
+              definedTags:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                description: 'Defined tags for this resource. Each key is predefined
+                  and scoped to a namespace. For more information, see Resource Tags
+                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                  Example: `{"Operations": {"CostCenter": "42"}}`'
+                type: object
+              freeformTags:
+                additionalProperties:
+                  type: string
+                description: Free-form tags for this resource.
+                type: object
+              imageId:
+                description: OCID of the image to be used to launch the instance.
+                type: string
+              instanceId:
+                description: OCID of launched compute instance.
+                type: string
+              instanceOptions:
+                description: InstanceOptions defines the instance options
+                properties:
+                  areLegacyImdsEndpointsDisabled:
+                    description: Whether to disable the legacy (/v1) instance metadata
+                      service endpoints. Customers who have migrated to /v2 should
+                      set this to true for added security. Default is false.
+                    type: boolean
+                type: object
+              instanceSourceViaImageConfig:
+                description: InstanceSourceViaImageConfig defines the options for
+                  booting up instances via images
+                properties:
+                  bootVolumeVpusPerGB:
+                    description: 'BootVolumeVpusPerGB defines the number of volume
+                      performance units (VPUs) that will be applied to this volume
+                      per GB, representing the Block Volume service''s elastic performance
+                      options. See Block Volume Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
+                      for more information. Allowed values: * `10`: Represents Balanced
+                      option. * `20`: Represents Higher Performance option. * `30`-`120`:
+                      Represents the Ultra High Performance option. For volumes with
+                      the auto-tuned performance feature enabled, this is set to the
+                      default (minimum) VPUs/GB.'
+                    format: int64
+                    type: integer
+                  kmsKeyId:
+                    description: KmsKeyId defines the OCID of the Key Management key
+                      to assign as the master encryption key for the boot volume.
+                    type: string
+                type: object
+              ipxeScript:
+                type: string
+              isPvEncryptionInTransitEnabled:
+                default: true
+                description: Is in transit encryption of volumes required.
+                type: boolean
+              launchOptions:
+                description: LaunchOptions defines the options for tuning the compatibility
+                  and performance of VM shapes
+                properties:
+                  bootVolumeType:
+                    description: BootVolumeType defines Emulation type for the boot
+                      volume. * `ISCSI` - ISCSI attached block storage device. * `SCSI`
+                      - Emulated SCSI disk. * `IDE` - Emulated IDE disk. * `VFIO`
+                      - Direct attached Virtual Function storage. This is the default
+                      option for local data volumes on platform images. * `PARAVIRTUALIZED`
+                      - Paravirtualized disk. This is the default for boot volumes
+                      and remote block storage volumes on platform images.
+                    type: string
+                  firmware:
+                    description: Firmware defines the firmware used to boot VM. Select
+                      the option that matches your operating system. * `BIOS` - Boot
+                      VM using BIOS style firmware. This is compatible with both 32
+                      bit and 64 bit operating systems that boot using MBR style bootloaders.
+                      * `UEFI_64` - Boot VM using UEFI style firmware compatible with
+                      64 bit operating systems. This is the default for platform images.
+                    type: string
+                  isConsistentVolumeNamingEnabled:
+                    description: IsConsistentVolumeNamingEnabled defines whether to
+                      enable consistent volume naming feature. Defaults to false.
+                    type: boolean
+                  networkType:
+                    description: NetworkType defines the emulation type for the physical
+                      network interface card (NIC). * `E1000` - Emulated Gigabit ethernet
+                      controller. Compatible with Linux e1000 network driver. * `VFIO`
+                      - Direct attached Virtual Function network controller. This
+                      is the networking type when you launch an instance using hardware-assisted
+                      (SR-IOV) networking. * `PARAVIRTUALIZED` - VM instances launch
+                      with paravirtualized devices using VirtIO drivers.
+                    type: string
+                  remoteDataVolumeType:
+                    description: RemoteDataVolumeType defines the emulation type for
+                      volume. * `ISCSI` - ISCSI attached block storage device. * `SCSI`
+                      - Emulated SCSI disk. * `IDE` - Emulated IDE disk. * `VFIO`
+                      - Direct attached Virtual Function storage. This is the default
+                      option for local data volumes on platform images. * `PARAVIRTUALIZED`
+                      - Paravirtualized disk. This is the default for boot volumes
+                      and remote block storage volumes on platform images.
+                    type: string
+                type: object
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Custom metadata key/value pairs that you provide, such
+                  as the SSH public key required to connect to the instance.
+                type: object
+              networkDetails:
+                description: NetworkDetails defines the configuration options for
+                  the network
+                properties:
+                  assignPrivateDnsRecord:
+                    description: AssignPrivateDnsRecord defines whether the VNIC should
+                      be assigned a DNS record.
+                    type: boolean
+                  assignPublicIp:
+                    description: AssignPublicIp defines whether the instance should
+                      have a public IP address
+                    type: boolean
+                  displayName:
+                    description: DisplayName defines a user-friendly name. Does not
+                      have to be unique, and it's changeable. Avoid entering confidential
+                      information.
+                    type: string
+                  hostnameLabel:
+                    description: HostnameLabel defines the hostname for the VNIC's
+                      primary private IP. Used for DNS.
+                    type: string
+                  nsgId:
+                    description: "Deprecated, use \tNsgNames parameter to define the
+                      NSGs"
+                    type: string
+                  nsgNames:
+                    description: NsgNames defines a list of the nsg names of the network
+                      security groups (NSGs) to add the VNIC to.
+                    items:
+                      type: string
+                    type: array
+                  skipSourceDestCheck:
+                    description: SkipSourceDestCheck defines whether the source/destination
+                      check is disabled on the VNIC.
+                    type: boolean
+                  subnetId:
+                    description: SubnetId defines the ID of the subnet to use. Deprecated,
+                      use SubnetName parameter
+                    type: string
+                  subnetName:
+                    description: SubnetName defines the subnet name to use for the
+                      VNIC
+                    type: string
+                type: object
+              nsgName:
+                description: The name of NSG to use. The name here refers to the NSGs
+                  defined in the OCICluster Spec. Optional, only if multiple NSGs
+                  of a type is defined, else the first element is used. Deprecated,
+                  please use NetworkDetails.NSGNames
+                type: string
+              platformConfig:
+                description: PlatformConfig defines the platform config parameters
+                properties:
+                  amdMilanBmPlatformConfig:
+                    description: AmdMilanBmPlatformConfig describe AMD Milan BM platform
+                      configuration
+                    properties:
+                      areVirtualInstructionsEnabled:
+                        description: Whether virtualization instructions are available.
+                          For example, Secure Virtual Machine for AMD shapes or VT-x
+                          for Intel shapes.
+                        type: boolean
+                      isAccessControlServiceEnabled:
+                        description: Whether the Access Control Service is enabled
+                          on the instance. When enabled, the platform can enforce
+                          PCIe device isolation, required for VFIO device pass-through.
+                        type: boolean
+                      isInputOutputMemoryManagementUnitEnabled:
+                        description: Whether the input-output memory management unit
+                          is enabled.
+                        type: boolean
+                      isMeasuredBootEnabled:
+                        description: Whether the Measured Boot feature is enabled
+                          on the instance.
+                        type: boolean
+                      isMemoryEncryptionEnabled:
+                        description: Whether the instance is a confidential instance.
+                          If this value is `true`, the instance is a confidential
+                          instance. The default value is `false`.
+                        type: boolean
+                      isSecureBootEnabled:
+                        description: Whether Secure Boot is enabled on the instance.
+                        type: boolean
+                      isSymmetricMultiThreadingEnabled:
+                        description: Whether symmetric multithreading is enabled on
+                          the instance. Symmetric multithreading is also called simultaneous
+                          multithreading (SMT) or Intel Hyper-Threading. Intel and
+                          AMD processors have two hardware execution threads per core
+                          (OCPU). SMT permits multiple independent threads of execution,
+                          to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread
+                          is permitted to run on each core, which can provide higher
+                          or more predictable performance for some workloads.
+                        type: boolean
+                      isTrustedPlatformModuleEnabled:
+                        description: Whether the Trusted Platform Module (TPM) is
+                          enabled on the instance.
+                        type: boolean
+                      numaNodesPerSocket:
+                        description: 'The number of NUMA nodes per socket (NPS). The
+                          following values are supported: * `NPS0` * `NPS1` * `NPS2`
+                          * `NPS4`'
+                        type: string
+                      percentageOfCoresEnabled:
+                        description: The percentage of cores enabled. Value must be
+                          a multiple of 25%. If the requested percentage results in
+                          a fractional number of cores, the system rounds up the number
+                          of cores across processors and provisions an instance with
+                          a whole number of cores. If the applications that you run
+                          on the instance use a core-based licensing model and need
+                          fewer cores than the full size of the shape, you can disable
+                          cores to reduce your licensing costs. The instance itself
+                          is billed for the full shape, regardless of whether all
+                          cores are enabled.
+                        type: integer
+                    type: object
+                  amdRomeBmGpuPlatformConfig:
+                    description: AmdMilanBmPlatformConfig describe AMD Rome BM platform
+                      configuration
+                    properties:
+                      areVirtualInstructionsEnabled:
+                        description: Whether virtualization instructions are available.
+                          For example, Secure Virtual Machine for AMD shapes or VT-x
+                          for Intel shapes.
+                        type: boolean
+                      isAccessControlServiceEnabled:
+                        description: Whether the Access Control Service is enabled
+                          on the instance. When enabled, the platform can enforce
+                          PCIe device isolation, required for VFIO device pass-through.
+                        type: boolean
+                      isInputOutputMemoryManagementUnitEnabled:
+                        description: Whether the input-output memory management unit
+                          is enabled.
+                        type: boolean
+                      isMeasuredBootEnabled:
+                        description: Whether the Measured Boot feature is enabled
+                          on the instance.
+                        type: boolean
+                      isMemoryEncryptionEnabled:
+                        description: Whether the instance is a confidential instance.
+                          If this value is `true`, the instance is a confidential
+                          instance. The default value is `false`.
+                        type: boolean
+                      isSecureBootEnabled:
+                        description: Whether Secure Boot is enabled on the instance.
+                        type: boolean
+                      isSymmetricMultiThreadingEnabled:
+                        description: Whether symmetric multithreading is enabled on
+                          the instance. Symmetric multithreading is also called simultaneous
+                          multithreading (SMT) or Intel Hyper-Threading. Intel and
+                          AMD processors have two hardware execution threads per core
+                          (OCPU). SMT permits multiple independent threads of execution,
+                          to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread
+                          is permitted to run on each core, which can provide higher
+                          or more predictable performance for some workloads.
+                        type: boolean
+                      isTrustedPlatformModuleEnabled:
+                        description: Whether the Trusted Platform Module (TPM) is
+                          enabled on the instance.
+                        type: boolean
+                      numaNodesPerSocket:
+                        description: 'The number of NUMA nodes per socket (NPS). The
+                          following values are supported: * `NPS0` * `NPS1` * `NPS2`
+                          * `NPS4`'
+                        type: string
+                    type: object
+                  amdRomeBmPlatformConfig:
+                    description: AmdMilanBmPlatformConfig describe AMD Rome BM platform
+                      configuration
+                    properties:
+                      areVirtualInstructionsEnabled:
+                        description: Whether virtualization instructions are available.
+                          For example, Secure Virtual Machine for AMD shapes or VT-x
+                          for Intel shapes.
+                        type: boolean
+                      isAccessControlServiceEnabled:
+                        description: Whether the Access Control Service is enabled
+                          on the instance. When enabled, the platform can enforce
+                          PCIe device isolation, required for VFIO device pass-through.
+                        type: boolean
+                      isInputOutputMemoryManagementUnitEnabled:
+                        description: Whether the input-output memory management unit
+                          is enabled.
+                        type: boolean
+                      isMeasuredBootEnabled:
+                        description: Whether the Measured Boot feature is enabled
+                          on the instance.
+                        type: boolean
+                      isMemoryEncryptionEnabled:
+                        description: Whether the instance is a confidential instance.
+                          If this value is `true`, the instance is a confidential
+                          instance. The default value is `false`.
+                        type: boolean
+                      isSecureBootEnabled:
+                        description: Whether Secure Boot is enabled on the instance.
+                        type: boolean
+                      isSymmetricMultiThreadingEnabled:
+                        description: Whether symmetric multithreading is enabled on
+                          the instance. Symmetric multithreading is also called simultaneous
+                          multithreading (SMT) or Intel Hyper-Threading. Intel and
+                          AMD processors have two hardware execution threads per core
+                          (OCPU). SMT permits multiple independent threads of execution,
+                          to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread
+                          is permitted to run on each core, which can provide higher
+                          or more predictable performance for some workloads.
+                        type: boolean
+                      isTrustedPlatformModuleEnabled:
+                        description: Whether the Trusted Platform Module (TPM) is
+                          enabled on the instance.
+                        type: boolean
+                      numaNodesPerSocket:
+                        description: 'The number of NUMA nodes per socket (NPS). The
+                          following values are supported: * `NPS0` * `NPS1` * `NPS2`
+                          * `NPS4`'
+                        type: string
+                      percentageOfCoresEnabled:
+                        description: The percentage of cores enabled. Value must be
+                          a multiple of 25%. If the requested percentage results in
+                          a fractional number of cores, the system rounds up the number
+                          of cores across processors and provisions an instance with
+                          a whole number of cores. If the applications that you run
+                          on the instance use a core-based licensing model and need
+                          fewer cores than the full size of the shape, you can disable
+                          cores to reduce your licensing costs. The instance itself
+                          is billed for the full shape, regardless of whether all
+                          cores are enabled.
+                        type: integer
+                    type: object
+                  amdVmPlatformConfig:
+                    description: AmdMilanBmPlatformConfig describe AMD VM platform
+                      configuration
+                    properties:
+                      isMeasuredBootEnabled:
+                        description: Whether the Measured Boot feature is enabled
+                          on the instance.
+                        type: boolean
+                      isMemoryEncryptionEnabled:
+                        description: Whether the instance is a confidential instance.
+                          If this value is `true`, the instance is a confidential
+                          instance. The default value is `false`.
+                        type: boolean
+                      isSecureBootEnabled:
+                        description: Whether Secure Boot is enabled on the instance.
+                        type: boolean
+                      isTrustedPlatformModuleEnabled:
+                        description: Whether the Trusted Platform Module (TPM) is
+                          enabled on the instance.
+                        type: boolean
+                    type: object
+                  intelIcelakeBmPlatformConfig:
+                    description: AmdMilanBmPlatformConfig describe Intel Skylke BM
+                      platform configuration
+                    properties:
+                      isInputOutputMemoryManagementUnitEnabled:
+                        description: Whether the input-output memory management unit
+                          is enabled.
+                        type: boolean
+                      isMeasuredBootEnabled:
+                        description: Whether the Measured Boot feature is enabled
+                          on the instance.
+                        type: boolean
+                      isMemoryEncryptionEnabled:
+                        description: Whether the instance is a confidential instance.
+                          If this value is `true`, the instance is a confidential
+                          instance. The default value is `false`.
+                        type: boolean
+                      isSecureBootEnabled:
+                        description: Whether Secure Boot is enabled on the instance.
+                        type: boolean
+                      isSymmetricMultiThreadingEnabled:
+                        description: Whether symmetric multithreading is enabled on
+                          the instance. Symmetric multithreading is also called simultaneous
+                          multithreading (SMT) or Intel Hyper-Threading. Intel and
+                          AMD processors have two hardware execution threads per core
+                          (OCPU). SMT permits multiple independent threads of execution,
+                          to better use the resources and increase the efficiency
+                          of the CPU. When multithreading is disabled, only one thread
+                          is permitted to run on each core, which can provide higher
+                          or more predictable performance for some workloads.
+                        type: boolean
+                      isTrustedPlatformModuleEnabled:
+                        description: Whether the Trusted Platform Module (TPM) is
+                          enabled on the instance.
+                        type: boolean
+                      numaNodesPerSocket:
+                        description: 'The number of NUMA nodes per socket (NPS). The
+                          following values are supported: * `NPS1` * `NPS2`'
+                        type: string
+                      percentageOfCoresEnabled:
+                        description: The percentage of cores enabled. Value must be
+                          a multiple of 25%. If the requested percentage results in
+                          a fractional number of cores, the system rounds up the number
+                          of cores across processors and provisions an instance with
+                          a whole number of cores. If the applications that you run
+                          on the instance use a core-based licensing model and need
+                          fewer cores than the full size of the shape, you can disable
+                          cores to reduce your licensing costs. The instance itself
+                          is billed for the full shape, regardless of whether all
+                          cores are enabled.
+                        type: integer
+                    type: object
+                  intelSkylakeBmPlatformConfig:
+                    description: AmdMilanBmPlatformConfig describe Intel Skylke BM
+                      platform configuration
+                    properties:
+                      isMeasuredBootEnabled:
+                        description: Whether the Measured Boot feature is enabled
+                          on the instance.
+                        type: boolean
+                      isMemoryEncryptionEnabled:
+                        description: Whether the instance is a confidential instance.
+                          If this value is `true`, the instance is a confidential
+                          instance. The default value is `false`.
+                        type: boolean
+                      isSecureBootEnabled:
+                        description: Whether Secure Boot is enabled on the instance.
+                        type: boolean
+                      isTrustedPlatformModuleEnabled:
+                        description: Whether the Trusted Platform Module (TPM) is
+                          enabled on the instance.
+                        type: boolean
+                    type: object
+                  intelVmPlatformConfig:
+                    description: AmdMilanBmPlatformConfig describe Intel VM platform
+                      configuration
+                    properties:
+                      isMeasuredBootEnabled:
+                        description: Whether the Measured Boot feature is enabled
+                          on the instance.
+                        type: boolean
+                      isMemoryEncryptionEnabled:
+                        description: Whether the instance is a confidential instance.
+                          If this value is `true`, the instance is a confidential
+                          instance. The default value is `false`.
+                        type: boolean
+                      isSecureBootEnabled:
+                        description: Whether Secure Boot is enabled on the instance.
+                        type: boolean
+                      isTrustedPlatformModuleEnabled:
+                        description: Whether the Trusted Platform Module (TPM) is
+                          enabled on the instance.
+                        type: boolean
+                    type: object
+                  platformConfigType:
+                    description: The type of platform configuration. Valid values
+                      are * `AMD_ROME_BM_GPU` * `AMD_ROME_BM` * `INTEL_ICELAKE_BM`
+                      * `AMD_VM` * `INTEL_VM` * `INTEL_SKYLAKE_BM` * `AMD_MILAN_BM`
+                      Based on the enum, exactly one of the specific configuration
+                      types must be set
+                    type: string
+                type: object
+              preemptibleInstanceConfig:
+                description: PreemptibleInstanceConfig Configuration options for preemptible
+                  instances.
+                properties:
+                  terminatePreemptionAction:
+                    description: TerminatePreemptionAction terminates the preemptible
+                      instance when it is interrupted for eviction.
+                    properties:
+                      preserveBootVolume:
+                        description: PreserveBootVolume defines whether to preserve
+                          the boot volume that was used to launch the preemptible
+                          instance when the instance is terminated. Defaults to false
+                          if not specified.
+                        type: boolean
+                    type: object
+                type: object
+              providerID:
+                description: Provider ID of the instance, this will be set by Cluster
+                  API provider itself, users should not set this parameter.
+                type: string
+              shape:
+                description: Shape of the instance.
+                type: string
+              shapeConfig:
+                description: The shape configuration of rhe instance, applicable for
+                  flex instances.
+                properties:
+                  baselineOcpuUtilization:
+                    description: 'The baseline OCPU utilization for a subcore burstable
+                      VM instance. Leave this attribute blank for a non-burstable
+                      instance, or explicitly specify non-burstable with `BASELINE_1_1`.
+                      The following values are supported: - `BASELINE_1_8` - baseline
+                      usage is 1/8 of an OCPU. - `BASELINE_1_2` - baseline usage is
+                      1/2 of an OCPU. - `BASELINE_1_1` - baseline usage is an entire
+                      OCPU. This represents a non-burstable instance.'
+                    type: string
+                  memoryInGBs:
+                    description: The total amount of memory available to the instance,
+                      in gigabytes.
+                    type: string
+                  nvmes:
+                    description: Nvmes defines the number of NVMe drives to be used
+                      for storage. A single drive has 6.8 TB available.
+                    type: integer
+                  ocpus:
+                    description: The total number of OCPUs available to the instance.
+                    type: string
+                type: object
+              subnetName:
+                description: The name of the subnet to use. The name here refers to
+                  the subnets defined in the OCICluster Spec. Optional, only if multiple
+                  subnets of a type is defined, else the first element is used.
+                type: string
+              vnicAttachments:
+                description: VnicAttachments defines the configuration options for
+                  the vnic(s) attached to the machine The network bandwidth and number
+                  of VNICs scale proportionately with the number of OCPUs.
+                items:
+                  properties:
+                    assignPublicIp:
+                      description: AssignPublicIp defines whether the vnic should
+                        have a public IP address
+                      type: boolean
+                    displayName:
+                      description: DisplayName defines a user-friendly name. Does
+                        not have to be unique. Avoid entering confidential information.
+                      type: string
+                    nicIndex:
+                      description: NicIndex defines which physical Network Interface
+                        Card (NIC) to use You can determine which NICs are active
+                        for a shape by reviewing the https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
+                      type: integer
+                    subnetName:
+                      description: SubnetName defines the subnet name to use for the
+                        VNIC Defaults to the "worker" subnet if not provided
+                      type: string
+                    vnicAttachmentId:
+                      description: VnicAttachmentId defines the ID of the VnicAttachment
+                      type: string
+                  required:
+                  - displayName
+                  type: object
+                type: array
+            type: object
+          status:
+            description: OCIMachineStatus defines the observed state of OCIMachine.
+            properties:
+              addresses:
+                description: Addresses contains the addresses of the associated OCI
+                  instance.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the OCIMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              createBackendWorkRequestId:
+                description: Create Backend OPC work request ID for the machine backend.
+                type: string
+              deleteBackendWorkRequestId:
+                description: Delete Backend OPC work request ID for the machine backend.
+                type: string
+              failureMessage:
+                description: The error message corresponding to the error on the machine.
+                type: string
+              failureReason:
+                description: Error status on the machine.
+                type: string
+              launchInstanceWorkRequestId:
+                description: Launch instance work request ID.
+                type: string
+              ready:
+                description: Flag set to true when machine is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: ocimachinetemplates.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OCIMachineTemplate
+    listKind: OCIMachineTemplateList
+    plural: ocimachinetemplates
+    singular: ocimachinetemplate
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OCIMachineTemplate is the schema for the OCI compute instance
+          machine template.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIMachineTemplateSpec defines the desired state of OCIMachineTemplate.
+            properties:
+              template:
+                description: OCIMachineTemplateResource describes the data needed
+                  to create an OCIMachine from a template.
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      agentConfig:
+                        description: AgentConfig defines the options for the Oracle
+                          Cloud Agent software running on the instance.
+                        properties:
+                          areAllPluginsDisabled:
+                            description: AreAllPluginsDisabled defines whether Oracle
+                              Cloud Agent can run all the available plugins. This
+                              includes the management and monitoring plugins. To get
+                              a list of available plugins, use the ListInstanceagentAvailablePlugins
+                              operation in the Oracle Cloud Agent API. For more information
+                              about the available plugins, see Managing Plugins with
+                              Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                            type: boolean
+                          isManagementDisabled:
+                            description: 'IsManagementDisabled defines whether Oracle
+                              Cloud Agent can run all the available management plugins.
+                              Default value is false (management plugins are enabled).
+                              These are the management plugins: OS Management Service
+                              Agent and Compute Instance Run Command. The management
+                              plugins are controlled by this parameter and by the
+                              per-plugin configuration in the `pluginsConfig` object.
+                              - If `isManagementDisabled` is true, all of the management
+                              plugins are disabled, regardless of the per-plugin configuration.
+                              - If `isManagementDisabled` is false, all of the management
+                              plugins are enabled. You can optionally disable individual
+                              management plugins by providing a value in the `pluginsConfig`
+                              object.'
+                            type: boolean
+                          isMonitoringDisabled:
+                            description: 'IsMonitoringDisabled defines whether Oracle
+                              Cloud Agent can gather performance metrics and monitor
+                              the instance using the monitoring plugins. Default value
+                              is false (monitoring plugins are enabled). These are
+                              the monitoring plugins: Compute Instance Monitoring
+                              and Custom Logs Monitoring. The monitoring plugins are
+                              controlled by this parameter and by the per-plugin configuration
+                              in the `pluginsConfig` object. - If `isMonitoringDisabled`
+                              is true, all of the monitoring plugins are disabled,
+                              regardless of the per-plugin configuration. - If `isMonitoringDisabled`
+                              is false, all of the monitoring plugins are enabled.
+                              You can optionally disable individual monitoring plugins
+                              by providing a value in the `pluginsConfig` object.'
+                            type: boolean
+                          pluginsConfigs:
+                            description: PluginsConfig defines the configuration of
+                              plugins associated with this instance.
+                            items:
+                              description: InstanceAgentPluginConfig defines the configuration
+                                of plugins associated with this instance.
+                              properties:
+                                desiredState:
+                                  description: 'DesiredState defines whether the plugin
+                                    should be enabled or disabled. To enable the monitoring
+                                    and management plugins, the `isMonitoringDisabled`
+                                    and `isManagementDisabled` attributes must also
+                                    be set to false. The following values are supported:
+                                    * `ENABLED` * `DISABLED`'
+                                  type: string
+                                name:
+                                  description: Name defines the name of the plugin.
+                                    To get a list of available plugins, use the ListInstanceagentAvailablePlugins
+                                    operation in the Oracle Cloud Agent API. For more
+                                    information about the available plugins, see Managing
+                                    Plugins with Oracle Cloud Agent (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/manage-plugins.htm).
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      availabilityConfig:
+                        description: LaunchInstanceAvailabilityConfig defines the
+                          options for VM migration during infrastructure maintenance
+                          events and for defining the availability of a VM instance
+                          after a maintenance event that impacts the underlying hardware.
+                        properties:
+                          isLiveMigrationPreferred:
+                            description: IsLiveMigrationPreferred defines whether
+                              to live migrate supported VM instances to a healthy
+                              physical VM host without disrupting running instances
+                              during infrastructure maintenance events. If null, Oracle
+                              chooses the best option for migrating the VM during
+                              infrastructure maintenance events.
+                            type: boolean
+                          recoveryAction:
+                            description: RecoveryAction defines the lifecycle state
+                              for an instance when it is recovered after infrastructure
+                              maintenance. * `RESTORE_INSTANCE` - The instance is
+                              restored to the lifecycle state it was in before the
+                              maintenance event. If the instance was running, it is
+                              automatically rebooted. This is the default action when
+                              a value is not set. * `STOP_INSTANCE` - The instance
+                              is recovered in the stopped state.
+                            type: string
+                        type: object
+                      bootVolumeSizeInGBs:
+                        description: The size of boot volume. Please see https://docs.oracle.com/en-us/iaas/Content/Block/Tasks/extendingbootpartition.htm
+                          to extend the boot volume size.
+                        type: string
+                      capacityReservationId:
+                        description: CapacityReservationId defines the OCID of the
+                          compute capacity reservation this instance is launched under.
+                          You can opt out of all default reservations by specifying
+                          an empty string as input for this field. For more information,
+                          see Capacity Reservations (https://docs.cloud.oracle.com/iaas/Content/Compute/Tasks/reserve-capacity.htm#default).
+                        type: string
+                      compartmentId:
+                        description: Compartment to launch the instance in.
+                        type: string
+                      dedicatedVmHostId:
+                        description: DedicatedVmHostId defines the OCID of the dedicated
+                          VM host.
+                        type: string
+                      definedTags:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: 'Defined tags for this resource. Each key is
+                          predefined and scoped to a namespace. For more information,
+                          see Resource Tags (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                          Example: `{"Operations": {"CostCenter": "42"}}`'
+                        type: object
+                      freeformTags:
+                        additionalProperties:
+                          type: string
+                        description: Free-form tags for this resource.
+                        type: object
+                      imageId:
+                        description: OCID of the image to be used to launch the instance.
+                        type: string
+                      instanceId:
+                        description: OCID of launched compute instance.
+                        type: string
+                      instanceOptions:
+                        description: InstanceOptions defines the instance options
+                        properties:
+                          areLegacyImdsEndpointsDisabled:
+                            description: Whether to disable the legacy (/v1) instance
+                              metadata service endpoints. Customers who have migrated
+                              to /v2 should set this to true for added security. Default
+                              is false.
+                            type: boolean
+                        type: object
+                      instanceSourceViaImageConfig:
+                        description: InstanceSourceViaImageConfig defines the options
+                          for booting up instances via images
+                        properties:
+                          bootVolumeVpusPerGB:
+                            description: 'BootVolumeVpusPerGB defines the number of
+                              volume performance units (VPUs) that will be applied
+                              to this volume per GB, representing the Block Volume
+                              service''s elastic performance options. See Block Volume
+                              Performance Levels (https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/blockvolumeperformance.htm#perf_levels)
+                              for more information. Allowed values: * `10`: Represents
+                              Balanced option. * `20`: Represents Higher Performance
+                              option. * `30`-`120`: Represents the Ultra High Performance
+                              option. For volumes with the auto-tuned performance
+                              feature enabled, this is set to the default (minimum)
+                              VPUs/GB.'
+                            format: int64
+                            type: integer
+                          kmsKeyId:
+                            description: KmsKeyId defines the OCID of the Key Management
+                              key to assign as the master encryption key for the boot
+                              volume.
+                            type: string
+                        type: object
+                      ipxeScript:
+                        type: string
+                      isPvEncryptionInTransitEnabled:
+                        default: true
+                        description: Is in transit encryption of volumes required.
+                        type: boolean
+                      launchOptions:
+                        description: LaunchOptions defines the options for tuning
+                          the compatibility and performance of VM shapes
+                        properties:
+                          bootVolumeType:
+                            description: BootVolumeType defines Emulation type for
+                              the boot volume. * `ISCSI` - ISCSI attached block storage
+                              device. * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated
+                              IDE disk. * `VFIO` - Direct attached Virtual Function
+                              storage. This is the default option for local data volumes
+                              on platform images. * `PARAVIRTUALIZED` - Paravirtualized
+                              disk. This is the default for boot volumes and remote
+                              block storage volumes on platform images.
+                            type: string
+                          firmware:
+                            description: Firmware defines the firmware used to boot
+                              VM. Select the option that matches your operating system.
+                              * `BIOS` - Boot VM using BIOS style firmware. This is
+                              compatible with both 32 bit and 64 bit operating systems
+                              that boot using MBR style bootloaders. * `UEFI_64` -
+                              Boot VM using UEFI style firmware compatible with 64
+                              bit operating systems. This is the default for platform
+                              images.
+                            type: string
+                          isConsistentVolumeNamingEnabled:
+                            description: IsConsistentVolumeNamingEnabled defines whether
+                              to enable consistent volume naming feature. Defaults
+                              to false.
+                            type: boolean
+                          networkType:
+                            description: NetworkType defines the emulation type for
+                              the physical network interface card (NIC). * `E1000`
+                              - Emulated Gigabit ethernet controller. Compatible with
+                              Linux e1000 network driver. * `VFIO` - Direct attached
+                              Virtual Function network controller. This is the networking
+                              type when you launch an instance using hardware-assisted
+                              (SR-IOV) networking. * `PARAVIRTUALIZED` - VM instances
+                              launch with paravirtualized devices using VirtIO drivers.
+                            type: string
+                          remoteDataVolumeType:
+                            description: RemoteDataVolumeType defines the emulation
+                              type for volume. * `ISCSI` - ISCSI attached block storage
+                              device. * `SCSI` - Emulated SCSI disk. * `IDE` - Emulated
+                              IDE disk. * `VFIO` - Direct attached Virtual Function
+                              storage. This is the default option for local data volumes
+                              on platform images. * `PARAVIRTUALIZED` - Paravirtualized
+                              disk. This is the default for boot volumes and remote
+                              block storage volumes on platform images.
+                            type: string
+                        type: object
+                      metadata:
+                        additionalProperties:
+                          type: string
+                        description: Custom metadata key/value pairs that you provide,
+                          such as the SSH public key required to connect to the instance.
+                        type: object
+                      networkDetails:
+                        description: NetworkDetails defines the configuration options
+                          for the network
+                        properties:
+                          assignPrivateDnsRecord:
+                            description: AssignPrivateDnsRecord defines whether the
+                              VNIC should be assigned a DNS record.
+                            type: boolean
+                          assignPublicIp:
+                            description: AssignPublicIp defines whether the instance
+                              should have a public IP address
+                            type: boolean
+                          displayName:
+                            description: DisplayName defines a user-friendly name.
+                              Does not have to be unique, and it's changeable. Avoid
+                              entering confidential information.
+                            type: string
+                          hostnameLabel:
+                            description: HostnameLabel defines the hostname for the
+                              VNIC's primary private IP. Used for DNS.
+                            type: string
+                          nsgId:
+                            description: "Deprecated, use \tNsgNames parameter to
+                              define the NSGs"
+                            type: string
+                          nsgNames:
+                            description: NsgNames defines a list of the nsg names
+                              of the network security groups (NSGs) to add the VNIC
+                              to.
+                            items:
+                              type: string
+                            type: array
+                          skipSourceDestCheck:
+                            description: SkipSourceDestCheck defines whether the source/destination
+                              check is disabled on the VNIC.
+                            type: boolean
+                          subnetId:
+                            description: SubnetId defines the ID of the subnet to
+                              use. Deprecated, use SubnetName parameter
+                            type: string
+                          subnetName:
+                            description: SubnetName defines the subnet name to use
+                              for the VNIC
+                            type: string
+                        type: object
+                      nsgName:
+                        description: The name of NSG to use. The name here refers
+                          to the NSGs defined in the OCICluster Spec. Optional, only
+                          if multiple NSGs of a type is defined, else the first element
+                          is used. Deprecated, please use NetworkDetails.NSGNames
+                        type: string
+                      platformConfig:
+                        description: PlatformConfig defines the platform config parameters
+                        properties:
+                          amdMilanBmPlatformConfig:
+                            description: AmdMilanBmPlatformConfig describe AMD Milan
+                              BM platform configuration
+                            properties:
+                              areVirtualInstructionsEnabled:
+                                description: Whether virtualization instructions are
+                                  available. For example, Secure Virtual Machine for
+                                  AMD shapes or VT-x for Intel shapes.
+                                type: boolean
+                              isAccessControlServiceEnabled:
+                                description: Whether the Access Control Service is
+                                  enabled on the instance. When enabled, the platform
+                                  can enforce PCIe device isolation, required for
+                                  VFIO device pass-through.
+                                type: boolean
+                              isInputOutputMemoryManagementUnitEnabled:
+                                description: Whether the input-output memory management
+                                  unit is enabled.
+                                type: boolean
+                              isMeasuredBootEnabled:
+                                description: Whether the Measured Boot feature is
+                                  enabled on the instance.
+                                type: boolean
+                              isMemoryEncryptionEnabled:
+                                description: Whether the instance is a confidential
+                                  instance. If this value is `true`, the instance
+                                  is a confidential instance. The default value is
+                                  `false`.
+                                type: boolean
+                              isSecureBootEnabled:
+                                description: Whether Secure Boot is enabled on the
+                                  instance.
+                                type: boolean
+                              isSymmetricMultiThreadingEnabled:
+                                description: Whether symmetric multithreading is enabled
+                                  on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel
+                                  Hyper-Threading. Intel and AMD processors have two
+                                  hardware execution threads per core (OCPU). SMT
+                                  permits multiple independent threads of execution,
+                                  to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only
+                                  one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance
+                                  for some workloads.
+                                type: boolean
+                              isTrustedPlatformModuleEnabled:
+                                description: Whether the Trusted Platform Module (TPM)
+                                  is enabled on the instance.
+                                type: boolean
+                              numaNodesPerSocket:
+                                description: 'The number of NUMA nodes per socket
+                                  (NPS). The following values are supported: * `NPS0`
+                                  * `NPS1` * `NPS2` * `NPS4`'
+                                type: string
+                              percentageOfCoresEnabled:
+                                description: The percentage of cores enabled. Value
+                                  must be a multiple of 25%. If the requested percentage
+                                  results in a fractional number of cores, the system
+                                  rounds up the number of cores across processors
+                                  and provisions an instance with a whole number of
+                                  cores. If the applications that you run on the instance
+                                  use a core-based licensing model and need fewer
+                                  cores than the full size of the shape, you can disable
+                                  cores to reduce your licensing costs. The instance
+                                  itself is billed for the full shape, regardless
+                                  of whether all cores are enabled.
+                                type: integer
+                            type: object
+                          amdRomeBmGpuPlatformConfig:
+                            description: AmdMilanBmPlatformConfig describe AMD Rome
+                              BM platform configuration
+                            properties:
+                              areVirtualInstructionsEnabled:
+                                description: Whether virtualization instructions are
+                                  available. For example, Secure Virtual Machine for
+                                  AMD shapes or VT-x for Intel shapes.
+                                type: boolean
+                              isAccessControlServiceEnabled:
+                                description: Whether the Access Control Service is
+                                  enabled on the instance. When enabled, the platform
+                                  can enforce PCIe device isolation, required for
+                                  VFIO device pass-through.
+                                type: boolean
+                              isInputOutputMemoryManagementUnitEnabled:
+                                description: Whether the input-output memory management
+                                  unit is enabled.
+                                type: boolean
+                              isMeasuredBootEnabled:
+                                description: Whether the Measured Boot feature is
+                                  enabled on the instance.
+                                type: boolean
+                              isMemoryEncryptionEnabled:
+                                description: Whether the instance is a confidential
+                                  instance. If this value is `true`, the instance
+                                  is a confidential instance. The default value is
+                                  `false`.
+                                type: boolean
+                              isSecureBootEnabled:
+                                description: Whether Secure Boot is enabled on the
+                                  instance.
+                                type: boolean
+                              isSymmetricMultiThreadingEnabled:
+                                description: Whether symmetric multithreading is enabled
+                                  on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel
+                                  Hyper-Threading. Intel and AMD processors have two
+                                  hardware execution threads per core (OCPU). SMT
+                                  permits multiple independent threads of execution,
+                                  to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only
+                                  one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance
+                                  for some workloads.
+                                type: boolean
+                              isTrustedPlatformModuleEnabled:
+                                description: Whether the Trusted Platform Module (TPM)
+                                  is enabled on the instance.
+                                type: boolean
+                              numaNodesPerSocket:
+                                description: 'The number of NUMA nodes per socket
+                                  (NPS). The following values are supported: * `NPS0`
+                                  * `NPS1` * `NPS2` * `NPS4`'
+                                type: string
+                            type: object
+                          amdRomeBmPlatformConfig:
+                            description: AmdMilanBmPlatformConfig describe AMD Rome
+                              BM platform configuration
+                            properties:
+                              areVirtualInstructionsEnabled:
+                                description: Whether virtualization instructions are
+                                  available. For example, Secure Virtual Machine for
+                                  AMD shapes or VT-x for Intel shapes.
+                                type: boolean
+                              isAccessControlServiceEnabled:
+                                description: Whether the Access Control Service is
+                                  enabled on the instance. When enabled, the platform
+                                  can enforce PCIe device isolation, required for
+                                  VFIO device pass-through.
+                                type: boolean
+                              isInputOutputMemoryManagementUnitEnabled:
+                                description: Whether the input-output memory management
+                                  unit is enabled.
+                                type: boolean
+                              isMeasuredBootEnabled:
+                                description: Whether the Measured Boot feature is
+                                  enabled on the instance.
+                                type: boolean
+                              isMemoryEncryptionEnabled:
+                                description: Whether the instance is a confidential
+                                  instance. If this value is `true`, the instance
+                                  is a confidential instance. The default value is
+                                  `false`.
+                                type: boolean
+                              isSecureBootEnabled:
+                                description: Whether Secure Boot is enabled on the
+                                  instance.
+                                type: boolean
+                              isSymmetricMultiThreadingEnabled:
+                                description: Whether symmetric multithreading is enabled
+                                  on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel
+                                  Hyper-Threading. Intel and AMD processors have two
+                                  hardware execution threads per core (OCPU). SMT
+                                  permits multiple independent threads of execution,
+                                  to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only
+                                  one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance
+                                  for some workloads.
+                                type: boolean
+                              isTrustedPlatformModuleEnabled:
+                                description: Whether the Trusted Platform Module (TPM)
+                                  is enabled on the instance.
+                                type: boolean
+                              numaNodesPerSocket:
+                                description: 'The number of NUMA nodes per socket
+                                  (NPS). The following values are supported: * `NPS0`
+                                  * `NPS1` * `NPS2` * `NPS4`'
+                                type: string
+                              percentageOfCoresEnabled:
+                                description: The percentage of cores enabled. Value
+                                  must be a multiple of 25%. If the requested percentage
+                                  results in a fractional number of cores, the system
+                                  rounds up the number of cores across processors
+                                  and provisions an instance with a whole number of
+                                  cores. If the applications that you run on the instance
+                                  use a core-based licensing model and need fewer
+                                  cores than the full size of the shape, you can disable
+                                  cores to reduce your licensing costs. The instance
+                                  itself is billed for the full shape, regardless
+                                  of whether all cores are enabled.
+                                type: integer
+                            type: object
+                          amdVmPlatformConfig:
+                            description: AmdMilanBmPlatformConfig describe AMD VM
+                              platform configuration
+                            properties:
+                              isMeasuredBootEnabled:
+                                description: Whether the Measured Boot feature is
+                                  enabled on the instance.
+                                type: boolean
+                              isMemoryEncryptionEnabled:
+                                description: Whether the instance is a confidential
+                                  instance. If this value is `true`, the instance
+                                  is a confidential instance. The default value is
+                                  `false`.
+                                type: boolean
+                              isSecureBootEnabled:
+                                description: Whether Secure Boot is enabled on the
+                                  instance.
+                                type: boolean
+                              isTrustedPlatformModuleEnabled:
+                                description: Whether the Trusted Platform Module (TPM)
+                                  is enabled on the instance.
+                                type: boolean
+                            type: object
+                          intelIcelakeBmPlatformConfig:
+                            description: AmdMilanBmPlatformConfig describe Intel Skylke
+                              BM platform configuration
+                            properties:
+                              isInputOutputMemoryManagementUnitEnabled:
+                                description: Whether the input-output memory management
+                                  unit is enabled.
+                                type: boolean
+                              isMeasuredBootEnabled:
+                                description: Whether the Measured Boot feature is
+                                  enabled on the instance.
+                                type: boolean
+                              isMemoryEncryptionEnabled:
+                                description: Whether the instance is a confidential
+                                  instance. If this value is `true`, the instance
+                                  is a confidential instance. The default value is
+                                  `false`.
+                                type: boolean
+                              isSecureBootEnabled:
+                                description: Whether Secure Boot is enabled on the
+                                  instance.
+                                type: boolean
+                              isSymmetricMultiThreadingEnabled:
+                                description: Whether symmetric multithreading is enabled
+                                  on the instance. Symmetric multithreading is also
+                                  called simultaneous multithreading (SMT) or Intel
+                                  Hyper-Threading. Intel and AMD processors have two
+                                  hardware execution threads per core (OCPU). SMT
+                                  permits multiple independent threads of execution,
+                                  to better use the resources and increase the efficiency
+                                  of the CPU. When multithreading is disabled, only
+                                  one thread is permitted to run on each core, which
+                                  can provide higher or more predictable performance
+                                  for some workloads.
+                                type: boolean
+                              isTrustedPlatformModuleEnabled:
+                                description: Whether the Trusted Platform Module (TPM)
+                                  is enabled on the instance.
+                                type: boolean
+                              numaNodesPerSocket:
+                                description: 'The number of NUMA nodes per socket
+                                  (NPS). The following values are supported: * `NPS1`
+                                  * `NPS2`'
+                                type: string
+                              percentageOfCoresEnabled:
+                                description: The percentage of cores enabled. Value
+                                  must be a multiple of 25%. If the requested percentage
+                                  results in a fractional number of cores, the system
+                                  rounds up the number of cores across processors
+                                  and provisions an instance with a whole number of
+                                  cores. If the applications that you run on the instance
+                                  use a core-based licensing model and need fewer
+                                  cores than the full size of the shape, you can disable
+                                  cores to reduce your licensing costs. The instance
+                                  itself is billed for the full shape, regardless
+                                  of whether all cores are enabled.
+                                type: integer
+                            type: object
+                          intelSkylakeBmPlatformConfig:
+                            description: AmdMilanBmPlatformConfig describe Intel Skylke
+                              BM platform configuration
+                            properties:
+                              isMeasuredBootEnabled:
+                                description: Whether the Measured Boot feature is
+                                  enabled on the instance.
+                                type: boolean
+                              isMemoryEncryptionEnabled:
+                                description: Whether the instance is a confidential
+                                  instance. If this value is `true`, the instance
+                                  is a confidential instance. The default value is
+                                  `false`.
+                                type: boolean
+                              isSecureBootEnabled:
+                                description: Whether Secure Boot is enabled on the
+                                  instance.
+                                type: boolean
+                              isTrustedPlatformModuleEnabled:
+                                description: Whether the Trusted Platform Module (TPM)
+                                  is enabled on the instance.
+                                type: boolean
+                            type: object
+                          intelVmPlatformConfig:
+                            description: AmdMilanBmPlatformConfig describe Intel VM
+                              platform configuration
+                            properties:
+                              isMeasuredBootEnabled:
+                                description: Whether the Measured Boot feature is
+                                  enabled on the instance.
+                                type: boolean
+                              isMemoryEncryptionEnabled:
+                                description: Whether the instance is a confidential
+                                  instance. If this value is `true`, the instance
+                                  is a confidential instance. The default value is
+                                  `false`.
+                                type: boolean
+                              isSecureBootEnabled:
+                                description: Whether Secure Boot is enabled on the
+                                  instance.
+                                type: boolean
+                              isTrustedPlatformModuleEnabled:
+                                description: Whether the Trusted Platform Module (TPM)
+                                  is enabled on the instance.
+                                type: boolean
+                            type: object
+                          platformConfigType:
+                            description: The type of platform configuration. Valid
+                              values are * `AMD_ROME_BM_GPU` * `AMD_ROME_BM` * `INTEL_ICELAKE_BM`
+                              * `AMD_VM` * `INTEL_VM` * `INTEL_SKYLAKE_BM` * `AMD_MILAN_BM`
+                              Based on the enum, exactly one of the specific configuration
+                              types must be set
+                            type: string
+                        type: object
+                      preemptibleInstanceConfig:
+                        description: PreemptibleInstanceConfig Configuration options
+                          for preemptible instances.
+                        properties:
+                          terminatePreemptionAction:
+                            description: TerminatePreemptionAction terminates the
+                              preemptible instance when it is interrupted for eviction.
+                            properties:
+                              preserveBootVolume:
+                                description: PreserveBootVolume defines whether to
+                                  preserve the boot volume that was used to launch
+                                  the preemptible instance when the instance is terminated.
+                                  Defaults to false if not specified.
+                                type: boolean
+                            type: object
+                        type: object
+                      providerID:
+                        description: Provider ID of the instance, this will be set
+                          by Cluster API provider itself, users should not set this
+                          parameter.
+                        type: string
+                      shape:
+                        description: Shape of the instance.
+                        type: string
+                      shapeConfig:
+                        description: The shape configuration of rhe instance, applicable
+                          for flex instances.
+                        properties:
+                          baselineOcpuUtilization:
+                            description: 'The baseline OCPU utilization for a subcore
+                              burstable VM instance. Leave this attribute blank for
+                              a non-burstable instance, or explicitly specify non-burstable
+                              with `BASELINE_1_1`. The following values are supported:
+                              - `BASELINE_1_8` - baseline usage is 1/8 of an OCPU.
+                              - `BASELINE_1_2` - baseline usage is 1/2 of an OCPU.
+                              - `BASELINE_1_1` - baseline usage is an entire OCPU.
+                              This represents a non-burstable instance.'
+                            type: string
+                          memoryInGBs:
+                            description: The total amount of memory available to the
+                              instance, in gigabytes.
+                            type: string
+                          nvmes:
+                            description: Nvmes defines the number of NVMe drives to
+                              be used for storage. A single drive has 6.8 TB available.
+                            type: integer
+                          ocpus:
+                            description: The total number of OCPUs available to the
+                              instance.
+                            type: string
+                        type: object
+                      subnetName:
+                        description: The name of the subnet to use. The name here
+                          refers to the subnets defined in the OCICluster Spec. Optional,
+                          only if multiple subnets of a type is defined, else the
+                          first element is used.
+                        type: string
+                      vnicAttachments:
+                        description: VnicAttachments defines the configuration options
+                          for the vnic(s) attached to the machine The network bandwidth
+                          and number of VNICs scale proportionately with the number
+                          of OCPUs.
+                        items:
+                          properties:
+                            assignPublicIp:
+                              description: AssignPublicIp defines whether the vnic
+                                should have a public IP address
+                              type: boolean
+                            displayName:
+                              description: DisplayName defines a user-friendly name.
+                                Does not have to be unique. Avoid entering confidential
+                                information.
+                              type: string
+                            nicIndex:
+                              description: NicIndex defines which physical Network
+                                Interface Card (NIC) to use You can determine which
+                                NICs are active for a shape by reviewing the https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
+                              type: integer
+                            subnetName:
+                              description: SubnetName defines the subnet name to use
+                                for the VNIC Defaults to the "worker" subnet if not
+                                provided
+                              type: string
+                            vnicAttachmentId:
+                              description: VnicAttachmentId defines the ID of the
+                                VnicAttachment
+                              type: string
+                          required:
+                          - displayName
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: ocimanagedclusters.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: OCIManagedCluster
+    listKind: OCIManagedClusterList
+    plural: ocimanagedclusters
+    singular: ocimanagedcluster
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OCIManagedCluster is the Schema for the ocimanagedclusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIManagedClusterSpec defines the desired state of OCI OKE
+              Cluster
+            properties:
+              compartmentId:
+                description: Compartment to create the cluster network.
+                type: string
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane. This will not be set by the
+                  user, this will be updated by the Cluster Reconciler after OKe cluster
+                  has been created and the cluster has an endpoint address
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              definedTags:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                description: 'Defined tags for this resource. Each key is predefined
+                  and scoped to a namespace. For more information, see Resource Tags
+                  (https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+                  Example: `{"Operations": {"CostCenter": "42"}}`'
+                type: object
+              freeformTags:
+                additionalProperties:
+                  type: string
+                description: Free-form tags for this resource.
+                type: object
+              identityRef:
+                description: IdentityRef is a reference to an identity(principal)
+                  to be used when reconciling this cluster
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              networkSpec:
+                description: NetworkSpec encapsulates all things related to OCI network.
+                properties:
+                  apiServerLoadBalancer:
+                    description: API Server LB configuration.
+                    properties:
+                      loadBalancerId:
+                        description: ID of Load Balancer.
+                        type: string
+                      name:
+                        description: LoadBalancer Name.
+                        type: string
+                    type: object
+                  skipNetworkManagement:
+                    description: SkipNetworkManagement defines if the networking spec(VCN
+                      related) specified by the user needs to be reconciled(actioned-upon)
+                      or used as it is. APIServerLB will still be reconciled.
+                    type: boolean
+                  vcn:
+                    description: VCN configuration.
+                    properties:
+                      cidr:
+                        description: VCN CIDR.
+                        type: string
+                      id:
+                        description: VCN OCID.
+                        type: string
+                      internetGatewayId:
+                        description: ID of Internet Gateway.
+                        type: string
+                      name:
+                        description: VCN Name.
+                        type: string
+                      natGatewayId:
+                        description: ID of Nat Gateway.
+                        type: string
+                      networkSecurityGroups:
+                        description: NetworkSecurityGroups is the configuration for
+                          the Network Security Groups required in the VCN.
+                        items:
+                          description: NSG defines configuration for a Network Security
+                            Group. https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/networksecuritygroups.htm
+                          properties:
+                            egressRules:
+                              description: EgressRules on the NSG.
+                              items:
+                                description: EgressSecurityRuleForNSG is EgressSecurityRule
+                                  for NSG.
+                                properties:
+                                  egressRule:
+                                    description: EgressSecurityRule A rule for allowing
+                                      outbound IP packets.
+                                    properties:
+                                      description:
+                                        description: An optional description of your
+                                          choice for the rule.
+                                        type: string
+                                      destination:
+                                        description: 'Conceptually, this is the range
+                                          of IP addresses that a packet originating
+                                          from the instance can go to. Allowed values:
+                                          * IP address range in CIDR notation. For
+                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                          Note that IPv6 addressing is currently supported
+                                          only in certain regions. See IPv6 Addresses
+                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                          * The `cidrBlock` value for a Service, if
+                                          you''re setting up a security list rule
+                                          for traffic destined for a particular `Service`
+                                          through a service gateway. For example:
+                                          `oci-phx-objectstorage`.'
+                                        type: string
+                                      destinationType:
+                                        description: 'Type of destination for the
+                                          rule. The default is `CIDR_BLOCK`. Allowed
+                                          values: * `CIDR_BLOCK`: If the rule''s `destination`
+                                          is an IP address range in CIDR notation.
+                                          * `SERVICE_CIDR_BLOCK`: If the rule''s `destination`
+                                          is the `cidrBlock` value for a Service (the
+                                          rule is for traffic destined for a particular
+                                          `Service` through a service gateway).'
+                                        type: string
+                                      icmpOptions:
+                                        description: 'IcmpOptions Optional and valid
+                                          only for ICMP and ICMPv6. Use to specify
+                                          a particular ICMP type and code as defined
+                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                          - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                          If you specify ICMP or ICMPv6 as the protocol
+                                          but omit this object, then all ICMP types
+                                          and codes are allowed. If you do provide
+                                          this object, the type is required and the
+                                          code is optional. To enable MTU negotiation
+                                          for ingress internet traffic via IPv4, make
+                                          sure to allow type 3 ("Destination Unreachable")
+                                          code 4 ("Fragmentation Needed and Don''t
+                                          Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create
+                                          a separate security list rule for each.'
+                                        properties:
+                                          code:
+                                            description: The ICMP code (optional).
+                                            type: integer
+                                          type:
+                                            description: The ICMP type.
+                                            type: integer
+                                        type: object
+                                      isStateless:
+                                        description: A stateless rule allows traffic
+                                          in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if
+                                          you need to support bidirectional traffic.
+                                          For example, if egress traffic allows TCP
+                                          destination port 80, there should be an
+                                          ingress rule to allow TCP source port 80.
+                                          Defaults to false, which means the rule
+                                          is stateful and a corresponding rule is
+                                          not necessary for bidirectional traffic.
+                                        type: boolean
+                                      protocol:
+                                        description: The transport protocol. Specify
+                                          either `all` or an IPv4 protocol number
+                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"),
+                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        type: string
+                                      tcpOptions:
+                                        description: TcpOptions Optional and valid
+                                          only for TCP. Use to specify particular
+                                          destination ports for TCP rules. If you
+                                          specify TCP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      udpOptions:
+                                        description: UdpOptions Optional and valid
+                                          only for UDP. Use to specify particular
+                                          destination ports for UDP rules. If you
+                                          specify UDP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                    type: object
+                                  id:
+                                    description: 'EgressSecurityRule ID for NSG. Deprecated:
+                                      this field is not populated and used during
+                                      reconciliation'
+                                    type: string
+                                type: object
+                              type: array
+                            id:
+                              description: NSG OCID.
+                              type: string
+                            ingressRules:
+                              description: IngressRules on the NSG.
+                              items:
+                                description: IngressSecurityRuleForNSG is IngressSecurityRule
+                                  for NSG
+                                properties:
+                                  id:
+                                    description: 'IngressSecurityRule ID for NSG.
+                                      Deprecated: this field is not populated and
+                                      used during reconciliation'
+                                    type: string
+                                  ingressRule:
+                                    description: IngressSecurityRule A rule for allowing
+                                      inbound IP packets.
+                                    properties:
+                                      description:
+                                        description: An optional description of your
+                                          choice for the rule.
+                                        type: string
+                                      icmpOptions:
+                                        description: 'IcmpOptions Optional and valid
+                                          only for ICMP and ICMPv6. Use to specify
+                                          a particular ICMP type and code as defined
+                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                          - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                          If you specify ICMP or ICMPv6 as the protocol
+                                          but omit this object, then all ICMP types
+                                          and codes are allowed. If you do provide
+                                          this object, the type is required and the
+                                          code is optional. To enable MTU negotiation
+                                          for ingress internet traffic via IPv4, make
+                                          sure to allow type 3 ("Destination Unreachable")
+                                          code 4 ("Fragmentation Needed and Don''t
+                                          Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create
+                                          a separate security list rule for each.'
+                                        properties:
+                                          code:
+                                            description: The ICMP code (optional).
+                                            type: integer
+                                          type:
+                                            description: The ICMP type.
+                                            type: integer
+                                        type: object
+                                      isStateless:
+                                        description: A stateless rule allows traffic
+                                          in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if
+                                          you need to support bidirectional traffic.
+                                          For example, if ingress traffic allows TCP
+                                          destination port 80, there should be an
+                                          egress rule to allow TCP source port 80.
+                                          Defaults to false, which means the rule
+                                          is stateful and a corresponding rule is
+                                          not necessary for bidirectional traffic.
+                                        type: boolean
+                                      protocol:
+                                        description: The transport protocol. Specify
+                                          either `all` or an IPv4 protocol number
+                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"),
+                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        type: string
+                                      source:
+                                        description: 'Conceptually, this is the range
+                                          of IP addresses that a packet coming into
+                                          the instance can come from. Allowed values:
+                                          * IP address range in CIDR notation. For
+                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                          IPv6 addressing is supported for all commercial
+                                          and government regions. See IPv6 Addresses
+                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                          * The `cidrBlock` value for a Service, if
+                                          you''re setting up a security list rule
+                                          for traffic coming from a particular `Service`
+                                          through a service gateway. For example:
+                                          `oci-phx-objectstorage`.'
+                                        type: string
+                                      sourceType:
+                                        description: 'Type of source for the rule.
+                                          The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
+                                          If the rule''s `source` is an IP address
+                                          range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
+                                          If the rule''s `source` is the `cidrBlock`
+                                          value for a Service (the rule is for traffic
+                                          coming from a particular `Service` through
+                                          a service gateway).'
+                                        type: string
+                                      tcpOptions:
+                                        description: TcpOptions Optional and valid
+                                          only for TCP. Use to specify particular
+                                          destination ports for TCP rules. If you
+                                          specify TCP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      udpOptions:
+                                        description: UdpOptions Optional and valid
+                                          only for UDP. Use to specify particular
+                                          destination ports for UDP rules. If you
+                                          specify UDP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                    type: object
+                                type: object
+                              type: array
+                            name:
+                              description: NSG Name.
+                              type: string
+                            role:
+                              description: Role defines the NSG role (eg. control-plane,
+                                control-plane-endpoint, service-lb, worker).
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      privateRouteTableId:
+                        description: ID of Private Route Table.
+                        type: string
+                      publicRouteTableId:
+                        description: ID of Public Route Table.
+                        type: string
+                      serviceGatewayId:
+                        description: ID of Service Gateway.
+                        type: string
+                      subnets:
+                        description: Subnets is the configuration for subnets required
+                          in the VCN.
+                        items:
+                          description: Subnet defines the configuration for a network's
+                            subnet https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingVCNs_topic-Overview_of_VCNs_and_Subnets.htm#Overview
+                          properties:
+                            cidr:
+                              description: Subnet CIDR.
+                              type: string
+                            id:
+                              description: Subnet OCID.
+                              type: string
+                            name:
+                              description: Subnet Name.
+                              type: string
+                            role:
+                              description: Role defines the subnet role (eg. control-plane,
+                                control-plane-endpoint, service-lb, worker).
+                              type: string
+                            securityList:
+                              description: The security list associated with Subnet.
+                              properties:
+                                egressRules:
+                                  description: EgressRules on the SecurityList.
+                                  items:
+                                    description: EgressSecurityRule A rule for allowing
+                                      outbound IP packets.
+                                    properties:
+                                      description:
+                                        description: An optional description of your
+                                          choice for the rule.
+                                        type: string
+                                      destination:
+                                        description: 'Conceptually, this is the range
+                                          of IP addresses that a packet originating
+                                          from the instance can go to. Allowed values:
+                                          * IP address range in CIDR notation. For
+                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
+                                          Note that IPv6 addressing is currently supported
+                                          only in certain regions. See IPv6 Addresses
+                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                          * The `cidrBlock` value for a Service, if
+                                          you''re setting up a security list rule
+                                          for traffic destined for a particular `Service`
+                                          through a service gateway. For example:
+                                          `oci-phx-objectstorage`.'
+                                        type: string
+                                      destinationType:
+                                        description: 'Type of destination for the
+                                          rule. The default is `CIDR_BLOCK`. Allowed
+                                          values: * `CIDR_BLOCK`: If the rule''s `destination`
+                                          is an IP address range in CIDR notation.
+                                          * `SERVICE_CIDR_BLOCK`: If the rule''s `destination`
+                                          is the `cidrBlock` value for a Service (the
+                                          rule is for traffic destined for a particular
+                                          `Service` through a service gateway).'
+                                        type: string
+                                      icmpOptions:
+                                        description: 'IcmpOptions Optional and valid
+                                          only for ICMP and ICMPv6. Use to specify
+                                          a particular ICMP type and code as defined
+                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                          - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                          If you specify ICMP or ICMPv6 as the protocol
+                                          but omit this object, then all ICMP types
+                                          and codes are allowed. If you do provide
+                                          this object, the type is required and the
+                                          code is optional. To enable MTU negotiation
+                                          for ingress internet traffic via IPv4, make
+                                          sure to allow type 3 ("Destination Unreachable")
+                                          code 4 ("Fragmentation Needed and Don''t
+                                          Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create
+                                          a separate security list rule for each.'
+                                        properties:
+                                          code:
+                                            description: The ICMP code (optional).
+                                            type: integer
+                                          type:
+                                            description: The ICMP type.
+                                            type: integer
+                                        type: object
+                                      isStateless:
+                                        description: A stateless rule allows traffic
+                                          in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if
+                                          you need to support bidirectional traffic.
+                                          For example, if egress traffic allows TCP
+                                          destination port 80, there should be an
+                                          ingress rule to allow TCP source port 80.
+                                          Defaults to false, which means the rule
+                                          is stateful and a corresponding rule is
+                                          not necessary for bidirectional traffic.
+                                        type: boolean
+                                      protocol:
+                                        description: The transport protocol. Specify
+                                          either `all` or an IPv4 protocol number
+                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"),
+                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        type: string
+                                      tcpOptions:
+                                        description: TcpOptions Optional and valid
+                                          only for TCP. Use to specify particular
+                                          destination ports for TCP rules. If you
+                                          specify TCP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      udpOptions:
+                                        description: UdpOptions Optional and valid
+                                          only for UDP. Use to specify particular
+                                          destination ports for UDP rules. If you
+                                          specify UDP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                id:
+                                  description: ID of the SecurityList.
+                                  type: string
+                                ingressRules:
+                                  description: IngressRules on the SecurityList.
+                                  items:
+                                    description: IngressSecurityRule A rule for allowing
+                                      inbound IP packets.
+                                    properties:
+                                      description:
+                                        description: An optional description of your
+                                          choice for the rule.
+                                        type: string
+                                      icmpOptions:
+                                        description: 'IcmpOptions Optional and valid
+                                          only for ICMP and ICMPv6. Use to specify
+                                          a particular ICMP type and code as defined
+                                          in: - ICMP Parameters (http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+                                          - ICMPv6 Parameters (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml)
+                                          If you specify ICMP or ICMPv6 as the protocol
+                                          but omit this object, then all ICMP types
+                                          and codes are allowed. If you do provide
+                                          this object, the type is required and the
+                                          code is optional. To enable MTU negotiation
+                                          for ingress internet traffic via IPv4, make
+                                          sure to allow type 3 ("Destination Unreachable")
+                                          code 4 ("Fragmentation Needed and Don''t
+                                          Fragment was Set"). If you need to specify
+                                          multiple codes for a single type, create
+                                          a separate security list rule for each.'
+                                        properties:
+                                          code:
+                                            description: The ICMP code (optional).
+                                            type: integer
+                                          type:
+                                            description: The ICMP type.
+                                            type: integer
+                                        type: object
+                                      isStateless:
+                                        description: A stateless rule allows traffic
+                                          in one direction. Remember to add a corresponding
+                                          stateless rule in the other direction if
+                                          you need to support bidirectional traffic.
+                                          For example, if ingress traffic allows TCP
+                                          destination port 80, there should be an
+                                          egress rule to allow TCP source port 80.
+                                          Defaults to false, which means the rule
+                                          is stateful and a corresponding rule is
+                                          not necessary for bidirectional traffic.
+                                        type: boolean
+                                      protocol:
+                                        description: The transport protocol. Specify
+                                          either `all` or an IPv4 protocol number
+                                          as defined in Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+                                          Options are supported only for ICMP ("1"),
+                                          TCP ("6"), UDP ("17"), and ICMPv6 ("58").
+                                        type: string
+                                      source:
+                                        description: 'Conceptually, this is the range
+                                          of IP addresses that a packet coming into
+                                          the instance can come from. Allowed values:
+                                          * IP address range in CIDR notation. For
+                                          example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
+                                          IPv6 addressing is supported for all commercial
+                                          and government regions. See IPv6 Addresses
+                                          (https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
+                                          * The `cidrBlock` value for a Service, if
+                                          you''re setting up a security list rule
+                                          for traffic coming from a particular `Service`
+                                          through a service gateway. For example:
+                                          `oci-phx-objectstorage`.'
+                                        type: string
+                                      sourceType:
+                                        description: 'Type of source for the rule.
+                                          The default is `CIDR_BLOCK`. * `CIDR_BLOCK`:
+                                          If the rule''s `source` is an IP address
+                                          range in CIDR notation. * `SERVICE_CIDR_BLOCK`:
+                                          If the rule''s `source` is the `cidrBlock`
+                                          value for a Service (the rule is for traffic
+                                          coming from a particular `Service` through
+                                          a service gateway).'
+                                        type: string
+                                      tcpOptions:
+                                        description: TcpOptions Optional and valid
+                                          only for TCP. Use to specify particular
+                                          destination ports for TCP rules. If you
+                                          specify TCP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      udpOptions:
+                                        description: UdpOptions Optional and valid
+                                          only for UDP. Use to specify particular
+                                          destination ports for UDP rules. If you
+                                          specify UDP as the protocol but omit this
+                                          object, then all destination ports are allowed.
+                                        properties:
+                                          destinationPortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                          sourcePortRange:
+                                            description: PortRange The representation
+                                              of PortRange.
+                                            properties:
+                                              max:
+                                                description: The maximum port number,
+                                                  which must not be less than the
+                                                  minimum port number. To specify
+                                                  a single port number, set both the
+                                                  min and max to the same value.
+                                                type: integer
+                                              min:
+                                                description: The minimum port number,
+                                                  which must not be greater than the
+                                                  maximum port number.
+                                                type: integer
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                name:
+                                  description: SecurityList Name.
+                                  type: string
+                              type: object
+                            type:
+                              description: Type defines the subnet type (e.g. public,
+                                private).
+                              type: string
+                          required:
+                          - name
+                          - role
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  vcnPeering:
+                    description: VCNPeering configuration.
+                    properties:
+                      drg:
+                        description: DRG configuration refers to the DRG which has
+                          to be created if required. If management cluster and workload
+                          cluster shares the same DRG, this fields is not required
+                          to be specified.
+                        properties:
+                          id:
+                            description: ID is the OCID for the created DRG.
+                            type: string
+                          manage:
+                            description: Manage defines whether the DRG has to be
+                              managed(including create). If set to false(the default)
+                              the ID has to be specified by the user to a valid DRG
+                              ID to which the VCN has to be attached.
+                            type: boolean
+                          name:
+                            description: Name is the name of the created DRG.
+                            type: string
+                          vcnAttachmentId:
+                            description: VcnAttachmentId is the ID of the VCN attachment
+                              of the DRG. The workload cluster VCN can be attached
+                              to either the management cluster VCN if they are sharing
+                              the same DRG or to the workload cluster DRG.
+                            type: string
+                        type: object
+                      peerRouteRules:
+                        description: PeerRouteRules defines the routing rules which
+                          will be added to the private route tables of the workload
+                          cluster VCN. The routes defined here will be directed to
+                          DRG.
+                        items:
+                          description: PeerRouteRule defines a Route Rule to be routed
+                            via a DRG.
+                          properties:
+                            vcnCIDRRange:
+                              description: VCNCIDRRange is the CIDR Range of peer
+                                VCN to which the workload cluster VCN will be peered.
+                                The CIDR range is required to add the route rule in
+                                the workload cluster VCN, the route rule will forward
+                                any traffic to the CIDR to the DRG.
+                              type: string
+                          type: object
+                        type: array
+                      remotePeeringConnections:
+                        description: RemotePeeringConnections defines the RPC connections
+                          which be established with the workload cluster DRG.
+                        items:
+                          description: RemotePeeringConnection is used to peer VCNs
+                            residing in different regions(typically). Remote VCN Peering
+                            is explained here - https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/remoteVCNpeering.htm
+                          properties:
+                            managePeerRPC:
+                              description: ManagePeerRPC will define if the Peer VCN
+                                needs to be managed. If set to true a Remote Peering
+                                Connection will be created in the Peer DRG and the
+                                connection will be created between local and peer
+                                RPC.
+                              type: boolean
+                            peerDRGId:
+                              description: PeerDRGId defines the DRG ID of the peer.
+                              type: string
+                            peerRPCConnectionId:
+                              description: PeerRPCConnectionId defines the RPC ID
+                                of peer. If ManagePeerRPC is set to true this will
+                                be created by Cluster API Provider for OCI, otherwise
+                                this has be defined by the user.
+                              type: string
+                            peerRegionName:
+                              description: PeerRegionName defined the region name
+                                of Peer VCN.
+                              type: string
+                            rpcConnectionId:
+                              description: RPCConnectionId is the connection ID of
+                                the connection between peer and local RPC.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              ociResourceIdentifier:
+                description: The unique ID which will be used to tag all the resources
+                  created by this Cluster. The tag will be used to identify resources
+                  belonging to this cluster. this will be auto-generated and should
+                  not be set by the user.
+                type: string
+              region:
+                description: Region the cluster operates in. It must be one of available
+                  regions in Region Identifier format. See https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm
+                type: string
+            type: object
+          status:
+            description: OCIManagedClusterStatus defines the observed state of OCICluster
+            properties:
+              availabilityDomains:
+                additionalProperties:
+                  description: OCIAvailabilityDomain contains information about an
+                    Availability Domain (AD).
+                  properties:
+                    faultDomains:
+                      description: 'FaultDomains a list of fault domain (FD) names.
+                        Example: ["FAULT-DOMAIN-1"]'
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: 'Name is the AD''s full name. Example: Uocm:PHX-AD-1'
+                      type: string
+                  type: object
+                description: AvailabilityDomains encapsulates the clusters Availability
+                  Domain (AD) information in a map where the map key is the AD name
+                  and the struct is details about the AD.
+                type: object
+              conditions:
+                description: NetworkSpec encapsulates all things related to OCI network.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of FailureDomains.
+                type: object
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: ocimanagedcontrolplanes.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: OCIManagedControlPlane
+    listKind: OCIManagedControlPlaneList
+    plural: ocimanagedcontrolplanes
+    singular: ocimanagedcontrolplane
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OCIManagedControlPlane is the Schema for the ocimanagedcontrolplane
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIManagedControlPlaneSpec defines the desired state of OCIManagedControlPlane.
+              The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateClusterDetails
+            properties:
+              clusterOptions:
+                description: ClusterOptions defines Optional attributes for the cluster.
+                properties:
+                  addOnOptions:
+                    description: AddOnOptions defines the properties that define options
+                      for supported add-ons.
+                    properties:
+                      isKubernetesDashboardEnabled:
+                        description: IsKubernetesDashboardEnabled defines whether
+                          or not to enable the Kubernetes Dashboard add-on.
+                        type: boolean
+                      isTillerEnabled:
+                        description: IsKubernetesDashboardEnabled defines whether
+                          or not to enable the Tiller add-on.
+                        type: boolean
+                    type: object
+                  admissionControllerOptions:
+                    description: AdmissionControllerOptions defines the properties
+                      that define supported admission controllers.
+                    properties:
+                      isPodSecurityPolicyEnabled:
+                        description: IsPodSecurityPolicyEnabled defines whether or
+                          not to enable the Pod Security Policy admission controller.
+                        type: boolean
+                    type: object
+                type: object
+              clusterPodNetworkOptions:
+                description: ClusterPodNetworkOptions defines the available CNIs and
+                  network options for existing and new node pools of the cluster
+                items:
+                  description: ClusterPodNetworkOptions defines the available CNIs
+                    and network options for existing and new node pools of the cluster
+                  properties:
+                    cniType:
+                      description: The CNI to be used are OCI_VCN_IP_NATIVE and FLANNEL_OVERLAY
+                      type: string
+                  type: object
+                type: array
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              id:
+                description: ID of the OKEcluster.
+                type: string
+              imagePolicyConfig:
+                description: ImagePolicyConfig defines the properties that define
+                  a image verification policy.
+                properties:
+                  isPolicyEnabled:
+                    description: IsPolicyEnabled defines Whether the image verification
+                      policy is enabled.
+                    type: boolean
+                  keyDetails:
+                    description: KeyDetails defines a list of KMS key details.
+                    items:
+                      description: KeyDetails defines the properties that define the
+                        kms keys used by OKE for Image Signature verification.
+                      properties:
+                        keyDetails:
+                          description: KmsKeyId defines the OCID of the KMS key that
+                            will be used to verify whether the images are signed by
+                            an approved source.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              kmsKeyId:
+                description: KmsKeyId defines the OCID of the KMS key to be used as
+                  the master encryption key for Kubernetes secret encryption. When
+                  used,
+                type: string
+              version:
+                description: Version represents the version of the Kubernetes Cluster
+                  Control Plane.
+                type: string
+            type: object
+          status:
+            description: OCIManagedControlPlaneStatus defines the observed state of
+              OCIManagedControlPlane
+            properties:
+              conditions:
+                description: NetworkSpec encapsulates all things related to OCI network.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              initialized:
+                description: Initialized denotes whether or not the control plane
+                  has the uploaded kubernetes config-map.
+                type: boolean
+              ready:
+                type: boolean
+              version:
+                description: Version represents the current Kubernetes version for
+                  the control plane.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: ocimanagedmachinepools.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: OCIManagedMachinePool
+    listKind: OCIManagedMachinePoolList
+    plural: ocimanagedmachinepools
+    singular: ocimanagedmachinepool
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OCIManagedMachinePool is the Schema for the ocimanagedmachinepool
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIManagedMachinePoolSpec defines the desired state of an
+              OCI managed machine pool. An OCIManagedMachinePool translates to an
+              OKE NodePool. The properties are generated from https://docs.oracle.com/en-us/iaas/api/#/en/containerengine/20180222/datatypes/CreateNodePoolDetails
+            properties:
+              id:
+                description: ID is the OCID of the associated NodePool
+                type: string
+              initialNodeLabels:
+                description: InitialNodeLabels defines a list of key/value pairs to
+                  add to nodes after they join the Kubernetes cluster.
+                items:
+                  description: KeyValue The properties that define a key value pair.
+                  properties:
+                    key:
+                      description: The key of the pair.
+                      type: string
+                    value:
+                      description: The value of the pair.
+                      type: string
+                  type: object
+                type: array
+              nodeEvictionNodePoolSettings:
+                description: NodeEvictionNodePoolSettings defines the eviction settings.
+                properties:
+                  evictionGraceDuration:
+                    description: 'EvictionGraceDuration defines the duration after
+                      which OKE will give up eviction of the pods on the node. PT0M
+                      will indicate you want to delete the node without cordon and
+                      drain. Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601
+                      e.g PT30M'
+                    type: string
+                  isForceDeleteAfterGraceDuration:
+                    description: IsForceDeleteAfterGraceDuration defines if the underlying
+                      compute instance should be deleted if you cannot evict all the
+                      pods in grace period
+                    type: boolean
+                type: object
+              nodeMetadata:
+                additionalProperties:
+                  type: string
+                description: NodeMetadata defines a list of key/value pairs to add
+                  to each underlying OCI instance in the node pool on launch.
+                type: object
+              nodePoolNodeConfig:
+                description: NodePoolNodeConfig defines the configuration of nodes
+                  in the node pool.
+                properties:
+                  isPvEncryptionInTransitEnabled:
+                    description: IsPvEncryptionInTransitEnabled defines whether in
+                      transit encryption should be enabled on the nodes.
+                    type: boolean
+                  kmsKeyId:
+                    description: KmsKeyId  defines whether in transit encryption should
+                      be enabled on the nodes.
+                    type: string
+                  nodePoolPodNetworkOptionDetails:
+                    description: NodePoolPodNetworkOptionDetails defines the pod networking
+                      details of the node pool
+                    properties:
+                      cniType:
+                        description: CniType describes the CNI plugin used by this
+                          node pool. Allowed values are OCI_VCN_IP_NATIVE and FLANNEL_OVERLAY.
+                        type: string
+                      vcnIpNativePodNetworkOptions:
+                        description: VcnIpNativePodNetworkOptions describes the network
+                          options specific to using the OCI VCN Native CNI
+                        properties:
+                          maxPodsPerNode:
+                            description: MemoryInGBs defines the max number of pods
+                              per node in the node pool. This value will be limited
+                              by the number of VNICs attachable to the node pool shape
+                            type: integer
+                          nsgNames:
+                            description: NSGNames defines the NSGs associated with
+                              the native pod network.
+                            items:
+                              type: string
+                            type: array
+                          subnetNames:
+                            description: SubnetNames defines the Subnets associated
+                              with the native pod network.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  nsgNames:
+                    description: NsgNames defines the names of NSGs which will be
+                      associated with the nodes. the NSGs are defined in OCIManagedCluster
+                      object.
+                    items:
+                      type: string
+                    type: array
+                  placementConfigs:
+                    description: PlacementConfigs defines the placement configurations
+                      for the node pool.
+                    items:
+                      description: PlacementConfig defines the placement configurations
+                        for the node pool.
+                      properties:
+                        availabilityDomain:
+                          description: AvailabilityDomain defines the availability
+                            domain in which to place nodes.
+                          type: string
+                        capacityReservationId:
+                          description: CapacityReservationId defines the OCID of the
+                            compute capacity reservation in which to place the compute
+                            instance.
+                          type: string
+                        faultDomains:
+                          description: FaultDomains defines the list of fault domains
+                            in which to place nodes.
+                          items:
+                            type: string
+                          type: array
+                        subnetName:
+                          description: SubnetName defines the name of the subnet which
+                            need ot be associated with the Nodepool. The subnets are
+                            defined in the OCiManagedCluster object.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              nodeShape:
+                description: NodeShape defines the name of the node shape of the nodes
+                  in the node pool.
+                type: string
+              nodeShapeConfig:
+                description: NodeShapeConfig defines the configuration of the shape
+                  to launch nodes in the node pool.
+                properties:
+                  memoryInGBs:
+                    description: MemoryInGBs defines the total amount of memory available
+                      to each node, in gigabytes.
+                    type: string
+                  ocpus:
+                    description: Ocpus defines the total number of OCPUs available
+                      to each node in the node pool.
+                    type: string
+                type: object
+              nodeSourceViaImage:
+                description: NodeSourceViaImage defines the image configuration of
+                  the nodes in the nodepool.
+                properties:
+                  bootVolumeSizeInGBs:
+                    description: BootVolumeSizeInGBs defines the size of the boot
+                      volume in GBs.
+                    format: int64
+                    type: integer
+                  imageId:
+                    description: ImageId defines the OCID of the image used to boot
+                      the node.
+                    type: string
+                type: object
+              providerID:
+                description: ProviderID is the OCID of the associated NodePool in
+                  a provider format
+                type: string
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
+                items:
+                  type: string
+                type: array
+              sshPublicKey:
+                description: SshPublicKey defines the SSH public key on each node
+                  in the node pool on launch.
+                type: string
+              version:
+                description: Version represents the version of the OKE node pool.
+                type: string
+            type: object
+          status:
+            description: OCIManagedMachinePoolStatus defines the observed state of
+              OCIManagedMachinePool
+            properties:
+              conditions:
+                description: NetworkSpec encapsulates all things related to OCI network.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessages:
+                items:
+                  type: string
+                type: array
+              failureReason:
+                description: MachineStatusError defines errors states for Machine
+                  objects.
+                type: string
+              ready:
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-controller-manager
+  namespace: cluster-api-provider-oci-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-leader-election-role
+  namespace: cluster-api-provider-oci-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-manager-role
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ociclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ociclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ociclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimachines/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimachines/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimachinepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimachinepools
+  - ocimachinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimanagedclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimanagedclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimanagedclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimanagedcontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimanagedcontrolplanes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimanagedcontrolplanes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimanagedmachinepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimanagedmachinepools/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ocimanagedmachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - ociclusteridentities
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-leader-election-rolebinding
+  namespace: cluster-api-provider-oci-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capoci-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capoci-controller-manager
+  namespace: cluster-api-provider-oci-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capoci-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capoci-controller-manager
+  namespace: cluster-api-provider-oci-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capoci-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: capoci-controller-manager
+  namespace: cluster-api-provider-oci-system
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 237d8a8a.cluster.x-k8s.io
+kind: ConfigMap
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-manager-config
+  namespace: cluster-api-provider-oci-system
+---
+apiVersion: v1
+data:
+  fingerprint: ${OCI_CREDENTIALS_FINGERPRINT_B64:=""}
+  key: ${OCI_CREDENTIALS_KEY_B64:=""}
+  passphrase: ${OCI_CREDENTIALS_PASSPHRASE_B64:=""}
+  region: ${OCI_REGION_B64:=""}
+  tenancy: ${OCI_TENANCY_ID_B64:=""}
+  useInstancePrincipal: ${USE_INSTANCE_PRINCIPAL_B64:="ZmFsc2U="}
+  user: ${OCI_USER_ID_B64:=""}
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-auth-config
+  namespace: cluster-api-provider-oci-system
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    control-plane: controller-manager
+  name: capoci-controller-manager-metrics-service
+  namespace: cluster-api-provider-oci-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-webhook-service
+  namespace: cluster-api-provider-oci-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-oci
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    control-plane: controller-manager
+  name: capoci-controller-manager
+  namespace: cluster-api-provider-oci-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: infrastructure-oci
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: infrastructure-oci
+        control-plane: controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: ${K8S_CP_LABEL:=node-role.kubernetes.io/control-plane}
+                operator: Exists
+            weight: 10
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+            weight: 10
+      containers:
+      - args:
+        - --leader-elect
+        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},OKE=${EXP_OKE:=false}
+        - --metrics-bind-address=127.0.0.1:8080
+        - --logging-format=${LOG_FORMAT:=text}
+        - --init-oci-clients-on-startup=${INIT_OCI_CLIENTS_ON_STARTUP:=true}
+        command:
+        - /manager
+        env:
+        - name: AUTH_CONFIG_DIR
+          value: /etc/oci
+        image: ghcr.io/oracle/cluster-api-oci-controller:v0.8.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /etc/oci
+          name: auth-config-dir
+          readOnly: true
+      serviceAccountName: capoci-controller-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: capoci-webhook-service-cert
+      - name: auth-config-dir
+        secret:
+          secretName: capoci-auth-config
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-serving-cert
+  namespace: cluster-api-provider-oci-system
+spec:
+  dnsNames:
+  - capoci-webhook-service.cluster-api-provider-oci-system.svc
+  - capoci-webhook-service.cluster-api-provider-oci-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capoci-selfsigned-issuer
+  secretName: capoci-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-selfsigned-issuer
+  namespace: cluster-api-provider-oci-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: cluster-api-provider-oci-system/capoci-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capoci-webhook-service
+      namespace: cluster-api-provider-oci-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-ocicluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.ocicluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ociclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capoci-webhook-service
+      namespace: cluster-api-provider-oci-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-ocimanagedcluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.ocimanagedcluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocimanagedclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capoci-webhook-service
+      namespace: cluster-api-provider-oci-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-ocimanagedcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.ocimanagedcontrolplane.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocimanagedcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capoci-webhook-service
+      namespace: cluster-api-provider-oci-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-ocimanagedmachinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.ocimanagedmachinepool.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocimanagedmachinepools
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: cluster-api-provider-oci-system/capoci-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+  name: capoci-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capoci-webhook-service
+      namespace: cluster-api-provider-oci-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-ocicluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ocicluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ociclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capoci-webhook-service
+      namespace: cluster-api-provider-oci-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-ocimachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ocimachinetemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocimachinetemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capoci-webhook-service
+      namespace: cluster-api-provider-oci-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-ocimanagedcluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ocimanagedcluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocimanagedclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capoci-webhook-service
+      namespace: cluster-api-provider-oci-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-ocimanagedcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ocimanagedcontrolplane.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocimanagedcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: capoci-webhook-service
+      namespace: cluster-api-provider-oci-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-ocimanagedmachinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ocimanagedmachinepool.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocimanagedmachinepools
+  sideEffects: None

--- a/platform-operator/capi/infrastructure-oci/v0.8.1/metadata.yaml
+++ b/platform-operator/capi/infrastructure-oci/v0.8.1/metadata.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 # maps release series of major.minor to cluster-api contract version
 # the contract version may change between minor or major versions, but *not*
 # between patch versions.

--- a/platform-operator/capi/infrastructure-oci/v0.8.1/metadata.yaml
+++ b/platform-operator/capi/infrastructure-oci/v0.8.1/metadata.yaml
@@ -1,0 +1,31 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+releaseSeries:
+  - major: 0
+    minor: 1
+    contract: v1beta1
+  - major: 0
+    minor: 2
+    contract: v1beta1
+  - major: 0
+    minor: 3
+    contract: v1beta1
+  - major: 0
+    minor: 4
+    contract: v1beta1
+  - major: 0
+    minor: 5
+    contract: v1beta1
+  - major: 0
+    minor: 6
+    contract: v1beta1
+  - major: 0
+    minor: 7
+    contract: v1beta1
+  - major: 0
+    minor: 8
+    contract: v1beta1


### PR DESCRIPTION
This pull request embeds the manifests/metadata of the providers installed with the CAPI component in the VPO image.  With this change installing CAPI will not pull the manifiest/metadata from the internet.