### PR TITLE
VZ-9863: Fix incorrect vz yaml

### DIFF
--- a/tests/e2e/config/scripts/v1beta1/install-verrazzano-ocne.yaml
+++ b/tests/e2e/config/scripts/v1beta1/install-verrazzano-ocne.yaml
@@ -10,7 +10,7 @@ spec:
     dns:
       wildcard:
         domain: nip.io
-    ingress:
+    ingressNGINX:
       type: LoadBalancer
     istio:
       enabled: true

--- a/tests/e2e/config/scripts/v1beta1/install-verrazzano-ocne.yaml
+++ b/tests/e2e/config/scripts/v1beta1/install-verrazzano-ocne.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: install.verrazzano.io/v1beta1


### PR DESCRIPTION
This pull request fixes invalid vz yaml being user during an OCNE acceptance test.  This was caught because the vz cli now validates the vz yaml.