### PR TITLE
VZ-9761 Synchronize Rancher TLS CA with Verrazzano TLS

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -101,6 +101,12 @@ const VerrazzanoESInternal = "verrazzano-es-internal"
 // VerrazzanoPromInternal is the name of the Verrazzano internal Prometheus secret in the Verrazzano system namespace
 const VerrazzanoPromInternal = "verrazzano-prom-internal"
 
+// RancherTLSCA is a tls secret that contains CA if private CA is being used
+const RancherTLSCA = "tls-ca"
+
+// RancherTLSCAKey is the key containing the CA in the secret specified by the RancherTLSCA constant
+const RancherTLSCAKey = "cacerts.pem"
+
 // AdditionalTLS is an optional tls secret that contains additional CA
 const AdditionalTLS = "tls-ca-additional"
 


### PR DESCRIPTION
Currently, when the Verrazzano self-signed CA bundle expires, Cert-Manager properly rotates the CA and leaf certificates, but the copy of the CA bundle used by Rancher does not get updated. This may be applicable even when using a custom private CA. This PR tries to address this issue by making VPO to synchronize CA in `tls-ca` Rancher secret with that of in `verrazzano-tls` secret whenever there is an update to `verrazzano-tls` secret. It also restarts Rancher POD when there is an update to `tls-ca` Rancher secret  to get the secret reflected in the POD. 