### PR TITLE
Revert: VZ-5060 add streaming directives to nginx configuration to address websocket errors in Rancher console

### DIFF
--- a/platform-operator/controllers/verrazzano/component/nginx/nginx.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nginx
@@ -61,9 +61,6 @@ func AppendOverrides(context spi.ComponentContext, _ string, _ string, _ string,
 
 	// Convert NGINX install-args to helm overrides
 	newKvs = append(newKvs, helm.GetInstallArgs(getInstallArgs(cr))...)
-
-	newKvs = append(newKvs, bom.KeyValue{Key: "controller.allowSnippetAnnotations", Value: "true"})
-
 	return newKvs, nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nginx

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nginx
@@ -39,7 +39,7 @@ func TestAppendNGINXOverrides(t *testing.T) {
 	vz := &vzapi.Verrazzano{}
 	kvs, err := AppendOverrides(spi.NewFakeContext(nil, vz, nil, false), ComponentName, nginxutil.IngressNGINXNamespace(), "", []bom.KeyValue{})
 	assert.NoError(t, err)
-	assert.Len(t, kvs, 2)
+	assert.Len(t, kvs, 1)
 }
 
 // TestAppendNGINXOverridesWithInstallArgs tests the AppendOverrides fn
@@ -63,7 +63,7 @@ func TestAppendNGINXOverridesWithInstallArgs(t *testing.T) {
 	}
 	kvs, err := AppendOverrides(spi.NewFakeContext(nil, vz, nil, false), ComponentName, nginxutil.IngressNGINXNamespace(), "", []bom.KeyValue{})
 	assert.NoError(t, err)
-	assert.Len(t, kvs, 5)
+	assert.Len(t, kvs, 4)
 }
 
 // TestAppendNGINXOverridesExtraKVs tests the AppendOverrides fn
@@ -93,7 +93,7 @@ func TestAppendNGINXOverridesWithExternalDNS(t *testing.T) {
 	}
 	kvs, err := AppendOverrides(spi.NewFakeContext(nil, vz, nil, false), ComponentName, nginxutil.IngressNGINXNamespace(), "", []bom.KeyValue{})
 	assert.NoError(t, err)
-	assert.Len(t, kvs, 7)
+	assert.Len(t, kvs, 6)
 }
 
 // TestAppendNGINXOverridesExtraKVs tests the AppendOverrides fn
@@ -112,7 +112,7 @@ func TestAppendNGINXOverridesExtraKVs(t *testing.T) {
 	}
 	kvs, err := AppendOverrides(spi.NewFakeContext(nil, vz, nil, false), ComponentName, nginxutil.IngressNGINXNamespace(), "", kvs)
 	assert.NoError(t, err)
-	assert.Len(t, kvs, 3)
+	assert.Len(t, kvs, 2)
 }
 
 // TestNGINXPreInstall tests the PreInstall fn

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package nginx

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -67,30 +67,6 @@ const cattleShellImageName = "rancher-shell"
 // cattleUIEnvName is the environment variable name to set for the Rancher dashboard
 const cattleUIEnvName = "CATTLE_UI_OFFLINE_PREFERRED"
 
-const streamSnippetAnnotation = `ingress.extraAnnotations.nginx\.ingress\.kubernetes\.io/stream-snippet`
-
-const streamSnippet = `
-    upstream rancher_servers_http {
-        least_conn;
-        server %[1]s.%[2]s.svc.cluster.local:80 max_fails=3 fail_timeout=5s;
-    }
-
-    server {
-        listen 80;
-        proxy_pass rancher_servers_http;
-    }
-
-    upstream rancher_servers_https {
-        least_conn;
-        server %[1]s.%[2]s.svc.cluster.local:443 max_fails=3 fail_timeout=5s;
-    }
-
-    server {
-        listen 443;
-        proxy_pass rancher_servers_https;
-    }
-`
-
 // Environment variables for the Rancher images
 // format: imageName: baseEnvVar
 var imageEnvVars = map[string]string{
@@ -207,11 +183,6 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 	kvs = append(kvs, bom.KeyValue{
 		Key:   rancherIngressClassNameKey,
 		Value: vzconfig.GetIngressClassName(ctx.EffectiveCR()),
-	})
-	kvs = append(kvs, bom.KeyValue{
-		Key:       streamSnippetAnnotation,
-		Value:     fmt.Sprintf(streamSnippet, ComponentName, ComponentNamespace),
-		SetString: true,
 	})
 	kvs, err = appendPSPEnabledOverrides(ctx, kvs)
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -82,17 +82,17 @@ func TestAppendRegistryOverrides(t *testing.T) {
 	registry := "foobar"
 	imageRepo := "barfoo"
 	kvs, _ := AppendOverrides(ctx, "", "", "", []bom.KeyValue{})
-	assert.Equal(t, 29, len(kvs)) // should only have LetsEncrypt + useBundledSystemChart + RancherImage Overrides
+	assert.Equal(t, 28, len(kvs)) // should only have LetsEncrypt + useBundledSystemChart + RancherImage Overrides
 	_ = os.Setenv(constants.RegistryOverrideEnvVar, registry)
 	kvs, _ = AppendOverrides(ctx, "", "", "", []bom.KeyValue{})
-	assert.Equal(t, 30, len(kvs)) // one extra for the systemDefaultRegistry override
+	assert.Equal(t, 29, len(kvs)) // one extra for the systemDefaultRegistry override
 	v, ok := getValue(kvs, systemDefaultRegistryKey)
 	assert.True(t, ok)
 	assert.Equal(t, registry, v)
 
 	_ = os.Setenv(constants.ImageRepoOverrideEnvVar, imageRepo)
 	kvs, _ = AppendOverrides(ctx, "", "", "", []bom.KeyValue{})
-	assert.Equal(t, 30, len(kvs))
+	assert.Equal(t, 29, len(kvs))
 	v, ok = getValue(kvs, systemDefaultRegistryKey)
 	assert.True(t, ok)
 	assert.Equal(t, fmt.Sprintf("%s/%s", registry, imageRepo), v)


### PR DESCRIPTION
Revert this PR and investigate MC and uninstall failures.