### PR TITLE
VZ-9531: Support installing VPO image from private registry with credentials

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/istio_install_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package istio

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install_test.go
@@ -421,6 +421,10 @@ func getIstioInstallMock(t *testing.T) *mocks.MockClient {
 		Return(errors.NewNotFound(schema.GroupResource{Group: constants.DefaultNamespace, Resource: "Secret"}, constants.GlobalImagePullSecName)).AnyTimes()
 
 	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoInstallNamespace, Name: constants.GlobalImagePullSecName}, gomock.Not(gomock.Nil())).
+		Return(errors.NewNotFound(schema.GroupResource{Group: constants.DefaultNamespace, Resource: "Secret"}, constants.GlobalImagePullSecName)).AnyTimes()
+
+	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: IstioNamespace, Name: constants.GlobalImagePullSecName}, gomock.Not(gomock.Nil())).
 		Return(errors.NewNotFound(schema.GroupResource{Group: IstioNamespace, Resource: "Secret"}, constants.GlobalImagePullSecName)).AnyTimes()
 	return mock

--- a/platform-operator/controllers/verrazzano/secret/image_pull_secret.go
+++ b/platform-operator/controllers/verrazzano/secret/image_pull_secret.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package secret
 

--- a/platform-operator/controllers/verrazzano/secret/image_pull_secret.go
+++ b/platform-operator/controllers/verrazzano/secret/image_pull_secret.go
@@ -4,6 +4,7 @@ package secret
 
 import (
 	"context"
+
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -24,11 +25,18 @@ func CheckImagePullSecret(client client.Client, targetNamespace string) (bool, e
 	var sourceSecret v1.Secret
 	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: constants.GlobalImagePullSecName}, &sourceSecret); err != nil {
 		if errors.IsNotFound(err) {
-			// Global secret not found
-			return false, nil
+			// Global secret not found in default namespace, check the verrazzano-install namespace
+			if err = client.Get(context.TODO(), types.NamespacedName{Namespace: constants.VerrazzanoInstallNamespace, Name: constants.GlobalImagePullSecName}, &sourceSecret); err != nil {
+				if errors.IsNotFound(err) {
+					return false, nil
+				}
+			}
 		}
-		// we had an unexpected error
-		return false, err
+
+		if err != nil {
+			// we had an unexpected error
+			return false, err
+		}
 	}
 
 	targetSecret := v1.Secret{

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
@@ -71,10 +71,6 @@ spec:
             - name: CLUSTER_OPERATOR_IMAGE
               value: {{ .Values.global.clusterOperatorImage }}
             {{- end }}
-            {{- if .Values.global.imagePullSecrets }}
-            - name: IMAGE_PULL_SECRETS
-              value: {{ join "," .Values.global.imagePullSecrets }}
-            {{- end }}
           resources:
             requests:
               memory: 72Mi

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/values.yaml
@@ -6,7 +6,8 @@ createNamespace: true
 namespaceLabelKey: verrazzano.io/namespace
 
 global:
-  imagePullSecrets: []
+  imagePullSecrets:
+    - verrazzano-container-registry
 
 # NOTE: The image value gets set in the bill of materials file (verrazzano-bom.json) during the
 # platform operator docker build.


### PR DESCRIPTION
The current public doc instructions for installing from a private registry state that the VPO image must be public (i.e. pullable without credentials). This PR fixes that so the VPO image can be private.

The VPO already copies the `verrazzano-container-registry` secret from the default namespace (if it exists) to all target namespaces when installing components. This PR enables the VPO to also look for the secret in the `verrazzano-install` namespace if the secret does not exist in the default namespace.

Once this is merged, the public documentation will be updated to instruct the user to create the `verrazzano-container-registry` secret in the `verrazzan-install` namespace instead of the default namespace. We will also remove the instructions on making the VPO image public.

Once this is merged and the latest private registry pipeline changes for air gap are merged, I will submit a PR to update that pipeline to create the secret in the `verrazzano-install` namespace and make the VPO image private.