### PR TITLE
VZ-7679 Acceptance test support for K8s 1.25

### DIFF
--- a/.third-party-test-versions
+++ b/.third-party-test-versions
@@ -1,6 +1,6 @@
-# Copyright (C) 2021, Oracle and/or its affiliates.
+# Copyright (C) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-calico-version=3.18.1
+calico-version=3.24.5
 google-chrome-version=90.0.4430.93-1
 chrome-driver-version=90.0.4430.24

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Features:
 - Added a None profile that comes with all components disabled by default
 - Added Thanos, which supports high availability and long-term storage on top of Prometheus
 - Enhanced the Verrazzano CLI to support installing and upgrading from a private registry and in air-gapped environments
+- Added support for Kubernetes v1.25
 
 Component version updates:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -359,7 +359,7 @@ pipeline {
             }
         }
 
-        stage('Kind Acceptance Tests on 1.24') {
+        stage('Kind Acceptance Tests on 1.25') {
             when {
                 allOf {
                     not { buildingTag() }
@@ -382,7 +382,7 @@ pipeline {
                     script {
                         build job: "verrazzano-new-kind-acceptance-tests/${BRANCH_NAME.replace("/", "%2F")}",
                             parameters: [
-                                string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
+                                string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.25'),
                                 string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                 string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
                                 string(name: 'CRD_API_VERSION', value: params.CRD_API_VERSION),

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -201,7 +201,7 @@ pipeline {
                             script {
                                 build job: "/verrazzano-analyze-tool-test/${CLEAN_BRANCH_NAME}",
                                     parameters: [
-                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
+                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.25'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                     ], wait: true
                             }

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -230,13 +230,13 @@ pipeline {
                        }
                    }
                }
-                stage('Kind Acceptance Tests With HA and Grafana DB on 1.24') {
+                stage('Kind Acceptance Tests With HA and Grafana DB on 1.25') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
                                 build job: "/verrazzano-new-kind-acceptance-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
-                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
+                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.25'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
@@ -283,13 +283,30 @@ pipeline {
                         }
                     }
                 }
+                stage('Kind Acceptance Tests on 1.24') {
+                    steps {
+                        retry(count: JOB_PROMOTION_RETRIES) {
+                            script {
+                                build job: "/verrazzano-new-kind-acceptance-tests/${CLEAN_BRANCH_NAME}",
+                                        parameters: [
+                                                string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
+                                                string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
+                                                string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                                string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                                string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                                booleanParam(name: 'ENABLE_JWT_TESTING', value: true)
+                                        ], wait: true
+                            }
+                        }
+                    }
+                }
                 stage('Verrazzano a-la-carte') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
                                 build job: "/verrazzano-a-la-carte/${CLEAN_BRANCH_NAME}",
                                         parameters: [
-                                                string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
+                                                string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.25'),
                                                 string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         ], wait: true
                             }
@@ -337,14 +354,14 @@ pipeline {
                         }
                     }
                 }
-                stage('Kind Acceptance Tests on 1.24 Non-Calico') {
+                stage('Kind Acceptance Tests on 1.25 Non-Calico') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
                                 // Do not use Calico
                                 build job: "verrazzano-new-kind-acceptance-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
-                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
+                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.25'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: false),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
@@ -362,14 +379,14 @@ pipeline {
                         }
                     }
                 }
-                stage('Kind Acceptance Tests on 1.24 sslip.io') {
+                stage('Kind Acceptance Tests on 1.25 sslip.io') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
                                 // test with sslip.io
                                 build job: "verrazzano-new-kind-acceptance-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
-                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
+                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.25'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'WILDCARD_DNS_DOMAIN', value: 'sslip.io'),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
@@ -393,7 +410,7 @@ pipeline {
                             script {
                                 build job: "verrazzano-dynamic-config-suite/${CLEAN_BRANCH_NAME}",
                                     parameters: [
-                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
+                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.25'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
@@ -463,7 +480,7 @@ pipeline {
                             script {
                                 def builtExamples = build job: "/verrazzano-examples/${CLEAN_BRANCH_NAME}",
                                     parameters: [
-                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
+                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.25'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -232,7 +232,7 @@ pipeline {
                             script {
                                 build job: "/verrazzano-no-injection-tests/${CLEAN_BRANCH_NAME}",
                                     parameters: [
-                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.24'),
+                                        string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.25'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                         string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/ci/backup/JenkinsfileAlllBackupKinDTest
+++ b/ci/backup/JenkinsfileAlllBackupKinDTest
@@ -28,7 +28,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/ci/backup/JenkinsfileAlllBackupOKETest
+++ b/ci/backup/JenkinsfileAlllBackupOKETest
@@ -48,7 +48,7 @@ pipeline {
         choice (name: 'OKE_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value
-                choices: [ "v1.24.1", "v1.23.4", "v1.22.5", "v1.21.5" ])
+                choices: [ "v1.25.4", "v1.24.1", "v1.23.4", "v1.22.5" ])
         choice (name: 'CRD_API_VERSION',
                 description: 'This is the API crd version.',
                 // 1st choice is the default value

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: ["1.21", "1.22", "1.23", "1.24" ])
+                choices: ["1.22", "1.23", "1.24", "1.25" ])
         string (name: 'VERSION_FOR_INSTALL',
                 defaultValue: 'v1.4.3',
                 description: 'This is the Verrazzano version for install.  By default, the latest Master release will be installed',

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -25,7 +25,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/ci/examples/Jenkinsfile
+++ b/ci/examples/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/ci/generic/Jenkinsfile
+++ b/ci/generic/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/ci/generic/Jenkinsfile-singletarget
+++ b/ci/generic/Jenkinsfile-singletarget
@@ -26,7 +26,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -33,7 +33,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value, use older version as default to ensure cluster will perform upgrade
-                choices: [ "v1.23.4", "v1.22.5", "v1.21.5", "v1.24.1" ])
+                choices: [ "v1.23.4", "v1.22.5", "v1.24.1", "v1.25.4" ])
         choice (name: 'OKE_NODE_POOL',
                 description: 'OKE node pool configuration',
                 // 1st choice is the default value

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/ci/make/kind.mk
+++ b/ci/make/kind.mk
@@ -1,4 +1,4 @@
-# Copyright (C) 2022, Oracle and/or its affiliates.
+# Copyright (C) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 include env.mk
@@ -9,7 +9,7 @@ setup-kind: export INSTALL_CONFIG_FILE_KIND ?= ${TEST_SCRIPTS_DIR}/v1beta1/insta
 setup-kind: export CREATE_CLUSTER_USE_CALICO ?= false
 setup-kind: export CALICO_HOME ?= ${CI_SCRIPTS_DIR}/calico
 setup-kind: export TESTS_EXECUTED_FILE ?= ${WORKSPACE}/tests_executed_file.tmp
-setup-kind: export KUBERNETES_CLUSTER_VERSION ?= 1.24
+setup-kind: export KUBERNETES_CLUSTER_VERSION ?= 1.25
 .PHONY: setup-kind
 setup-kind:
 	@echo "Setup KIND cluster"

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -47,11 +47,11 @@ pipeline {
         choice (name: 'OKE_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value
-                choices: [ "v1.24.1", "v1.22.5", "v1.23.4", "v1.21.5" ])
+                choices: [ "v1.25.4", "v1.24.1", "v1.22.5", "v1.23.4" ])
         choice (name: 'KIND_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.22", "1.23", "1.21" ])
+                choices: [ "1.25", "1.24", "1.22", "1.23" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
             choices: [ "VM.Standard.E3.Flex-4-2", "VM.Standard2.4-2", "VM.Standard.E3.Flex-8-2" ])
         choice (description: 'Kubernetes Version for OKE Cluster', name: 'OKE_CLUSTER_VERSION',
                 // 1st choice is the default value
-                choices: [ "v1.24.1", "v1.23.4", "v1.22.5", "v1.21.5" ])
+                choices: [ "v1.25.4", "v1.24.1", "v1.23.4", "v1.22.5" ])
         string defaultValue: 'dev', description: 'Verrazzano install profile name', name: "INSTALL_PROFILE", trim: true
         choice (name: 'CRD_API_VERSION',
                 description: 'This is the API crd version.',

--- a/ci/no-injection/Jenkinsfile
+++ b/ci/no-injection/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -40,11 +40,11 @@ pipeline {
             choices: [ "VM.Standard.E3.Flex-4-2", "VM.Standard2.4-2", "VM.Standard.E3.Flex-8-2", "VM.Standard.E2.2" ])
         choice (description: 'Kubernetes Version for OKE Cluster', name: 'OKE_CLUSTER_VERSION',
             // 1st choice is the default value
-            choices: [ "v1.24.1", "v1.23.4", "v1.22.5", "v1.21.5" ])
+            choices: [ "v1.25.4", "v1.24.1", "v1.23.4", "v1.22.5" ])
         choice (description: 'Kubernetes Version for KinD Cluster',
             name: 'KIND_CLUSTER_VERSION',
             // 1st choice is the default value
-            choices: [ "1.24", "1.23", "1.22", "1.21" ])
+            choices: [ "1.25", "1.24", "1.23", "1.22" ])
         choice(description: 'Verrazzano Install Profile', name: "INSTALL_PROFILE", choices: installProfiles )
         string defaultValue: 'NONE', description: 'Verrazzano platform operator image name (within ghcr.io/verrazzano repo)', name: 'VERRAZZANO_OPERATOR_IMAGE', trim: true
         choice (name: 'WILDCARD_DNS_DOMAIN',

--- a/ci/ocne-cluster-driver/Jenkinsfile
+++ b/ci/ocne-cluster-driver/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                     choices: [ "GLOBAL","PRIVATE" ])
         choice (description: 'Kubernetes Version for OKE Cluster', name: 'OKE_CLUSTER_VERSION',
                 // 1st choice is the default value
-                choices: [ "v1.24.1", "v1.23.4", "v1.22.5", "v1.21.5" ])
+                choices: [ "v1.25.4", "v1.24.1", "v1.23.4", "v1.22.5" ])
         choice (name: 'CRD_API_VERSION',
                 description: 'This is the API crd version.',
                 // 1st choice is the default value

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
                     choices: [ "GLOBAL","PRIVATE" ])
         choice (description: 'Kubernetes Version for OKE Cluster', name: 'OKE_CLUSTER_VERSION',
                 // 1st choice is the default value
-                choices: [ "v1.24.1", "v1.23.4", "v1.22.5", "v1.21.5" ])
+                choices: [ "v1.25.4", "v1.24.1", "v1.23.4", "v1.22.5" ])
         choice (name: 'CRD_API_VERSION',
                 description: 'This is the API crd version.',
                 // 1st choice is the default value

--- a/ci/oke-ocidns/JenknsfileDnsKind
+++ b/ci/oke-ocidns/JenknsfileDnsKind
@@ -48,7 +48,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                         description: 'Kubernetes Version for KinD Cluster',
                         // 1st choice is the default value
-                        choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                        choices: [ "1.25", 1.24", "1.23", "1.22" ])
         choice (description: 'Use instance principal for oci dns tests', name: 'OCI_DNS_AUTH',
                 // 1st choice is the default value
                 choices: [ "user_principal", "instance_principal" ])

--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -16,7 +16,7 @@ def agentLabel=env.JOB_NAME.contains('-ocne') ? "" : env.JOB_NAME.contains('mast
 def availableRegions=["us-ashburn-1"]
 def availableDomains=["hXgQ:US-ASHBURN-AD-1", "hXgQ:US-ASHBURN-AD-2", "hXgQ:US-ASHBURN-AD-3"]
 Collections.shuffle(availableDomains)
-def kubernetesVersions=[ "v1.24.1", "v1.23.4", "v1.22.5", "v1.21.5" ]
+def kubernetesVersions=[ "v1.25.4", "v1.24.1", "v1.23.4", "v1.22.5" ]
 def ocneVersions=[ "1.5"]
 def osVersions=['8', '7']
 def uniquePrefix=UUID.randomUUID().toString().substring(0,4).replace('-','')

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         choice (name: 'DISTRIBUTION_VARIANT',
                 description: 'Verrazzano Distribution Variant to use for testing',
                 choices: ["Full", "Lite"])

--- a/ci/psr/Jenkinsfile
+++ b/ci/psr/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     }
 
     parameters {
-        choice (name: 'KUBERNETES_CLUSTER_VERSION', description: 'Kubernetes Version for KinD Cluster', choices: [ "1.24", "1.23", "1.22", "1.21" ])
+        choice (name: 'KUBERNETES_CLUSTER_VERSION', description: 'Kubernetes Version for KinD Cluster', choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'VZ_BRANCH_TO_USE', defaultValue: 'master', trim: true, description: 'This is the name of the Verrazzano product branch to use for testing the PSR tooling; CURRENT means using the working branch')
         string (name: 'VERRAZZANO_OPERATOR_IMAGE', defaultValue: 'NONE', trim: true, description: 'Uses a specific Verrazzano platform operator image name (in ghcr.io repo).  If not specified, the latest operator.yaml from related Verrazzano repo branch will be used to create Verrazzano platform operator manifest')
         string (name: 'KIND_NODE_COUNT', defaultValue: '3', trim: true, description: 'Number of nodes for the KIND cluster for smoke testing')

--- a/ci/scripts/install_calico.sh
+++ b/ci/scripts/install_calico.sh
@@ -23,6 +23,6 @@ for image_archive in *.tar; do
     kind load image-archive "$image_archive" --name "${CLUSTER_NAME}"
 done
 
-echo "Apply ${CALICO_HOME}/${CALICO_VERSION}/k8s-manifests/calico.yaml."
-cd ${CALICO_HOME}/${CALICO_VERSION}/k8s-manifests
+echo "Apply ${CALICO_HOME}/${CALICO_VERSION}/manifests/calico.yaml."
+cd ${CALICO_HOME}/${CALICO_VERSION}/manifests
 kubectl apply -f calico.yaml

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
         choice (name: 'OKE_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value
-                choices: [ "v1.24.1", "v1.23.4", "v1.22.5", "v1.21.5" ])
+                choices: [ "v1.25.4", "v1.24.1", "v1.23.4", "v1.22.5" ])
         choice (name: 'CRD_API_VERSION',
                 description: 'This is the API crd version.',
                 // 1st choice is the default value

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -66,7 +66,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.21", "1.22", "1.23" ])
+                choices: [ "1.25", "1.24", "1.22", "1.23" ])
 
         booleanParam (description: 'Whether to create kind cluster with Calico for AT testing (defaults to true)', name: 'CREATE_KIND_USE_CALICO', defaultValue: true)
         booleanParam (description: 'Whether to dump k8s cluster on success (off by default can be useful to capture for comparing to failed cluster)', name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', defaultValue: false)

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -60,11 +60,11 @@ pipeline {
         choice (name: 'OKE_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value
-                choices: [ "v1.21.5", "v1.22.5", "v1.23.4", "v1.24.1" ])
+                choices: [ "v1.22.5", "v1.23.4", "v1.24.1", "v1.25.4" ])
         choice (name: 'KIND_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value
-                choices: [ "1.21", "1.22", "1.23", "1.24" ])
+                choices: [ "1.22", "1.23", "1.24", "1.25" ])
         string (name: 'VERSION_FOR_INSTALL',
                 defaultValue: 'v1.3.0',
                 description: 'This is the Verrazzano version for install before doing an upgrade.  By default, the v1.3.0 release will be installed',

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -43,7 +43,7 @@ pipeline {
         choice (name: 'KIND_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KIND Cluster',
                 // 1st choice is the default value
-                choices: [ "1.21", "1.22", "1.23", "1.24" ])
+                choices: [ "1.22", "1.23", "1.24", "1.25" ])
         string (name: 'EXCLUDE_RELEASES',
                 defaultValue: "v1.0, v1.1, v1.2",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)

--- a/ci/vz-analyze/Jenkinsfile
+++ b/ci/vz-analyze/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for KinD Cluster',
                 // 1st choice is the default value
-                choices: [ "1.24", "1.23", "1.22", "1.21" ])
+                choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
                         defaultValue: 'NONE',
                         description: 'This is the full git commit hash from the source build to be used for all jobs',


### PR DESCRIPTION
Also, updated Calico version to support K8s 1.25 and removed K8s 1.21 testing from pipelines.
