### PR TITLE
VS-9644 Add Argo CD release note

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,7 @@ Fixes:
 - Fixed IngressTrait JWT related issues to allow multiple paths where one path has requestPrincipals and the other doesn't.
 - Fixed IngressTrait JWT so that requestPrincipals with no paths are allowed.
 - Fixed IngressTrait related AuthorizationPolicy cleanup when application is deleted.
+- Fixed Argo CD bug to allow the policy.csv field in the argocd-rbac-cm ConfigMap to be overridden.
 
 ### v1.4.0
 Features:


### PR DESCRIPTION
Add release note
"Fixed Argo CD bug to allow the policy.csv field in the argocd-rbac-cm ConfigMap to be overridden."