### PR TITLE
Update Keycloak image with Kafka client updated to v3.4.0, in release-1.3

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -411,7 +411,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "v15.0.2-20230426165041-9cc8bdc972",
+              "tag": "v15.0.2-20230508133223-83019f1119",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
This PR updates Keycloak image, built with the change https://github.com/verrazzano/keycloak/pull/16