### PR TITLE
VZ-9864: Uptake Prometheus 2.44.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Component version updates:
 - WebLogic Monitoring Exporter v2.1.3
 - Jaeger v1.42.0
 - Prometheus Operator v0.64.1
+- Prometheus v2.44.0
 - kube-prometheus-stack Helm chart v45.25.0
 
 Components added:

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -595,8 +595,8 @@
           "name": "prometheus",
           "images": [
             {
-              "image": "prometheus-jenkins",
-              "tag": "v2.44.0-20230530180138-20978541",
+              "image": "prometheus",
+              "tag": "v2.44.0-20230531160222-74087370",
               "helmRegKey": "prometheus.prometheusSpec.image.registry",
               "helmFullImageKey": "prometheus.prometheusSpec.image.repository",
               "helmTagKey": "prometheus.prometheusSpec.image.tag"

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -595,8 +595,8 @@
           "name": "prometheus",
           "images": [
             {
-              "image": "prometheus",
-              "tag": "v2.38.0-20230524145024-186a8ee6",
+              "image": "prometheus-jenkins",
+              "tag": "v2.44.0-20230530180138-20978541",
               "helmRegKey": "prometheus.prometheusSpec.image.registry",
               "helmFullImageKey": "prometheus.prometheusSpec.image.repository",
               "helmTagKey": "prometheus.prometheusSpec.image.tag"


### PR DESCRIPTION
Note that no Helm chart upgrade is needed because Prometheus is deployed by the Prometheus Operator which is installed via the kube-prometheus-stack Helm chart, and that chart was upgraded very recently.