### PR TITLE
VZ-9711: don't check for tigera-operator Rancher namespaces during install/uninstall

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -58,7 +58,6 @@ var rancherSystemNS = []string{
 	"cattle-fleet-clusters-system",
 	"cattle-fleet-system",
 	"cattle-fleet-local-system",
-	"tigera-operator",
 	"cattle-impersonation-system",
 	"rancher-operator-system",
 	"cattle-csp-adapter-system",


### PR DESCRIPTION
This pull request fixes the install of vz on a CAPI cluster which was failing with the error:
```
admission webhook "install.verrazzano.io.v1beta1" denied the request: found existing namespace tigera-operator not created by Verrazzano
```