### PR TITLE
VZ-9839 Create the Verrazzano Cluster Agent Helm chart

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/.helmignore
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/.helmignore
@@ -1,0 +1,22 @@
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/.helmignore
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/.helmignore
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 .DS_Store
 # Common VCS dirs

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/Chart.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/Chart.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: v1
+name: verrazzano-cluster-agent
+description: A Helm chart for the Verrazzano Cluster Agent
+version: 1.6.0
+appVersion: 1.6.0

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/Chart.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: v1
 name: verrazzano-cluster-agent

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrole.yaml
@@ -11,7 +11,9 @@ rules:
     resources:
       - namespaces
     verbs:
+      - list
       - get
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrole.yaml
@@ -1,0 +1,60 @@
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: verrazzano-cluster-agent
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - update
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - patch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+      - podmonitors
+    verbs:
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - clusters.verrazzano.io
+    resources:
+      - '*'
+      - '*/status'
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
     verbs:
       - create
       - update

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrolebinding.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: verrazzano-application-operator
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.name }}
+    namespace: {{ .Values.namespace }}

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrolebinding.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrolebinding.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: verrazzano-application-operator
+  name: verrazzano-cluster-agent
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.name }}

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/deployment.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+    spec:
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.name }}
+          image: {{ .Values.image }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - containerPort: 9443
+              name: https-webhook
+              protocol: TCP
+            - containerPort: 9100
+              name: http-metric
+              protocol: TCP
+          args:
+            - --zap-log-level={{ .Values.logLevel }}
+            - --run-app-operator=false
+            - --run-webhooks=false
+            - --run-webhook-init=false
+            - --run-cluster-agent=true
+          resources:
+            requests:
+              memory: {{ .Values.requestMemory }}
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      serviceAccountName: {{ .Values.name }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 999
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/deployment.yaml
@@ -1,5 +1,6 @@
 # Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/deployment.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: apps/v1

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/deployment.yaml
@@ -26,9 +26,6 @@ spec:
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
-            - containerPort: 9443
-              name: https-webhook
-              protocol: TCP
             - containerPort: 9100
               name: http-metric
               protocol: TCP

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/serviceaccount.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  {{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+  {{- end }}
+  {{- end }}

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/serviceaccount.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: v1

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml
@@ -6,8 +6,6 @@ namespace: verrazzano-system
 global:
   imagePullSecrets: []
 
-# NOTE: The image value gets set in the override file verrazzano-application-operator-values.yaml
-# during the platform operator docker image build.
 image:
 imagePullPolicy: IfNotPresent
 logLevel: info

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 name: verrazzano-cluster-agent
 namespace: verrazzano-system

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/values.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+name: verrazzano-cluster-agent
+namespace: verrazzano-system
+
+global:
+  imagePullSecrets: []
+
+# NOTE: The image value gets set in the override file verrazzano-application-operator-values.yaml
+# during the platform operator docker image build.
+image:
+imagePullPolicy: IfNotPresent
+logLevel: info
+
+requestMemory: 72Mi

--- a/platform-operator/thirdparty/charts/mysql/templates/deployment_cluster.yaml
+++ b/platform-operator/thirdparty/charts/mysql/templates/deployment_cluster.yaml
@@ -77,6 +77,10 @@ spec:
 {{- end }}
   secretName: {{ .Release.Name }}-cluster-secret
   imagePullPolicy : {{ .Values.image.pullPolicy }}
+{{- $repositoryPath := .Values.image.repository }}
+{{- if $repositoryPath }}
+  imageRepository: {{ $repositoryPath }}
+{{- end }}
   baseServerId: {{ required "baseServerId is required" .Values.baseServerId }}
   version: {{ .Values.serverVersion | default .Chart.AppVersion }}
   {{- if ((.Values).edition) }}

--- a/platform-operator/thirdparty/charts/mysql/templates/deployment_cluster.yaml
+++ b/platform-operator/thirdparty/charts/mysql/templates/deployment_cluster.yaml
@@ -77,10 +77,6 @@ spec:
 {{- end }}
   secretName: {{ .Release.Name }}-cluster-secret
   imagePullPolicy : {{ .Values.image.pullPolicy }}
-{{- $repositoryPath := .Values.image.repository }}
-{{- if $repositoryPath }}
-  imageRepository: {{ $repositoryPath }}
-{{- end }}
   baseServerId: {{ required "baseServerId is required" .Values.baseServerId }}
   version: {{ .Values.serverVersion | default .Chart.AppVersion }}
   {{- if ((.Values).edition) }}


### PR DESCRIPTION
**Changes**
- Added a Helm chart that deploys the Verrazzano cluster agent
- This change is ineffectual to the program, but provides scaffolding for future updates

**Testing**
- Deploy a minimal multicluster setup with a stripped back managed cluster Verrazzano CR
- Apply this helm chart with the correct image override
- Test managed cluster registration and make sure the MC Agent populates the metrics endpoint