### PR TITLE
Backport newline fix to release-1.5

### DIFF
--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package externaldns

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -82,7 +82,7 @@ func preInstall(compContext spi.ComponentContext) error {
 
 		// Extract data and create secret in the external DNS namespace
 		for k := range dnsSecret.Data {
-			externalDNSSecret.Data[ociSecretFileName] = append(dnsSecret.Data[k], []byte(fmt.Sprintf("compartment: %s", dns.OCI.DNSZoneCompartmentOCID))...)
+			externalDNSSecret.Data[ociSecretFileName] = append(dnsSecret.Data[k], []byte(fmt.Sprintf("\ncompartment: %s\n", dns.OCI.DNSZoneCompartmentOCID))...)
 		}
 
 		return nil


### PR DESCRIPTION
Backport a fix to prepend/append newlines to the compartment ID field we add when copying the OCI DNS secret 