### PR TITLE
Make MetalLB install script a bit more resilient around resource waits

### DIFF
--- a/tests/e2e/config/scripts/install-metallb.sh
+++ b/tests/e2e/config/scripts/install-metallb.sh
@@ -13,15 +13,11 @@ wget https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/
 sed -i -e "s|log-level=info|log-level=debug|g" metallb-native.yaml
 sed -i -e "s|failureThreshold: 3|failureThreshold: 6|g" metallb-native.yaml
 kubectl apply -f metallb-native.yaml --wait=true
-# Wait for the controller. webhook, and speaker to become ready
-kubectl wait --namespace metallb-system \
-                --for=condition=ready pod \
-                --selector=component=controller \
-                --timeout=600s
-kubectl wait --namespace metallb-system \
-                --for=condition=ready pod \
-                --selector=component=speaker \
-                --timeout=600s
+
+sleep 5 # wait a few before checking the status, sometimes we get some resource errors on MacOS if we check too soon
+kubectl rollout status -n metallb-system deployment controller --timeout=600s
+kubectl rollout status -n metallb-system daemonset speaker --timeout=600s
+
 kubectl set resources daemonset -n metallb-system speaker --limits memory=256Mi,cpu=200m
 
 # Create the IPAddressPool for the cluster


### PR DESCRIPTION
Use `kubectl rollout status` with a little sleep to work around some timing issues using the script locally.