### PR TITLE
VZ-9645.  Use verrazzano-system namespace for OCI DNS webhook

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/common/acme_utils.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/common/acme_utils.go
@@ -4,16 +4,36 @@
 package common
 
 import (
+	"fmt"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"strings"
 )
 
-func IsLetsEncryptProductionEnv(acme v1beta1.Acme) bool {
+func IsLetsEncryptProductionEnv(acme vzapi.Acme) bool {
 	return strings.ToLower(acme.Environment) == letsencryptProduction
 }
 
 func IsLetsEncryptStaging(compContext spi.ComponentContext) bool {
 	acmeEnvironment := compContext.EffectiveCR().Spec.Components.CertManager.Certificate.Acme.Environment
 	return acmeEnvironment != "" && strings.ToLower(acmeEnvironment) != "production"
+}
+
+func convertIfNecessary(vz interface{}) (*vzapi.Verrazzano, error) {
+	if vz == nil {
+		return nil, fmt.Errorf("Unable to convert, nil Verrazzano reference")
+	}
+	if vzv1beta1, ok := vz.(*v1beta1.Verrazzano); ok {
+		cr := &vzapi.Verrazzano{}
+		if err := cr.ConvertFrom(vzv1beta1); err != nil {
+			return nil, err
+		}
+		return cr, nil
+	}
+	cr, ok := vz.(*vzapi.Verrazzano)
+	if !ok {
+		return nil, fmt.Errorf("Unable to convert, not a Verrazzano v1alpha1 reference")
+	}
+	return cr, nil
 }

--- a/platform-operator/controllers/verrazzano/component/certmanager/config/certmanager_config_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/config/certmanager_config_component.go
@@ -184,7 +184,7 @@ func (c certManagerConfigComponent) validateConfiguration(new *v1beta1.Verrazzan
 		return nil
 	}
 
-	if err := cmcommon.ValidateConfiguration(cm.Certificate); err != nil {
+	if err := cmcommon.ValidateConfiguration(new); err != nil {
 		return err
 	}
 	return nil

--- a/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component.go
@@ -22,7 +22,7 @@ import (
 const ComponentName = cmcommon.CertManagerOCIDNSComponentName
 
 // ComponentNamespace is the namespace of the component
-const ComponentNamespace = constants.CertManagerNamespace
+const ComponentNamespace = constants.VerrazzanoSystemNamespace
 
 const componentChartName = "verrazzano-cert-manager-ocidns-webhook"
 
@@ -52,7 +52,7 @@ func NewComponent() spi.Component {
 }
 
 func (c certManagerOciDNSComponent) PreInstall(ctx spi.ComponentContext) error {
-	if err := common.CopyOCIDNSSecret(ctx, ComponentNamespace); err != nil {
+	if err := common.CopyOCIDNSSecret(ctx, constants.CertManagerNamespace); err != nil {
 		return err
 	}
 	return nil
@@ -67,6 +67,10 @@ func (c certManagerOciDNSComponent) IsEnabled(effectiveCR runtime.Object) bool {
 		return false
 	}
 	return vzcr.IsOCIDNSEnabled(effectiveCR)
+}
+
+func (c certManagerOciDNSComponent) PostUninstall(ctx spi.ComponentContext) error {
+	return c.postUninstall(ctx)
 }
 
 // IsReady component check

--- a/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component.go
@@ -66,7 +66,12 @@ func (c certManagerOciDNSComponent) IsEnabled(effectiveCR runtime.Object) bool {
 		logger.ErrorfThrottled("Unexpected error checking for CertManager in cluster: %v", err)
 		return false
 	}
-	return vzcr.IsOCIDNSEnabled(effectiveCR)
+	isACMEConfig, err := cmcommon.IsACMEConfig(effectiveCR)
+	if err != nil {
+		logger.ErrorfThrottled("Unexpected error checking certificate configuration: %v", err.Error())
+		return false
+	}
+	return isACMEConfig && vzcr.IsOCIDNSEnabled(effectiveCR)
 }
 
 func (c certManagerOciDNSComponent) PostUninstall(ctx spi.ComponentContext) error {

--- a/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package ocidns
+
+import (
+	"context"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apiextv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestIsCertManagerOciDNSEnabled tests the IsCertManagerEnabled fn
+// GIVEN a call to IsCertManagerEnabled
+// WHEN cert-manager is enabled
+// THEN the function returns true
+func TestIsCertManagerOciDNSEnabled(t *testing.T) {
+	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
+	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
+		return apiextv1fake.NewSimpleClientset(crtObjectToRuntimeObject(createCertManagerCRDs()...)...).ApiextensionsV1(), nil
+	}
+
+	localvz := vz.DeepCopy()
+	bt := true
+	localvz.Spec.Components.CertManager.Enabled = &bt
+	localvz.Spec.Components.DNS = &vzapi.DNSComponent{OCI: &vzapi.OCI{}}
+	assert.True(t, NewComponent().IsEnabled(localvz))
+}
+
+// TestIsCertManagerOciDNSDisabledNoCRDs tests the IsCertManagerEnabled fn
+// GIVEN a call to IsCertManagerEnabled
+// WHEN cert-manager is disabled
+// THEN the function returns false
+func TestIsCertManagerOciDNSDisabledNoCRDs(t *testing.T) {
+	localvz := vz.DeepCopy()
+	bf := false
+	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
+	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
+		return apiextv1fake.NewSimpleClientset().ApiextensionsV1(), nil
+	}
+
+	localvz.Spec.Components.CertManager.Enabled = &bf
+	assert.False(t, NewComponent().IsEnabled(localvz))
+}
+
+func TestIsCertManagerOciDNSDisabled(t *testing.T) {
+	localvz := vz.DeepCopy()
+	bt := true
+	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
+	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
+		return apiextv1fake.NewSimpleClientset(crtObjectToRuntimeObject(createCertManagerCRDs()...)...).ApiextensionsV1(), nil
+	}
+
+	localvz.Spec.Components.CertManager.Enabled = &bt
+	assert.False(t, NewComponent().IsEnabled(localvz))
+}
+
+// TestCertManagerPreInstall tests the PreInstall fn
+// GIVEN a call to this fn
+// WHEN I call PreInstall with dry-run = true
+// THEN no errors are returned
+func TestCertManagerOciDNSPreInstallDryRun(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
+	err := NewComponent().PreInstall(spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, true))
+	assert.NoError(t, err)
+}
+
+// TestCertManagerPreInstallOCIDNS tests the PreInstall fn
+// GIVEN a call to this fn
+// WHEN I call PreInstall and OCI DNS is enabled
+// THEN no errors are returned and the DNS secret is set up
+func TestCertManagerPreInstallOCIDNS(t *testing.T) {
+	config.Set(config.OperatorConfig{
+		VerrazzanoRootDir: "../../../../..", //since we are running inside the cert manager package, root is up 5 directories
+	})
+	client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oci",
+				Namespace: constants.VerrazzanoInstallNamespace,
+			},
+			Data: map[string][]byte{"oci.yaml": []byte("fake data")},
+		}).Build()
+	vz := &vzapi.Verrazzano{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-verrazzano", Namespace: "default", CreationTimestamp: metav1.Now()},
+		Spec: vzapi.VerrazzanoSpec{
+			EnvironmentName: "myenv",
+			Components: vzapi.ComponentSpec{
+				DNS: &vzapi.DNSComponent{
+					OCI: &vzapi.OCI{
+						OCIConfigSecret:        "oci",
+						DNSZoneCompartmentOCID: "compartmentID",
+						DNSZoneOCID:            "zoneID",
+						DNSZoneName:            "zone.name.io",
+					},
+				},
+			},
+		},
+	}
+	err := NewComponent().PreInstall(spi.NewFakeContext(client, vz, nil, false))
+	assert.NoError(t, err)
+
+	secret := &corev1.Secret{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: "oci", Namespace: constants.CertManagerNamespace}, secret)
+	assert.NoError(t, err)
+}
+
+// TestPostInstallAcme tests the PostInstall function
+// GIVEN a call to PostInstall
+//
+//	WHEN the cert type is Acme
+//	THEN no error is returned
+func TestPostInstallAcme(t *testing.T) {
+	localvz := vz.DeepCopy()
+	localvz.Spec.Components.CertManager.Certificate.Acme = acme
+	client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
+	// set OCI DNS secret value and create secret
+	localvz.Spec.Components.DNS = &vzapi.DNSComponent{
+		OCI: &vzapi.OCI{
+			OCIConfigSecret: "ociDNSSecret",
+			DNSZoneName:     "example.dns.io",
+		},
+	}
+	_ = client.Create(context.TODO(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ociDNSSecret",
+			Namespace: ComponentNamespace,
+		},
+	})
+	err := NewComponent().PostInstall(spi.NewFakeContext(client, localvz, nil, false))
+	assert.NoError(t, err)
+}
+
+// TestDryRun tests the behavior when DryRun is enabled, mainly for code coverage
+// GIVEN a call to PostInstall/PostUpgrade/PreInstall
+//
+//	WHEN the ComponentContext has DryRun set to true
+//	THEN no error is returned
+func TestDryRun(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	ctx := spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, true)
+
+	comp := certManagerOciDNSComponent{}
+	assert.True(t, comp.IsReady(ctx))
+}

--- a/platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         app: {{ include "cert-manager-webhook-oci.name" . }}
         release: {{ .Release.Name }}
+        sidecar.istio.io/inject: "false"
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/templates/rbac.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/templates/rbac.yaml
@@ -98,15 +98,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "cert-manager-webhook-oci.fullname" . }}:secret-reader
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.certManager.clusterResourceNamespace }}
 rules:
   - apiGroups:
     - ""
     resources:
     - "secrets"
-  {{- with .Values.ociProfileSecretNames }}
+    {{- with .Values.ociProfileSecretNames }}
     resourceNames:
-{{ toYaml . | indent 4 }}
+    {{ toYaml . | indent 4 }}
     {{- end }}
     verbs:
     - "get"
@@ -116,7 +116,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "cert-manager-webhook-oci.fullname" . }}:secret-reader
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.certManager.clusterResourceNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml
@@ -11,6 +11,7 @@ groupName: verrazzano.io
 
 certManager:
   namespace: cert-manager
+  clusterResourceNamespace: cert-manager
   serviceAccountName: cert-manager
 
 image:

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -106,6 +106,8 @@ var _ = t.Describe("In the Kubernetes Cluster", Label("f:platform-lcm.install"),
 			t.Entry("includes verrazzano-monitoring-operator", "verrazzano-monitoring-operator", true),
 			t.Entry("Check weblogic-operator deployment", "weblogic-operator", pkg.IsWebLogicOperatorEnabled(kubeconfigPath)),
 			t.Entry("Check coherence-operator deployment", "coherence-operator", pkg.IsCoherenceOperatorEnabled(kubeconfigPath)),
+			t.Entry("Check external-dns deployment", "external-dns", pkg.IsOCIDNSEnabled(kubeconfigPath)),
+			t.Entry("Check verrazzano-cert-manager-oci-dns-webhook deployment", "cert-manager-ocidns-provider", pkg.IsOCIDNSWebhookEnabled(kubeconfigPath)),
 		}
 
 		t.DescribeTable("Verrazzano components are deployed,",


### PR DESCRIPTION
Run the Verrazzano OCI DNS solver webhook in the `verrazzano-system` namespace
- give it permission to read secrets in the Cert-Manager `clusterResourceNamespace` (e.g., the OCI DNS auth secret)
- modify the RBAC permissions to allow Cert-Manager to discover and invoke the webhook APIService
- turn off Istio injection for the deployment
- Add E2E tests cases for external-dns and the webhook deployments if they are enabled

Other changes:
- Modify `IsEnabled` to check that the webhook is deployed IFF CM is enabled, OCI DNS is configured, and ACME is configured
- align validation functions on v1alpha1 API for now.