### PR TITLE
VZ-9458: Upgrade OSD image to fix CVE

### DIFF
--- a/tests/e2e/pkg/elasticsearch.go
+++ b/tests/e2e/pkg/elasticsearch.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pkg


### PR DESCRIPTION
- bump node version 14.21.3 in OSD 2.3