### PR TITLE
VZ-9469: Uptake new rancher image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -148,13 +148,13 @@
             {
               "image": "rancher",
               "dashboard": "v2.7.2-20230509143745-870a44e17",
-              "tag": "v2.7.2-20230511150331-f226b7e4e",
+              "tag": "v2.7.2-20230511223531-e5663b1ca",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.2-20230511150331-f226b7e4e"
+              "tag": "v2.7.2-20230511223531-e5663b1ca"
             }
           ]
         },


### PR DESCRIPTION
ClusterResourceset strategy is valid only for ApplyOnce. If Reconcile needs to be used then the keyword is mode
Failed to create objects: failed to create Object addons.cluster.x-k8s.io/v1beta1/clusterresourcesets: ClusterResourceSet.addons.cluster.x-k8s.io "c-vk7rh-ccm-resource-set" is invalid: spec.strategy: Unsupported value: "Reconcile": supported values: "ApplyOnce"