### PR TITLE
VZ-9644  verrazzano argocd component must not overwrite policy.csv

### DIFF
--- a/platform-operator/controllers/verrazzano/component/argocd/argocd_postinstall.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/argocd_postinstall.go
@@ -6,6 +6,7 @@ package argocd
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
@@ -138,7 +139,7 @@ func patchArgoCDRbacConfigMap(ctx spi.ComponentContext) error {
 		},
 	}
 
-	var policyString = `g, verrazzano-admins, role:admin`
+	var adminPolicy = `g, verrazzano-admins, role:admin`
 	var err error
 
 	// Disable the built-in admin user. Grant admin (role:admin) to verrazzano-admins group
@@ -146,7 +147,17 @@ func patchArgoCDRbacConfigMap(ctx spi.ComponentContext) error {
 		if rbaccm.Data == nil {
 			rbaccm.Data = make(map[string]string)
 		}
-		rbaccm.Data["policy.csv"] = policyString
+		// Make sure the policy.csv has the verrazzano admin policy
+		policyCSV, ok := rbaccm.Data["policy.csv"]
+		if !ok || len(policyCSV) == 0 {
+			// There is no policy.csv override, Add the verrazzano admin
+			rbaccm.Data["policy.csv"] = adminPolicy
+		} else if !strings.Contains(policyCSV, adminPolicy) {
+			// The policy.csv exists, but doesn't have the verrazzano admin policy.  Add it.
+			trim := strings.TrimSpace(policyCSV)
+			s := fmt.Sprintf("%s\n%s", trim, adminPolicy)
+			rbaccm.Data["policy.csv"] = s
+		}
 		return nil
 	}); err != nil {
 		ctx.Log().ErrorfNewErr("Failed to patch the Argo CD configmap argocd-rbac-cm: %s", err)

--- a/platform-operator/controllers/verrazzano/component/argocd/argocd_postinstall.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/argocd_postinstall.go
@@ -22,6 +22,11 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	adminPolicy  = `g, verrazzano-admins, role:admin`
+	policyCSVKey = `policy.csv`
+)
+
 type OIDCConfig struct {
 	Name            string   `json:"name"`
 	Issuer          string   `json:"issuer"`
@@ -139,7 +144,6 @@ func patchArgoCDRbacConfigMap(ctx spi.ComponentContext) error {
 		},
 	}
 
-	var adminPolicy = `g, verrazzano-admins, role:admin`
 	var err error
 
 	// Disable the built-in admin user. Grant admin (role:admin) to verrazzano-admins group
@@ -148,15 +152,15 @@ func patchArgoCDRbacConfigMap(ctx spi.ComponentContext) error {
 			rbaccm.Data = make(map[string]string)
 		}
 		// Make sure the policy.csv has the verrazzano admin policy
-		policyCSV, ok := rbaccm.Data["policy.csv"]
-		if !ok || len(policyCSV) == 0 {
+		policy, ok := rbaccm.Data[policyCSVKey]
+		if !ok || len(policy) == 0 {
 			// There is no policy.csv override, Add the verrazzano admin
-			rbaccm.Data["policy.csv"] = adminPolicy
-		} else if !strings.Contains(policyCSV, adminPolicy) {
+			rbaccm.Data[policyCSVKey] = adminPolicy
+		} else if !strings.Contains(policy, adminPolicy) {
 			// The policy.csv exists, but doesn't have the verrazzano admin policy.  Add it.
-			trim := strings.TrimSpace(policyCSV)
+			trim := strings.TrimSpace(policy)
 			s := fmt.Sprintf("%s\n%s", trim, adminPolicy)
-			rbaccm.Data["policy.csv"] = s
+			rbaccm.Data[policyCSVKey] = s
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
Tne verrazzano Argo CD component must not overwrite policy.csv, but rather add the g, verrazzano-admins, role:admin policy if it is missing.

This is a cherry-pick from master