### PR TITLE
Prefix compartment ID with newline when copying the OCI DNS secret

### DIFF
--- a/platform-operator/controllers/verrazzano/component/common/externaldns.go
+++ b/platform-operator/controllers/verrazzano/component/common/externaldns.go
@@ -53,7 +53,7 @@ func CopyOCIDNSSecret(compContext spi.ComponentContext, targetNamespace string) 
 
 		// Extract data and create secret in the external DNS namespace
 		for k := range dnsSecret.Data {
-			targetDNSSecret.Data[ociSecretFileName] = append(dnsSecret.Data[k], []byte(fmt.Sprintf("\ncompartment: %s", ociDNS.DNSZoneCompartmentOCID))...)
+			targetDNSSecret.Data[ociSecretFileName] = append(dnsSecret.Data[k], []byte(fmt.Sprintf("\ncompartment: %s\n", ociDNS.DNSZoneCompartmentOCID))...)
 		}
 
 		return nil

--- a/platform-operator/controllers/verrazzano/component/common/externaldns.go
+++ b/platform-operator/controllers/verrazzano/component/common/externaldns.go
@@ -53,7 +53,7 @@ func CopyOCIDNSSecret(compContext spi.ComponentContext, targetNamespace string) 
 
 		// Extract data and create secret in the external DNS namespace
 		for k := range dnsSecret.Data {
-			targetDNSSecret.Data[ociSecretFileName] = append(dnsSecret.Data[k], []byte(fmt.Sprintf("compartment: %s", ociDNS.DNSZoneCompartmentOCID))...)
+			targetDNSSecret.Data[ociSecretFileName] = append(dnsSecret.Data[k], []byte(fmt.Sprintf("\ncompartment: %s", ociDNS.DNSZoneCompartmentOCID))...)
 		}
 
 		return nil


### PR DESCRIPTION
Prefix/postfix newline chars to the `compartment` field when we add it to the OCI DNS secret on copy.