### PR TITLE
Update Keycloak, refresh few component images in release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -106,12 +106,12 @@
           "images": [
             {
               "image": "pilot",
-              "tag": "1.15.3-20230511165826-a25ae2d1",
+              "tag": "1.15.3-20230209181608-900a5c7b",
               "helmFullImageKey": "values.pilot.image"
             },
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230511165826-a25ae2d1",
+              "tag": "1.15.3-20230209181608-900a5c7b",
               "helmImageKey": "values.global.proxy.image",
               "helmTagKey": "values.global.tag",
               "helmRegistryAndRepoKey": "values.global.hub"
@@ -183,7 +183,7 @@
           "images": [
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230511165826-a25ae2d1",
+              "tag": "1.15.3-20230209181608-900a5c7b",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {
@@ -229,7 +229,7 @@
             },
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230511165826-a25ae2d1",
+              "tag": "1.15.3-20230209181608-900a5c7b",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -87,7 +87,7 @@
           "images": [
             {
               "image": "external-dns",
-              "tag": "v0.12.2-20230302040401-49b4f66e",
+              "tag": "v0.12.2-20230511162352-49b4f66e",
               "helmFullImageKey": "image.repository",
               "helmRegKey": "image.registry",
               "helmTagKey": "image.tag"
@@ -106,12 +106,12 @@
           "images": [
             {
               "image": "pilot",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.15.3-20230511165826-a25ae2d1",
               "helmFullImageKey": "values.pilot.image"
             },
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.15.3-20230511165826-a25ae2d1",
               "helmImageKey": "values.global.proxy.image",
               "helmTagKey": "values.global.tag",
               "helmRegistryAndRepoKey": "values.global.hub"
@@ -147,11 +147,11 @@
           "images": [
             {
               "image": "rancher-shell",
-              "tag": "v0.1.18-20230208201620-c659571"
+              "tag": "v0.1.18-20230512033248-c659571"
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.2.6-20230208201837-b7fc3c3"
+              "tag": "v0.2.6-20230512024307-b7fc3c3"
             },
             {
               "image": "rancher-fleet-agent",
@@ -163,7 +163,7 @@
             },
             {
               "image": "rancher-gitjob",
-              "tag": "v0.1.30-20230208185411-8e24107"
+              "tag": "v0.1.30-20230512033140-8e24107"
             },
             {
               "image": "rancher-cleanup",
@@ -183,12 +183,12 @@
           "images": [
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.15.3-20230511165826-a25ae2d1",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {
               "image": "fluentd-kubernetes-daemonset",
-              "tag": "v1.14.5-20230131231729-f85741b",
+              "tag": "v1.14.5-20230512021939-f85741b",
               "helmFullImageKey": "logging.fluentdImage"
             },
             {
@@ -229,7 +229,7 @@
             },
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.15.3-20230511165826-a25ae2d1",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {
@@ -449,7 +449,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "v20.0.1-20230406163645-080e314b71",
+              "tag": "v20.0.1-20230511162845-f765e95713",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -461,7 +461,7 @@
           "images": [
             {
               "image": "keycloak-oracle-theme",
-              "tag": "v1.5.0-20230124195518-771913f"
+              "tag": "v1.5.0-20230511152819-603bc3c"
             }
           ]
         }


### PR DESCRIPTION
This PR updates the following component images in verrazzano-bom.json

1. Keycloak 20.0.1 image is built with the change https://github.com/verrazzano/keycloak/pull/17
2. Created release-1.5 branch for keycloak-oracle-theme and the image is built from that branch
3. Other images are rebuilt with the base image, to get the latest packages.