### PR TITLE
VZ-8810: Update Keycloak 15.0.2 built with Kafka client v3.4.0

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -409,8 +409,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak-jenkins",
-              "tag": "v15.0.2-20230508102642-63c645b759",
+              "image": "keycloak",
+              "tag": "v15.0.2-20230508133223-83019f1119",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -409,8 +409,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak",
-              "tag": "v15.0.2-20230426165041-9cc8bdc972",
+              "image": "keycloak-jenkins",
+              "tag": "v15.0.2-20230508102642-63c645b759",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
This PR updates Keycloak image, built with the change https://github.com/verrazzano/keycloak/pull/16
