### PR TITLE
Fix doc link for api doc

### DIFF
--- a/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
+++ b/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
@@ -15,7 +15,7 @@ import (
 type VerrazzanoManagedClusterSpec struct {
 	// The name of a Secret that contains the CA certificate of the managed cluster. This is used to configure the
 	// admin cluster to scrape metrics from the Prometheus endpoint on the managed cluster. See the pre-registration
-	// <a href="../../../../docs/setup/install/multicluster/#preregistration-setup">instructions</a>
+	// <a href="../../../../docs/setup/install/mc-install/advanced/multicluster-no-rancher/#preregistration-setup">instructions</a>
 	// for how to create this Secret.
 	CASecret string `json:"caSecret,omitempty"`
 

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/crds/clusters.verrazzano.io_verrazzanomanagedclusters.yaml
@@ -45,7 +45,7 @@ spec:
                 description: The name of a Secret that contains the CA certificate
                   of the managed cluster. This is used to configure the admin cluster
                   to scrape metrics from the Prometheus endpoint on the managed cluster.
-                  See the pre-registration <a href="../../../../docs/setup/install/multicluster/#preregistration-setup">instructions</a>
+                  See the pre-registration <a href="../../../../docs/setup/install/mc-install/advanced/multicluster-no-rancher/#preregistration-setup">instructions</a>
                   for how to create this Secret.
                 type: string
               description:


### PR DESCRIPTION
This pull request fixes a link in the API docs which was changed in the reorg of docs.