### PR TITLE
VZ-9219: Uptake Keycloak 15.0.2 built with netty.io v4.1.86.Final in release-1.3

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -411,7 +411,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "v15.0.2-20230508133223-83019f1119",
+              "tag": "v15.0.2-20230522144211-2771f17d10",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updates Keycloak image built with the change https://github.com/verrazzano/keycloak/pull/20
