### PR TITLE
VZ-8718: Update Keycloak 15.0.2 image with Apache CXF runtime WS security and STS core v3.4.10

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -411,7 +411,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "v15.0.2-20230410125340-baa238fecb",
+              "tag": "v15.0.2-20230426165041-9cc8bdc972",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
This change updates Keycloak 15.0.2 image built with the change https://github.com/verrazzano/keycloak/pull/12