### PR TITLE
VZ-9459.  Update OCI DNS webhook image updated to CM 1.9.1

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -85,8 +85,8 @@
           "name": "verrazzano-ocidns-webhook",
           "images": [
             {
-              "image": "cert-manager-ocidns-provider-jenkins",
-              "tag": "v1.6.0-20230507022715-b5f032a",
+              "image": "cert-manager-ocidns-provider",
+              "tag": "v1.6.0-20230508014717-8f96003",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -86,7 +86,7 @@
           "images": [
             {
               "image": "cert-manager-ocidns-provider",
-              "tag": "v1.6.0-20230508014717-8f96003",
+              "tag": "v1.6.0-20230508022415-4c191ba",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -85,8 +85,8 @@
           "name": "verrazzano-ocidns-webhook",
           "images": [
             {
-              "image": "cert-manager-ocidns-provider",
-              "tag": "v1.6.0-20230504165629-66c95f5",
+              "image": "cert-manager-ocidns-provider-jenkins",
+              "tag": "v1.6.0-20230507022715-b5f032a",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updated OCI DNS webhook image built using CM 1.9.1 API.