### PR TITLE
Enable ClusterIssuer component for app stack stage in a-la-carte tests

### DIFF
--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -71,6 +71,7 @@ func (m appStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
 	cr.Spec.Components.ApplicationOperator = &vzapi.ApplicationOperatorComponent{Enabled: &trueVal}
 	cr.Spec.Components.AuthProxy = &vzapi.AuthProxyComponent{Enabled: &trueVal}
 	cr.Spec.Components.CertManager = &vzapi.CertManagerComponent{Enabled: &falseVal}
+	cr.Spec.Components.ClusterIssuer = &vzapi.ClusterIssuerComponent{Enabled: &trueVal}
 	cr.Spec.Components.Fluentd = &vzapi.FluentdComponent{Enabled: &trueVal}
 	cr.Spec.Components.Grafana = &vzapi.GrafanaComponent{Enabled: &trueVal}
 	cr.Spec.Components.Ingress = &vzapi.IngressNginxComponent{Enabled: &trueVal}


### PR DESCRIPTION
The a-la-carte tests have been updated to use an externally-installed Cert-Manager, meaning that it is installed outside of the Verrazzano install, and the `certManager` component is disabled.

With the introduction of the `clusterIssuer` Component users will now have to explicitly enable that for the "app-stack" (minimal configuration to allow ingress) to work.  This change enabled the `clusterIssuer` component going forward.
