### PR TITLE
VZ-9219: Uptake Keycloak 15.0.2 built with netty.io v4.1.86.Final in release-1.4

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -409,8 +409,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak-jenkins",
-              "tag": "v15.0.2-20230522090947-06192536e8",
+              "image": "keycloak",
+              "tag": "v15.0.2-20230522144211-2771f17d10",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -409,8 +409,8 @@
           "name": "keycloak",
           "images": [
             {
-              "image": "keycloak",
-              "tag": "v15.0.2-20230518143111-62e8429a49",
+              "image": "keycloak-jenkins",
+              "tag": "v15.0.2-20230522090947-06192536e8",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updates Keycloak image built with the change https://github.com/verrazzano/keycloak/pull/20