### PR TITLE
CI update to use Boolean param (#5971)

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -493,7 +493,7 @@ pipeline {
                                     string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                     string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                     string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                    string(name: 'RUN_TESTS', value: env.IS_PERIODIC_PIPELINE),
+                                    booleanParam (name: 'RUN_TESTS', value: env.IS_PERIODIC_PIPELINE),
                                 ], wait: true
                         }
                     }


### PR DESCRIPTION
This fixes the following error:
`The parameter 'RUN_TESTS' did not have the type expected by verrazzano-distributions-testing » master. Converting to Boolean Parameter.`