### PR TITLE
Update cert manager ocidns webhook image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -85,8 +85,8 @@
           "name": "verrazzano-ocidns-webhook",
           "images": [
             {
-              "image": "cert-manager-ocidns-provider",
-              "tag": "v1.6.0-20230516012126-783aef9",
+              "image": "cert-manager-webhook-oci",
+              "tag": "v0.1.0-20230526160243-7a73e30",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -68,8 +68,8 @@
               "helmTagKey": "cainjector.image.tag"
             },
             {
-              "image": "cert-manager-webhook",
-              "tag": "v1.9.1-20230524125601-3a732e40",
+              "image": "cert-manager-webhook-oci",
+              "tag": "v0.1.0-20230526160243-7a73e30",
               "helmFullImageKey": "webhook.image.repository",
               "helmTagKey": "webhook.image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -68,8 +68,8 @@
               "helmTagKey": "cainjector.image.tag"
             },
             {
-              "image": "cert-manager-webhook-oci",
-              "tag": "v0.1.0-20230526160243-7a73e30",
+              "image": "cert-manager-webhook",
+              "tag": "v1.9.1-20230524125601-3a732e40",
               "helmFullImageKey": "webhook.image.repository",
               "helmTagKey": "webhook.image.tag"
             }


### PR DESCRIPTION
This updates the webhook image name to the new image built from the github repo.
