### PR TITLE
VZ-9459.  Allow install-before-upgrade for OCI DNS CM webhook

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanagerconfig/certmanager_config_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanagerconfig/certmanager_config_component.go
@@ -6,7 +6,6 @@ package certmanagerconfig
 import (
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanagerocidns"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -43,7 +42,6 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
-			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_0_0,
 			Dependencies:              []string{networkpolicies.ComponentName, certmanager.ComponentName, certmanagerocidns.ComponentName},
 		},
 	}

--- a/platform-operator/controllers/verrazzano/component/certmanagerocidns/certmanagerocidns_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanagerocidns/certmanagerocidns_component.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"path/filepath"
 
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -44,8 +43,8 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
+			InstallBeforeUpgrade:      true,
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0].name",
-			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_0_0,
 			Dependencies:              []string{networkpolicies.ComponentName, certmanager.ComponentName},
 		},
 	}

--- a/tests/e2e/verify-distribution/verifydistribution/verify_distribution_test.go
+++ b/tests/e2e/verify-distribution/verifydistribution/verify_distribution_test.go
@@ -6,16 +6,14 @@ package verifydistribution
 import (
 	"bufio"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/onsi/gomega"
-	. "github.com/verrazzano/verrazzano/pkg/files"
-	. "github.com/verrazzano/verrazzano/pkg/string"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+
+	"github.com/onsi/gomega"
+	. "github.com/verrazzano/verrazzano/pkg/files"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 )
 
 const SLASH = string(filepath.Separator)
@@ -84,7 +82,7 @@ var _ = t.Describe("Verify VZ distribution", func() {
 				for _, each := range filesInfo {
 					filesList = append(filesList, each.Name())
 				}
-				compareContents(filesList, liteBundleZipContents)
+				gomega.Expect(filesList).Should(gomega.ConsistOf(liteBundleZipContents))
 			})
 
 			t.It("Verify Lite bundle extracted contents", func() {
@@ -150,7 +148,7 @@ var _ = t.Describe("Verify VZ distribution", func() {
 					eachName = regexTar.ReplaceAllString(eachName, "")
 					imagesList = append(imagesList, eachName)
 				}
-				compareContents(componentsList, imagesList)
+				gomega.Expect(imagesList).Should(gomega.ConsistOf(componentsList))
 			})
 		})
 	}
@@ -172,7 +170,7 @@ var _ = t.Describe("Verify VZ distribution", func() {
 				eachName := re1.ReplaceAllString(each, "")
 				chartsFilesListFiltered = append(chartsFilesListFiltered, eachName)
 			}
-			compareContents(sourcesFilesFilteredList, chartsFilesListFiltered)
+			gomega.Expect(sourcesFilesFilteredList).Should(gomega.ConsistOf(chartsFilesListFiltered))
 		})
 	})
 })
@@ -191,25 +189,10 @@ func verifyDistributionByDirectory(inputDir string, key string, variant string) 
 	}
 	if variant == liteDistribution {
 		fmt.Println("Provided variant is: ", variant)
-		compareContents(filesList, opensourcefileslistbydir[key])
+		gomega.Expect(filesList).Should(gomega.ConsistOf(opensourcefileslistbydir[key]))
 	} else {
 		fmt.Println("Provided variant is: Full")
-		compareContents(filesList, fullBundleFileslistbydir[key])
+		gomega.Expect(filesList).Should(gomega.ConsistOf(fullBundleFileslistbydir[key]))
 	}
 	fmt.Printf("All files found for %s \n", key)
-}
-
-func compareContents(slice1 []string, slice2 []string) {
-	areSame := AreSlicesEqualWithoutOrder(slice1, slice2)
-	if !areSame {
-		//Copy and sort for finding diff
-		s1 := make([]string, len(slice1))
-		s2 := make([]string, len(slice2))
-		copy(s1, slice1)
-		copy(s2, slice2)
-		sort.Strings(s1)
-		sort.Strings(s2)
-		t.Logs.Errorf("Found mismatch; %s", cmp.Diff(s1, s2))
-	}
-	gomega.Expect(areSame).To(gomega.BeTrue())
 }

--- a/tests/e2e/verify-distribution/verifydistribution/verify_distribution_test.go
+++ b/tests/e2e/verify-distribution/verifydistribution/verify_distribution_test.go
@@ -6,14 +6,16 @@ package verifydistribution
 import (
 	"bufio"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/onsi/gomega"
+	. "github.com/verrazzano/verrazzano/pkg/files"
+	. "github.com/verrazzano/verrazzano/pkg/string"
+	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
+	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"os"
 	"path/filepath"
 	"regexp"
-
-	"github.com/onsi/gomega"
-	. "github.com/verrazzano/verrazzano/pkg/files"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
-	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
+	"sort"
 )
 
 const SLASH = string(filepath.Separator)
@@ -82,7 +84,7 @@ var _ = t.Describe("Verify VZ distribution", func() {
 				for _, each := range filesInfo {
 					filesList = append(filesList, each.Name())
 				}
-				gomega.Expect(filesList).Should(gomega.ConsistOf(liteBundleZipContents))
+				compareContents(filesList, liteBundleZipContents)
 			})
 
 			t.It("Verify Lite bundle extracted contents", func() {
@@ -148,7 +150,7 @@ var _ = t.Describe("Verify VZ distribution", func() {
 					eachName = regexTar.ReplaceAllString(eachName, "")
 					imagesList = append(imagesList, eachName)
 				}
-				gomega.Expect(imagesList).Should(gomega.ConsistOf(componentsList))
+				compareContents(componentsList, imagesList)
 			})
 		})
 	}
@@ -170,7 +172,7 @@ var _ = t.Describe("Verify VZ distribution", func() {
 				eachName := re1.ReplaceAllString(each, "")
 				chartsFilesListFiltered = append(chartsFilesListFiltered, eachName)
 			}
-			gomega.Expect(sourcesFilesFilteredList).Should(gomega.ConsistOf(chartsFilesListFiltered))
+			compareContents(sourcesFilesFilteredList, chartsFilesListFiltered)
 		})
 	})
 })
@@ -189,10 +191,25 @@ func verifyDistributionByDirectory(inputDir string, key string, variant string) 
 	}
 	if variant == liteDistribution {
 		fmt.Println("Provided variant is: ", variant)
-		gomega.Expect(filesList).Should(gomega.ConsistOf(opensourcefileslistbydir[key]))
+		compareContents(filesList, opensourcefileslistbydir[key])
 	} else {
 		fmt.Println("Provided variant is: Full")
-		gomega.Expect(filesList).Should(gomega.ConsistOf(fullBundleFileslistbydir[key]))
+		compareContents(filesList, fullBundleFileslistbydir[key])
 	}
 	fmt.Printf("All files found for %s \n", key)
+}
+
+func compareContents(slice1 []string, slice2 []string) {
+	areSame := AreSlicesEqualWithoutOrder(slice1, slice2)
+	if !areSame {
+		//Copy and sort for finding diff
+		s1 := make([]string, len(slice1))
+		s2 := make([]string, len(slice2))
+		copy(s1, slice1)
+		copy(s2, slice2)
+		sort.Strings(s1)
+		sort.Strings(s2)
+		t.Logs.Errorf("Found mismatch; %s", cmp.Diff(s1, s2))
+	}
+	gomega.Expect(areSame).To(gomega.BeTrue())
 }


### PR DESCRIPTION
Set `InstallBeforeUpgrade=true` for new OCI DNS CM webhook solver, to allow it to spin up during upgrade from an earlier release.

Also remove the min-version hooks on the cert-manager-config and webhook components.
