### PR TITLE
VZ-9476: enable experimental capi features

### DIFF
--- a/platform-operator/controllers/verrazzano/component/capi/capi.go
+++ b/platform-operator/controllers/verrazzano/component/capi/capi.go
@@ -13,5 +13,14 @@ func preInstall(ctx spi.ComponentContext) error {
 	// Startup the OCI infrastructure provider without requiring OCI credentials
 	os.Setenv("INIT_OCI_CLIENTS_ON_STARTUP", "false")
 
+	// Enable experimental feature cluster resource set at boot up
+	os.Setenv("EXP_CLUSTER_RESOURCE_SET", "true")
+
+	// Enable experimental feature machine pool at boot up
+	os.Setenv("EXP_MACHINE_POOL", "true")
+
+	// Enable experimental feature cluster topology at boot up
+	os.Setenv("CLUSTER_TOPOLOGY", "true")
+
 	return nil
 }


### PR DESCRIPTION
Enabling experimental CAPI features at bootup
https://cluster-api.sigs.k8s.io/tasks/experimental-features/experimental-features.html
