### PR TITLE
Improve output of verify-distribution tests

### DIFF
--- a/tests/e2e/verify-distribution/verifydistribution/verify_distribution_test.go
+++ b/tests/e2e/verify-distribution/verifydistribution/verify_distribution_test.go
@@ -6,13 +6,14 @@ package verifydistribution
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
 	"github.com/onsi/gomega"
 	. "github.com/verrazzano/verrazzano/pkg/files"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
-	"os"
-	"path/filepath"
-	"regexp"
 )
 
 const SLASH = string(filepath.Separator)

--- a/tests/e2e/verify-distribution/verifydistribution/verify_distribution_test.go
+++ b/tests/e2e/verify-distribution/verifydistribution/verify_distribution_test.go
@@ -6,16 +6,13 @@ package verifydistribution
 import (
 	"bufio"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	. "github.com/verrazzano/verrazzano/pkg/files"
-	. "github.com/verrazzano/verrazzano/pkg/string"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 )
 
 const SLASH = string(filepath.Separator)
@@ -84,7 +81,7 @@ var _ = t.Describe("Verify VZ distribution", func() {
 				for _, each := range filesInfo {
 					filesList = append(filesList, each.Name())
 				}
-				compareContents(filesList, liteBundleZipContents)
+				gomega.Expect(filesList).Should(gomega.ConsistOf(liteBundleZipContents))
 			})
 
 			t.It("Verify Lite bundle extracted contents", func() {
@@ -150,7 +147,7 @@ var _ = t.Describe("Verify VZ distribution", func() {
 					eachName = regexTar.ReplaceAllString(eachName, "")
 					imagesList = append(imagesList, eachName)
 				}
-				compareContents(componentsList, imagesList)
+				gomega.Expect(imagesList).Should(gomega.ConsistOf(componentsList))
 			})
 		})
 	}
@@ -172,7 +169,7 @@ var _ = t.Describe("Verify VZ distribution", func() {
 				eachName := re1.ReplaceAllString(each, "")
 				chartsFilesListFiltered = append(chartsFilesListFiltered, eachName)
 			}
-			compareContents(sourcesFilesFilteredList, chartsFilesListFiltered)
+			gomega.Expect(sourcesFilesFilteredList).Should(gomega.ConsistOf(chartsFilesListFiltered))
 		})
 	})
 })
@@ -191,25 +188,10 @@ func verifyDistributionByDirectory(inputDir string, key string, variant string) 
 	}
 	if variant == liteDistribution {
 		fmt.Println("Provided variant is: ", variant)
-		compareContents(filesList, opensourcefileslistbydir[key])
+		gomega.Expect(filesList).Should(gomega.ConsistOf(opensourcefileslistbydir[key]))
 	} else {
 		fmt.Println("Provided variant is: Full")
-		compareContents(filesList, fullBundleFileslistbydir[key])
+		gomega.Expect(filesList).Should(gomega.ConsistOf(fullBundleFileslistbydir[key]))
 	}
 	fmt.Printf("All files found for %s \n", key)
-}
-
-func compareContents(slice1 []string, slice2 []string) {
-	areSame := AreSlicesEqualWithoutOrder(slice1, slice2)
-	if !areSame {
-		//Copy and sort for finding diff
-		s1 := make([]string, len(slice1))
-		s2 := make([]string, len(slice2))
-		copy(s1, slice1)
-		copy(s2, slice2)
-		sort.Strings(s1)
-		sort.Strings(s2)
-		t.Logs.Errorf("Found mismatch; %s", cmp.Diff(s1, s2))
-	}
-	gomega.Expect(areSame).To(gomega.BeTrue())
 }


### PR DESCRIPTION
Use Gomega matchers to improve the output of the `verify-distribution` tests.