### PR TITLE
VZ-9702.  Limit OCI DNS webhook secrets access to configured auth secret

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/ocidns/append_overrides_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/ocidns/append_overrides_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package ocidns
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/bom"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// All of this below is to make Sonar happy
+type appendOverridesTest struct {
+	testName  string
+	config    *vzapi.Verrazzano
+	expectErr bool
+}
+
+var (
+	enabled = true
+)
+
+// Test_appendOCIDNSOverrides tests the appendOCIDNSOverrides function
+// GIVEN a call to appendOCIDNSOverrides
+// WHEN CertManager or ExternalCertManager are configured
+// THEN the appropriate chart overrides are returned
+func Test_appendOCIDNSOverrides(t *testing.T) {
+	asserts := assert.New(t)
+
+	tests := []appendOverridesTest{
+		{
+			testName:  "OCI DNS Not configured",
+			config:    &vzapi.Verrazzano{},
+			expectErr: true,
+		},
+		{
+			testName: "OCI DNS Secret Not configured ",
+			config: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						CertManager: &vzapi.CertManagerComponent{
+							Enabled: &enabled,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			testName: "OCI DNS Secret configured ",
+			config: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						CertManager: &vzapi.CertManagerComponent{
+							Enabled: &enabled,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								OCIConfigSecret: "oci",
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			testName: "OCI DNS Secret configured alternate name ",
+			config: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						CertManager: &vzapi.CertManagerComponent{
+							Enabled: &enabled,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								OCIConfigSecret: "mysecret",
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			client := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).Build()
+			fakeContext := spi.NewFakeContext(client, tt.config, nil, false)
+
+			var overrides []bom.KeyValue
+			var err error
+			overrides, err = appendOCIDNSOverrides(fakeContext, "", "", "", overrides)
+
+			// Check error condition
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// if it failed skip the remaining checks
+			if err != nil {
+				return
+			}
+
+			assert.NoError(t, err)
+
+			assert.Len(t, overrides, 1)
+
+			asserts.Equal("ociAuthSecrets[0]", overrides[0].Key)
+			asserts.Equal(tt.config.Spec.Components.DNS.OCI.OCIConfigSecret, overrides[0].Value)
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component.go
@@ -45,6 +45,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
 			InstallBeforeUpgrade:      true,
+			AppendOverridesFunc:       appendOCIDNSOverrides,
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0].name",
 			Dependencies:              []string{networkpolicies.ComponentName, controller.ComponentName},
 		},

--- a/platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/templates/rbac.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/templates/rbac.yaml
@@ -101,16 +101,16 @@ metadata:
   namespace: {{ .Values.certManager.clusterResourceNamespace }}
 rules:
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - "secrets"
-    {{- with .Values.ociProfileSecretNames }}
+      - "secrets"
+    {{- with .Values.ociAuthSecrets }}
     resourceNames:
-    {{ toYaml . | indent 4 }}
+    {{ toYaml . | indent 2 }}
     {{- end }}
     verbs:
-    - "get"
-    - "watch"
+      - "get"
+      - "watch"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cert-manager-ocidns-webhook/values.yaml
@@ -49,6 +49,8 @@ tolerations: []
 
 affinity: {}
 
+ociAuthSecrets: []
+
 securityContext:
   allowPrivilegeEscalation: false
   privileged: false


### PR DESCRIPTION
Updates the RBAC for the OCI DNS Auth webhook to scope access to secrets in the Cert-Manager `clusterResourceNamespace` to only what is required/configured by Verrazzano.
