### PR TITLE
VZ-9701 pickup controllers with module metadata support

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -232,11 +232,11 @@
           "images": [
             {
               "image": "cluster-api-ocne-bootstrap-controller",
-              "tag": "v0.1.0-20230516205451-d9da513"
+              "tag": "v0.1.0-20230522163916-38da305"
             },
             {
               "image": "cluster-api-ocne-control-plane-controller",
-              "tag": "v0.1.0-20230516205451-d9da513"
+              "tag": "v0.1.0-20230522163916-38da305"
             }
           ]
         }


### PR DESCRIPTION
Pickup the latest builds of capi controllers with support for modules metadata and inclusion of module charts
