### PR TITLE
Bump the LRE upgrade timeout

### DIFF
--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -192,7 +192,7 @@ pipeline {
 
                         sh """
                             echo "Upgrading the Verrazzano installation to version" ${VERRAZZANO_UPGRADE_VERSION}
-                            ${GO_REPO_PATH}/vz upgrade --version ${VERRAZZANO_UPGRADE_VERSION} --manifests ${OPERATOR_YAML_LOCATION}
+                            ${GO_REPO_PATH}/vz upgrade --version ${VERRAZZANO_UPGRADE_VERSION} --manifests ${OPERATOR_YAML_LOCATION} --timeout 45m
                         """
                     } else {
                         echo "No upgrade is needed.  Verrazzano is already at the expected version."


### PR DESCRIPTION
This pull request bumps the LRE upgrade timeout to 45m.  There have a been a few upgrades that have taken longer than the default timeout of 30m.  The pipeline was failing even though upgrade was eventually successful.