### PR TITLE
Uptake latest keycloak-oracle-theme build (release-1.5)

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -461,7 +461,7 @@
           "images": [
             {
               "image": "keycloak-oracle-theme",
-              "tag": "v1.5.0-20230511152819-603bc3c"
+              "tag": "v1.5.0-20230519134308-f089d7d"
             }
           ]
         }


### PR DESCRIPTION
Tested in a local cluster, and the Oracle theme is rendered on the login screen as expected.