### PR TITLE
VZ-8749: Add update validators for Prometheus components

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component.go
@@ -1,9 +1,10 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package adapter
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
@@ -11,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -90,4 +93,22 @@ func (c prometheusAdapterComponent) MonitorOverrides(ctx spi.ComponentContext) b
 		return true
 	}
 	return false
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated
+func (c prometheusAdapterComponent) ValidateUpdate(old *v1alpha1.Verrazzano, new *v1alpha1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdate(old, new)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated (VZ v1beta1)
+func (c prometheusAdapterComponent) ValidateUpdateV1Beta1(old *v1beta1.Verrazzano, new *v1beta1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdateV1Beta1(old, new)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
@@ -1,15 +1,17 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package adapter
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const profilesRelativePath = "../../../../../manifests/profiles"
@@ -145,4 +147,111 @@ func TestPreInstallcomponent(t *testing.T) {
 	c := fake.NewClientBuilder().Build()
 	ctx := spi.NewFakeContext(c, &vzapi.Verrazzano{}, nil, true)
 	assert.Nil(t, NewComponent().PreInstall(ctx))
+}
+
+// TestValidateUpdate tests the validate update functions
+func TestValidateUpdate(t *testing.T) {
+	falseValue := false
+	trueValue := true
+	tests := []struct {
+		name    string
+		old     *v1alpha1.Verrazzano
+		new     *v1alpha1.Verrazzano
+		wantErr bool
+	}{
+		{
+			// GIVEN the component is disabled
+			// WHEN the component is enabled and we call the validate update function
+			// THEN no error is returned
+			name: "enable",
+			old: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			new: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is disabled and we call the validate update function
+			// THEN an error is returned
+			name: "disable",
+			old: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is not changed and we call the validate update function
+			// THEN no error is returned
+			name: "no change",
+			old: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			if err := c.ValidateUpdate(tt.old, tt.new); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			v1beta1New := &v1beta1.Verrazzano{}
+			v1beta1Old := &v1beta1.Verrazzano{}
+			err := tt.new.ConvertTo(v1beta1New)
+			assert.NoError(t, err)
+			err = tt.old.ConvertTo(v1beta1Old)
+			assert.NoError(t, err)
+
+			if err := c.ValidateUpdateV1Beta1(v1beta1Old, v1beta1New); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdateV1Beta1() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -155,8 +154,8 @@ func TestValidateUpdate(t *testing.T) {
 	trueValue := true
 	tests := []struct {
 		name    string
-		old     *v1alpha1.Verrazzano
-		new     *v1alpha1.Verrazzano
+		old     *vzapi.Verrazzano
+		new     *vzapi.Verrazzano
 		wantErr bool
 	}{
 		{
@@ -164,19 +163,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is enabled and we call the validate update function
 			// THEN no error is returned
 			name: "enable",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
 							Enabled: &falseValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
 							Enabled: &trueValue,
 						},
 					},
@@ -189,19 +188,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is disabled and we call the validate update function
 			// THEN an error is returned
 			name: "disable",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
 							Enabled: &trueValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
 							Enabled: &falseValue,
 						},
 					},
@@ -214,19 +213,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is not changed and we call the validate update function
 			// THEN no error is returned
 			name: "no change",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
 							Enabled: &trueValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusAdapter: &v1alpha1.PrometheusAdapterComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
 							Enabled: &trueValue,
 						},
 					},

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component.go
@@ -1,9 +1,10 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package kubestatemetrics
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
@@ -12,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	promoperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
@@ -105,4 +108,22 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		})
 	}
 	return kvs, nil
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated
+func (c kubeStateMetricsComponent) ValidateUpdate(old *v1alpha1.Verrazzano, new *v1alpha1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdate(old, new)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated (VZ v1beta1)
+func (c kubeStateMetricsComponent) ValidateUpdateV1Beta1(old *v1beta1.Verrazzano, new *v1beta1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdateV1Beta1(old, new)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -171,8 +170,8 @@ func TestValidateUpdate(t *testing.T) {
 	trueValue := true
 	tests := []struct {
 		name    string
-		old     *v1alpha1.Verrazzano
-		new     *v1alpha1.Verrazzano
+		old     *vzapi.Verrazzano
+		new     *vzapi.Verrazzano
 		wantErr bool
 	}{
 		{
@@ -180,19 +179,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is enabled and we call the validate update function
 			// THEN no error is returned
 			name: "enable",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
 							Enabled: &falseValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
 							Enabled: &trueValue,
 						},
 					},
@@ -205,19 +204,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is disabled and we call the validate update function
 			// THEN an error is returned
 			name: "disable",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
 							Enabled: &trueValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
 							Enabled: &falseValue,
 						},
 					},
@@ -230,19 +229,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is not changed and we call the validate update function
 			// THEN no error is returned
 			name: "no change",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
 							Enabled: &trueValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
 							Enabled: &trueValue,
 						},
 					},

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
@@ -10,7 +10,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 )
 
@@ -161,4 +163,111 @@ func TestAppendNGINXOverrides(t *testing.T) {
 	kvs, err := AppendOverrides(spi.NewFakeContext(nil, vz, nil, false), ComponentName, ComponentNamespace, "", []bom.KeyValue{})
 	assert.NoError(t, err)
 	assert.Len(t, kvs, 1)
+}
+
+// TestValidateUpdate tests the validate update functions
+func TestValidateUpdate(t *testing.T) {
+	falseValue := false
+	trueValue := true
+	tests := []struct {
+		name    string
+		old     *v1alpha1.Verrazzano
+		new     *v1alpha1.Verrazzano
+		wantErr bool
+	}{
+		{
+			// GIVEN the component is disabled
+			// WHEN the component is enabled and we call the validate update function
+			// THEN no error is returned
+			name: "enable",
+			old: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			new: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is disabled and we call the validate update function
+			// THEN an error is returned
+			name: "disable",
+			old: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is not changed and we call the validate update function
+			// THEN no error is returned
+			name: "no change",
+			old: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						KubeStateMetrics: &v1alpha1.KubeStateMetricsComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			if err := c.ValidateUpdate(tt.old, tt.new); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			v1beta1New := &v1beta1.Verrazzano{}
+			v1beta1Old := &v1beta1.Verrazzano{}
+			err := tt.new.ConvertTo(v1beta1New)
+			assert.NoError(t, err)
+			err = tt.old.ConvertTo(v1beta1Old)
+			assert.NoError(t, err)
+
+			if err := c.ValidateUpdateV1Beta1(v1beta1Old, v1beta1New); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdateV1Beta1() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nodeexporter
@@ -13,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	promoperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
@@ -118,4 +120,22 @@ func (c prometheusNodeExporterComponent) PostInstall(ctx spi.ComponentContext) e
 // PostUpgrade creates/updates associated resources after this component is installed
 func (c prometheusNodeExporterComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	return createOrUpdateNetworkPolicies(ctx)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated
+func (c prometheusNodeExporterComponent) ValidateUpdate(old *v1alpha1.Verrazzano, new *v1alpha1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdate(old, new)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated (VZ v1beta1)
+func (c prometheusNodeExporterComponent) ValidateUpdateV1Beta1(old *v1beta1.Verrazzano, new *v1beta1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdateV1Beta1(old, new)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nodeexporter
@@ -8,7 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -251,4 +253,111 @@ func TestPreInstallcomponent(t *testing.T) {
 	c := fake.NewClientBuilder().Build()
 	ctx := spi.NewFakeContext(c, &vzapi.Verrazzano{}, nil, true)
 	assert.Nil(t, NewComponent().PreInstall(ctx))
+}
+
+// TestValidateUpdate tests the validate update functions
+func TestValidateUpdate(t *testing.T) {
+	falseValue := false
+	trueValue := true
+	tests := []struct {
+		name    string
+		old     *v1alpha1.Verrazzano
+		new     *v1alpha1.Verrazzano
+		wantErr bool
+	}{
+		{
+			// GIVEN the component is disabled
+			// WHEN the component is enabled and we call the validate update function
+			// THEN no error is returned
+			name: "enable",
+			old: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			new: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is disabled and we call the validate update function
+			// THEN an error is returned
+			name: "disable",
+			old: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is not changed and we call the validate update function
+			// THEN no error is returned
+			name: "no change",
+			old: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			if err := c.ValidateUpdate(tt.old, tt.new); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			v1beta1New := &v1beta1.Verrazzano{}
+			v1beta1Old := &v1beta1.Verrazzano{}
+			err := tt.new.ConvertTo(v1beta1New)
+			assert.NoError(t, err)
+			err = tt.old.ConvertTo(v1beta1Old)
+			assert.NoError(t, err)
+
+			if err := c.ValidateUpdateV1Beta1(v1beta1Old, v1beta1New); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdateV1Beta1() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -261,8 +260,8 @@ func TestValidateUpdate(t *testing.T) {
 	trueValue := true
 	tests := []struct {
 		name    string
-		old     *v1alpha1.Verrazzano
-		new     *v1alpha1.Verrazzano
+		old     *vzapi.Verrazzano
+		new     *vzapi.Verrazzano
 		wantErr bool
 	}{
 		{
@@ -270,19 +269,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is enabled and we call the validate update function
 			// THEN no error is returned
 			name: "enable",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
 							Enabled: &falseValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
 							Enabled: &trueValue,
 						},
 					},
@@ -295,19 +294,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is disabled and we call the validate update function
 			// THEN an error is returned
 			name: "disable",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
 							Enabled: &trueValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
 							Enabled: &falseValue,
 						},
 					},
@@ -320,19 +319,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is not changed and we call the validate update function
 			// THEN no error is returned
 			name: "no change",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
 							Enabled: &trueValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusNodeExporter: &v1alpha1.PrometheusNodeExporterComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
 							Enabled: &trueValue,
 						},
 					},

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component.go
@@ -1,9 +1,10 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pushgateway
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
@@ -12,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	promoperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
@@ -106,4 +109,22 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		})
 	}
 	return kvs, nil
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated
+func (c prometheusPushgatewayComponent) ValidateUpdate(old *v1alpha1.Verrazzano, new *v1alpha1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdate(old, new)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated (VZ v1beta1)
+func (c prometheusPushgatewayComponent) ValidateUpdateV1Beta1(old *v1beta1.Verrazzano, new *v1beta1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdateV1Beta1(old, new)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component_test.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -197,8 +196,8 @@ func TestValidateUpdate(t *testing.T) {
 	trueValue := true
 	tests := []struct {
 		name    string
-		old     *v1alpha1.Verrazzano
-		new     *v1alpha1.Verrazzano
+		old     *vzapi.Verrazzano
+		new     *vzapi.Verrazzano
 		wantErr bool
 	}{
 		{
@@ -206,19 +205,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is enabled and we call the validate update function
 			// THEN no error is returned
 			name: "enable",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusPushgateway: &v1alpha1.PrometheusPushgatewayComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
 							Enabled: &falseValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusPushgateway: &v1alpha1.PrometheusPushgatewayComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
 							Enabled: &trueValue,
 						},
 					},
@@ -231,19 +230,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is disabled and we call the validate update function
 			// THEN an error is returned
 			name: "disable",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusPushgateway: &v1alpha1.PrometheusPushgatewayComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
 							Enabled: &trueValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusPushgateway: &v1alpha1.PrometheusPushgatewayComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
 							Enabled: &falseValue,
 						},
 					},
@@ -256,19 +255,19 @@ func TestValidateUpdate(t *testing.T) {
 			// WHEN the component is not changed and we call the validate update function
 			// THEN no error is returned
 			name: "no change",
-			old: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusPushgateway: &v1alpha1.PrometheusPushgatewayComponent{
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
 							Enabled: &trueValue,
 						},
 					},
 				},
 			},
-			new: &v1alpha1.Verrazzano{
-				Spec: v1alpha1.VerrazzanoSpec{
-					Components: v1alpha1.ComponentSpec{
-						PrometheusPushgateway: &v1alpha1.PrometheusPushgatewayComponent{
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
 							Enabled: &trueValue,
 						},
 					},


### PR DESCRIPTION
In versions 1.5.x and prior, we did not support disabling an already enabled component in the VZ CR. These four Prometheus components did not have validators that would immediately error on updating the VZ CR:
- Push Gateway
- Adapter
- Node Exporter
- Kube State Metrics

As a result, the VPO would go through an entire reconcile and the net result is a no-op. This PR adds validators so that we fail the VZ CR update and notify the user.

I performed a local test by applying a VZ CR that had the four components enabled, waited for the install to complete, then attempted to disable the four components. As expected the update failed immediately with the following message:
```
Error from server ([Disabling component prometheusAdapter is not allowed, Disabling component kubeStateMetrics is not allowed, Disabling component prometheusPushgateway is not allowed, Disabling component prometheusNodeExporter is not allowed]): error when applying patch:
```

