### PR TITLE
VZ-8694: fix CVE in OSD 2.3 by upgrading Node version

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -249,7 +249,7 @@
             },
             {
               "image": "opensearch-dashboards",
-              "tag": "2.3.0-20230324072109-f9e6353395",
+              "tag": "2.3.0-20230424094216-cff07fd190",
               "helmFullImageKey": "monitoringOperator.osdImage"
             },
             {


### PR DESCRIPTION
updated OSD image to upgrade Node version in OSD 2.3 to version 14.21.1.