### PR TITLE
VZ-9482 - Add --manifests flag to VZ CLI in order to be able to run it in air gapped environment without downloading VPO manifests

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -321,7 +321,7 @@ pipeline {
                         fi
                     else
                         echo "Upgrading VPO to this commit version"
-                        ${GO_REPO_PATH}/vz upgrade --operator-file ${WORKSPACE}/upgrade-test-operator.yaml --version ${VERRAZZANO_DEV_VERSION}
+                        ${GO_REPO_PATH}/vz upgrade --manifests ${WORKSPACE}/upgrade-test-operator.yaml --version ${VERRAZZANO_DEV_VERSION}
                          kubectl wait --timeout=45m --for=condition=UpgradeComplete verrazzano/my-verrazzano
                     fi
 

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -297,7 +297,7 @@ pipeline {
                             fi
 
                             echo "Installing Verrazzano"
-                            ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/platform-operator.yaml --timeout 45m --platform-operator-timeout 10m
+                            ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --manifests ${WORKSPACE}/platform-operator.yaml --timeout 45m --platform-operator-timeout 10m
 
                             # For now, manually scale the VPO webhook to 3 replicas until we have hooks for it in the product
                             kubectl  scale deployment -n verrazzano-install verrazzano-platform-operator-webhook --replicas 3

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -192,7 +192,7 @@ pipeline {
 
                         sh """
                             echo "Upgrading the Verrazzano installation to version" ${VERRAZZANO_UPGRADE_VERSION}
-                            ${GO_REPO_PATH}/vz upgrade --version ${VERRAZZANO_UPGRADE_VERSION} --operator-file ${OPERATOR_YAML_LOCATION}
+                            ${GO_REPO_PATH}/vz upgrade --version ${VERRAZZANO_UPGRADE_VERSION} --manifests ${OPERATOR_YAML_LOCATION}
                         """
                     } else {
                         echo "No upgrade is needed.  Verrazzano is already at the expected version."

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -833,7 +833,7 @@ def installVerrazzanoOnCluster(count, verrazzanoConfig) {
               ./tests/e2e/config/scripts/multicluster_edit_vz.sh ${count} ${verrazzanoConfig}
 
                 echo "Installing the Verrazzano Platform Operator"
-                time ${VZ_COMMAND} install --operator-file ${OPERATOR_YAML_FILE} -f ${verrazzanoConfig}
+                time ${VZ_COMMAND} install --manifests ${OPERATOR_YAML_FILE} -f ${verrazzanoConfig}
             """
         }
     }

--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -875,7 +875,7 @@ def installVerrazzano() {
     env.installedVZ="true"
     sh """
         # Install Verrazzano
-        $VZ_COMMAND install -f $INSTALL_CONFIG_FILE_OCNE --set profile="$INSTALL_PROFILE" --set environmentName="$VZ_ENVIRONMENT_NAME" --operator-file="$VZ_PLATFORM_OPERTOR_YAML"
+        $VZ_COMMAND install -f $INSTALL_CONFIG_FILE_OCNE --set profile="$INSTALL_PROFILE" --set environmentName="$VZ_ENVIRONMENT_NAME" --manifests="$VZ_PLATFORM_OPERTOR_YAML"
         $VZ_COMMAND status
 
         # Print out the namespaces

--- a/ci/scripts/install_verrazzano.sh
+++ b/ci/scripts/install_verrazzano.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # Required env vars:

--- a/ci/scripts/install_verrazzano.sh
+++ b/ci/scripts/install_verrazzano.sh
@@ -188,10 +188,10 @@ fi
 echo "Installing Verrazzano on Kind"
 if [ -f "$WORKSPACE/vz" ]; then
   cd $WORKSPACE
-  ./vz install --filename ${WORKSPACE}/acceptance-test-config.yaml --operator-file ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
+  ./vz install --filename ${WORKSPACE}/acceptance-test-config.yaml --manifests ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
 else
   cd ${GO_REPO_PATH}/verrazzano/tools/vz
-  GO111MODULE=on GOPRIVATE=github.com/verrazzano go run main.go install --filename ${VZ_INSTALL_FILE} --operator-file ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
+  GO111MODULE=on GOPRIVATE=github.com/verrazzano go run main.go install --filename ${VZ_INSTALL_FILE} --manifests ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
 fi
 
 result=$?

--- a/ci/scripts/prepare_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_jenkins_at_environment.sh
@@ -167,10 +167,10 @@ fi
 echo "Installing Verrazzano on Kind"
 if [ -f "$WORKSPACE/vz" ]; then
   cd $WORKSPACE
-  ./vz install --filename ${WORKSPACE}/acceptance-test-config.yaml --operator-file ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
+  ./vz install --filename ${WORKSPACE}/acceptance-test-config.yaml --manifests ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
 else
   cd ${GO_REPO_PATH}/verrazzano/tools/vz
-  GO111MODULE=on GOPRIVATE=github.com/verrazzano go run main.go install --filename ${VZ_INSTALL_FILE} --operator-file ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
+  GO111MODULE=on GOPRIVATE=github.com/verrazzano go run main.go install --filename ${VZ_INSTALL_FILE} --manifests ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
 fi
 result=$?
 if [[ $result -ne 0 ]]; then

--- a/ci/scripts/prepare_kind_cluster_dns_pipeline.sh
+++ b/ci/scripts/prepare_kind_cluster_dns_pipeline.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/ci/scripts/prepare_kind_cluster_dns_pipeline.sh
+++ b/ci/scripts/prepare_kind_cluster_dns_pipeline.sh
@@ -112,10 +112,10 @@ cd ${TEST_SCRIPTS_DIR}
 echo "Installing Verrazzano on Kind"
 if [ -f "$WORKSPACE/vz" ]; then
   cd $WORKSPACE
-  ./vz install --filename $INSTALL_CONFIG_FILE_OCIDNS --operator-file ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
+  ./vz install --filename $INSTALL_CONFIG_FILE_OCIDNS --manifests ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
 else
   cd ${GO_REPO_PATH}/verrazzano/tools/vz
-  GO111MODULE=on GOPRIVATE=github.com/verrazzano go run main.go install --filename $INSTALL_CONFIG_FILE_OCIDNS --operator-file ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
+  GO111MODULE=on GOPRIVATE=github.com/verrazzano go run main.go install --filename $INSTALL_CONFIG_FILE_OCIDNS --manifests ${TARGET_OPERATOR_FILE} --timeout ${INSTALL_TIMEOUT_VALUE}
 fi
 result=$?
 if [[ $result -ne 0 ]]; then

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -275,7 +275,7 @@ pipeline {
                     yq -i eval '.spec.components.prometheusPushgateway.enabled = true'  ${INSTALL_CONFIG_FILE}
 
                     echo "Installing Verrazzano on OKE"
-                    ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/acceptance-test-operator.yaml --timeout 45m
+                    ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --manifests ${WORKSPACE}/acceptance-test-operator.yaml --timeout 45m
 
                     ${TEST_SCRIPTS_DIR}/common-test-setup-script.sh "${GO_REPO_PATH}" "${TEST_CONFIG_FILE}" "${env.DOCKER_REPO}" "${KUBECONFIG}" "${OCR_CREDS_USR}" "${OCR_CREDS_PSW}" "default" "${env.OCR_REPO}"
                     ${TEST_SCRIPTS_DIR}/get_ingress_ip.sh ${TEST_CONFIG_FILE}
@@ -412,7 +412,7 @@ pipeline {
                     ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "verrazzano-install"
 
 
-                    ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --operator-file ${WORKSPACE}/acceptance-test-operator.yaml --timeout 45m
+                    ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE} --manifests ${WORKSPACE}/acceptance-test-operator.yaml --timeout 45m
 
                     ${TEST_SCRIPTS_DIR}/common-test-setup-script.sh "${GO_REPO_PATH}" "${TEST_CONFIG_FILE}" "${env.DOCKER_REPO}" "${KUBECONFIG}" "${OCR_CREDS_USR}" "${OCR_CREDS_PSW}" "default"
                     ${TEST_SCRIPTS_DIR}/get_ingress_ip.sh ${TEST_CONFIG_FILE}

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -360,7 +360,7 @@ def runInstallOnly(stagePrefix, iteration) {
             sh """
                 # sleep for a period to ensure async deletion of Verrazzano components from uninstall above has completed
                 #sleep 90
-                ${VZ_COMMAND} install --filename ${VZ_INSTALL_FILE} --operator-file ${TARGET_OPERATOR_FILE}
+                ${VZ_COMMAND} install --filename ${VZ_INSTALL_FILE} --manifests ${TARGET_OPERATOR_FILE}
             """
             if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
                dumpK8sCluster('verrazzano-${dirPrefix}-${iteration}-cluster-snapshot')

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -977,7 +977,7 @@ def installVerrazzanoOnCluster(count, verrazzanoConfig) {
                     ./tests/e2e/config/scripts/wait-for-verrazzano-install.sh
                 elif [ "${params.INSTALLATION_METHOD_PREUPGRADE}" == "vz cli" ]; then
                     # Install Verrazzano
-                    ${GO_REPO_PATH}/vz install --kubeconfig ${KUBECONFIG_DIR}/${count}/kube_config --filename ${verrazzanoConfig} --operator-file ${WORKSPACE}/acceptance-test-operator.yaml
+                    ${GO_REPO_PATH}/vz install --kubeconfig ${KUBECONFIG_DIR}/${count}/kube_config --filename ${verrazzanoConfig} --manifests ${WORKSPACE}/acceptance-test-operator.yaml
                 fi
             """
             RUNNING_OPERATOR_VERSION = sh(returnStdout: true, script: "export KUBECONFIG='${KUBECONFIG_DIR}/${count}/kube_config' && kubectl get verrazzano -o jsonpath='{.items[0].status.version}'").trim()
@@ -1126,7 +1126,7 @@ def upgradeVerrazzanoOnCluster(count, verrazzanoDevVersion) {
                     kubectl --kubeconfig=${kubeClusterConfig} wait --timeout=35m --for=condition=UpgradeComplete verrazzano/my-verrazzano
                 elif [ "${params.INSTALLATION_METHOD_UPGRADE}" == "vz cli" ]; then
                     echo "Upgrading the Verrazzano installation to version" ${verrazzanoDevVersion}
-                    ${GO_REPO_PATH}/vz upgrade --kubeconfig ${kubeClusterConfig} --version ${verrazzanoDevVersion} --operator-file ${upgradeOperatorFile} --timeout 35m
+                    ${GO_REPO_PATH}/vz upgrade --kubeconfig ${kubeClusterConfig} --version ${verrazzanoDevVersion} --manifests ${upgradeOperatorFile} --timeout 35m
                 fi
 
                 # Get the install job(s) and mke sure the it matches pre-install.  If there is more than 1 job or the job changed, then it won't match

--- a/tools/vz/cmd/helpers/command.go
+++ b/tools/vz/cmd/helpers/command.go
@@ -120,13 +120,20 @@ func getOperatorFileFromFlag(cmd *cobra.Command) (string, error) {
 // getManifestsFile returns the manifests file, which could come from the manifests flag or the
 // deprecated operator-file flag
 func getManifestsFile(cmd *cobra.Command) (string, error) {
+	// if manifests flag has been explicitly provided, use that. Else if operator-file flag is
+	// explicitly provided, use that. If neither is explicitly provided, use the default for the
+	// manifests flag
 	if cmd.PersistentFlags().Changed(constants.ManifestsFlag) {
 		return cmd.PersistentFlags().GetString(constants.ManifestsFlag)
 	}
-	return cmd.PersistentFlags().GetString(constants.OperatorFileFlag)
+	if cmd.PersistentFlags().Changed(constants.OperatorFileFlag) {
+		return cmd.PersistentFlags().GetString(constants.OperatorFileFlag)
+	}
+	// neither is explicitly specified, use the default value of manifests flag
+	return cmd.PersistentFlags().GetString(constants.ManifestsFlag)
 }
 
-// ManifestsFlagChanged returns whether the manifests flag (or deprecated operator-file flag) is specifed.
+// ManifestsFlagChanged returns whether the manifests flag (or deprecated operator-file flag) is specified.
 func ManifestsFlagChanged(cmd *cobra.Command) bool {
 	return cmd.PersistentFlags().Changed(constants.ManifestsFlag) || cmd.PersistentFlags().Changed(constants.OperatorFileFlag)
 }

--- a/tools/vz/cmd/helpers/command_test.go
+++ b/tools/vz/cmd/helpers/command_test.go
@@ -165,7 +165,7 @@ func TestGetOperatorFile(t *testing.T) {
 	// THEN the default value of operator file is returned.
 	operatorFile, err := getOperatorFileFromFlag(getCommandWithoutFlags())
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf(flagNotDefinedErrFmt, constants.OperatorFileFlag))
+	assert.Contains(t, err.Error(), fmt.Sprintf(flagNotDefinedErrFmt, constants.ManifestsFlag))
 	assert.NotNil(t, operatorFile)
 	assert.Equal(t, "", operatorFile)
 
@@ -173,7 +173,7 @@ func TestGetOperatorFile(t *testing.T) {
 	// WHEN we get the operator file,
 	// THEN the default value of operator file is returned.
 	cmdWithOperatorFile := getCommandWithoutFlags()
-	cmdWithOperatorFile.PersistentFlags().String(constants.OperatorFileFlag, "/tmp/operator.yaml", "")
+	cmdWithOperatorFile.PersistentFlags().String(constants.ManifestsFlag, "/tmp/operator.yaml", "")
 	operatorFile, err = getOperatorFileFromFlag(cmdWithOperatorFile)
 	assert.NoError(t, err)
 	assert.NotNil(t, operatorFile)

--- a/tools/vz/cmd/helpers/vpo_test.go
+++ b/tools/vz/cmd/helpers/vpo_test.go
@@ -139,7 +139,7 @@ func TestApplyPlatformOperatorYaml(t *testing.T) {
 	// WHEN ApplyPlatformOperatorYaml is invoked,
 	// THEN an error is returned as the VZ resource is not in InstallComplete state.
 	cmdWithOperatorYaml := getCommandWithoutFlags()
-	cmdWithOperatorYaml.PersistentFlags().String(constants.OperatorFileFlag, "operator.yaml", "")
+	cmdWithOperatorYaml.PersistentFlags().String(constants.ManifestsFlag, "operator.yaml", "")
 	err = ApplyPlatformOperatorYaml(cmdWithOperatorYaml, fakeClient, rc, "1.5.0")
 	assert.Error(t, err)
 }

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -82,10 +82,8 @@ func NewCmdInstall(vzHelper helpers.VZHelper) *cobra.Command {
 	// Flag to skip any confirmation questions
 	cmd.PersistentFlags().BoolP(constants.SkipConfirmationFlag, constants.SkipConfirmationShort, false, constants.SkipConfirmationFlagHelp)
 
-	// Initially the operator-file flag may be for internal use, hide from help until
-	// a decision is made on supporting this option.
-	cmd.PersistentFlags().String(constants.OperatorFileFlag, "", constants.OperatorFileFlagHelp)
-	cmd.PersistentFlags().MarkHidden(constants.OperatorFileFlag)
+	// Add flags related to specifying the platform operator manifests as a local file or a URL
+	cmdhelpers.AddManifestsFlags(cmd)
 
 	// Dry run flag is still being discussed - keep hidden for now
 	cmd.PersistentFlags().Bool(constants.DryRunFlag, false, "Simulate an install.")
@@ -128,9 +126,9 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 		return err
 	}
 
-	// When --operator-file is not used, get the version from the command line
+	// When manifests flag is not used, get the version from the command line
 	var version string
-	if !cmd.PersistentFlags().Changed(constants.OperatorFileFlag) {
+	if !cmdhelpers.ManifestsFlagChanged(cmd) {
 		version, err = cmdhelpers.GetVersion(cmd, vzHelper)
 		if err != nil {
 			return err
@@ -378,8 +376,8 @@ func waitForInstallToComplete(client clipkg.Client, kubeClient kubernetes.Interf
 
 // validateCmd - validate the command line options
 func validateCmd(cmd *cobra.Command) error {
-	if cmd.PersistentFlags().Changed(constants.VersionFlag) && cmd.PersistentFlags().Changed(constants.OperatorFileFlag) {
-		return fmt.Errorf("--%s and --%s cannot both be specified", constants.VersionFlag, constants.OperatorFileFlag)
+	if cmd.PersistentFlags().Changed(constants.VersionFlag) && cmdhelpers.ManifestsFlagChanged(cmd) {
+		return fmt.Errorf("--%s and --%s cannot both be specified", constants.VersionFlag, constants.ManifestsFlag)
 	}
 	prefix, err := cmd.PersistentFlags().GetString(constants.ImagePrefixFlag)
 	if err != nil {

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -54,13 +54,11 @@ func NewCmdUpgrade(vzHelper helpers.VZHelper) *cobra.Command {
 	cmd.PersistentFlags().String(constants.ImageRegistryFlag, constants.ImageRegistryFlagDefault, constants.ImageRegistryFlagHelp)
 	cmd.PersistentFlags().String(constants.ImagePrefixFlag, constants.ImagePrefixFlagDefault, constants.ImagePrefixFlagHelp)
 
+	// Add flags related to specifying the platform operator manifests as a local file or a URL
+	cmdhelpers.AddManifestsFlags(cmd)
+
 	// Flag to skip any confirmation questions
 	cmd.PersistentFlags().BoolP(constants.SkipConfirmationFlag, constants.SkipConfirmationShort, false, constants.SkipConfirmationFlagHelp)
-
-	// Initially the operator-file flag may be for internal use, hide from help until
-	// a decision is made on supporting this option.
-	cmd.PersistentFlags().String(constants.OperatorFileFlag, "", constants.OperatorFileFlagHelp)
-	cmd.PersistentFlags().MarkHidden(constants.OperatorFileFlag)
 
 	// Dry run flag is still being discussed - keep hidden for now
 	cmd.PersistentFlags().Bool(constants.DryRunFlag, false, "Simulate an upgrade.")

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -28,8 +28,11 @@ const (
 	SetFlag                  = "set"
 	SetFlagShorthand         = "s"
 	SetFlagHelp              = "Override a Verrazzano resource value (e.g. --set profile=dev).  This flag can be specified multiple times."
-	OperatorFileFlag         = "operator-file"
-	OperatorFileFlagHelp     = "The path to the file for installing the Verrazzano platform operator. The default is derived from the version string."
+	OperatorFileFlag         = "operator-file" // an alias for the manifests flag
+	OperatorFileDeprecateMsg = "Use --manifests instead"
+	ManifestsFlag            = "manifests"
+	ManifestsShorthand       = "m"
+	ManifestsFlagHelp        = "The location of the manifests used to install or upgrade Verrazzano. This can be a URL or the path to a local file. The default is the verrazzano-platform-operator.yaml file of the specified (or most recent) version of Verrazzano."
 	ImageRegistryFlag        = "image-registry"
 	ImageRegistryFlagHelp    = "The private registry where Verrazzano image repositories are located. If unspecified, the public Verrazzano image registry will be used."
 	ImageRegistryFlagDefault = ""


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
