### PR TITLE
Disable new install checks for external-dns and the CM OCI DNS webhook

### DIFF
--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -106,8 +106,8 @@ var _ = t.Describe("In the Kubernetes Cluster", Label("f:platform-lcm.install"),
 			t.Entry("includes verrazzano-monitoring-operator", "verrazzano-monitoring-operator", true),
 			t.Entry("Check weblogic-operator deployment", "weblogic-operator", pkg.IsWebLogicOperatorEnabled(kubeconfigPath)),
 			t.Entry("Check coherence-operator deployment", "coherence-operator", pkg.IsCoherenceOperatorEnabled(kubeconfigPath)),
-			t.Entry("Check external-dns deployment", "external-dns", pkg.IsOCIDNSEnabled(kubeconfigPath)),
-			t.Entry("Check verrazzano-cert-manager-oci-dns-webhook deployment", "cert-manager-ocidns-provider", pkg.IsOCIDNSWebhookEnabled(kubeconfigPath)),
+			//t.Entry("Check external-dns deployment", "external-dns", pkg.IsOCIDNSEnabled(kubeconfigPath)),
+			//t.Entry("Check verrazzano-cert-manager-oci-dns-webhook deployment", "cert-manager-ocidns-provider", pkg.IsOCIDNSWebhookEnabled(kubeconfigPath)),
 		}
 
 		t.DescribeTable("Verrazzano components are deployed,",


### PR DESCRIPTION
Revert new test cases for external-dns and OCI DNS webhook deployments, the tests do not account for upgrade scenario and are breaking LRE.