### PR TITLE
VZ-9434: BackPort: Add seLinuxOptions in Fluentd Daemonset Helm chart (#5875)

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-fluentd/templates/daemonset.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-fluentd/templates/daemonset.yaml
@@ -82,6 +82,13 @@ spec:
           image: {{ .Values.logging.fluentdImage }}
           imagePullPolicy: IfNotPresent
           securityContext:
+{{- if .Values.seLinuxOptions }}
+            seLinuxOptions:
+              type: {{ .Values.seLinuxOptions.type }}
+              level: {{ .Values.seLinuxOptions.level }}
+              role: {{ .Values.seLinuxOptions.role }}
+              user: {{ .Values.seLinuxOptions.user }}
+{{- end }}
             privileged: false
             allowPrivilegeEscalation: false
             capabilities:

--- a/platform-operator/helm_config/charts/verrazzano-fluentd/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-fluentd/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 name: verrazzano-fluentd
 
@@ -24,3 +24,15 @@ fluentd:
 monitoring:
   enabled: true
   useIstioCerts: true
+
+# In the environment where SELinux is enforcing, you can consider to override the default SELinux security context for the Fluentd so that it can have the required read/write privileges.
+# By customizing these options, you can ensure that Fluentd operates within the appropriate SELinux security context.
+seLinuxOptions:
+  # -- String to override the SELinux type for the Fluentd process. This determines the access permissions and restrictions for the Fluentd.
+  type: "" # spc_t
+  # -- String to override the  SELinux level for the Fluentd process. It represents the sensitivity level of the Fluentd in relation to other SELinux-labeled objects.
+  level: "" # s0
+  # -- String to override the SELinux role for the Fluentd process. It defines the role or set of permissions that the process running the Fluentd can have.
+  role: "" # system_r
+  # -- String to override the SELinux user for the Fluentd process. It specifies the SELinux user identity that the process should run as.
+  user: "" # system_u


### PR DESCRIPTION
To add seLinuxOptions to get it overridden in case selinux is enforcing.  
There will be no values passed to it by default. But customer can override these if they want to provide seLinuxOptions in case seLinux is enforcing.