### PR TITLE
VZ-9724.  Add new CertManager components to profiles, implement Certificate conversion 

### DIFF
--- a/pkg/profiles/merge.go
+++ b/pkg/profiles/merge.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package profiles
@@ -192,6 +192,12 @@ func AppendComponentOverrides(actual, profile *v1alpha1.Verrazzano) {
 	profileCertManager := profile.Spec.Components.CertManager
 	if actualCertManager != nil && profileCertManager != nil {
 		actualCertManager.ValueOverrides = mergeOverrides(actualCertManager.ValueOverrides, profileCertManager.ValueOverrides)
+	}
+
+	actualOCIWebhook := actual.Spec.Components.CertManagerWebhookOCI
+	profileOCIWebhook := profile.Spec.Components.CertManagerWebhookOCI
+	if actualOCIWebhook != nil && profileOCIWebhook != nil {
+		actualOCIWebhook.ValueOverrides = mergeOverrides(actualOCIWebhook.ValueOverrides, profileOCIWebhook.ValueOverrides)
 	}
 
 	actualCoherenceOperator := actual.Spec.Components.CoherenceOperator

--- a/pkg/vzcr/enabled.go
+++ b/pkg/vzcr/enabled.go
@@ -112,6 +112,38 @@ func IsCertManagerEnabled(cr runtime.Object) bool {
 	return true
 }
 
+// IsClusterIssuerEnabled - Returns false only if the ClusterIssuerComponent is explicitly disabled
+func IsClusterIssuerEnabled(cr runtime.Object) bool {
+	if vzv1alpha1, ok := cr.(*installv1alpha1.Verrazzano); ok {
+		if vzv1alpha1 != nil && vzv1alpha1.Spec.Components.ClusterIssuer != nil &&
+			vzv1alpha1.Spec.Components.ClusterIssuer.Enabled != nil {
+			return *vzv1alpha1.Spec.Components.ClusterIssuer.Enabled
+		}
+	} else if vzv1beta1, ok := cr.(*installv1beta1.Verrazzano); ok {
+		if vzv1beta1 != nil && vzv1beta1.Spec.Components.ClusterIssuer != nil &&
+			vzv1beta1.Spec.Components.ClusterIssuer.Enabled != nil {
+			return *vzv1beta1.Spec.Components.ClusterIssuer.Enabled
+		}
+	}
+	return true
+}
+
+// IsCertManagerWebhookOCIEnabled - Returns true IFF the ExternalCertManager component is explicitly enabled
+func IsCertManagerWebhookOCIEnabled(cr runtime.Object) bool {
+	if vzv1alpha1, ok := cr.(*installv1alpha1.Verrazzano); ok {
+		if vzv1alpha1 != nil && vzv1alpha1.Spec.Components.CertManagerWebhookOCI != nil &&
+			vzv1alpha1.Spec.Components.CertManagerWebhookOCI.Enabled != nil {
+			return *vzv1alpha1.Spec.Components.CertManagerWebhookOCI.Enabled
+		}
+	} else if vzv1beta1, ok := cr.(*installv1beta1.Verrazzano); ok {
+		if vzv1beta1 != nil && vzv1beta1.Spec.Components.CertManagerWebhookOCI != nil &&
+			vzv1beta1.Spec.Components.CertManagerWebhookOCI.Enabled != nil {
+			return *vzv1beta1.Spec.Components.CertManagerWebhookOCI.Enabled
+		}
+	}
+	return false
+}
+
 // IsKialiEnabled - Returns false only if explicitly disabled in the CR
 func IsKialiEnabled(cr runtime.Object) bool {
 	if vzv1alpha1, ok := cr.(*installv1alpha1.Verrazzano); ok {

--- a/pkg/vzcr/enabled_test.go
+++ b/pkg/vzcr/enabled_test.go
@@ -219,6 +219,102 @@ func TestIsKeycloakEnabled(t *testing.T) {
 		}}))
 }
 
+// TestIsClusterIssuerEnabled tests the IsClusterIssuerEnabled function
+// GIVEN a call to IsClusterIssuerEnabled
+//
+//	THEN the value of the Enabled flag is returned if present, true otherwise (enabled by default)
+func TestIsClusterIssuerEnabled(t *testing.T) {
+	asserts := assert.New(t)
+	asserts.True(IsClusterIssuerEnabled(nil))
+	asserts.True(IsClusterIssuerEnabled(&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{}}))
+	asserts.True(IsClusterIssuerEnabled(
+		&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				ClusterIssuer: &vzapi.ClusterIssuerComponent{},
+			},
+		}}))
+	asserts.True(IsClusterIssuerEnabled(
+		&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				ClusterIssuer: &vzapi.ClusterIssuerComponent{
+					Enabled: &trueValue,
+				},
+			},
+		}}))
+	asserts.False(IsClusterIssuerEnabled(
+		&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				ClusterIssuer: &vzapi.ClusterIssuerComponent{
+					Enabled: &falseValue,
+				},
+			},
+		}}))
+	asserts.True(IsClusterIssuerEnabled(
+		&installv1beta1.Verrazzano{Spec: installv1beta1.VerrazzanoSpec{
+			Components: installv1beta1.ComponentSpec{
+				ClusterIssuer: &installv1beta1.ClusterIssuerComponent{
+					Enabled: &trueValue,
+				},
+			},
+		}}))
+	asserts.False(IsClusterIssuerEnabled(
+		&installv1beta1.Verrazzano{Spec: installv1beta1.VerrazzanoSpec{
+			Components: installv1beta1.ComponentSpec{
+				ClusterIssuer: &installv1beta1.ClusterIssuerComponent{
+					Enabled: &falseValue,
+				},
+			},
+		}}))
+}
+
+// TestIsCertManagerOCIDNSWebhookEnabled tests the IsCertManagerWebhookOCIEnabled function
+// GIVEN a call to IsCertManagerWebhookOCIEnabled
+//
+//	THEN the value of the Enabled flag is returned if present, false otherwise (disabled by default)
+func TestIsCertManagerOCIDNSWebhookEnabled(t *testing.T) {
+	asserts := assert.New(t)
+	asserts.False(IsCertManagerWebhookOCIEnabled(nil))
+	asserts.False(IsCertManagerWebhookOCIEnabled(&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{}}))
+	asserts.False(IsCertManagerWebhookOCIEnabled(
+		&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				CertManagerWebhookOCI: &vzapi.CertManagerWebhookOCIComponent{},
+			},
+		}}))
+	asserts.True(IsCertManagerWebhookOCIEnabled(
+		&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				CertManagerWebhookOCI: &vzapi.CertManagerWebhookOCIComponent{
+					Enabled: &trueValue,
+				},
+			},
+		}}))
+	asserts.False(IsCertManagerWebhookOCIEnabled(
+		&vzapi.Verrazzano{Spec: vzapi.VerrazzanoSpec{
+			Components: vzapi.ComponentSpec{
+				CertManagerWebhookOCI: &vzapi.CertManagerWebhookOCIComponent{
+					Enabled: &falseValue,
+				},
+			},
+		}}))
+	asserts.True(IsCertManagerWebhookOCIEnabled(
+		&installv1beta1.Verrazzano{Spec: installv1beta1.VerrazzanoSpec{
+			Components: installv1beta1.ComponentSpec{
+				CertManagerWebhookOCI: &installv1beta1.CertManagerWebhookOCIComponent{
+					Enabled: &trueValue,
+				},
+			},
+		}}))
+	asserts.False(IsCertManagerWebhookOCIEnabled(
+		&installv1beta1.Verrazzano{Spec: installv1beta1.VerrazzanoSpec{
+			Components: installv1beta1.ComponentSpec{
+				CertManagerWebhookOCI: &installv1beta1.CertManagerWebhookOCIComponent{
+					Enabled: &falseValue,
+				},
+			},
+		}}))
+}
+
 // TestIsConsoleEnabled tests the IsConsoleEnabled function
 // GIVEN a call to IsConsoleEnabled
 //

--- a/platform-operator/apis/verrazzano/v1alpha1/issuer_utils.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/issuer_utils.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package v1alpha1
+
+import (
+	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+)
+
+func NewDefaultClusterIssuer() *ClusterIssuerComponent {
+	return &ClusterIssuerComponent{
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			CA: &CAIssuer{
+				SecretName: constants.DefaultVerrazzanoCASecretName,
+			},
+		},
+	}
+}
+
+// IsCAIssuer returns true of the issuer configuration is for a CA issuer, or an error if it is misconfigured
+func (c *ClusterIssuerComponent) IsCAIssuer() (bool, error) {
+	if c.CA != nil && c.LetsEncrypt != nil {
+		return false, fmt.Errorf("Illegal state, can not configure CAIssuer and LetsEncrypt issuer simultaneously")
+	}
+	return c.CA != nil, nil
+}
+
+// IsLetsEncryptIssuer returns true of the issuer configuration is for a LetsEncrypt issuer, or an error if it is misconfigured
+func (c *ClusterIssuerComponent) IsLetsEncryptIssuer() (bool, error) {
+	isCAIssuer, err := c.IsCAIssuer()
+	if err != nil {
+		return false, err
+	}
+	return !isCAIssuer, nil
+}
+
+// IsDefaultIssuer returns true of the issuer configuration is for the Verrazzano default self-signed issuer, or an error if it is misconfigured
+func (c *ClusterIssuerComponent) IsDefaultIssuer() (bool, error) {
+	isCAIssuer, err := c.IsCAIssuer()
+	if err != nil {
+		return false, err
+	}
+	return isCAIssuer && c.ClusterResourceNamespace == constants.CertManagerNamespace &&
+		c.CA.SecretName == constants.DefaultVerrazzanoCASecretName, nil
+}

--- a/platform-operator/apis/verrazzano/v1alpha1/issuer_utils_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/issuer_utils_test.go
@@ -9,6 +9,13 @@ import (
 	"testing"
 )
 
+const (
+	emailAddress                 = "foo@bar.com"
+	envType                      = "staging"
+	testClusterResourceNamespace = "myclusterResourceNamespace"
+	customCAName                 = "myCA"
+)
+
 // TestNewDefaultClusterIssuer Tests the TestNewDefaultClusterIssuer constructor
 // GIVEN a call to NewDefaultClusterIssuer()
 // THEN a valid ClusterIssuerComponent is returned with the default self-signed CA issuer configuration
@@ -33,17 +40,17 @@ func TestNewDefaultClusterIssuer(t *testing.T) {
 	asserts.NoError(err)
 }
 
-// TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer Tests the IsCAIssuer and IsLetsEncryptIssuer methods
+// TestClusterIssuerComponentIsCAIssuerIsLEIssuer Tests the IsCAIssuer and IsLetsEncryptIssuer methods
 // GIVEN a call to IsCAIssuer() or IsLetsEncryptIssuer() for various configurations
 // THEN the functions behave as expected
-func TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer(t *testing.T) {
+func TestClusterIssuerComponentIsCAIssuerIsLEIssuer(t *testing.T) {
 	asserts := assert.New(t)
 
 	caIssuer := ClusterIssuerComponent{
 		Enabled:                  newBool(true),
 		ClusterResourceNamespace: constants.CertManagerNamespace,
 		IssuerConfig: IssuerConfig{
-			CA: &CAIssuer{SecretName: "myCA"},
+			CA: &CAIssuer{SecretName: customCAName},
 		},
 	}
 
@@ -60,8 +67,8 @@ func TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer(t *testing.T) {
 		ClusterResourceNamespace: constants.CertManagerNamespace,
 		IssuerConfig: IssuerConfig{
 			LetsEncrypt: &LetsEncryptACMEIssuer{
-				EmailAddress: "foo@bar.com",
-				Environment:  "staging",
+				EmailAddress: emailAddress,
+				Environment:  envType,
 			},
 		},
 	}
@@ -75,11 +82,11 @@ func TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer(t *testing.T) {
 	asserts.NoError(err)
 }
 
-// TestClusterIssuerComponent_NotDefaultIssuer Tests the IsDefaultIssuer method
+// TestClusterIssuerComponentNotDefaultIssuer Tests the IsDefaultIssuer method
 // GIVEN a call to IsDefaultIssuer()
 // WHEN the issuer configuration is not a default self-signed configuration
 // THEN the function returns false, or an error if the issuer is misconfigured
-func TestClusterIssuerComponent_NotDefaultIssuer(t *testing.T) {
+func TestClusterIssuerComponentNotDefaultIssuer(t *testing.T) {
 	asserts := assert.New(t)
 
 	// Test default clusterResourceNamespace, non-default secret name
@@ -98,7 +105,7 @@ func TestClusterIssuerComponent_NotDefaultIssuer(t *testing.T) {
 	// Test default secret name, non-default cluster resource namespace
 	caIssuer2 := ClusterIssuerComponent{
 		Enabled:                  newBool(true),
-		ClusterResourceNamespace: "mycluserResourceNamespace",
+		ClusterResourceNamespace: testClusterResourceNamespace,
 		IssuerConfig: IssuerConfig{
 			CA: &CAIssuer{SecretName: constants.DefaultVerrazzanoCASecretName},
 		},
@@ -113,8 +120,8 @@ func TestClusterIssuerComponent_NotDefaultIssuer(t *testing.T) {
 		ClusterResourceNamespace: constants.CertManagerNamespace,
 		IssuerConfig: IssuerConfig{
 			LetsEncrypt: &LetsEncryptACMEIssuer{
-				EmailAddress: "foo@bar.com",
-				Environment:  "staging",
+				EmailAddress: emailAddress,
+				Environment:  envType,
 			},
 		},
 	}
@@ -123,21 +130,21 @@ func TestClusterIssuerComponent_NotDefaultIssuer(t *testing.T) {
 	asserts.NoError(err)
 }
 
-// TestClusterIssuerComponent_BadIssuerConfig Tests the various IsXXX method
+// TestClusterIssuerComponentBadIssuerConfig Tests the various IsXXX method
 // GIVEN a call to IsXXXXIssuer()
 // WHEN the issuer configuration is invalid
 // THEN the functions returns false and an error
-func TestClusterIssuerComponent_BadIssuerConfig(t *testing.T) {
+func TestClusterIssuerComponentBadIssuerConfig(t *testing.T) {
 	asserts := assert.New(t)
 
 	badConfig := ClusterIssuerComponent{
 		Enabled:                  newBool(true),
 		ClusterResourceNamespace: constants.CertManagerNamespace,
 		IssuerConfig: IssuerConfig{
-			CA: &CAIssuer{SecretName: "myCA"},
+			CA: &CAIssuer{SecretName: customCAName},
 			LetsEncrypt: &LetsEncryptACMEIssuer{
-				EmailAddress: "foo@bar.com",
-				Environment:  "staging",
+				EmailAddress: emailAddress,
+				Environment:  envType,
 			},
 		},
 	}

--- a/platform-operator/apis/verrazzano/v1alpha1/issuer_utils_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/issuer_utils_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package v1alpha1
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"testing"
+)
+
+// TestNewDefaultClusterIssuer Tests the TestNewDefaultClusterIssuer constructor
+// GIVEN a call to NewDefaultClusterIssuer()
+// THEN a valid ClusterIssuerComponent is returned with the default self-signed CA issuer configuration
+func TestNewDefaultClusterIssuer(t *testing.T) {
+	asserts := assert.New(t)
+	issuer := NewDefaultClusterIssuer()
+
+	asserts.Equal(constants.CertManagerNamespace, issuer.ClusterResourceNamespace)
+	asserts.Equal(constants.DefaultVerrazzanoCASecretName, issuer.CA.SecretName)
+	asserts.Nil(issuer.LetsEncrypt)
+
+	isDefaultIssuer, err := issuer.IsDefaultIssuer()
+	asserts.True(isDefaultIssuer)
+	asserts.NoError(err)
+
+	isCAIssuer, err := issuer.IsCAIssuer()
+	asserts.True(isCAIssuer)
+	asserts.NoError(err)
+
+	isACMEIssuer, err := issuer.IsLetsEncryptIssuer()
+	asserts.False(isACMEIssuer)
+	asserts.NoError(err)
+}
+
+// TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer Tests the IsCAIssuer and IsLetsEncryptIssuer methods
+// GIVEN a call to IsCAIssuer() or IsLetsEncryptIssuer() for various configurations
+// THEN the functions behave as expected
+func TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer(t *testing.T) {
+	asserts := assert.New(t)
+
+	caIssuer := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			CA: &CAIssuer{SecretName: "myCA"},
+		},
+	}
+
+	isCAIssuer, err := caIssuer.IsCAIssuer()
+	asserts.True(isCAIssuer)
+	asserts.NoError(err)
+
+	isACMEIssuer, err := caIssuer.IsLetsEncryptIssuer()
+	asserts.False(isACMEIssuer)
+	asserts.NoError(err)
+
+	leIssuer := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			LetsEncrypt: &LetsEncryptACMEIssuer{
+				EmailAddress: "foo@bar.com",
+				Environment:  "staging",
+			},
+		},
+	}
+
+	isCAIssuer, err = leIssuer.IsCAIssuer()
+	asserts.False(isCAIssuer)
+	asserts.NoError(err)
+
+	isACMEIssuer, err = leIssuer.IsLetsEncryptIssuer()
+	asserts.True(isACMEIssuer)
+	asserts.NoError(err)
+}
+
+// TestClusterIssuerComponent_NotDefaultIssuer Tests the IsDefaultIssuer method
+// GIVEN a call to IsDefaultIssuer()
+// WHEN the issuer configuration is not a default self-signed configuration
+// THEN the function returns false, or an error if the issuer is misconfigured
+func TestClusterIssuerComponent_NotDefaultIssuer(t *testing.T) {
+	asserts := assert.New(t)
+
+	// Test default clusterResourceNamespace, non-default secret name
+	caIssuer1 := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			CA: &CAIssuer{SecretName: "myCA"},
+		},
+	}
+
+	isDefIssuer1, err := caIssuer1.IsDefaultIssuer()
+	asserts.False(isDefIssuer1)
+	asserts.NoError(err)
+
+	// Test default secret name, non-default cluster resource namespace
+	caIssuer2 := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: "mycluserResourceNamespace",
+		IssuerConfig: IssuerConfig{
+			CA: &CAIssuer{SecretName: constants.DefaultVerrazzanoCASecretName},
+		},
+	}
+	isDefIssuer2, err := caIssuer2.IsDefaultIssuer()
+	asserts.False(isDefIssuer2)
+	asserts.NoError(err)
+
+	// Test LE issuer
+	leIssuer := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			LetsEncrypt: &LetsEncryptACMEIssuer{
+				EmailAddress: "foo@bar.com",
+				Environment:  "staging",
+			},
+		},
+	}
+	isDefIssuer3, err := leIssuer.IsDefaultIssuer()
+	asserts.False(isDefIssuer3)
+	asserts.NoError(err)
+}
+
+// TestClusterIssuerComponent_BadIssuerConfig Tests the various IsXXX method
+// GIVEN a call to IsXXXXIssuer()
+// WHEN the issuer configuration is invalid
+// THEN the functions returns false and an error
+func TestClusterIssuerComponent_BadIssuerConfig(t *testing.T) {
+	asserts := assert.New(t)
+
+	badConfig := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			CA: &CAIssuer{SecretName: "myCA"},
+			LetsEncrypt: &LetsEncryptACMEIssuer{
+				EmailAddress: "foo@bar.com",
+				Environment:  "staging",
+			},
+		},
+	}
+
+	isCAIssuer, err := badConfig.IsCAIssuer()
+	asserts.Error(err)
+	asserts.False(isCAIssuer)
+
+	isLEIssuer, err := badConfig.IsLetsEncryptIssuer()
+	asserts.Error(err)
+	asserts.False(isLEIssuer)
+
+	isDefIssuer, err := badConfig.IsDefaultIssuer()
+	asserts.Error(err)
+	asserts.False(isDefIssuer)
+}

--- a/platform-operator/apis/verrazzano/v1beta1/issuer_utils.go
+++ b/platform-operator/apis/verrazzano/v1beta1/issuer_utils.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package v1beta1
+
+import (
+	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+)
+
+// NewDefaultClusterIssuer creates a default ClusterIssuerComponent
+func NewDefaultClusterIssuer() *ClusterIssuerComponent {
+	return &ClusterIssuerComponent{
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			CA: &CAIssuer{
+				SecretName: constants.DefaultVerrazzanoCASecretName,
+			},
+		},
+	}
+}
+
+// IsCAIssuer returns true of the issuer configuration is for a CA issuer, or an error if it is misconfigured
+func (c *ClusterIssuerComponent) IsCAIssuer() (bool, error) {
+	if c.CA != nil && c.LetsEncrypt != nil {
+		return false, fmt.Errorf("Illegal state, can not configure CAIssuer and LetsEncrypt issuer simultaneously")
+	}
+	return c.CA != nil, nil
+}
+
+// IsLetsEncryptIssuer returns true of the issuer configuration is for a LetsEncrypt issuer, or an error if it is misconfigured
+func (c *ClusterIssuerComponent) IsLetsEncryptIssuer() (bool, error) {
+	isCAIssuer, err := c.IsCAIssuer()
+	if err != nil {
+		return false, err
+	}
+	return !isCAIssuer, nil
+}
+
+// IsDefaultIssuer returns true of the issuer configuration is for the Verrazzano default self-signed issuer, or an error if it is misconfigured
+func (c *ClusterIssuerComponent) IsDefaultIssuer() (bool, error) {
+	isCAIssuer, err := c.IsCAIssuer()
+	if err != nil {
+		return false, err
+	}
+	return isCAIssuer && c.ClusterResourceNamespace == constants.CertManagerNamespace &&
+		c.CA.SecretName == constants.DefaultVerrazzanoCASecretName, nil
+}

--- a/platform-operator/apis/verrazzano/v1beta1/issuer_utils_test.go
+++ b/platform-operator/apis/verrazzano/v1beta1/issuer_utils_test.go
@@ -9,6 +9,13 @@ import (
 	"testing"
 )
 
+const (
+	emailAddress                 = "foo@bar.com"
+	envType                      = "staging"
+	testClusterResourceNamespace = "myclusterResourceNamespace"
+	customCAName                 = "myCA"
+)
+
 // TestNewDefaultClusterIssuer Tests the TestNewDefaultClusterIssuer constructor
 // GIVEN a call to NewDefaultClusterIssuer()
 // THEN a valid ClusterIssuerComponent is returned with the default self-signed CA issuer configuration
@@ -33,17 +40,17 @@ func TestNewDefaultClusterIssuer(t *testing.T) {
 	asserts.NoError(err)
 }
 
-// TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer Tests the IsCAIssuer and IsLetsEncryptIssuer methods
+// TestClusterIssuerComponentIsCAIssuerIsLEIssuer Tests the IsCAIssuer and IsLetsEncryptIssuer methods
 // GIVEN a call to IsCAIssuer() or IsLetsEncryptIssuer() for various configurations
 // THEN the functions behave as expected
-func TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer(t *testing.T) {
+func TestClusterIssuerComponentIsCAIssuerIsLEIssuer(t *testing.T) {
 	asserts := assert.New(t)
 
 	caIssuer := ClusterIssuerComponent{
 		Enabled:                  newBool(true),
 		ClusterResourceNamespace: constants.CertManagerNamespace,
 		IssuerConfig: IssuerConfig{
-			CA: &CAIssuer{SecretName: "myCA"},
+			CA: &CAIssuer{SecretName: customCAName},
 		},
 	}
 
@@ -60,8 +67,8 @@ func TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer(t *testing.T) {
 		ClusterResourceNamespace: constants.CertManagerNamespace,
 		IssuerConfig: IssuerConfig{
 			LetsEncrypt: &LetsEncryptACMEIssuer{
-				EmailAddress: "foo@bar.com",
-				Environment:  "staging",
+				EmailAddress: emailAddress,
+				Environment:  envType,
 			},
 		},
 	}
@@ -75,11 +82,11 @@ func TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer(t *testing.T) {
 	asserts.NoError(err)
 }
 
-// TestClusterIssuerComponent_NotDefaultIssuer Tests the IsDefaultIssuer method
+// TestClusterIssuerComponentNotDefaultIssuer Tests the IsDefaultIssuer method
 // GIVEN a call to IsDefaultIssuer()
 // WHEN the issuer configuration is not a default self-signed configuration
 // THEN the function returns false, or an error if the issuer is misconfigured
-func TestClusterIssuerComponent_NotDefaultIssuer(t *testing.T) {
+func TestClusterIssuerComponentNotDefaultIssuer(t *testing.T) {
 	asserts := assert.New(t)
 
 	// Test default clusterResourceNamespace, non-default secret name
@@ -98,7 +105,7 @@ func TestClusterIssuerComponent_NotDefaultIssuer(t *testing.T) {
 	// Test default secret name, non-default cluster resource namespace
 	caIssuer2 := ClusterIssuerComponent{
 		Enabled:                  newBool(true),
-		ClusterResourceNamespace: "mycluserResourceNamespace",
+		ClusterResourceNamespace: testClusterResourceNamespace,
 		IssuerConfig: IssuerConfig{
 			CA: &CAIssuer{SecretName: constants.DefaultVerrazzanoCASecretName},
 		},
@@ -113,8 +120,8 @@ func TestClusterIssuerComponent_NotDefaultIssuer(t *testing.T) {
 		ClusterResourceNamespace: constants.CertManagerNamespace,
 		IssuerConfig: IssuerConfig{
 			LetsEncrypt: &LetsEncryptACMEIssuer{
-				EmailAddress: "foo@bar.com",
-				Environment:  "staging",
+				EmailAddress: emailAddress,
+				Environment:  envType,
 			},
 		},
 	}
@@ -123,21 +130,21 @@ func TestClusterIssuerComponent_NotDefaultIssuer(t *testing.T) {
 	asserts.NoError(err)
 }
 
-// TestClusterIssuerComponent_BadIssuerConfig Tests the various IsXXX method
+// TestClusterIssuerComponentBadIssuerConfig Tests the various IsXXX method
 // GIVEN a call to IsXXXXIssuer()
 // WHEN the issuer configuration is invalid
 // THEN the functions returns false and an error
-func TestClusterIssuerComponent_BadIssuerConfig(t *testing.T) {
+func TestClusterIssuerComponentBadIssuerConfig(t *testing.T) {
 	asserts := assert.New(t)
 
 	badConfig := ClusterIssuerComponent{
 		Enabled:                  newBool(true),
 		ClusterResourceNamespace: constants.CertManagerNamespace,
 		IssuerConfig: IssuerConfig{
-			CA: &CAIssuer{SecretName: "myCA"},
+			CA: &CAIssuer{SecretName: customCAName},
 			LetsEncrypt: &LetsEncryptACMEIssuer{
-				EmailAddress: "foo@bar.com",
-				Environment:  "staging",
+				EmailAddress: emailAddress,
+				Environment:  envType,
 			},
 		},
 	}

--- a/platform-operator/apis/verrazzano/v1beta1/issuer_utils_test.go
+++ b/platform-operator/apis/verrazzano/v1beta1/issuer_utils_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package v1beta1
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"testing"
+)
+
+// TestNewDefaultClusterIssuer Tests the TestNewDefaultClusterIssuer constructor
+// GIVEN a call to NewDefaultClusterIssuer()
+// THEN a valid ClusterIssuerComponent is returned with the default self-signed CA issuer configuration
+func TestNewDefaultClusterIssuer(t *testing.T) {
+	asserts := assert.New(t)
+	issuer := NewDefaultClusterIssuer()
+
+	asserts.Equal(constants.CertManagerNamespace, issuer.ClusterResourceNamespace)
+	asserts.Equal(constants.DefaultVerrazzanoCASecretName, issuer.CA.SecretName)
+	asserts.Nil(issuer.LetsEncrypt)
+
+	isDefaultIssuer, err := issuer.IsDefaultIssuer()
+	asserts.True(isDefaultIssuer)
+	asserts.NoError(err)
+
+	isCAIssuer, err := issuer.IsCAIssuer()
+	asserts.True(isCAIssuer)
+	asserts.NoError(err)
+
+	isACMEIssuer, err := issuer.IsLetsEncryptIssuer()
+	asserts.False(isACMEIssuer)
+	asserts.NoError(err)
+}
+
+// TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer Tests the IsCAIssuer and IsLetsEncryptIssuer methods
+// GIVEN a call to IsCAIssuer() or IsLetsEncryptIssuer() for various configurations
+// THEN the functions behave as expected
+func TestClusterIssuerComponent_IsCAIssuer_IsLEIssuer(t *testing.T) {
+	asserts := assert.New(t)
+
+	caIssuer := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			CA: &CAIssuer{SecretName: "myCA"},
+		},
+	}
+
+	isCAIssuer, err := caIssuer.IsCAIssuer()
+	asserts.True(isCAIssuer)
+	asserts.NoError(err)
+
+	isACMEIssuer, err := caIssuer.IsLetsEncryptIssuer()
+	asserts.False(isACMEIssuer)
+	asserts.NoError(err)
+
+	leIssuer := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			LetsEncrypt: &LetsEncryptACMEIssuer{
+				EmailAddress: "foo@bar.com",
+				Environment:  "staging",
+			},
+		},
+	}
+
+	isCAIssuer, err = leIssuer.IsCAIssuer()
+	asserts.False(isCAIssuer)
+	asserts.NoError(err)
+
+	isACMEIssuer, err = leIssuer.IsLetsEncryptIssuer()
+	asserts.True(isACMEIssuer)
+	asserts.NoError(err)
+}
+
+// TestClusterIssuerComponent_NotDefaultIssuer Tests the IsDefaultIssuer method
+// GIVEN a call to IsDefaultIssuer()
+// WHEN the issuer configuration is not a default self-signed configuration
+// THEN the function returns false, or an error if the issuer is misconfigured
+func TestClusterIssuerComponent_NotDefaultIssuer(t *testing.T) {
+	asserts := assert.New(t)
+
+	// Test default clusterResourceNamespace, non-default secret name
+	caIssuer1 := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			CA: &CAIssuer{SecretName: "myCA"},
+		},
+	}
+
+	isDefIssuer1, err := caIssuer1.IsDefaultIssuer()
+	asserts.False(isDefIssuer1)
+	asserts.NoError(err)
+
+	// Test default secret name, non-default cluster resource namespace
+	caIssuer2 := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: "mycluserResourceNamespace",
+		IssuerConfig: IssuerConfig{
+			CA: &CAIssuer{SecretName: constants.DefaultVerrazzanoCASecretName},
+		},
+	}
+	isDefIssuer2, err := caIssuer2.IsDefaultIssuer()
+	asserts.False(isDefIssuer2)
+	asserts.NoError(err)
+
+	// Test LE issuer
+	leIssuer := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			LetsEncrypt: &LetsEncryptACMEIssuer{
+				EmailAddress: "foo@bar.com",
+				Environment:  "staging",
+			},
+		},
+	}
+	isDefIssuer3, err := leIssuer.IsDefaultIssuer()
+	asserts.False(isDefIssuer3)
+	asserts.NoError(err)
+}
+
+// TestClusterIssuerComponent_BadIssuerConfig Tests the various IsXXX method
+// GIVEN a call to IsXXXXIssuer()
+// WHEN the issuer configuration is invalid
+// THEN the functions returns false and an error
+func TestClusterIssuerComponent_BadIssuerConfig(t *testing.T) {
+	asserts := assert.New(t)
+
+	badConfig := ClusterIssuerComponent{
+		Enabled:                  newBool(true),
+		ClusterResourceNamespace: constants.CertManagerNamespace,
+		IssuerConfig: IssuerConfig{
+			CA: &CAIssuer{SecretName: "myCA"},
+			LetsEncrypt: &LetsEncryptACMEIssuer{
+				EmailAddress: "foo@bar.com",
+				Environment:  "staging",
+			},
+		},
+	}
+
+	isCAIssuer, err := badConfig.IsCAIssuer()
+	asserts.Error(err)
+	asserts.False(isCAIssuer)
+
+	isLEIssuer, err := badConfig.IsLetsEncryptIssuer()
+	asserts.Error(err)
+	asserts.False(isLEIssuer)
+
+	isDefIssuer, err := badConfig.IsDefaultIssuer()
+	asserts.Error(err)
+	asserts.False(isDefIssuer)
+}

--- a/platform-operator/controllers/verrazzano/component/spi/component_context_test.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context_test.go
@@ -202,7 +202,12 @@ func TestContextProfilesMerge(t *testing.T) {
 			// Tests EffectiveCR method
 			a.NotNil(context.EffectiveCR(), "Effective CR was nil")
 			a.Equal(v1alpha1.VerrazzanoStatus{}, context.EffectiveCR().Status, "Effective CR status not empty")
-			a.True(equality.Semantic.DeepEqual(expectedVZ, context.EffectiveCR()), "Effective CR did not match expected results in %s", test.expectedYAML)
+
+			// Compare YAML strings to get proper diffs
+			expectedBytes, _ := yaml.Marshal(expectedVZ)
+			ecrBytes, _ := yaml.Marshal(context.EffectiveCR())
+			a.YAMLEqf(string(expectedBytes), string(ecrBytes), "Unexpected diffs")
+
 			// Tests Log method
 			a.Equal(log, context.Log(), "The log in the context doesn't match the original one")
 		})

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
@@ -66,6 +66,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicDevMerged.yaml
@@ -66,6 +66,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
@@ -64,6 +64,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicManagedClusterMerged.yaml
@@ -64,6 +64,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicNoneMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicNoneMerged.yaml
@@ -64,6 +64,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: false
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: false
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicNoneMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicNoneMerged.yaml
@@ -64,6 +64,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: false
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
@@ -64,6 +64,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicProdMerged.yaml
@@ -64,6 +64,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
@@ -66,6 +66,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devAllDisabledMerged.yaml
@@ -66,6 +66,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: false
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
@@ -67,6 +67,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devCertManagerOverrideMerged.yaml
@@ -67,6 +67,12 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      letsEncrypt:
+        emailAddress: "myemail"
+        environment: "production"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
@@ -74,6 +74,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devESArgsStorageOverride.yaml
@@ -74,6 +74,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devKeycloakInstallArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devKeycloakInstallArgsStorageOverride.yaml
@@ -73,6 +73,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devKeycloakInstallArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devKeycloakInstallArgsStorageOverride.yaml
@@ -73,6 +73,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
@@ -66,6 +66,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/devOCIOverrideMerged.yaml
@@ -66,6 +66,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
@@ -64,6 +64,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/managedClusterEnableAllOverrideMerged.yaml
@@ -64,6 +64,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneCertManagerOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneCertManagerOverrideMerged.yaml
@@ -65,6 +65,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: false
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneCertManagerOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneCertManagerOverrideMerged.yaml
@@ -65,6 +65,12 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: false
+      clusterResourceNamespace: "cert-manager"
+      letsEncrypt:
+          emailAddress: "myemail"
+          environment: "production"
     clusterOperator:
       enabled: false
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneESArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneESArgsStorageOverride.yaml
@@ -74,6 +74,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: false
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: false
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneESArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneESArgsStorageOverride.yaml
@@ -74,6 +74,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: false
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneKeycloakInstallArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneKeycloakInstallArgsStorageOverride.yaml
@@ -71,6 +71,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: false
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: false
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneKeycloakInstallArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneKeycloakInstallArgsStorageOverride.yaml
@@ -71,6 +71,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: false
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneOCIOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneOCIOverrideMerged.yaml
@@ -64,6 +64,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: false
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: false
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneOCIOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneOCIOverrideMerged.yaml
@@ -64,6 +64,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: false
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
@@ -74,6 +74,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodESOverridesMerged.yaml
@@ -74,6 +74,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodESStorageArgsMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodESStorageArgsMerged.yaml
@@ -64,6 +64,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodESStorageArgsMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodESStorageArgsMerged.yaml
@@ -64,6 +64,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
@@ -64,6 +64,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodFluentdOverridesMerged.yaml
@@ -64,6 +64,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
@@ -64,6 +64,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodIngressIstioOverridesMerged.yaml
@@ -64,6 +64,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodNoStorageOpenSearchOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodNoStorageOpenSearchOverrides.yaml
@@ -65,6 +65,8 @@ spec:
                         topologyKey: kubernetes.io/hostname
                       weight: 100
               replicaCount: 1
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/prodNoStorageOpenSearchOverrides.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/prodNoStorageOpenSearchOverrides.yaml
@@ -65,6 +65,11 @@ spec:
                         topologyKey: kubernetes.io/hostname
                       weight: 100
               replicaCount: 1
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/controllers/verrazzano/transform/convert_certificate.go
+++ b/platform-operator/controllers/verrazzano/transform/convert_certificate.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package transform
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+)
+
+var (
+	defaultCertConfigV1Alpha1 = v1alpha1.Certificate{
+		CA: v1alpha1.CA{
+			SecretName:               constants.DefaultVerrazzanoCASecretName,
+			ClusterResourceNamespace: constants.CertManagerNamespace,
+		},
+	}
+
+	defaultCertConfigV1Beta1 = v1beta1.Certificate{
+		CA: v1beta1.CA{
+			SecretName:               constants.DefaultVerrazzanoCASecretName,
+			ClusterResourceNamespace: constants.CertManagerNamespace,
+		},
+	}
+)
+
+// convertCertificateToClusterIssuerV1Beta1 aligns the ClusterIssuer configurations between CertManager and the newer ClusterIssuer
+// configurations.  The webhook validators will ensure only one is set to a non-defaulted value, so if one is
+// configured align it with the other.
+func convertCertificateToClusterIssuerV1Beta1(effectiveCR *v1beta1.Verrazzano) error {
+	// Internally components will derive Issuer configuration from the ClusterIssuerComponent, so
+	// we need to determine if the legacy CertManager component is configured and convert that to the ClusterIssuer
+	// configuration.
+	certManagerConfig := effectiveCR.Spec.Components.CertManager
+	clusterIssuerConfig := effectiveCR.Spec.Components.ClusterIssuer
+
+	isDefaultIssuer, err := clusterIssuerConfig.IsDefaultIssuer()
+	if err != nil {
+		return err
+	}
+
+	cmCertificateConfig := certManagerConfig.Certificate
+
+	// Check if it's a CA issuer config
+	isCAConfig, err := isCAConfig(cmCertificateConfig)
+	if err != nil {
+		// The certificate object is invalid
+		return err
+	}
+
+	isDefaultCertificateConfig := isDefaultCertificateConfig(cmCertificateConfig)
+	if !isDefaultCertificateConfig && !isDefaultIssuer {
+		return fmt.Errorf("Illegal state, both CertManager Certificate and ClusterIssuer components are configured")
+	}
+
+	if isDefaultIssuer && !isDefaultCertificateConfig {
+		// Issuer is the default configuration, but the CM Certificate config is configured explicitly,
+		// align the ClusterIssuer configuration internally on the CM configuration
+		if err := convertCertificateConfiguration(cmCertificateConfig, clusterIssuerConfig, isCAConfig); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// convertCertificateToClusterIssuerV1Alpha1 converts a legacy CertManagerComponent.Certificate object to a
+// ClusterIssuerComponent configuration.  The conversion is done only in the case where the ClusterIssuerComponent is
+// not explicitly configured with a non-default issuer configuration.
+//
+// The webhook validators will ensure only one is set to a non-defaulted value.
+func convertCertificateToClusterIssuerV1Alpha1(effectiveCR *v1alpha1.Verrazzano) error {
+	// Internally components will derive Issuer configuration from the ClusterIssuerComponent, so
+	// we need to determine if the legacy CertManager component is configured and convert that to the ClusterIssuer
+	// configuration.
+	certManagerConfig := effectiveCR.Spec.Components.CertManager
+	clusterIssuerConfig := effectiveCR.Spec.Components.ClusterIssuer
+
+	isDefaultIssuer, err := clusterIssuerConfig.IsDefaultIssuer()
+	if err != nil {
+		return err
+	}
+
+	cmCertificateConfig := certManagerConfig.Certificate
+
+	// Check if it's a CA issuer config
+	isCAConfig, err := isCAConfig(cmCertificateConfig)
+	if err != nil {
+		// The certificate object is invalid
+		return err
+	}
+
+	isDefaultCertificateConfig := isDefaultCertificateConfig(cmCertificateConfig)
+	if !isDefaultCertificateConfig && !isDefaultIssuer {
+		return fmt.Errorf("Illegal state, both CertManager Certificate and ClusterIssuer components are configured")
+	}
+
+	if isDefaultIssuer && !isDefaultCertificateConfig {
+		// Issuer is the default configuration, but the CM Certificate config is configured explicitly,
+		// align the ClusterIssuer configuration internally on the CM configuration
+		if err := convertCertificateConfiguration(cmCertificateConfig, clusterIssuerConfig, isCAConfig); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isDefaultCertificateConfig(certificateConfig interface{}) bool {
+	if v1alpha1Config, ok := certificateConfig.(v1alpha1.Certificate); ok {
+		return v1alpha1Config == defaultCertConfigV1Alpha1
+	}
+	if v1beta1Config, ok := certificateConfig.(v1beta1.Certificate); ok {
+		return v1beta1Config == defaultCertConfigV1Beta1
+	}
+	return false
+}
+
+func isNotDefaultCANamespace(certManagerConfig interface{}) bool {
+	if v1alpha1Config, ok := certManagerConfig.(v1alpha1.Certificate); ok {
+		return len(v1alpha1Config.CA.ClusterResourceNamespace) > 0 &&
+			v1alpha1Config.CA.ClusterResourceNamespace != constants.CertManagerNamespace
+	}
+	if v1beta11Config, ok := certManagerConfig.(v1beta1.Certificate); ok {
+		return len(v1beta11Config.CA.ClusterResourceNamespace) > 0 &&
+			v1beta11Config.CA.ClusterResourceNamespace != constants.CertManagerNamespace
+	}
+	return false
+}
+
+func isCAConfig(certConfig interface{}) (isCAConfig bool, err error) {
+	var caNotEmpty bool
+	if certv1alpha1, ok := certConfig.(v1alpha1.Certificate); ok {
+		// Check if Ca or Acme is empty
+		caNotEmpty = certv1alpha1.CA != v1alpha1.CA{}
+		acmeNotEmpty := certv1alpha1.Acme != v1alpha1.Acme{}
+		if caNotEmpty && acmeNotEmpty {
+			return false, errors.New("certificate object Acme and CA cannot be simultaneously populated")
+		} else if !caNotEmpty && !acmeNotEmpty {
+			return false, errors.New("Either Acme or CA certificate authorities must be configured")
+		}
+	}
+	if certv1beta1, ok := certConfig.(v1beta1.Certificate); ok {
+		// Check if Ca or Acme is empty
+		caNotEmpty = certv1beta1.CA != v1beta1.CA{}
+		acmeNotEmpty := certv1beta1.Acme != v1beta1.Acme{}
+		if caNotEmpty && acmeNotEmpty {
+			return false, errors.New("certificate object Acme and CA cannot be simultaneously populated")
+		} else if !caNotEmpty && !acmeNotEmpty {
+			return false, errors.New("Either Acme or CA certificate authorities must be configured")
+		}
+	}
+	return caNotEmpty, nil
+}
+
+func convertCertificateConfiguration(cmCertificateConfig interface{}, clusterIssuerConfig interface{}, isCAConfig bool) error {
+	if issuerV1Alpha1, ok := clusterIssuerConfig.(*v1alpha1.ClusterIssuerComponent); ok {
+		certV1Alpha1, _ := cmCertificateConfig.(v1alpha1.Certificate)
+		if isCAConfig {
+			// align on the CA config
+			issuerV1Alpha1.CA = &v1alpha1.CAIssuer{SecretName: certV1Alpha1.CA.SecretName}
+			issuerV1Alpha1.LetsEncrypt = nil
+		} else {
+			// align on the LetsEncrypt config
+			issuerV1Alpha1.CA = nil
+			issuerV1Alpha1.LetsEncrypt = &v1alpha1.LetsEncryptACMEIssuer{
+				EmailAddress: certV1Alpha1.Acme.EmailAddress,
+				Environment:  certV1Alpha1.Acme.Environment,
+			}
+		}
+		// Update the clusterResourceNamespace if it is not the default
+		if isNotDefaultCANamespace(certV1Alpha1) {
+			issuerV1Alpha1.ClusterResourceNamespace = certV1Alpha1.CA.ClusterResourceNamespace
+		}
+	}
+	if issuerV1Beta1, ok := clusterIssuerConfig.(*v1beta1.ClusterIssuerComponent); ok {
+		certV1Beta1, _ := cmCertificateConfig.(v1beta1.Certificate)
+		if isCAConfig {
+			// align on the CA config
+			issuerV1Beta1.CA = &v1beta1.CAIssuer{SecretName: certV1Beta1.CA.SecretName}
+			issuerV1Beta1.LetsEncrypt = nil
+		} else {
+			// align on the LetsEncrypt config
+			issuerV1Beta1.CA = nil
+			issuerV1Beta1.LetsEncrypt = &v1beta1.LetsEncryptACMEIssuer{
+				EmailAddress: certV1Beta1.Acme.EmailAddress,
+				Environment:  certV1Beta1.Acme.Environment,
+			}
+		}
+		// Update the clusterResourceNamespace if it is not the default
+		if isNotDefaultCANamespace(certV1Beta1) {
+			issuerV1Beta1.ClusterResourceNamespace = certV1Beta1.CA.ClusterResourceNamespace
+		}
+	}
+
+	return nil
+}

--- a/platform-operator/controllers/verrazzano/transform/convert_certificate.go
+++ b/platform-operator/controllers/verrazzano/transform/convert_certificate.go
@@ -6,7 +6,6 @@ package transform
 import (
 	"errors"
 	"fmt"
-
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -195,6 +194,10 @@ func convertCertificateConfiguration(cmCertificateConfig interface{}, clusterIss
 		return nil
 	}
 
+	return doConversion(cmCertificateConfig, clusterIssuerConfig, isCAConfig)
+}
+
+func doConversion(cmCertificateConfig interface{}, clusterIssuerConfig interface{}, isCAConfig bool) error {
 	if issuerV1Alpha1, ok := clusterIssuerConfig.(*v1alpha1.ClusterIssuerComponent); ok {
 		certV1Alpha1, _ := cmCertificateConfig.(v1alpha1.Certificate)
 		if isCAConfig {
@@ -213,6 +216,7 @@ func convertCertificateConfiguration(cmCertificateConfig interface{}, clusterIss
 		if isNotDefaultCANamespace(certV1Alpha1) {
 			issuerV1Alpha1.ClusterResourceNamespace = certV1Alpha1.CA.ClusterResourceNamespace
 		}
+		return nil
 	}
 	if issuerV1Beta1, ok := clusterIssuerConfig.(*v1beta1.ClusterIssuerComponent); ok {
 		certV1Beta1, _ := cmCertificateConfig.(v1beta1.Certificate)
@@ -232,7 +236,7 @@ func convertCertificateConfiguration(cmCertificateConfig interface{}, clusterIss
 		if isNotDefaultCANamespace(certV1Beta1) {
 			issuerV1Beta1.ClusterResourceNamespace = certV1Beta1.CA.ClusterResourceNamespace
 		}
+		return nil
 	}
-
-	return nil
+	return fmt.Errorf("Unknown issuer type passed in: %T", clusterIssuerConfig)
 }

--- a/platform-operator/controllers/verrazzano/transform/convert_certificate_test.go
+++ b/platform-operator/controllers/verrazzano/transform/convert_certificate_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package transform
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	"testing"
+)
+
+// Test_convertCertificateToClusterIssuerV1Beta1 tests the convertCertificateToClusterIssuerV1Beta1 function
+// GIVEN a call to convertCertificateToClusterIssuerV1Beta1
+// THEN the appropriate conversions from the deprecated Certificate object to the ClusterIssuer Component
+func Test_convertCertificateToClusterIssuerV1Beta1(t *testing.T) {
+	asserts := assert.New(t)
+	tests := []struct {
+		testName             string
+		certConfig           v1beta1.Certificate
+		issuerConfig         *v1beta1.ClusterIssuerComponent
+		expectErr            bool
+		expectedIssuerConfig *v1beta1.ClusterIssuerComponent
+	}{
+		{
+			testName:             "Neither configured",
+			certConfig:           v1beta1.Certificate{},
+			issuerConfig:         v1beta1.NewDefaultClusterIssuer(),
+			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
+			expectErr:            true,
+		},
+		{
+			testName: "Non Default CA Certificate",
+			certConfig: v1beta1.Certificate{
+				CA: v1beta1.CA{
+					ClusterResourceNamespace: "myns",
+					SecretName:               "mySecret",
+				},
+			},
+			issuerConfig: v1beta1.NewDefaultClusterIssuer(),
+			expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
+				ClusterResourceNamespace: "myns",
+				IssuerConfig: v1beta1.IssuerConfig{
+					CA: &v1beta1.CAIssuer{SecretName: "mySecret"},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			testName: "LetsEncrypt Certificate",
+			certConfig: v1beta1.Certificate{
+				Acme: v1beta1.Acme{
+					EmailAddress: "foo@bar.com",
+					Environment:  "staging",
+					Provider:     v1beta1.LetsEncrypt,
+				},
+			},
+			issuerConfig: v1beta1.NewDefaultClusterIssuer(),
+			expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
+				ClusterResourceNamespace: constants.CertManagerNamespace,
+				IssuerConfig: v1beta1.IssuerConfig{
+					LetsEncrypt: &v1beta1.LetsEncryptACMEIssuer{
+						EmailAddress: "foo@bar.com",
+						Environment:  "staging",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			testName: "Illegal Certificate",
+			certConfig: v1beta1.Certificate{
+				CA: v1beta1.CA{
+					ClusterResourceNamespace: "myns",
+					SecretName:               "mySecret",
+				},
+				Acme: v1beta1.Acme{
+					EmailAddress: "foo@bar.com",
+					Environment:  "staging",
+					Provider:     v1beta1.LetsEncrypt,
+				},
+			},
+			issuerConfig: v1beta1.NewDefaultClusterIssuer(),
+			expectErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			vz := &v1beta1.Verrazzano{
+				Spec: v1beta1.VerrazzanoSpec{
+					Components: v1beta1.ComponentSpec{
+						CertManager: &v1beta1.CertManagerComponent{
+							Certificate: tt.certConfig,
+						},
+						ClusterIssuer: tt.issuerConfig,
+					},
+				},
+			}
+			err := convertCertificateToClusterIssuerV1Beta1(vz)
+			if tt.expectErr {
+				asserts.Error(err)
+			} else {
+				asserts.NoError(err)
+				asserts.Equal(tt.expectedIssuerConfig, vz.Spec.Components.ClusterIssuer)
+			}
+		})
+	}
+}
+
+// Test_convertCertificateToClusterIssuerV1Alpha1 tests the convertCertificateToClusterIssuerV1Alpha1 function
+// GIVEN a call to convertCertificateToClusterIssuerV1Beta1
+// THEN the appropriate conversions from the deprecated Certificate object to the ClusterIssuer Component
+func Test_convertCertificateToClusterIssuerV1Alpha1(t *testing.T) {
+	asserts := assert.New(t)
+	tests := []struct {
+		testName             string
+		certConfig           v1alpha1.Certificate
+		issuerConfig         *v1alpha1.ClusterIssuerComponent
+		expectErr            bool
+		expectedIssuerConfig *v1alpha1.ClusterIssuerComponent
+	}{
+		{
+			testName:     "Neither configured",
+			certConfig:   v1alpha1.Certificate{},
+			issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+			expectErr:    true,
+		},
+		{
+			testName: "Non Default CA Certificate",
+			certConfig: v1alpha1.Certificate{
+				CA: v1alpha1.CA{
+					ClusterResourceNamespace: "myns",
+					SecretName:               "mySecret",
+				},
+			},
+			issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+			expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
+				ClusterResourceNamespace: "myns",
+				IssuerConfig: v1alpha1.IssuerConfig{
+					CA: &v1alpha1.CAIssuer{SecretName: "mySecret"},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			testName: "LetsEncrypt Certificate",
+			certConfig: v1alpha1.Certificate{
+				Acme: v1alpha1.Acme{
+					EmailAddress: "foo@bar.com",
+					Environment:  "staging",
+					Provider:     v1alpha1.LetsEncrypt,
+				},
+			},
+			issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+			expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
+				ClusterResourceNamespace: constants.CertManagerNamespace,
+				IssuerConfig: v1alpha1.IssuerConfig{
+					LetsEncrypt: &v1alpha1.LetsEncryptACMEIssuer{
+						EmailAddress: "foo@bar.com",
+						Environment:  "staging",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			testName: "Illegal Certificate",
+			certConfig: v1alpha1.Certificate{
+				CA: v1alpha1.CA{
+					ClusterResourceNamespace: "myns",
+					SecretName:               "mySecret",
+				},
+				Acme: v1alpha1.Acme{
+					EmailAddress: "foo@bar.com",
+					Environment:  "staging",
+					Provider:     v1alpha1.LetsEncrypt,
+				},
+			},
+			issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+			expectErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			vz := &v1alpha1.Verrazzano{
+				Spec: v1alpha1.VerrazzanoSpec{
+					Components: v1alpha1.ComponentSpec{
+						CertManager: &v1alpha1.CertManagerComponent{
+							Certificate: tt.certConfig,
+						},
+						ClusterIssuer: tt.issuerConfig,
+					},
+				},
+			}
+			err := convertCertificateToClusterIssuerV1Alpha1(vz)
+			if tt.expectErr {
+				asserts.Error(err)
+			} else {
+				asserts.NoError(err)
+				asserts.Equal(tt.expectedIssuerConfig, vz.Spec.Components.ClusterIssuer)
+			}
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/transform/convert_certificate_test.go
+++ b/platform-operator/controllers/verrazzano/transform/convert_certificate_test.go
@@ -4,11 +4,12 @@
 package transform
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
-	"testing"
 )
 
 // Test_convertCertificateToClusterIssuerV1Beta1 tests the convertCertificateToClusterIssuerV1Beta1 function
@@ -41,7 +42,7 @@ func Test_convertCertificateToClusterIssuerV1Beta1(t *testing.T) {
 			certConfig:           &v1beta1.CertManagerComponent{},
 			issuerConfig:         nil,
 			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectErr:            true,
+			expectErr:            false,
 		},
 		{
 			testName:             "Default CM Certificate nil ClusterIssuer",
@@ -55,14 +56,14 @@ func Test_convertCertificateToClusterIssuerV1Beta1(t *testing.T) {
 			certConfig:           &v1beta1.CertManagerComponent{},
 			issuerConfig:         v1beta1.NewDefaultClusterIssuer(),
 			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectErr:            true,
+			expectErr:            false,
 		},
 		{
 			testName:             "Neither Certificate field configured",
 			certConfig:           &v1beta1.CertManagerComponent{},
 			issuerConfig:         v1beta1.NewDefaultClusterIssuer(),
 			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectErr:            true,
+			expectErr:            false,
 		},
 		{
 			testName: "Non Default CA Certificate",
@@ -184,8 +185,9 @@ func Test_convertCertificateToClusterIssuerV1Beta1(t *testing.T) {
 					},
 				},
 			},
-			issuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectErr:    true,
+			issuerConfig:         v1beta1.NewDefaultClusterIssuer(),
+			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
+			expectErr:            false,
 		},
 		{
 			testName:   "Both Certificate and ClusterIssuer Configured",
@@ -207,6 +209,7 @@ func Test_convertCertificateToClusterIssuerV1Beta1(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
+			t.Logf("Running test %s", tt.testName)
 			vz := &v1beta1.Verrazzano{
 				Spec: v1beta1.VerrazzanoSpec{
 					Components: v1beta1.ComponentSpec{
@@ -256,7 +259,7 @@ func Test_convertCertificateToClusterIssuerV1Alpha1(t *testing.T) {
 			certConfig:           &v1alpha1.CertManagerComponent{},
 			issuerConfig:         nil,
 			expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectErr:            true,
+			expectErr:            false,
 		},
 		{
 			testName:             "Default CM Certificate nil ClusterIssuer",
@@ -270,14 +273,14 @@ func Test_convertCertificateToClusterIssuerV1Alpha1(t *testing.T) {
 			certConfig:           &v1alpha1.CertManagerComponent{},
 			issuerConfig:         v1alpha1.NewDefaultClusterIssuer(),
 			expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectErr:            true,
+			expectErr:            false,
 		},
 		{
 			testName:             "Neither Certificate field configured",
 			certConfig:           &v1alpha1.CertManagerComponent{},
 			issuerConfig:         v1alpha1.NewDefaultClusterIssuer(),
 			expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectErr:            true,
+			expectErr:            false,
 		},
 		{
 			testName: "Non Default CA Certificate",
@@ -399,8 +402,9 @@ func Test_convertCertificateToClusterIssuerV1Alpha1(t *testing.T) {
 					},
 				},
 			},
-			issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectErr:    true,
+			issuerConfig:         v1alpha1.NewDefaultClusterIssuer(),
+			expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+			expectErr:            false,
 		},
 		{
 			testName:   "Both Certificate and ClusterIssuer Configured",
@@ -422,6 +426,7 @@ func Test_convertCertificateToClusterIssuerV1Alpha1(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
+			t.Logf("Running test %s", tt.testName)
 			vz := &v1alpha1.Verrazzano{
 				Spec: v1alpha1.VerrazzanoSpec{
 					Components: v1alpha1.ComponentSpec{

--- a/platform-operator/controllers/verrazzano/transform/convert_certificate_test.go
+++ b/platform-operator/controllers/verrazzano/transform/convert_certificate_test.go
@@ -35,10 +35,10 @@ var (
 	}
 )
 
-// Test_convertCertificateToClusterIssuerV1Beta1 tests the convertCertificateToClusterIssuerV1Beta1 function
+// TestConvertCertificateToClusterIssuerV1Beta1 tests the convertCertificateToClusterIssuerV1Beta1 function
 // GIVEN a call to convertCertificateToClusterIssuerV1Beta1
 // THEN the appropriate conversions from the deprecated Certificate object to the ClusterIssuer Component
-func Test_convertCertificateToClusterIssuerV1Beta1(t *testing.T) {
+func TestConvertCertificateToClusterIssuerV1Beta1(t *testing.T) {
 	asserts := assert.New(t)
 	for _, tt := range v1beta1Tests {
 		t.Run(tt.testName, func(t *testing.T) {
@@ -62,10 +62,10 @@ func Test_convertCertificateToClusterIssuerV1Beta1(t *testing.T) {
 	}
 }
 
-// Test_convertCertificateToClusterIssuerV1Alpha1 tests the convertCertificateToClusterIssuerV1Alpha1 function
+// TestConvertCertificateToClusterIssuerV1Alpha1 tests the convertCertificateToClusterIssuerV1Alpha1 function
 // GIVEN a call to convertCertificateToClusterIssuerV1Beta1
 // THEN the appropriate conversions from the deprecated Certificate object to the ClusterIssuer Component
-func Test_convertCertificateToClusterIssuerV1Alpha1(t *testing.T) {
+func TestConvertCertificateToClusterIssuerV1Alpha1(t *testing.T) {
 	asserts := assert.New(t)
 	for _, tt := range v1alpha1Tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/platform-operator/controllers/verrazzano/transform/convert_certificate_test.go
+++ b/platform-operator/controllers/verrazzano/transform/convert_certificate_test.go
@@ -12,202 +12,35 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 )
 
+const (
+	emailAddress    = "foo@bar.com"
+	environmentType = "staging"
+	customNamespace = "myns"
+	customSecret    = "mySecret"
+)
+
+var (
+	nonDefaultCA = v1alpha1.Certificate{
+		CA: v1alpha1.CA{
+			ClusterResourceNamespace: customNamespace,
+			SecretName:               customSecret,
+		},
+	}
+
+	nonDefaultCAV1Beta1 = v1beta1.Certificate{
+		CA: v1beta1.CA{
+			ClusterResourceNamespace: customNamespace,
+			SecretName:               customSecret,
+		},
+	}
+)
+
 // Test_convertCertificateToClusterIssuerV1Beta1 tests the convertCertificateToClusterIssuerV1Beta1 function
 // GIVEN a call to convertCertificateToClusterIssuerV1Beta1
 // THEN the appropriate conversions from the deprecated Certificate object to the ClusterIssuer Component
 func Test_convertCertificateToClusterIssuerV1Beta1(t *testing.T) {
 	asserts := assert.New(t)
-	nonDefaultCA := v1beta1.Certificate{
-		CA: v1beta1.CA{
-			ClusterResourceNamespace: "myns",
-			SecretName:               "mySecret",
-		},
-	}
-	tests := []struct {
-		testName             string
-		certConfig           *v1beta1.CertManagerComponent
-		issuerConfig         *v1beta1.ClusterIssuerComponent
-		expectErr            bool
-		expectedIssuerConfig *v1beta1.ClusterIssuerComponent
-	}{
-		{
-			testName:             "No CM or ClusterIssuer",
-			certConfig:           nil,
-			issuerConfig:         nil,
-			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName:             "Empty CM Certificate nil ClusterIssuer",
-			certConfig:           &v1beta1.CertManagerComponent{},
-			issuerConfig:         nil,
-			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName:             "Default CM Certificate nil ClusterIssuer",
-			certConfig:           &v1beta1.CertManagerComponent{Certificate: defaultCertConfigV1Beta1},
-			issuerConfig:         nil,
-			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName:             "Empty CM Certificate default ClusterIssuer",
-			certConfig:           &v1beta1.CertManagerComponent{},
-			issuerConfig:         v1beta1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName:             "Neither Certificate field configured",
-			certConfig:           &v1beta1.CertManagerComponent{},
-			issuerConfig:         v1beta1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName: "Non Default CA Certificate",
-			certConfig: &v1beta1.CertManagerComponent{
-				Certificate: nonDefaultCA,
-			},
-			issuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "myns",
-				IssuerConfig: v1beta1.IssuerConfig{
-					CA: &v1beta1.CAIssuer{SecretName: "mySecret"},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName: "Non Default CA Certificate nil ClusterIssuer",
-			certConfig: &v1beta1.CertManagerComponent{
-				Certificate: nonDefaultCA,
-			},
-			issuerConfig: nil,
-			expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "myns",
-				IssuerConfig: v1beta1.IssuerConfig{
-					CA: &v1beta1.CAIssuer{SecretName: "mySecret"},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName: "Non Default CA Certificate",
-			certConfig: &v1beta1.CertManagerComponent{
-				Certificate: nonDefaultCA,
-			},
-			issuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "myns",
-				IssuerConfig: v1beta1.IssuerConfig{
-					CA: &v1beta1.CAIssuer{SecretName: "mySecret"},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName: "LetsEncrypt Certificate",
-			certConfig: &v1beta1.CertManagerComponent{
-				Certificate: v1beta1.Certificate{
-					Acme: v1beta1.Acme{
-						EmailAddress: "foo@bar.com",
-						Environment:  "staging",
-						Provider:     v1beta1.LetsEncrypt,
-					},
-				},
-			},
-			issuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
-				ClusterResourceNamespace: constants.CertManagerNamespace,
-				IssuerConfig: v1beta1.IssuerConfig{
-					LetsEncrypt: &v1beta1.LetsEncryptACMEIssuer{
-						EmailAddress: "foo@bar.com",
-						Environment:  "staging",
-					},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName:   "LetsEncrypt ClusterIssuer",
-			certConfig: &v1beta1.CertManagerComponent{Certificate: defaultCertConfigV1Beta1},
-			issuerConfig: &v1beta1.ClusterIssuerComponent{
-				ClusterResourceNamespace: constants.CertManagerNamespace,
-				IssuerConfig: v1beta1.IssuerConfig{
-					LetsEncrypt: &v1beta1.LetsEncryptACMEIssuer{
-						EmailAddress: "foo@bar.com",
-						Environment:  "staging",
-					},
-				},
-			},
-			expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
-				ClusterResourceNamespace: constants.CertManagerNamespace,
-				IssuerConfig: v1beta1.IssuerConfig{
-					LetsEncrypt: &v1beta1.LetsEncryptACMEIssuer{
-						EmailAddress: "foo@bar.com",
-						Environment:  "staging",
-					},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName:   "CA ClusterIssuer",
-			certConfig: &v1beta1.CertManagerComponent{Certificate: defaultCertConfigV1Beta1},
-			issuerConfig: &v1beta1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "clusterIssuerNamespace",
-				IssuerConfig: v1beta1.IssuerConfig{
-					CA: &v1beta1.CAIssuer{SecretName: "issuerSecret"},
-				},
-			},
-			expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "clusterIssuerNamespace",
-				IssuerConfig: v1beta1.IssuerConfig{
-					CA: &v1beta1.CAIssuer{SecretName: "issuerSecret"},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName: "Illegal Certificate",
-			certConfig: &v1beta1.CertManagerComponent{
-				Certificate: v1beta1.Certificate{
-					CA: v1beta1.CA{
-						ClusterResourceNamespace: "myns",
-						SecretName:               "mySecret",
-					},
-					Acme: v1beta1.Acme{
-						EmailAddress: "foo@bar.com",
-						Environment:  "staging",
-						Provider:     v1beta1.LetsEncrypt,
-					},
-				},
-			},
-			issuerConfig:         v1beta1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName:   "Both Certificate and ClusterIssuer Configured",
-			certConfig: &v1beta1.CertManagerComponent{Certificate: nonDefaultCA},
-			issuerConfig: &v1beta1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "clusterIssuerNamespace",
-				IssuerConfig: v1beta1.IssuerConfig{
-					CA: &v1beta1.CAIssuer{SecretName: "issuerSecret"},
-				},
-			},
-			expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "clusterIssuerNamespace",
-				IssuerConfig: v1beta1.IssuerConfig{
-					CA: &v1beta1.CAIssuer{SecretName: "issuerSecret"},
-				},
-			},
-			expectErr: true,
-		},
-	}
-	for _, tt := range tests {
+	for _, tt := range v1beta1Tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			t.Logf("Running test %s", tt.testName)
 			vz := &v1beta1.Verrazzano{
@@ -234,197 +67,7 @@ func Test_convertCertificateToClusterIssuerV1Beta1(t *testing.T) {
 // THEN the appropriate conversions from the deprecated Certificate object to the ClusterIssuer Component
 func Test_convertCertificateToClusterIssuerV1Alpha1(t *testing.T) {
 	asserts := assert.New(t)
-	nonDefaultCA := v1alpha1.Certificate{
-		CA: v1alpha1.CA{
-			ClusterResourceNamespace: "myns",
-			SecretName:               "mySecret",
-		},
-	}
-	tests := []struct {
-		testName             string
-		certConfig           *v1alpha1.CertManagerComponent
-		issuerConfig         *v1alpha1.ClusterIssuerComponent
-		expectErr            bool
-		expectedIssuerConfig *v1alpha1.ClusterIssuerComponent
-	}{
-		{
-			testName:             "No CM or ClusterIssuer",
-			certConfig:           nil,
-			issuerConfig:         nil,
-			expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName:             "Empty CM Certificate nil ClusterIssuer",
-			certConfig:           &v1alpha1.CertManagerComponent{},
-			issuerConfig:         nil,
-			expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName:             "Default CM Certificate nil ClusterIssuer",
-			certConfig:           &v1alpha1.CertManagerComponent{Certificate: defaultCertConfigV1Alpha1},
-			issuerConfig:         nil,
-			expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName:             "Empty CM Certificate default ClusterIssuer",
-			certConfig:           &v1alpha1.CertManagerComponent{},
-			issuerConfig:         v1alpha1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName:             "Neither Certificate field configured",
-			certConfig:           &v1alpha1.CertManagerComponent{},
-			issuerConfig:         v1alpha1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName: "Non Default CA Certificate",
-			certConfig: &v1alpha1.CertManagerComponent{
-				Certificate: nonDefaultCA,
-			},
-			issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "myns",
-				IssuerConfig: v1alpha1.IssuerConfig{
-					CA: &v1alpha1.CAIssuer{SecretName: "mySecret"},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName: "Non Default CA Certificate nil ClusterIssuer",
-			certConfig: &v1alpha1.CertManagerComponent{
-				Certificate: nonDefaultCA,
-			},
-			issuerConfig: nil,
-			expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "myns",
-				IssuerConfig: v1alpha1.IssuerConfig{
-					CA: &v1alpha1.CAIssuer{SecretName: "mySecret"},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName: "Non Default CA Certificate",
-			certConfig: &v1alpha1.CertManagerComponent{
-				Certificate: nonDefaultCA,
-			},
-			issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "myns",
-				IssuerConfig: v1alpha1.IssuerConfig{
-					CA: &v1alpha1.CAIssuer{SecretName: "mySecret"},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName: "LetsEncrypt Certificate",
-			certConfig: &v1alpha1.CertManagerComponent{
-				Certificate: v1alpha1.Certificate{
-					Acme: v1alpha1.Acme{
-						EmailAddress: "foo@bar.com",
-						Environment:  "staging",
-						Provider:     v1alpha1.LetsEncrypt,
-					},
-				},
-			},
-			issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
-				ClusterResourceNamespace: constants.CertManagerNamespace,
-				IssuerConfig: v1alpha1.IssuerConfig{
-					LetsEncrypt: &v1alpha1.LetsEncryptACMEIssuer{
-						EmailAddress: "foo@bar.com",
-						Environment:  "staging",
-					},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName:   "LetsEncrypt ClusterIssuer",
-			certConfig: &v1alpha1.CertManagerComponent{Certificate: defaultCertConfigV1Alpha1},
-			issuerConfig: &v1alpha1.ClusterIssuerComponent{
-				ClusterResourceNamespace: constants.CertManagerNamespace,
-				IssuerConfig: v1alpha1.IssuerConfig{
-					LetsEncrypt: &v1alpha1.LetsEncryptACMEIssuer{
-						EmailAddress: "foo@bar.com",
-						Environment:  "staging",
-					},
-				},
-			},
-			expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
-				ClusterResourceNamespace: constants.CertManagerNamespace,
-				IssuerConfig: v1alpha1.IssuerConfig{
-					LetsEncrypt: &v1alpha1.LetsEncryptACMEIssuer{
-						EmailAddress: "foo@bar.com",
-						Environment:  "staging",
-					},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName:   "CA ClusterIssuer",
-			certConfig: &v1alpha1.CertManagerComponent{Certificate: defaultCertConfigV1Alpha1},
-			issuerConfig: &v1alpha1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "clusterIssuerNamespace",
-				IssuerConfig: v1alpha1.IssuerConfig{
-					CA: &v1alpha1.CAIssuer{SecretName: "issuerSecret"},
-				},
-			},
-			expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "clusterIssuerNamespace",
-				IssuerConfig: v1alpha1.IssuerConfig{
-					CA: &v1alpha1.CAIssuer{SecretName: "issuerSecret"},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			testName: "Illegal Certificate",
-			certConfig: &v1alpha1.CertManagerComponent{
-				Certificate: v1alpha1.Certificate{
-					CA: v1alpha1.CA{
-						ClusterResourceNamespace: "myns",
-						SecretName:               "mySecret",
-					},
-					Acme: v1alpha1.Acme{
-						EmailAddress: "foo@bar.com",
-						Environment:  "staging",
-						Provider:     v1alpha1.LetsEncrypt,
-					},
-				},
-			},
-			issuerConfig:         v1alpha1.NewDefaultClusterIssuer(),
-			expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
-			expectErr:            false,
-		},
-		{
-			testName:   "Both Certificate and ClusterIssuer Configured",
-			certConfig: &v1alpha1.CertManagerComponent{Certificate: nonDefaultCA},
-			issuerConfig: &v1alpha1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "clusterIssuerNamespace",
-				IssuerConfig: v1alpha1.IssuerConfig{
-					CA: &v1alpha1.CAIssuer{SecretName: "issuerSecret"},
-				},
-			},
-			expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
-				ClusterResourceNamespace: "clusterIssuerNamespace",
-				IssuerConfig: v1alpha1.IssuerConfig{
-					CA: &v1alpha1.CAIssuer{SecretName: "issuerSecret"},
-				},
-			},
-			expectErr: true,
-		},
-	}
-	for _, tt := range tests {
+	for _, tt := range v1alpha1Tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			t.Logf("Running test %s", tt.testName)
 			vz := &v1alpha1.Verrazzano{
@@ -444,4 +87,374 @@ func Test_convertCertificateToClusterIssuerV1Alpha1(t *testing.T) {
 			}
 		})
 	}
+}
+
+var v1alpha1Tests = []struct {
+	testName             string
+	certConfig           *v1alpha1.CertManagerComponent
+	issuerConfig         *v1alpha1.ClusterIssuerComponent
+	expectErr            bool
+	expectedIssuerConfig *v1alpha1.ClusterIssuerComponent
+}{
+	{
+		testName:             "No CM or ClusterIssuer",
+		certConfig:           nil,
+		issuerConfig:         nil,
+		expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName:             "Empty CM Certificate nil ClusterIssuer",
+		certConfig:           &v1alpha1.CertManagerComponent{},
+		issuerConfig:         nil,
+		expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName:             "Default CM Certificate nil ClusterIssuer",
+		certConfig:           &v1alpha1.CertManagerComponent{Certificate: defaultCertConfigV1Alpha1},
+		issuerConfig:         nil,
+		expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName:             "Empty CM Certificate default ClusterIssuer",
+		certConfig:           &v1alpha1.CertManagerComponent{},
+		issuerConfig:         v1alpha1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName:             "Neither Certificate field configured",
+		certConfig:           &v1alpha1.CertManagerComponent{},
+		issuerConfig:         v1alpha1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName: "Non Default CA Certificate",
+		certConfig: &v1alpha1.CertManagerComponent{
+			Certificate: nonDefaultCA,
+		},
+		issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1alpha1.IssuerConfig{
+				CA: &v1alpha1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName: "Non Default CA Certificate nil ClusterIssuer",
+		certConfig: &v1alpha1.CertManagerComponent{
+			Certificate: nonDefaultCA,
+		},
+		issuerConfig: nil,
+		expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1alpha1.IssuerConfig{
+				CA: &v1alpha1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName: "Non Default CA Certificate",
+		certConfig: &v1alpha1.CertManagerComponent{
+			Certificate: nonDefaultCA,
+		},
+		issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1alpha1.IssuerConfig{
+				CA: &v1alpha1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName: "LetsEncrypt Certificate",
+		certConfig: &v1alpha1.CertManagerComponent{
+			Certificate: v1alpha1.Certificate{
+				Acme: v1alpha1.Acme{
+					EmailAddress: emailAddress,
+					Environment:  environmentType,
+					Provider:     v1alpha1.LetsEncrypt,
+				},
+			},
+		},
+		issuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
+			ClusterResourceNamespace: constants.CertManagerNamespace,
+			IssuerConfig: v1alpha1.IssuerConfig{
+				LetsEncrypt: &v1alpha1.LetsEncryptACMEIssuer{
+					EmailAddress: emailAddress,
+					Environment:  environmentType,
+				},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName:   "LetsEncrypt ClusterIssuer",
+		certConfig: &v1alpha1.CertManagerComponent{Certificate: defaultCertConfigV1Alpha1},
+		issuerConfig: &v1alpha1.ClusterIssuerComponent{
+			ClusterResourceNamespace: constants.CertManagerNamespace,
+			IssuerConfig: v1alpha1.IssuerConfig{
+				LetsEncrypt: &v1alpha1.LetsEncryptACMEIssuer{
+					EmailAddress: emailAddress,
+					Environment:  environmentType,
+				},
+			},
+		},
+		expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
+			ClusterResourceNamespace: constants.CertManagerNamespace,
+			IssuerConfig: v1alpha1.IssuerConfig{
+				LetsEncrypt: &v1alpha1.LetsEncryptACMEIssuer{
+					EmailAddress: emailAddress,
+					Environment:  environmentType,
+				},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName:   "CA ClusterIssuer",
+		certConfig: &v1alpha1.CertManagerComponent{Certificate: defaultCertConfigV1Alpha1},
+		issuerConfig: &v1alpha1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1alpha1.IssuerConfig{
+				CA: &v1alpha1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1alpha1.IssuerConfig{
+				CA: &v1alpha1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName: "Illegal Certificate",
+		certConfig: &v1alpha1.CertManagerComponent{
+			Certificate: v1alpha1.Certificate{
+				CA: v1alpha1.CA{
+					ClusterResourceNamespace: customNamespace,
+					SecretName:               customSecret,
+				},
+				Acme: v1alpha1.Acme{
+					EmailAddress: emailAddress,
+					Environment:  environmentType,
+					Provider:     v1alpha1.LetsEncrypt,
+				},
+			},
+		},
+		issuerConfig:         v1alpha1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: v1alpha1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName:   "Both Certificate and ClusterIssuer Configured",
+		certConfig: &v1alpha1.CertManagerComponent{Certificate: nonDefaultCA},
+		issuerConfig: &v1alpha1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1alpha1.IssuerConfig{
+				CA: &v1alpha1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectedIssuerConfig: &v1alpha1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1alpha1.IssuerConfig{
+				CA: &v1alpha1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectErr: true,
+	},
+}
+
+var v1beta1Tests = []struct {
+	testName             string
+	certConfig           *v1beta1.CertManagerComponent
+	issuerConfig         *v1beta1.ClusterIssuerComponent
+	expectErr            bool
+	expectedIssuerConfig *v1beta1.ClusterIssuerComponent
+}{
+	{
+		testName:             "No CM or ClusterIssuer",
+		certConfig:           nil,
+		issuerConfig:         nil,
+		expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName:             "Empty CM Certificate nil ClusterIssuer",
+		certConfig:           &v1beta1.CertManagerComponent{},
+		issuerConfig:         nil,
+		expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName:             "Default CM Certificate nil ClusterIssuer",
+		certConfig:           &v1beta1.CertManagerComponent{Certificate: defaultCertConfigV1Beta1},
+		issuerConfig:         nil,
+		expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName:             "Empty CM Certificate default ClusterIssuer",
+		certConfig:           &v1beta1.CertManagerComponent{},
+		issuerConfig:         v1beta1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName:             "Neither Certificate field configured",
+		certConfig:           &v1beta1.CertManagerComponent{},
+		issuerConfig:         v1beta1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName: "Non Default CA Certificate",
+		certConfig: &v1beta1.CertManagerComponent{
+			Certificate: nonDefaultCAV1Beta1,
+		},
+		issuerConfig: v1beta1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1beta1.IssuerConfig{
+				CA: &v1beta1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName: "Non Default CA Certificate nil ClusterIssuer",
+		certConfig: &v1beta1.CertManagerComponent{
+			Certificate: nonDefaultCAV1Beta1,
+		},
+		issuerConfig: nil,
+		expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1beta1.IssuerConfig{
+				CA: &v1beta1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName: "Non Default CA Certificate",
+		certConfig: &v1beta1.CertManagerComponent{
+			Certificate: nonDefaultCAV1Beta1,
+		},
+		issuerConfig: v1beta1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1beta1.IssuerConfig{
+				CA: &v1beta1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName: "LetsEncrypt Certificate",
+		certConfig: &v1beta1.CertManagerComponent{
+			Certificate: v1beta1.Certificate{
+				Acme: v1beta1.Acme{
+					EmailAddress: emailAddress,
+					Environment:  environmentType,
+					Provider:     v1beta1.LetsEncrypt,
+				},
+			},
+		},
+		issuerConfig: v1beta1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
+			ClusterResourceNamespace: constants.CertManagerNamespace,
+			IssuerConfig: v1beta1.IssuerConfig{
+				LetsEncrypt: &v1beta1.LetsEncryptACMEIssuer{
+					EmailAddress: emailAddress,
+					Environment:  environmentType,
+				},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName:   "LetsEncrypt ClusterIssuer",
+		certConfig: &v1beta1.CertManagerComponent{Certificate: defaultCertConfigV1Beta1},
+		issuerConfig: &v1beta1.ClusterIssuerComponent{
+			ClusterResourceNamespace: constants.CertManagerNamespace,
+			IssuerConfig: v1beta1.IssuerConfig{
+				LetsEncrypt: &v1beta1.LetsEncryptACMEIssuer{
+					EmailAddress: emailAddress,
+					Environment:  environmentType,
+				},
+			},
+		},
+		expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
+			ClusterResourceNamespace: constants.CertManagerNamespace,
+			IssuerConfig: v1beta1.IssuerConfig{
+				LetsEncrypt: &v1beta1.LetsEncryptACMEIssuer{
+					EmailAddress: emailAddress,
+					Environment:  environmentType,
+				},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName:   "CA ClusterIssuer",
+		certConfig: &v1beta1.CertManagerComponent{Certificate: defaultCertConfigV1Beta1},
+		issuerConfig: &v1beta1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1beta1.IssuerConfig{
+				CA: &v1beta1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1beta1.IssuerConfig{
+				CA: &v1beta1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectErr: false,
+	},
+	{
+		testName: "Illegal Certificate",
+		certConfig: &v1beta1.CertManagerComponent{
+			Certificate: v1beta1.Certificate{
+				CA: v1beta1.CA{
+					ClusterResourceNamespace: customNamespace,
+					SecretName:               customSecret,
+				},
+				Acme: v1beta1.Acme{
+					EmailAddress: emailAddress,
+					Environment:  environmentType,
+					Provider:     v1beta1.LetsEncrypt,
+				},
+			},
+		},
+		issuerConfig:         v1beta1.NewDefaultClusterIssuer(),
+		expectedIssuerConfig: v1beta1.NewDefaultClusterIssuer(),
+		expectErr:            false,
+	},
+	{
+		testName:   "Both Certificate and ClusterIssuer Configured",
+		certConfig: &v1beta1.CertManagerComponent{Certificate: nonDefaultCAV1Beta1},
+		issuerConfig: &v1beta1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1beta1.IssuerConfig{
+				CA: &v1beta1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectedIssuerConfig: &v1beta1.ClusterIssuerComponent{
+			ClusterResourceNamespace: customNamespace,
+			IssuerConfig: v1beta1.IssuerConfig{
+				CA: &v1beta1.CAIssuer{SecretName: customSecret},
+			},
+		},
+		expectErr: true,
+	},
 }

--- a/platform-operator/controllers/verrazzano/transform/merge.go
+++ b/platform-operator/controllers/verrazzano/transform/merge.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package transform
@@ -6,7 +6,6 @@ package transform
 import (
 	"strings"
 
-	"github.com/verrazzano/verrazzano/pkg/constants"
 	vzprofiles "github.com/verrazzano/verrazzano/pkg/profiles"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -40,14 +39,12 @@ func GetEffectiveCR(actualCR *v1alpha1.Verrazzano) (*v1alpha1.Verrazzano, error)
 		return nil, err
 	}
 	effectiveCR.Status = v1alpha1.VerrazzanoStatus{} // Don't replicate the CR status in the effective config
-	// if Certificate in CertManager is empty, set it to default CA
-	var emptyCertConfig = v1alpha1.Certificate{}
-	if effectiveCR.Spec.Components.CertManager.Certificate == emptyCertConfig {
-		effectiveCR.Spec.Components.CertManager.Certificate.CA = v1alpha1.CA{
-			SecretName:               constants.DefaultVerrazzanoCASecretName,
-			ClusterResourceNamespace: constants.CertManagerNamespace,
-		}
+
+	// Align the ClusterIssuer configurations between CertManager and ClusterIssuer components
+	if err := convertCertificateToClusterIssuerV1Alpha1(effectiveCR); err != nil {
+		return nil, err
 	}
+
 	return effectiveCR, nil
 }
 
@@ -73,13 +70,11 @@ func GetEffectiveV1beta1CR(actualCR *v1beta1.Verrazzano) (*v1beta1.Verrazzano, e
 		return nil, err
 	}
 	effectiveCR.Status = v1beta1.VerrazzanoStatus{} // Don't replicate the CR status in the effective config
-	// if Certificate in CertManager is empty, set it to default CA
-	var emptyCertConfig = v1beta1.Certificate{}
-	if effectiveCR.Spec.Components.CertManager.Certificate == emptyCertConfig {
-		effectiveCR.Spec.Components.CertManager.Certificate.CA = v1beta1.CA{
-			SecretName:               constants.DefaultVerrazzanoCASecretName,
-			ClusterResourceNamespace: constants.CertManagerNamespace,
-		}
+
+	// Align the ClusterIssuer configurations between CertManager and ClusterIssuer components
+	if err := convertCertificateToClusterIssuerV1Beta1(effectiveCR); err != nil {
+		return nil, err
 	}
+
 	return effectiveCR, nil
 }

--- a/platform-operator/manifests/profiles/v1alpha1/base.yaml
+++ b/platform-operator/manifests/profiles/v1alpha1/base.yaml
@@ -63,6 +63,11 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     clusterOperator:
       enabled: true
     coherenceOperator:

--- a/platform-operator/manifests/profiles/v1alpha1/base.yaml
+++ b/platform-operator/manifests/profiles/v1alpha1/base.yaml
@@ -63,6 +63,8 @@ spec:
                             app: webhook
                         topologyKey: kubernetes.io/hostname
                       weight: 100
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/manifests/profiles/v1alpha1/none.yaml
+++ b/platform-operator/manifests/profiles/v1alpha1/none.yaml
@@ -10,6 +10,12 @@ spec:
       enabled: false
     certManager:
       enabled: false
+      certificate:
+        ca:
+          secretName: "verrazzano-ca-certificate-secret"
+          clusterResourceNamespace: "cert-manager"
+    clusterIssuer:
+      enabled: false
     clusterOperator:
       enabled: false
     coherenceOperator:

--- a/platform-operator/manifests/profiles/v1beta1/base.yaml
+++ b/platform-operator/manifests/profiles/v1beta1/base.yaml
@@ -66,6 +66,11 @@ spec:
                         topologyKey: kubernetes.io/hostname
                       weight: 100
               replicaCount: 1
+    clusterIssuer:
+      enabled: true
+      clusterResourceNamespace: "cert-manager"
+      ca:
+        secretName: "verrazzano-ca-certificate-secret"
     coherenceOperator:
       enabled: true
     console:

--- a/platform-operator/manifests/profiles/v1beta1/base.yaml
+++ b/platform-operator/manifests/profiles/v1beta1/base.yaml
@@ -66,6 +66,8 @@ spec:
                         topologyKey: kubernetes.io/hostname
                       weight: 100
               replicaCount: 1
+    certManagerWebhookOCI:
+      enabled: false
     clusterIssuer:
       enabled: true
       clusterResourceNamespace: "cert-manager"

--- a/platform-operator/manifests/profiles/v1beta1/none.yaml
+++ b/platform-operator/manifests/profiles/v1beta1/none.yaml
@@ -10,6 +10,10 @@ spec:
       enabled: false
     certManager:
       enabled: false
+      certificate:
+        ca:
+          secretName: "verrazzano-ca-certificate-secret"
+          clusterResourceNamespace: "cert-manager"
     coherenceOperator:
       enabled: false
     console:


### PR DESCRIPTION
Adds the new CertManager components to the Verrazzano profiles:

* ClusterIssuerComponent
* CertManagerWebhookOCI

In addition, logic has been added to the `effectiveCR` merge in the VPO to  preserve legacy `certManager.certificate` configurations and convert it forward to the `clusterIssuer` when the the effective configuration is computed.  This will allow VPO components internally to align on the `ClusterIssuerComponent` and phase out the `CertManagerComponent.Certificate` field.

Additional changes:
- Some additional `ClusterIssuerComponent` utils have been added in the API packages
- Added support for merging the `InstallOverrides` for the `CertManagerWebhookOCI` component
- Added `vzcr.IsClusterIssuerEnabled` and `vzcr.IsCertManagerWebhookOCIEnabled` functions
- fixed a bug in the `none.yaml` profiles where the CertManager override was wiping out the `base.yaml` values for the `certificate` field (merge strategy for that field is replace)
