### PR TITLE
VZ-9208: AuthorizationPolicy Missing for Jaeger Traces to be transmitted

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano/values.yaml
@@ -97,6 +97,6 @@ istio:
   enabled: true
 
 jaegerOperator:
-  enabled: false
+  enabled: true
   namespace: verrazzano-monitoring
   jaegerServiceAccount: jaeger-operator-jaeger


### PR DESCRIPTION
Enable AuthorizationPolicy for Jaeger Operator component when the component is enabled