### PR TITLE
VZ-9458: bump node version to 14.21.3 in OSD 2.3

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -249,7 +249,7 @@
             },
             {
               "image": "opensearch-dashboards",
-              "tag": "2.3.0-20230424094216-cff07fd190",
+              "tag": "2.3.0-20230427070433-cc04b43c2b",
               "helmFullImageKey": "monitoringOperator.osdImage"
             },
             {


### PR DESCRIPTION
bump node version to 14.21.3 in OSD 2.3 to fix CVE
