### PR TITLE
VZ-9644 verrazzano argocd component must not overwrite policy.csv

### DIFF
--- a/platform-operator/controllers/verrazzano/component/argocd/argocd_postinstall.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/argocd_postinstall.go
@@ -146,7 +146,11 @@ func patchArgoCDRbacConfigMap(ctx spi.ComponentContext) error {
 		if rbaccm.Data == nil {
 			rbaccm.Data = make(map[string]string)
 		}
-		rbaccm.Data["policy.csv"] = policyString
+		// Set policy.csv only if it hasn't been explicitly set
+		val, ok := rbaccm.Data["policy.csv"]
+		if !ok || len(val) == 0 {
+			rbaccm.Data["policy.csv"] = policyString
+		}
 		return nil
 	}); err != nil {
 		ctx.Log().ErrorfNewErr("Failed to patch the Argo CD configmap argocd-rbac-cm: %s", err)

--- a/platform-operator/controllers/verrazzano/component/argocd/argocd_postinstall.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/argocd_postinstall.go
@@ -209,9 +209,3 @@ func GetRootCA(ctx spi.ComponentContext) ([]byte, error) {
 func buildRestartAnnotationString(time time.Time) string {
 	return time.String()
 }
-
-// Ensure that verrazzano admin policy is included in the rbac
-func ensureRbacVerrazzanoAdmin(rbac string) string {
-
-	return ""
-}


### PR DESCRIPTION
Tne verrazzano argocd component must not overwrite policy.csv, but rather add the `g, verrazzano-admins, role:admin` policy if it is missing.