### PR TITLE
VZ-9306: PR to update new version of additional rancher images for VZ release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,15 +151,15 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.2.6-20230208201837-b7fc3c3"
+              "tag": "v0.3.2-20230420144706-e94a4e1"
             },
             {
               "image": "rancher-fleet-agent",
-              "tag": "v0.3.11-20230208201743-7400667"
+              "tag": "v0.5.1-20230501171656-8296311"
             },
             {
               "image": "rancher-fleet",
-              "tag": "v0.3.11-20230208201743-7400667"
+              "tag": "v0.5.1-20230501171656-8296311"
             },
             {
               "image": "rancher-gitjob",
@@ -728,7 +728,7 @@
           "images": [
             {
               "image": "rancher-backup-restore-operator",
-              "tag": "v2.1.3-20230208201830-0977be7",
+              "tag": "v3.0.0-20230502110013-6ab52e7",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -740,7 +740,7 @@
           "images": [
             {
               "image": "rancher-kubectl",
-              "tag": "v1.20.2-20230208201835-2f0ea54",
+              "tag": "v1.24.5-20230427142044-2f0ea54",
               "helmFullImageKey": "global.kubectl.repository",
               "helmTagKey": "global.kubectl.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,7 +151,7 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.3.2-20230420144706-e94a4e1"
+              "tag": "v0.2.6-20230208201837-b7fc3c3"
             },
             {
               "image": "rancher-fleet-agent",


### PR DESCRIPTION
This PR updates VZ release-1.5 with new version of additional rancher images such as rancher-kubectl, backup and restore operator, fleet, and fleet-agent. 