### PR TITLE
Enable capi component install for private registry tests

### DIFF
--- a/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
@@ -89,6 +89,7 @@ yq eval -i '.spec.components.velero.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 yq eval -i '.spec.components.rancherBackup.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 yq eval -i '.spec.components.jaegerOperator.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 yq eval -i '.spec.components.argoCD.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
+yq eval -i '.spec.components.capi.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 
 # Configure the custom resource to install Verrazzano on Kind
 ./tests/e2e/config/scripts/process_kind_install_yaml.sh ${INSTALL_CONFIG_FILE_KIND} ${WILDCARD_DNS_DOMAIN}


### PR DESCRIPTION
This pull request enables the capi component install for private registry tests.