### PR TITLE
VZ-9788 Backport limiting number of helm releases and updating component generation when upgrade complete

### DIFF
--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -144,7 +144,7 @@ func GetValuesMap(log vzlog.VerrazzanoLogger, releaseName string, namespace stri
 func Upgrade(log vzlog.VerrazzanoLogger, releaseName string, namespace string, chartDir string, wait bool, dryRun bool, overrides []HelmOverrides) (stdout []byte, stderr []byte, err error) {
 	// Helm upgrade command will apply the new chart, but use all the existing
 	// overrides that we used during the install.
-	args := []string{"--install"}
+	args := []string{"--install", "--history-max", "1"}
 
 	// Do not pass the --reuse-values arg to 'helm upgrade'.  Instead, pass the
 	// values retrieved from 'helm get values' with the -f arg to 'helm upgrade'. This is a workaround to avoid

--- a/pkg/helm/helmcli_test.go
+++ b/pkg/helm/helmcli_test.go
@@ -88,6 +88,8 @@ func TestUpgrade(t *testing.T) {
 			"--namespace",
 			"my_namespace",
 			"--install",
+			"--history-max",
+			"1",
 			"-f",
 			"my-override.yaml",
 		},
@@ -116,6 +118,8 @@ func TestUpgradeCustomFileOverrides(t *testing.T) {
 			"--namespace",
 			"my_namespace",
 			"--install",
+			"--history-max",
+			"1",
 			"-f",
 			"my-override.yaml",
 			"-f",
@@ -720,11 +724,11 @@ func Test_maskSensitiveData(t *testing.T) {
 	// WHEN the maskSensitiveData function is called
 	// THEN the returned string has sensitive values masked
 	str := `Running command: /usr/bin/helm upgrade mysql /verrazzano/platform-operator/thirdparty/charts/mysql
-		--wait --namespace keycloak --install -f /verrazzano/platform-operator/helm_config/overrides/mysql-values.yaml
+		--wait --namespace keycloak --install --history-max 1 -f /verrazzano/platform-operator/helm_config/overrides/mysql-values.yaml
 		-f /tmp/values-145495151.yaml
 		--set imageTag=8.0.26,image=ghcr.io/verrazzano/mysql,mysqlPassword=BgD2SBNaGm,mysqlRootPassword=ydqtBpasQ4`
 	expected := `Running command: /usr/bin/helm upgrade mysql /verrazzano/platform-operator/thirdparty/charts/mysql
-		--wait --namespace keycloak --install -f /verrazzano/platform-operator/helm_config/overrides/mysql-values.yaml
+		--wait --namespace keycloak --install --history-max 1 -f /verrazzano/platform-operator/helm_config/overrides/mysql-values.yaml
 		-f /tmp/values-145495151.yaml
 		--set imageTag=8.0.26,image=ghcr.io/verrazzano/mysql,mysqlPassword=*****,mysqlRootPassword=*****`
 	maskedStr := maskSensitiveData(str)
@@ -734,7 +738,7 @@ func Test_maskSensitiveData(t *testing.T) {
 	// WHEN the maskSensitiveData function is called
 	// THEN the returned string is unaltered
 	str = `Running command: /usr/bin/helm upgrade ingress-controller /verrazzano/platform-operator/thirdparty/charts/ingress-nginx
-		--wait --namespace ingress-nginx --install -f /verrazzano/platform-operator/helm_config/overrides/ingress-nginx-values.yaml
+		--wait --namespace ingress-nginx --install --history-max 1 -f /verrazzano/platform-operator/helm_config/overrides/ingress-nginx-values.yaml
 		-f /tmp/values-037653479.yaml --set controller.image.tag=0.46.0-20211005200943-bd017fde2,
 		controller.image.repository=ghcr.io/verrazzano/nginx-ingress-controller,
 		defaultBackend.image.tag=0.46.0-20211005200943-bd017fde2,

--- a/platform-operator/controllers/verrazzano/healthcheck/status_updater.go
+++ b/platform-operator/controllers/verrazzano/healthcheck/status_updater.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package healthcheck

--- a/platform-operator/controllers/verrazzano/healthcheck/status_updater.go
+++ b/platform-operator/controllers/verrazzano/healthcheck/status_updater.go
@@ -83,7 +83,7 @@ func (v *VerrazzanoStatusUpdater) Start() {
 					return
 				}
 				if err := v.doUpdate(event); err != nil {
-					v.logger.Errorf("%v", err)
+					v.logger.Errorf("Error updating component status: %v", err)
 				}
 			}
 		}()

--- a/platform-operator/controllers/verrazzano/reconcile/status.go
+++ b/platform-operator/controllers/verrazzano/reconcile/status.go
@@ -159,7 +159,7 @@ func (r *Reconciler) updateComponentStatus(compContext spi.ComponentContext, mes
 		}
 	}
 	var instanceInfo *installv1alpha1.InstanceInfo
-	if conditionType == installv1alpha1.CondInstallComplete {
+	if conditionType == installv1alpha1.CondInstallComplete || conditionType == installv1alpha1.CondUpgradeComplete {
 		if componentStatus.ReconcilingGeneration > 0 {
 			componentStatus.LastReconciledGeneration = componentStatus.ReconcilingGeneration
 			componentStatus.ReconcilingGeneration = 0


### PR DESCRIPTION
Implementing similar functionality to PR https://github.com/verrazzano/verrazzano/pull/6095 for the Release 1.5 branch