### PR TITLE
Remove CRD checks in CM components in favor of component checks

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/common/validate.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/common/validate.go
@@ -58,7 +58,10 @@ func IsACMEConfig(vz interface{}) (bool, error) {
 	}
 	if vzv1alpha1.Spec.Components.CertManager != nil {
 		isCA, err := checkExactlyOneIssuerConfiguration(vzv1alpha1.Spec.Components.CertManager.Certificate)
-		return !isCA, err
+		if err != nil {
+			return false, err
+		}
+		return !isCA, nil
 	}
 	return false, nil
 }

--- a/platform-operator/controllers/verrazzano/component/certmanager/config/certmanager_config_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/config/certmanager_config_test.go
@@ -77,53 +77,29 @@ func init() {
 	_ = apiextv1.AddToScheme(testScheme)
 }
 
-// TestIsCertManagerEnabled tests the IsCertManagerEnabled fn
+// TestIsClusterIssuerEnabled tests the IsCertManagerEnabled fn
 // GIVEN a call to IsCertManagerEnabled
 // WHEN cert-manager is enabled
 // THEN the function returns true
-func TestIsCertManagerEnabled(t *testing.T) {
-	crdObjs := createCertManagerCRDs()
-
-	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
-	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
-		return apiextv1fake.NewSimpleClientset(crtObjectToRuntimeObject(crdObjs...)...).ApiextensionsV1(), nil
-	}
+func TestIsClusterIssuerEnabled(t *testing.T) {
+	assert.True(t, fakeComponent.IsEnabled(&vzapi.Verrazzano{}))
 
 	localvz := defaultVZConfig.DeepCopy()
 	localvz.Spec.Components.CertManager.Enabled = getBoolPtr(true)
-
 	assert.True(t, fakeComponent.IsEnabled(localvz))
-}
 
-// TestIsCertManagerEnabledCRDsNotPresent tests the IsCertManagerEnabled fn
-// GIVEN a call to IsCertManagerEnabled
-// WHEN no CertManager CRDs are present
-// THEN the function returns false
-func TestIsCertManagerEnabledCRDsNotPresent(t *testing.T) {
-
-	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
-	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
-		return apiextv1fake.NewSimpleClientset().ApiextensionsV1(), nil
-	}
-
-	localvz := defaultVZConfig.DeepCopy()
-	localvz.Spec.Components.CertManager.Enabled = getBoolPtr(true)
-
-	assert.False(t, fakeComponent.IsEnabled(localvz))
-}
-
-// TestIsCertManagerDisabled tests the IsCertManagerEnabled fn
-// GIVEN a call to IsCertManagerEnabled
-// WHEN cert-manager is disabled
-// THEN the function returns false
-func TestIsCertManagerDisabled(t *testing.T) {
-	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
-	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
-		return apiextv1fake.NewSimpleClientset().ApiextensionsV1(), nil
-	}
-
-	localvz := defaultVZConfig.DeepCopy()
+	localvz = defaultVZConfig.DeepCopy()
 	localvz.Spec.Components.CertManager.Enabled = getBoolPtr(false)
+	localvz.Spec.Components.ClusterIssuer = &vzapi.ClusterIssuerComponent{
+		Enabled: getBoolPtr(true),
+	}
+	assert.True(t, fakeComponent.IsEnabled(localvz))
+
+	localvz = defaultVZConfig.DeepCopy()
+	localvz.Spec.Components.CertManager.Enabled = getBoolPtr(false)
+	localvz.Spec.Components.ClusterIssuer = &vzapi.ClusterIssuerComponent{
+		Enabled: getBoolPtr(false),
+	}
 	assert.False(t, fakeComponent.IsEnabled(localvz))
 }
 
@@ -163,22 +139,6 @@ func TestCertManagerOCIDNSPreUpgrade(t *testing.T) {
 	defer func() { config.Set(defaultConfig) }()
 
 	runPreChecksTest(t, true, false, createCertManagerCRDs()...)
-}
-
-// TestCertManagerOCIDNSPreInstallNoCertManagerCRDs tests the PreInstall fn
-// GIVEN a call to this fn
-// WHEN I call PreInstall and the CertManager CRDs are not present in the cluster
-// THEN An error is returned
-func TestCertManagerOCIDNSPreInstallNoCertManagerCRDs(t *testing.T) {
-	runPreChecksTest(t, false, true)
-}
-
-// TestCertManagerOCIDNSPreUpgradeNoCertManagerCRDs tests the PreUpgrade fn
-// GIVEN a call to this fn
-// WHEN I call PreInstall and the CertManager CRDs are not present in the cluster
-// THEN An error is returned
-func TestCertManagerOCIDNSPreUpgradeNoCertManagerCRDs(t *testing.T) {
-	runPreChecksTest(t, true, true)
 }
 
 func runPreChecksTest(t *testing.T, isUpgrade bool, expectErr bool, crdObjs ...clipkg.Object) {

--- a/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component.go
@@ -5,8 +5,10 @@ package ocidns
 
 import (
 	"github.com/verrazzano/verrazzano/pkg/constants"
-	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/controller"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -15,16 +17,26 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"path/filepath"
 )
 
-// ComponentName is the name of the component
-const ComponentName = cmcommon.CertManagerOCIDNSComponentName
+const (
+	// ComponentName is the name of the component
+	ComponentName = cmcommon.CertManagerOCIDNSComponentName
 
-// ComponentNamespace is the namespace of the component
-const ComponentNamespace = constants.VerrazzanoSystemNamespace
+	// ComponentJSONName is the Webhook component JSON name in the Verrazzano CR
+	ComponentJSONName = "certManagerOCIWebhook"
 
-const componentChartName = "verrazzano-cert-manager-ocidns-webhook"
+	// ComponentNamespace is the namespace of the component
+	ComponentNamespace = constants.VerrazzanoSystemNamespace
+
+	// componentChartName is the Webhook Chart name
+	componentChartName = "verrazzano-cert-manager-ocidns-webhook"
+
+	// webhookDeploymentName is the Webhook deployment object name
+	webhookDeploymentName = "cert-manager-ocidns-provider"
+)
 
 // certManagerOciDnsComponent represents an CertManager component
 type certManagerOciDNSComponent struct {
@@ -39,15 +51,25 @@ func NewComponent() spi.Component {
 	return certManagerOciDNSComponent{
 		helm.HelmComponent{
 			ReleaseName:               ComponentName,
+			JSONName:                  ComponentJSONName,
 			ChartDir:                  filepath.Join(config.GetHelmChartsDir(), componentChartName),
 			ChartNamespace:            ComponentNamespace,
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
 			InstallBeforeUpgrade:      true,
+			GetInstallOverridesFunc:   GetOverrides,
 			AppendOverridesFunc:       appendOCIDNSOverrides,
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0].name",
 			Dependencies:              []string{networkpolicies.ComponentName, controller.ComponentName},
+			AvailabilityObjects: &ready.AvailabilityObjects{
+				DeploymentNames: []types.NamespacedName{
+					{
+						Name:      webhookDeploymentName,
+						Namespace: ComponentNamespace,
+					},
+				},
+			},
 		},
 	}
 }
@@ -59,20 +81,11 @@ func (c certManagerOciDNSComponent) PreInstall(ctx spi.ComponentContext) error {
 	return nil
 }
 
-// IsEnabled returns true if the cert-manager is enabled, which is the default
+// IsEnabled returns true if the component is explicitly enabled OR if OCI DNS/LetsEncrypt are configured
 func (c certManagerOciDNSComponent) IsEnabled(effectiveCR runtime.Object) bool {
-	logger := vzlog.DefaultLogger()
-	err := cmcommon.CertManagerExistsInCluster(logger)
-	if err != nil {
-		logger.ErrorfThrottled("Unexpected error checking for CertManager in cluster: %v", err)
-		return false
-	}
-	isACMEConfig, err := cmcommon.IsACMEConfig(effectiveCR)
-	if err != nil {
-		logger.ErrorfThrottled("Unexpected error checking certificate configuration: %v", err.Error())
-		return false
-	}
-	return isACMEConfig && vzcr.IsOCIDNSEnabled(effectiveCR)
+	isACMEConfig, _ := cmcommon.IsACMEConfig(effectiveCR)
+	return vzcr.IsCertManagerWebhookOCIEnabled(effectiveCR) ||
+		(vzcr.IsOCIDNSEnabled(effectiveCR) && isACMEConfig && vzcr.IsCertManagerEnabled(effectiveCR))
 }
 
 func (c certManagerOciDNSComponent) PostUninstall(ctx spi.ComponentContext) error {
@@ -89,4 +102,30 @@ func (c certManagerOciDNSComponent) IsReady(ctx spi.ComponentContext) bool {
 		return isCertManagerOciDNSReady(ctx)
 	}
 	return false
+}
+
+// MonitorOverrides checks whether monitoring of install overrides is enabled or not
+func (c certManagerOciDNSComponent) MonitorOverrides(ctx spi.ComponentContext) bool {
+	if ctx.EffectiveCR().Spec.Components.CertManagerWebhookOCI != nil {
+		if ctx.EffectiveCR().Spec.Components.CertManagerWebhookOCI.MonitorChanges != nil {
+			return *ctx.EffectiveCR().Spec.Components.CertManagerWebhookOCI.MonitorChanges
+		}
+		return true
+	}
+	return false
+}
+
+// GetOverrides gets the install overrides
+func GetOverrides(object runtime.Object) interface{} {
+	if effectiveCR, ok := object.(*vzapi.Verrazzano); ok {
+		if effectiveCR.Spec.Components.CertManagerWebhookOCI != nil {
+			return effectiveCR.Spec.Components.CertManagerWebhookOCI.ValueOverrides
+		}
+		return []vzapi.Overrides{}
+	}
+	effectiveCR := object.(*v1beta1.Verrazzano)
+	if effectiveCR.Spec.Components.CertManagerWebhookOCI != nil {
+		return effectiveCR.Spec.Components.CertManagerWebhookOCI.ValueOverrides
+	}
+	return []v1beta1.Overrides{}
 }

--- a/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/ocidns/certmanagerocidns_component_test.go
@@ -27,10 +27,6 @@ import (
 // WHEN cert-manager is enabled with ACME and OCI DNS is configured
 // THEN the function returns true
 func TestIsCertManagerOciDNSEnabled(t *testing.T) {
-	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
-	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
-		return apiextv1fake.NewSimpleClientset(crtObjectToRuntimeObject(createCertManagerCRDs()...)...).ApiextensionsV1(), nil
-	}
 
 	bt := true
 
@@ -56,8 +52,7 @@ func TestIsCertManagerOciDNSEnabled(t *testing.T) {
 		},
 		Enabled: &bt,
 	}
-	localvz.Spec.Components.DNS = &vzapi.DNSComponent{OCI: &vzapi.OCI{}}
-	assert.True(t, NewComponent().IsEnabled(localvz))
+	assert.False(t, NewComponent().IsEnabled(localvz))
 
 	localvz = vz.DeepCopy()
 	localvz.Spec.Components.CertManager = &vzapi.CertManagerComponent{
@@ -66,7 +61,8 @@ func TestIsCertManagerOciDNSEnabled(t *testing.T) {
 		},
 		Enabled: &bt,
 	}
-	assert.False(t, NewComponent().IsEnabled(localvz))
+	localvz.Spec.Components.DNS = &vzapi.DNSComponent{OCI: &vzapi.OCI{}}
+	assert.True(t, NewComponent().IsEnabled(localvz))
 }
 
 // TestIsCertManagerOciDNSDisabledNoCRDs tests the IsCertManagerEnabled fn


### PR DESCRIPTION
Removes earlier attempts to base decisions around the webhook deployment and issuer configuration based on the availability of CertManager CRDs, in favor of the new component APIs.