### PR TITLE
VZ-9580: Backport to release-1.5: Update OS image to bump Netty to 4.1.86.Final 

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -244,7 +244,7 @@
             },
             {
               "image": "opensearch",
-              "tag": "2.3.0-20230428051711-2c1119c9188",
+              "tag": "2.3.0-20230509104157-071cbb2e727",
               "helmFullImageKey": "monitoringOperator.osImage"
             },
             {


### PR DESCRIPTION
Update OS image to bump Netty to 4.1.86.Final 