### PR TITLE
VZ-8902: Refresh component images in release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -28,13 +28,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20230302040354-bf21e9603",
+              "tag": "v1.3.1-20230515114238-05e7a995d",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "v1.3.1-20230302040354-bf21e9603",
+              "tag": "v1.3.1-20230515114238-05e7a995d",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -52,24 +52,24 @@
           "images": [
             {
               "image": "cert-manager-controller",
-              "tag": "v1.9.1-20230209063813-3a732e40",
+              "tag": "v1.9.1-20230524125601-3a732e40",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "cert-manager-acmesolver",
-              "tag": "v1.9.1-20230209063813-3a732e40",
+              "tag": "v1.9.1-20230524125601-3a732e40",
               "helmFullImageKey": "extraArgs[0]"
             },
             {
               "image": "cert-manager-cainjector",
-              "tag": "v1.9.1-20230209063813-3a732e40",
+              "tag": "v1.9.1-20230524125601-3a732e40",
               "helmFullImageKey": "cainjector.image.repository",
               "helmTagKey": "cainjector.image.tag"
             },
             {
               "image": "cert-manager-webhook",
-              "tag": "v1.9.1-20230209063813-3a732e40",
+              "tag": "v1.9.1-20230524125601-3a732e40",
               "helmFullImageKey": "webhook.image.repository",
               "helmTagKey": "webhook.image.tag"
             }
@@ -199,13 +199,13 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20230302040354-bf21e9603",
+              "tag": "v1.3.1-20230515114238-05e7a995d",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "v0.10.0-20230209071016-7cf62c11",
+              "tag": "v0.10.0-20230524141908-7cf62c11",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }
@@ -234,12 +234,12 @@
             },
             {
               "image": "grafana",
-              "tag": "v7.5.17-20230324124607-7afbf50a",
+              "tag": "v7.5.17-20230524152354-7afbf50a",
               "helmFullImageKey": "monitoringOperator.grafanaImage"
             },
             {
               "image": "k8s-sidecar",
-              "tag": "v1.15.0-20230209100034-7adaf012",
+              "tag": "v1.15.0-20230524130741-7adaf012",
               "helmFullImageKey": "monitoringOperator.k8sSidecarImage"
             },
             {
@@ -254,7 +254,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20230302040354-bf21e9603",
+              "tag": "v1.3.1-20230515114238-05e7a995d",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]
@@ -287,7 +287,7 @@
           "images": [
             {
               "image": "oam-kubernetes-runtime",
-              "tag": "v0.3.3-20230209072020-c8b5d4a",
+              "tag": "v0.3.3-20230524141408-c8b5d4a",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -378,7 +378,7 @@
           "images": [
             {
               "image": "kiali",
-              "tag": "v1.57.1-20230324120010-d94b80c9",
+              "tag": "v1.57.1-20230524133011-d94b80c9",
               "helmFullImageKey": "deployment.image_name",
               "helmTagKey": "deployment.image_version"
             }
@@ -478,13 +478,13 @@
           "images": [
             {
               "image": "prometheus-operator",
-              "tag": "v0.59.1-20230209073203-fb82ffaa",
+              "tag": "v0.59.1-20230524144112-fb82ffaa",
               "helmFullImageKey": "prometheusOperator.image.repository",
               "helmTagKey": "prometheusOperator.image.tag"
             },
             {
               "image": "kube-webhook-certgen",
-              "tag": "v1.3.1-20230302040354-bf21e9603",
+              "tag": "v1.3.1-20230515114238-05e7a995d",
               "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
               "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"
             }
@@ -496,7 +496,7 @@
           "images": [
             {
               "image": "prometheus-config-reloader",
-              "tag": "v0.59.1-20230209073203-fb82ffaa",
+              "tag": "v0.59.1-20230524144112-fb82ffaa",
               "helmFullImageKey": "prometheusOperator.prometheusConfigReloader.image.repository",
               "helmTagKey": "prometheusOperator.prometheusConfigReloader.image.tag"
             }
@@ -508,7 +508,7 @@
           "images": [
             {
               "image": "alertmanager",
-              "tag": "v0.24.0-20230324104837-18128160",
+              "tag": "v0.24.0-20230524114801-18128160",
               "helmFullImageKey": "alertmanager.alertmanagerSpec.image.repository",
               "helmTagKey": "alertmanager.alertmanagerSpec.image.tag"
             }
@@ -520,7 +520,7 @@
           "images": [
             {
               "image": "prometheus",
-              "tag": "v2.38.0-20230324105920-186a8ee6",
+              "tag": "v2.38.0-20230524145024-186a8ee6",
               "helmFullImageKey": "prometheus.prometheusSpec.image.repository",
               "helmTagKey": "prometheus.prometheusSpec.image.tag"
             }
@@ -537,7 +537,7 @@
           "images": [
             {
               "image": "prometheus-adapter",
-              "tag": "v0.10.0-20230209071833-9313ff7b",
+              "tag": "v0.10.0-20230524142355-9313ff7b",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -571,7 +571,7 @@
           "images": [
             {
               "image": "prometheus-pushgateway",
-              "tag": "v1.4.2-20230209072927-3af6d83b",
+              "tag": "v1.4.2-20230524143811-3af6d83b",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -588,7 +588,7 @@
           "images": [
             {
               "image": "node-exporter",
-              "tag": "v1.3.1-20230323153951-b7f69924",
+              "tag": "v1.3.1-20230524142053-b7f69924",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -606,7 +606,7 @@
           "images": [
             {
               "image": "jaeger-operator",
-              "tag": "1.42.0-20230327230723-9970d003",
+              "tag": "1.42.0-20230524130308-9970d003",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -618,7 +618,7 @@
           "images": [
             {
               "image": "jaeger-agent",
-              "tag": "1.42.0-20230327232727-cd357656",
+              "tag": "1.42.0-20230524133808-cd357656",
               "helmFullImageKey": "jaegerAgentImage"
             }
           ]
@@ -629,7 +629,7 @@
           "images": [
             {
               "image": "jaeger-collector",
-              "tag": "1.42.0-20230327232727-cd357656",
+              "tag": "1.42.0-20230524133808-cd357656",
               "helmFullImageKey": "jaegerCollectorImage"
             }
           ]
@@ -640,7 +640,7 @@
           "images": [
             {
               "image": "jaeger-query",
-              "tag": "1.42.0-20230327232727-cd357656",
+              "tag": "1.42.0-20230524133808-cd357656",
               "helmFullImageKey": "jaegerQueryImage"
             }
           ]
@@ -651,7 +651,7 @@
           "images": [
             {
               "image": "jaeger-ingester",
-              "tag": "1.42.0-20230327232727-cd357656",
+              "tag": "1.42.0-20230524133808-cd357656",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -662,7 +662,7 @@
           "images": [
             {
               "image": "jaeger-es-index-cleaner",
-              "tag": "1.42.0-20230327232727-cd357656",
+              "tag": "1.42.0-20230524133808-cd357656",
               "helmFullImageKey": "jaegerESIndexCleanerImage"
             }
           ]
@@ -673,7 +673,7 @@
           "images": [
             {
               "image": "jaeger-es-rollover",
-              "tag": "1.42.0-20230327232727-cd357656",
+              "tag": "1.42.0-20230524133808-cd357656",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]
@@ -684,7 +684,7 @@
           "images": [
             {
               "image": "jaeger-all-in-one",
-              "tag": "1.42.0-20230327232727-cd357656",
+              "tag": "1.42.0-20230524133808-cd357656",
               "helmFullImageKey": "jaegerAllInOneImage"
             }
           ]
@@ -707,12 +707,12 @@
             },
             {
               "image": "velero-plugin-for-aws",
-              "tag": "v1.5.0-20230209073455-9b26984f",
+              "tag": "v1.5.0-20230524144106-9b26984f",
               "helmFullImageKey": "initContainers[0].image"
             },
             {
               "image": "velero-restic-restore-helper",
-              "tag": "v1.9.1-20230209073855-edba946d",
+              "tag": "v1.9.1-20230524144448-edba946d",
               "helmFullImageKey": "configMaps.restic-restore-action-config.data.image"
             }
           ]


### PR DESCRIPTION
Refreshes components built from source in verrazzano-bom.json for 1.5. Except the images built from ingress-nginx repository, all other images are built with the same commit. There is a change which is compatible with release-1.5 in ingress-nginx, so used the latest source for the same.
