### PR TITLE
VZ-8718: Update Keycloak 15.0.2 image with Apache CXF runtime WS security and STS core v3.4.10, in release-1.4

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -409,8 +409,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak-jenkins",
-              "tag": "v15.0.2-20230426115635-6ee8c9fe58",
+              "image": "keycloak",
+              "tag": "v15.0.2-20230426165041-9cc8bdc972",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -409,8 +409,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak",
-              "tag": "v15.0.2-20230410125340-baa238fecb",
+              "image": "keycloak-jenkins",
+              "tag": "v15.0.2-20230426115635-6ee8c9fe58",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
This change updates Keycloak 15.0.2 image built with the change https://github.com/verrazzano/keycloak/pull/12
