### PR TITLE
VZ-8749: Add update validators for Prometheus components (release-1.4)

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component.go
@@ -1,17 +1,21 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package adapter
 
 import (
-	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
-	"k8s.io/apimachinery/pkg/runtime"
+	"fmt"
 	"path/filepath"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
 )
 
 // ComponentName is the name of the component
@@ -76,4 +80,22 @@ func (c prometheusAdapterComponent) MonitorOverrides(ctx spi.ComponentContext) b
 		return true
 	}
 	return false
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated
+func (c prometheusAdapterComponent) ValidateUpdate(old *v1alpha1.Verrazzano, new *v1alpha1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdate(old, new)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated (VZ v1beta1)
+func (c prometheusAdapterComponent) ValidateUpdateV1Beta1(old *v1beta1.Verrazzano, new *v1beta1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdateV1Beta1(old, new)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/adapter/promadapter_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package adapter
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 )
 
@@ -68,6 +69,113 @@ func TestIsEnabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := spi.NewFakeContext(nil, &tests[i].actualCR, nil, false, profilesRelativePath)
 			assert.Equal(t, tt.expectTrue, NewComponent().IsEnabled(ctx.EffectiveCR()))
+		})
+	}
+}
+
+// TestValidateUpdate tests the validate update functions
+func TestValidateUpdate(t *testing.T) {
+	falseValue := false
+	trueValue := true
+	tests := []struct {
+		name    string
+		old     *vzapi.Verrazzano
+		new     *vzapi.Verrazzano
+		wantErr bool
+	}{
+		{
+			// GIVEN the component is disabled
+			// WHEN the component is enabled and we call the validate update function
+			// THEN no error is returned
+			name: "enable",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is disabled and we call the validate update function
+			// THEN an error is returned
+			name: "disable",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is not changed and we call the validate update function
+			// THEN no error is returned
+			name: "no change",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusAdapter: &vzapi.PrometheusAdapterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			if err := c.ValidateUpdate(tt.old, tt.new); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			v1beta1New := &v1beta1.Verrazzano{}
+			v1beta1Old := &v1beta1.Verrazzano{}
+			err := tt.new.ConvertTo(v1beta1New)
+			assert.NoError(t, err)
+			err = tt.old.ConvertTo(v1beta1Old)
+			assert.NoError(t, err)
+
+			if err := c.ValidateUpdateV1Beta1(v1beta1Old, v1beta1New); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdateV1Beta1() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component.go
@@ -1,13 +1,17 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package kubestatemetrics
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
+	"fmt"
 	"path/filepath"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	promoperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
@@ -91,4 +95,22 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		})
 	}
 	return kvs, nil
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated
+func (c kubeStateMetricsComponent) ValidateUpdate(old *v1alpha1.Verrazzano, new *v1alpha1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdate(old, new)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated (VZ v1beta1)
+func (c kubeStateMetricsComponent) ValidateUpdateV1Beta1(old *v1beta1.Verrazzano, new *v1beta1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdateV1Beta1(old, new)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package kubestatemetrics

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/kubestatemetrics_component_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 )
 
@@ -68,6 +69,113 @@ func TestIsEnabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := spi.NewFakeContext(nil, &tests[i].actualCR, nil, false, profilesRelativePath)
 			assert.Equal(t, tt.expectTrue, NewComponent().IsEnabled(ctx.EffectiveCR()))
+		})
+	}
+}
+
+// TestValidateUpdate tests the validate update functions
+func TestValidateUpdate(t *testing.T) {
+	falseValue := false
+	trueValue := true
+	tests := []struct {
+		name    string
+		old     *vzapi.Verrazzano
+		new     *vzapi.Verrazzano
+		wantErr bool
+	}{
+		{
+			// GIVEN the component is disabled
+			// WHEN the component is enabled and we call the validate update function
+			// THEN no error is returned
+			name: "enable",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is disabled and we call the validate update function
+			// THEN an error is returned
+			name: "disable",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is not changed and we call the validate update function
+			// THEN no error is returned
+			name: "no change",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						KubeStateMetrics: &vzapi.KubeStateMetricsComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			if err := c.ValidateUpdate(tt.old, tt.new); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			v1beta1New := &v1beta1.Verrazzano{}
+			v1beta1Old := &v1beta1.Verrazzano{}
+			err := tt.new.ConvertTo(v1beta1New)
+			assert.NoError(t, err)
+			err = tt.old.ConvertTo(v1beta1Old)
+			assert.NoError(t, err)
+
+			if err := c.ValidateUpdateV1Beta1(v1beta1Old, v1beta1New); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdateV1Beta1() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
@@ -5,8 +5,9 @@ package nodeexporter
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime"
 	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nodeexporter
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	promoperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
@@ -104,4 +106,22 @@ func (c prometheusNodeExporterComponent) PostInstall(ctx spi.ComponentContext) e
 // PostUpgrade creates/updates associated resources after this component is installed
 func (c prometheusNodeExporterComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	return createOrUpdateNetworkPolicies(ctx)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated
+func (c prometheusNodeExporterComponent) ValidateUpdate(old *v1alpha1.Verrazzano, new *v1alpha1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdate(old, new)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated (VZ v1beta1)
+func (c prometheusNodeExporterComponent) ValidateUpdateV1Beta1(old *v1beta1.Verrazzano, new *v1beta1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdateV1Beta1(old, new)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nodeexporter
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -177,4 +178,111 @@ func TestPostUpgrade(t *testing.T) {
 	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false, profilesRelativePath)
 	err := NewComponent().PostUpgrade(ctx)
 	assert.NoError(t, err)
+}
+
+// TestValidateUpdate tests the validate update functions
+func TestValidateUpdate(t *testing.T) {
+	falseValue := false
+	trueValue := true
+	tests := []struct {
+		name    string
+		old     *vzapi.Verrazzano
+		new     *vzapi.Verrazzano
+		wantErr bool
+	}{
+		{
+			// GIVEN the component is disabled
+			// WHEN the component is enabled and we call the validate update function
+			// THEN no error is returned
+			name: "enable",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is disabled and we call the validate update function
+			// THEN an error is returned
+			name: "disable",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is not changed and we call the validate update function
+			// THEN no error is returned
+			name: "no change",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			if err := c.ValidateUpdate(tt.old, tt.new); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			v1beta1New := &v1beta1.Verrazzano{}
+			v1beta1Old := &v1beta1.Verrazzano{}
+			err := tt.new.ConvertTo(v1beta1New)
+			assert.NoError(t, err)
+			err = tt.old.ConvertTo(v1beta1Old)
+			assert.NoError(t, err)
+
+			if err := c.ValidateUpdateV1Beta1(v1beta1Old, v1beta1New); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdateV1Beta1() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component.go
@@ -1,13 +1,17 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pushgateway
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
+	"fmt"
 	"path/filepath"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	promoperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
@@ -92,4 +96,22 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		})
 	}
 	return kvs, nil
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated
+func (c prometheusPushgatewayComponent) ValidateUpdate(old *v1alpha1.Verrazzano, new *v1alpha1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdate(old, new)
+}
+
+// ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated (VZ v1beta1)
+func (c prometheusPushgatewayComponent) ValidateUpdateV1Beta1(old *v1beta1.Verrazzano, new *v1beta1.Verrazzano) error {
+	// we do not allow disabling this component once it has been enabled
+	if c.IsEnabled(old) && !c.IsEnabled(new) {
+		return fmt.Errorf("Disabling component %s is not allowed", ComponentJSONName)
+	}
+	return c.HelmComponent.ValidateUpdateV1Beta1(old, new)
 }

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/pushgateway_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pushgateway
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 )
 
@@ -96,6 +97,113 @@ func TestIsEnabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := spi.NewFakeContext(nil, &tests[i].actualCR, nil, false, profilesRelativePath)
 			assert.Equal(t, tt.expectTrue, NewComponent().IsEnabled(ctx.EffectiveCR()))
+		})
+	}
+}
+
+// TestValidateUpdate tests the validate update functions
+func TestValidateUpdate(t *testing.T) {
+	falseValue := false
+	trueValue := true
+	tests := []struct {
+		name    string
+		old     *vzapi.Verrazzano
+		new     *vzapi.Verrazzano
+		wantErr bool
+	}{
+		{
+			// GIVEN the component is disabled
+			// WHEN the component is enabled and we call the validate update function
+			// THEN no error is returned
+			name: "enable",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is disabled and we call the validate update function
+			// THEN an error is returned
+			name: "disable",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			// GIVEN the component is enabled
+			// WHEN the component is not changed and we call the validate update function
+			// THEN no error is returned
+			name: "no change",
+			old: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			new: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			if err := c.ValidateUpdate(tt.old, tt.new); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			v1beta1New := &v1beta1.Verrazzano{}
+			v1beta1Old := &v1beta1.Verrazzano{}
+			err := tt.new.ConvertTo(v1beta1New)
+			assert.NoError(t, err)
+			err = tt.old.ConvertTo(v1beta1Old)
+			assert.NoError(t, err)
+
+			if err := c.ValidateUpdateV1Beta1(v1beta1Old, v1beta1New); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateUpdateV1Beta1() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Cherry pick of release-1.5 fix to add update validators to the Prometheus components.

See https://github.com/verrazzano/verrazzano/pull/5840 for details.