### PR TITLE
Thanos Istio proxy container Prometheus scrape fix

### DIFF
--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
@@ -51,9 +51,13 @@ spec:
         # api port
         - port: 10902
           protocol: TCP
+        # Istio proxy metrics port
+        - port: 15090
+          protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}
+      app.kubernetes.io/component: query-frontend
   policyTypes:
     - Ingress
 ---
@@ -95,8 +99,12 @@ spec:
         # api port
         - port: 10902
           protocol: TCP
+        # Istio proxy metrics port
+        - port: 15090
+          protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}
+      app.kubernetes.io/component: query
   policyTypes:
     - Ingress

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
@@ -57,7 +57,6 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}
-      app.kubernetes.io/component: query-frontend
   policyTypes:
     - Ingress
 ---
@@ -105,6 +104,5 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}
-      app.kubernetes.io/component: query
   policyTypes:
     - Ingress


### PR DESCRIPTION
While I was doing manual testing of the Prometheus Operator upgrade, I noticed that Prometheus was not able to scrape metrics from the Thanos Istio proxy containers in the Query and Query Frontend pods. My test cluster had Calico enabled.

The problem was the NetworkPolicy resources were blocking access to the Istio proxy metrics ports in those pods. I have made the following changes to the Thanos NetworkPolicies:
- Updated the Query and Query Frontend policies to add a label match selector on the component. Without this, the policies were selecting all Thanos pods.
- Updated the Query and Query Frontend policies to include the Istio proxy metrics port.

I tested by installing in cluster with Calico enabled and validated that the scrape targets for the Thanos and Istio proxy containers in the Thanos pods were healthy. I also navigated to the Query Frontend UI and validated that the Store Gateway showed healthy in the list of stores (confirming that the Query NetworkPolicy was not needed).
