### PR TITLE
VZ-9847.  Align remaining VPO components on new CertManager APIs

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/config/certmanager_config_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/config/certmanager_config_test.go
@@ -150,9 +150,9 @@ func runPreChecksTest(t *testing.T, isUpgrade bool, expectErr bool, crdObjs ...c
 
 	var err error
 	if !isUpgrade {
-		err = fakeComponent.PreInstall(spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false))
+		err = fakeComponent.PreInstall(spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false, profileDir))
 	} else {
-		err = fakeComponent.PreUpgrade(spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false))
+		err = fakeComponent.PreUpgrade(spi.NewFakeContext(client, &vzapi.Verrazzano{}, nil, false, profileDir))
 	}
 	if expectErr {
 		assert.Error(t, err, "Did not get expected error")

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
@@ -44,10 +44,9 @@ import (
 )
 
 const (
-	testBomFilePath     = "../../testdata/test_bom.json"
-	overrideJSON        = "{\"serviceAccount\": {\"create\": false}}"
-	unexpectedError     = "unexpected error"
-	notFoundErrorString = "not found"
+	testBomFilePath = "../../testdata/test_bom.json"
+	overrideJSON    = "{\"serviceAccount\": {\"create\": false}}"
+	unexpectedError = "unexpected error"
 )
 
 var (

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -90,6 +90,7 @@ const (
 	caTLSSource                = "secret"
 	caCertsPem                 = "cacerts.pem"
 	caCert                     = "ca.crt"
+	customCACertKey            = "tls.crt"
 	privateCAValue             = "true"
 	useBundledSystemChartValue = "true"
 )
@@ -231,7 +232,7 @@ var cattleClusterReposGVR = schema.GroupVersionResource{
 	Resource: "clusterrepos",
 }
 
-func useAdditionalCAs(acme vzapi.Acme) bool {
+func useAdditionalCAs(acme vzapi.LetsEncryptACMEIssuer) bool {
 	return acme.Environment != "production"
 }
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -244,11 +244,11 @@ func createOkeDriver() unstructured.Unstructured {
 //	THEN useAdditionalCAs return true or false if additional CAs are required
 func TestUseAdditionalCAs(t *testing.T) {
 	var tests = []struct {
-		in  vzapi.Acme
+		in  vzapi.LetsEncryptACMEIssuer
 		out bool
 	}{
-		{vzapi.Acme{Environment: "dev"}, true},
-		{vzapi.Acme{Environment: "production"}, false},
+		{vzapi.LetsEncryptACMEIssuer{Environment: "staging"}, true},
+		{vzapi.LetsEncryptACMEIssuer{Environment: "production"}, false},
 	}
 
 	for _, tt := range tests {

--- a/platform-operator/controllers/verrazzano/component/spi/component_context.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component_context.go
@@ -74,6 +74,15 @@ func NewFakeContext(c clipkg.Client, actualCR *v1alpha1.Verrazzano, actualV1beta
 		}
 	}
 
+	if effectiveCR != nil && effectiveV1beta1CR == nil {
+		effectiveV1beta1CR = &v1beta1.Verrazzano{}
+		effectiveCR.ConvertTo(effectiveV1beta1CR)
+	}
+	if effectiveV1beta1CR != nil && effectiveCR == nil {
+		effectiveCR = &v1alpha1.Verrazzano{}
+		effectiveCR.ConvertFrom(effectiveV1beta1CR)
+	}
+
 	return componentContext{
 		log:                log,
 		client:             c,

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"os"
 
+	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	oam "github.com/crossplane/oam-kubernetes-runtime/apis/core"
 	promoperapi "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -52,6 +53,7 @@ func init() {
 
 	// Add cert-manager components to the scheme
 	_ = cmapiv1.AddToScheme(scheme)
+	_ = acmev1.AddToScheme(scheme)
 
 	// Add the Prometheus Operator resources to the scheme
 	_ = promoperapi.AddToScheme(scheme)


### PR DESCRIPTION
Update components in the VPO to use the new clusterIssuer component for certificates configuration.  This largely consists of the Rancher code which sometimes needs to set up additional CA bundles to communicate with other components internally and remote managed clusters.

The `ComponentContext.EffectiveCR` is used to organize the other VPO components around the certificate issuer configuration using the new `ClusterIssuerComponent`.  That change was introduced in an earlier PR.  When the `EffectiveCR` is computed, the existing `CertManager` configuration is merged into the `ClusterIssuerComponent` configuration.  This prevents component code from having to switch between the `CertManagerComponent.Certificate` field and the `ClusterIssuerComponent`, and preserves  backwards compatibility with earlier release configurations.

Changes:
- Convert the Rancher component code over to the `ClusterIssuerComponent` for certificate issuer configuration
- Where appropriate update the unit tests to use a fake `ComponentContext` to compute the EffectiveCR for the scenario
- Update the `spi.NewFakeContext()` constructor to compute the effectiveCRs automatically if appropriate

Other changes:
- Reverted a change to `HelmComponent` that was caching the resolved namespaces of a component; it's not clear if that's necessary at this point and might introduce subtle bugs
- Fixes Rancher Keycloak SSO using a Custom CA using the new APIs (see VZ-9882)
- Adds the Cert-Manager ACME API scheme to the VPO controllerruntime client scheme 