### PR TITLE
VZ-9552 Use the CLI in the private registry tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -442,6 +442,21 @@ pipeline {
                 stage("Build Product Zip") {
                     steps {
                         script {
+                            try {
+                                sh """
+                                     echo "${OCR_CREDS_PSW}" | docker login -u ${OCR_CREDS_USR} ${OCR_REPO} --password-stdin
+                                """
+                            } catch(error) {
+                                echo "OCIR docker login at ${OCIR_REPO} failed, retrying after sleep"
+                                retry(4) {
+                                    sleep(30)
+                                    sh """
+                                        echo "${OCR_CREDS_PSW}" | docker login -u ${OCR_CREDS_USR} ${OCR_REPO} --password-stdin
+                                    """
+                                }
+                            }
+                        }
+                        script {
                             sh """
                                 ci/scripts/generate_vz_distribution.sh ${WORKSPACE} ${VERRAZZANO_DEV_VERSION} ${SHORT_COMMIT_HASH}
                             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,8 @@ pipeline {
         OCI_OS_ARTIFACT_BUCKET="build-failure-artifacts"
         OCI_OS_BUCKET="verrazzano-builds"
         OCI_OS_COMMIT_BUCKET="verrazzano-builds-by-commit"
-        OCI_OS_REGION="us-phoenix-1"
+        OCI_OS_REGION="us-phoenix-1" // where to download existing artifacts from
+        OCI_OS_DIST_REGION="eu-frankfurt-1" // where to upload distributions to
 
         // used to emit metrics
         PROMETHEUS_CREDENTIALS = credentials('prometheus-credentials')

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "blocked-large"
+def agentLabel = params.DISTRIBUTION_VARIANT == "Lite" ? "phx-large" : "blocked-large"
 def ocirRegion = "fra"
 def ociRegionFull     = "eu-frankfurt-1"
 def ocirRegistry = "${ocirRegion}.ocir.io"

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -336,21 +336,6 @@ pipeline {
             }
             steps {
                 script {
-                    try {
-                        sh """
-                            echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
-                        """
-                    } catch(error) {
-                        echo "docker login failed, retrying after sleep"
-                        retry(4) {
-                            sleep(30)
-                            sh """
-                            echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
-                            """
-                        }
-                    }
-                }
-                script {
                     if (params.DISTRIBUTION_VARIANT == "Full") {
                         sh """
                             # Create OCIR repos for the images in the tarballs in the test compartment
@@ -362,6 +347,19 @@ pipeline {
                             ${TARBALL_DIR}/bin/vz-registry-image-helper.sh -t ${ocirRegistry} -l ./images -r ${baseImageRepo}
                         """
                     } else {
+                        try {
+                            sh """
+                                echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
+                            """
+                        } catch(error) {
+                            echo "docker login failed, retrying after sleep"
+                            retry(4) {
+                                sleep(30)
+                                sh """
+                                echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
+                                """
+                            }
+                        }
                         sh """
                             # Create OCIR repos for the images in the tarballs in the test compartment
                             cd ${TARBALL_DIR}

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -570,33 +570,6 @@ pipeline {
                 }
             }
         }
-        stage("Verify Uninstall") {
-            when {
-                expression {
-                    return runPipeline()
-                }
-            }
-            steps {
-                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    sh """
-                        ${LOOPING_TEST_SCRIPTS_DIR}/dump_cluster.sh ${WORKSPACE}/verrazzano/build/resources/post-uninstall-resources false
-                        ${LOOPING_TEST_SCRIPTS_DIR}/verify_uninstall.sh ${WORKSPACE}/verrazzano/build/resources
-                    """
-                }
-            }
-            post {
-                success {
-                    script {
-                        if (EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS == true) {
-                            dumpK8sCluster('verify-uninstall-success-cluster-snapshot')
-                        }
-                    }
-                }
-                failure {
-                    dumpK8sCluster('verify-uninstall-failed-cluster-snapshot')
-                }
-            }
-        }
     }
 
     post {

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -602,7 +602,7 @@ pipeline {
     post {
         always {
             script {
-                if (!env.AIR_GAPPED) {
+                if (DISTRIBUTION_VARIANT == "Full" && !env.AIR_GAPPED) {
                     echo "Airgap check failed, not running post actions."
                     sh "exit 0"
                 }

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -147,6 +147,11 @@ pipeline {
 
     stages {
         stage('Verify Air-Gapped') {
+            when {
+                expression {
+                    DISTRIBUTION_VARIANT == "Full"
+                }
+            }
             steps {
                 script {
                     echo "Checking if we are running in an air-gapped environment"

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -326,15 +326,30 @@ pipeline {
         }
 
         stage('Upload Verrazzano Images') {
-             when {
-                 expression {
-                     return runPipeline()
-                }
-             }
-             environment {
-                 TARBALL_DIR="${TARBALL_ROOT_DIR}/verrazzano-${VERRAZZANO_DEV_VERSION}"
-             }
+            when {
+                expression {
+                    return runPipeline()
+               }
+            }
+            environment {
+                TARBALL_DIR="${TARBALL_ROOT_DIR}/verrazzano-${VERRAZZANO_DEV_VERSION}"
+            }
             steps {
+                script {
+                    try {
+                        sh """
+                            echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
+                        """
+                    } catch(error) {
+                        echo "docker login failed, retrying after sleep"
+                        retry(4) {
+                            sleep(30)
+                            sh """
+                            echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
+                            """
+                        }
+                    }
+                }
                 script {
                     if (params.DISTRIBUTION_VARIANT == "Full") {
                         sh """

--- a/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
@@ -79,7 +79,6 @@ yq eval -i '.spec.components.velero.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 yq eval -i '.spec.components.rancherBackup.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 yq eval -i '.spec.components.jaegerOperator.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 yq eval -i '.spec.components.argoCD.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
-yq eval -i '.spec.components.capi.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 
 # Configure the custom resource to install Verrazzano on Kind
 ./tests/e2e/config/scripts/process_kind_install_yaml.sh ${INSTALL_CONFIG_FILE_KIND} ${WILDCARD_DNS_DOMAIN}

--- a/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
@@ -87,4 +87,4 @@ yq eval -i '.spec.components.capi.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 echo "Installing Verrazzano on Kind"
 ${GO_REPO_PATH}/vz install -f "${INSTALL_CONFIG_FILE_KIND}" --manifests "${TARBALL_DIR}/manifests/k8s/verrazzano-platform-operator.yaml" --image-registry ${REGISTRY} --image-prefix ${PRIVATE_REPO}
 
-exit 0
+exit $?

--- a/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
@@ -62,18 +62,8 @@ cd ${GO_REPO_PATH}/verrazzano
 ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${REGISTRY}" "${PRIVATE_REGISTRY_USR}" "${PRIVATE_REGISTRY_PSW}"
 ./tests/e2e/config/scripts/create-image-pull-secret.sh ocr "${OCR_REPO}" "${OCR_CREDS_USR}" "${OCR_CREDS_PSW}"
 
-echo "Install Platform Operator"
-VPO_IMAGE=$(cat ${BOM_FILE} | jq -r '.components[].subcomponents[] | select(.name == "verrazzano-platform-operator") | "\(.repository)/\(.images[].image):\(.images[].tag)"')
-
-helm upgrade --install myv8o ${CHART_LOCATION}/verrazzano-platform-operator \
-    --set global.imagePullSecrets[0]=${IMAGE_PULL_SECRET} \
-    --set image=${REGISTRY}/${PRIVATE_REPO}/${VPO_IMAGE} --set global.registry=${REGISTRY} \
-    --set global.repository=${PRIVATE_REPO}
-
-# make sure ns exists
-./tests/e2e/config/scripts/check_verrazzano_ns_exists.sh verrazzano-install
-
 # Create docker secret for platform operator image
+kubectl create ns verrazzano-install
 ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${REGISTRY}" "${PRIVATE_REGISTRY_USR}" "${PRIVATE_REGISTRY_PSW}" verrazzano-install
 
 # optionally create a cluster dump snapshot for verifying uninstalls
@@ -94,22 +84,7 @@ yq eval -i '.spec.components.capi.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 # Configure the custom resource to install Verrazzano on Kind
 ./tests/e2e/config/scripts/process_kind_install_yaml.sh ${INSTALL_CONFIG_FILE_KIND} ${WILDCARD_DNS_DOMAIN}
 
-echo "Wait for Operator to be ready"
-cd ${GO_REPO_PATH}/verrazzano
-kubectl -n verrazzano-install rollout status deployment/verrazzano-platform-operator
-if [ $? -ne 0 ]; then
-  echo "Operator is not ready"
-  exit 1
-fi
-
 echo "Installing Verrazzano on Kind"
-# ${GO_REPO_PATH}/vz install --filename ${INSTALL_CONFIG_FILE_KIND}
-kubectl apply -f ${INSTALL_CONFIG_FILE_KIND}
-
-# wait for Verrazzano install to complete
-./tests/e2e/config/scripts/wait-for-verrazzano-install.sh
-if [ $? -ne 0 ]; then
-  exit 1
-fi
+${GO_REPO_PATH}/vz install -f "${INSTALL_CONFIG_FILE_KIND}" --manifests "${TARBALL_DIR}manifests/k8s/verrazzano-platform-operator.yaml" --image-registry ${REGISTRY}--image-prefix ${PRIVATE_REPO}
 
 exit 0

--- a/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
@@ -85,6 +85,6 @@ yq eval -i '.spec.components.capi.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 ./tests/e2e/config/scripts/process_kind_install_yaml.sh ${INSTALL_CONFIG_FILE_KIND} ${WILDCARD_DNS_DOMAIN}
 
 echo "Installing Verrazzano on Kind"
-${GO_REPO_PATH}/vz install -f "${INSTALL_CONFIG_FILE_KIND}" --manifests "${TARBALL_DIR}/manifests/k8s/verrazzano-platform-operator.yaml" --image-registry ${REGISTRY}--image-prefix ${PRIVATE_REPO}
+${GO_REPO_PATH}/vz install -f "${INSTALL_CONFIG_FILE_KIND}" --manifests "${TARBALL_DIR}/manifests/k8s/verrazzano-platform-operator.yaml" --image-registry ${REGISTRY} --image-prefix ${PRIVATE_REPO}
 
 exit 0

--- a/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_distribution_test_jenkins_at_environment.sh
@@ -85,6 +85,6 @@ yq eval -i '.spec.components.capi.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 ./tests/e2e/config/scripts/process_kind_install_yaml.sh ${INSTALL_CONFIG_FILE_KIND} ${WILDCARD_DNS_DOMAIN}
 
 echo "Installing Verrazzano on Kind"
-${GO_REPO_PATH}/vz install -f "${INSTALL_CONFIG_FILE_KIND}" --manifests "${TARBALL_DIR}manifests/k8s/verrazzano-platform-operator.yaml" --image-registry ${REGISTRY}--image-prefix ${PRIVATE_REPO}
+${GO_REPO_PATH}/vz install -f "${INSTALL_CONFIG_FILE_KIND}" --manifests "${TARBALL_DIR}/manifests/k8s/verrazzano-platform-operator.yaml" --image-registry ${REGISTRY}--image-prefix ${PRIVATE_REPO}
 
 exit 0


### PR DESCRIPTION
**Changes**
- Use the VZ CLI in the private registry tests
- Fix the verrazzano pipeline to run the private registry tests
- Fix the lite distribution for the private registry tests