### PR TITLE
Revert "VZ-9712 - Make ArgoCD cluster registration and Rancher manifest pushes work on managed cluster with 'none' profile."

### DIFF
--- a/cluster-operator/controllers/vmc/argocd.go
+++ b/cluster-operator/controllers/vmc/argocd.go
@@ -85,11 +85,7 @@ func (r *VerrazzanoManagedClusterReconciler) registerManagedClusterWithArgoCD(vm
 		return newArgoCDRegistration(clusterapi.MCRegistrationFailed, msg), err
 	}
 	isActive, err := isManagedClusterActiveInRancher(rc, clusterID, r.log)
-	if err != nil {
-		msg := fmt.Sprintf("Error checking Rancher status of managed cluster with id %s: %v", clusterID, err)
-		return newArgoCDRegistration(clusterapi.RegistrationPendingRancher, msg), err
-	}
-	if !isActive {
+	if err != nil || !isActive {
 		msg := fmt.Sprintf("Waiting for managed cluster with id %s to become active before registering in Argo CD", clusterID)
 		return newArgoCDRegistration(clusterapi.RegistrationPendingRancher, msg), err
 	}
@@ -200,7 +196,7 @@ func (r *VerrazzanoManagedClusterReconciler) mutateArgoCDClusterSecret(secret *c
 		createNewToken = now.After(timeCreated.Add(lifespan * 3 / 4))
 	}
 	if okCreated && !okExpires {
-		// get token by userId/clusterId
+		//get token by userId/clusterId
 		userID, err := r.getArgoCDClusterUserID()
 		if err != nil {
 			return err

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
@@ -125,3 +125,19 @@ rules:
       - get
       - list
       - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: verrazzano-cluster-registrar
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - update
+      - list
+      - get
+      - watch

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2023, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -82,21 +82,4 @@ rules:
       - get
       - patch
       - update
-      - watch
----
-# ClusterRole verrazzano-cluster-registrar is needed for Verrazzano managed cluster operations via Rancher proxy
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: verrazzano-cluster-registrar
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - update
-      - list
-      - get
       - watch


### PR DESCRIPTION
Reverts verrazzano/verrazzano#6015