### PR TITLE
VZ-9833: Uptake kube-state-metrics 2.8.2 and Helm chart 5.6.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,9 @@ Component version updates:
 - Jaeger v1.42.0
 - Prometheus Operator v0.64.1
 - Prometheus v2.44.0
+- kube-state-metrics v2.8.2
 - kube-prometheus-stack Helm chart v45.25.0
+- kube-state-metrics Helm chart v5.6.4
 
 Components added:
 - Thanos v0.30.2

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/Chart.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
 - prometheus
 - kubernetes
 type: application
-version: 4.20.1
-appVersion: 2.6.0
+version: 5.6.4
+appVersion: 2.8.2
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/
@@ -18,4 +18,4 @@ maintainers:
 - name: mrueg
   email: manuel@rueg.eu
 - name: dotdc
-  email: davidcalvertfr@gmail.com
+  email: david@0xdc.me

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/README.md
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/README.md
@@ -2,14 +2,15 @@
 
 Installs the [kube-state-metrics agent](https://github.com/kubernetes/kube-state-metrics).
 
-## Get Repo Info
-
+## Get Repository Info
+<!-- textlint-disable -->
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
 _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+<!-- textlint-enable -->
 
 ## Install Chart
 
@@ -43,19 +44,18 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 You can upgrade in-place:
 
-1. [get repo info](#get-repo-info)
-1. [upgrade](#upgrading-chart) your existing release name using the new chart repo
-
+1. [get repository info](#get-repository-info)
+1. [upgrade](#upgrading-chart) your existing release name using the new chart repository
 
 ## Upgrading to v3.0.0
 
 v3.0.0 includes kube-state-metrics v2.0, see the [changelog](https://github.com/kubernetes/kube-state-metrics/blob/release-2.0/CHANGELOG.md) for major changes on the application-side.
 
 The upgraded chart now the following changes:
+
 * Dropped support for helm v2 (helm v3 or later is required)
 * collectors key was renamed to resources
 * namespace key was renamed to namespaces
-
 
 ## Configuration
 
@@ -65,4 +65,21 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 helm show values prometheus-community/kube-state-metrics
 ```
 
-You may also run `helm show values` on this chart's [dependencies](#dependencies) for additional options.
+### kube-rbac-proxy
+
+You can enable `kube-state-metrics` endpoint protection using `kube-rbac-proxy`. By setting `kubeRBACProxy.enabled: true`, this chart will deploy one RBAC proxy container per endpoint (metrics & telemetry).
+To authorize access, authenticate your requests (via a `ServiceAccount` for example) with a `ClusterRole` attached such as:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics-read
+rules:
+  - apiGroups: [ "" ]
+    resources: ["services/kube-state-metrics"]
+    verbs:
+      - get
+```
+
+See [kube-rbac-proxy examples](https://github.com/brancz/kube-rbac-proxy/tree/master/examples/resource-attributes) for more details.

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/NOTES.txt
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/NOTES.txt
@@ -8,3 +8,16 @@ In your case, {{ template "kube-state-metrics.fullname" . }}.{{ template "kube-s
 They are served either as plaintext or protobuf depending on the Accept header.
 They are designed to be consumed either by Prometheus itself or by a scraper that is compatible with scraping a Prometheus client endpoint.
 
+{{- if .Values.kubeRBACProxy.enabled}}
+
+kube-rbac-proxy endpoint protections is enabled:
+- Metrics endpoints are now HTTPS
+- Ensure that the client authenticates the requests (e.g. via service account) with the following role permissions:
+```
+rules:
+  - apiGroups: [ "" ]
+    resources: ["services/{{ template "kube-state-metrics.fullname" . }}"]
+    verbs:
+      - get
+```
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/_helpers.tpl
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/_helpers.tpl
@@ -77,6 +77,80 @@ release: {{ .Release.Name }}
 Selector labels
 */}}
 {{- define "kube-state-metrics.selectorLabels" }}
+{{- if .Values.selectorOverride }}
+{{ toYaml .Values.selectorOverride }}
+{{- else }}
 app.kubernetes.io/name: {{ include "kube-state-metrics.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- end }}
+
+{{/* Sets default scrape limits for servicemonitor */}}
+{{- define "servicemonitor.scrapeLimits" -}}
+{{- with .sampleLimit }}
+sampleLimit: {{ . }}
+{{- end }}
+{{- with .targetLimit }}
+targetLimit: {{ . }}
+{{- end }}
+{{- with .labelLimit }}
+labelLimit: {{ . }}
+{{- end }}
+{{- with .labelNameLengthLimit }}
+labelNameLengthLimit: {{ . }}
+{{- end }}
+{{- with .labelValueLengthLimit }}
+labelValueLengthLimit: {{ . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Formats imagePullSecrets. Input is (dict "Values" .Values "imagePullSecrets" .{specific imagePullSecrets})
+*/}}
+{{- define "kube-state-metrics.imagePullSecrets" -}}
+{{- range (concat .Values.global.imagePullSecrets .imagePullSecrets) }}
+  {{- if eq (typeOf .) "map[string]interface {}" }}
+- {{ toYaml . | trim }}
+  {{- else }}
+- name: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+The image to use for kube-state-metrics
+*/}}
+{{- define "kube-state-metrics.image" -}}
+{{- if .Values.image.sha }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.sha }}
+{{- else }}
+{{- printf "%s/%s:%s@%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.sha }}
+{{- end }}
+{{- else }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- else }}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+The image to use for kubeRBACProxy
+*/}}
+{{- define "kubeRBACProxy.image" -}}
+{{- if .Values.kubeRBACProxy.image.sha }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) .Values.kubeRBACProxy.image.sha }}
+{{- else }}
+{{- printf "%s/%s:%s@%s" .Values.kubeRBACProxy.image.registry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) .Values.kubeRBACProxy.image.sha }}
+{{- end }}
+{{- else }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) }}
+{{- else }}
+{{- printf "%s/%s:%s" .Values.kubeRBACProxy.image.registry .Values.kubeRBACProxy.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.kubeRBACProxy.image.tag) }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}
       containers:
+      {{- $httpPort := ternary 9090 (.Values.service.port | default 8080) .Values.kubeRBACProxy.enabled}}
+      {{- $telemetryPort := ternary 9091 (.Values.selfMonitor.telemetryPort | default 8081) .Values.kubeRBACProxy.enabled}}
       - name: {{ template "kube-state-metrics.name" . }}
         {{- if .Values.autosharding.enabled }}
         env:
@@ -56,9 +58,7 @@ spec:
         {{-  if .Values.extraArgs  }}
         {{- .Values.extraArgs | toYaml | nindent 8 }}
         {{-  end  }}
-        {{- if .Values.service.port }}
-        - --port={{ .Values.service.port | default 8080}}
-        {{-  end  }}
+        - --port={{ $httpPort }}
         {{-  if .Values.collectors  }}
         - --resources={{ .Values.collectors | join "," }}
         {{-  end  }}
@@ -76,7 +76,7 @@ spec:
         {{- end }}
         {{- $namespaces := list }}
         {{- if .Values.namespaces }}
-        {{- range $ns := split "," .Values.namespaces }}
+        {{- range $ns := join "," .Values.namespaces | split "," }}
         {{- $namespaces = append $namespaces (tpl $ns $) }}
         {{- end }}
         {{- end }}
@@ -96,11 +96,16 @@ spec:
         {{- if .Values.kubeconfig.enabled }}
         - --kubeconfig=/opt/k8s/.kube/config
         {{- end }}
+        {{- if .Values.kubeRBACProxy.enabled }}
+        - --telemetry-host=127.0.0.1
+        - --telemetry-port={{ $telemetryPort }}
+        {{- else }}
         {{- if .Values.selfMonitor.telemetryHost }}
         - --telemetry-host={{ .Values.selfMonitor.telemetryHost }}
         {{- end }}
         {{- if .Values.selfMonitor.telemetryPort }}
-        - --telemetry-port={{ .Values.selfMonitor.telemetryPort | default 8081 }}
+        - --telemetry-port={{ $telemetryPort }}
+        {{- end }}
         {{- end }}
         {{- if or (.Values.kubeconfig.enabled) (.Values.volumeMounts) }}
         volumeMounts:
@@ -114,28 +119,26 @@ spec:
         {{- end }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.image.sha }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- end }}
+        image: {{ include "kube-state-metrics.image" . }}
+        {{- if eq .Values.kubeRBACProxy.enabled false }}
         ports:
         - containerPort: {{ .Values.service.port | default 8080}}
           name: "http"
         {{- if .Values.selfMonitor.enabled }}
-        - containerPort: {{ .Values.selfMonitor.telemetryPort | default 8081 }}
+        - containerPort: {{ $telemetryPort }}
           name: "metrics"
+        {{- end }}
         {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz
-            port: {{ .Values.service.port | default 8080}}
+            port: {{ $httpPort }}
           initialDelaySeconds: 5
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /
-            port: {{ .Values.service.port | default 8080}}
+            port: {{ $httpPort }}
           initialDelaySeconds: 5
           timeoutSeconds: 5
         {{- if .Values.resources }}
@@ -146,9 +149,87 @@ spec:
         securityContext:
 {{ toYaml .Values.containerSecurityContext | indent 10 }}
 {{- end }}
-{{- if .Values.imagePullSecrets }}
+        {{-  if .Values.kubeRBACProxy.enabled  }}
+      - name: kube-rbac-proxy-http
+        args:
+        {{-  if .Values.kubeRBACProxy.extraArgs  }}
+        {{- .Values.kubeRBACProxy.extraArgs | toYaml | nindent 8 }}
+        {{-  end  }}
+        - --secure-listen-address=:{{ .Values.service.port | default 8080}}
+        - --upstream=http://127.0.0.1:{{ $httpPort }}/
+        - --proxy-endpoints-port=8888
+        - --config-file=/etc/kube-rbac-proxy-config/config-file.yaml
+        volumeMounts:
+          - name: kube-rbac-proxy-config
+            mountPath: /etc/kube-rbac-proxy-config
+          {{- with .Values.kubeRBACProxy.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
+        image: {{ include "kubeRBACProxy.image" . }}
+        ports:
+          - containerPort: {{ .Values.service.port | default 8080}}
+            name: "http"
+          - containerPort: 8888
+            name: "http-healthz"
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            port: 8888
+            path: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        {{- if .Values.kubeRBACProxy.resources }}
+        resources:
+{{ toYaml .Values.kubeRBACProxy.resources | indent 10 }}
+{{- end }}
+{{- if .Values.kubeRBACProxy.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.kubeRBACProxy.containerSecurityContext | indent 10 }}
+{{- end }}
+      {{-  if .Values.selfMonitor.enabled  }}
+      - name: kube-rbac-proxy-telemetry
+        args:
+        {{-  if .Values.kubeRBACProxy.extraArgs  }}
+        {{- .Values.kubeRBACProxy.extraArgs | toYaml | nindent 8 }}
+        {{-  end  }}
+        - --secure-listen-address=:{{ .Values.selfMonitor.telemetryPort | default 8081 }}
+        - --upstream=http://127.0.0.1:{{ $telemetryPort }}/
+        - --proxy-endpoints-port=8889
+        - --config-file=/etc/kube-rbac-proxy-config/config-file.yaml
+        volumeMounts:
+          - name: kube-rbac-proxy-config
+            mountPath: /etc/kube-rbac-proxy-config
+          {{- with .Values.kubeRBACProxy.volumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
+        image: {{ include "kubeRBACProxy.image" . }}
+        ports:
+          - containerPort: {{ .Values.selfMonitor.telemetryPort | default 8081 }}
+            name: "metrics"
+          - containerPort: 8889
+            name: "metrics-healthz"
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            port: 8889
+            path: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        {{- if .Values.kubeRBACProxy.resources }}
+        resources:
+{{ toYaml .Values.kubeRBACProxy.resources | indent 10 }}
+{{- end }}
+{{- if .Values.kubeRBACProxy.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.kubeRBACProxy.containerSecurityContext | indent 10 }}
+{{- end }}
+      {{- end }}
+      {{- end }}
+{{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
+        {{- include "kube-state-metrics.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.imagePullSecrets) | indent 8 }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity:
@@ -166,12 +247,17 @@ spec:
       topologySpreadConstraints:
 {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
       {{- end }}
-      {{- if or (.Values.kubeconfig.enabled) (.Values.volumes) }}
+      {{- if or (.Values.kubeconfig.enabled) (.Values.volumes) (.Values.kubeRBACProxy.enabled) }}
       volumes:
       {{- if .Values.kubeconfig.enabled}}
         - name: kubeconfig
           secret:
             secretName: {{ template "kube-state-metrics.fullname" . }}-kubeconfig
+      {{- end }}
+      {{- if .Values.kubeRBACProxy.enabled}}
+        - name: kube-rbac-proxy-config
+          configMap:
+            name: {{ template "kube-state-metrics.fullname" . }}-rbac-config
       {{- end }}
       {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 8 }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/podsecuritypolicy.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/podsecuritypolicy.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.podSecurityPolicy.enabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -37,5 +36,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
-{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -1,5 +1,4 @@
-{{- if and .Values.podSecurityPolicy.enabled .Values.rbac.create -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -17,5 +16,4 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "kube-state-metrics.fullname" . }}
-{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
-{{- if and .Values.podSecurityPolicy.enabled .Values.rbac.create -}}
+{{- if and .Values.podSecurityPolicy.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,5 +13,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}
     namespace: {{ template "kube-state-metrics.namespace" . }}
-{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/role.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.rbac.create true) (not .Values.rbac.useExistingRole) -}}
-{{- range (ternary (split "," .Values.namespaces) (list "") (eq $.Values.rbac.useClusterRole false)) }}
+{{- range (ternary (join "," .Values.namespaces | split "," ) (list "") (eq $.Values.rbac.useClusterRole false)) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if eq $.Values.rbac.useClusterRole false }}
@@ -67,6 +67,12 @@ rules:
 - apiGroups: ["batch"]
   resources:
   - jobs
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if has "leases" $.Values.collectors }}
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if has "limitranges" $.Values.collectors }}
@@ -183,6 +189,16 @@ rules:
     - verticalpodautoscalers
   verbs: ["list", "watch"]
 {{ end -}}
+{{-  if $.Values.kubeRBACProxy.enabled  }}
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+    - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+    - subjectaccessreviews
+  verbs: ["create"]
+{{- end }}
 {{ if $.Values.rbac.extraRules }}
 {{ toYaml $.Values.rbac.extraRules }}
 {{ end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/rolebinding.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq  .Values.rbac.create true) (eq .Values.rbac.useClusterRole false) -}}
-{{- range (split "," $.Values.namespaces) }}
+{{- range (join "," $.Values.namespaces) | split "," }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/service.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/service.yaml
@@ -34,7 +34,15 @@ spec:
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
 {{- end }}
-{{- if .Values.service.clusterIP }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
+{{- if .Values.autosharding.enabled }}
+  clusterIP: None
+{{- else if .Values.service.clusterIP }}
   clusterIP: "{{ .Values.service.clusterIP }}"
 {{- end }}
   selector:

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/serviceaccount.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/serviceaccount.yaml
@@ -11,5 +11,5 @@ metadata:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- end }}
 imagePullSecrets:
-{{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
+  {{- include "kube-state-metrics.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.serviceAccount.imagePullSecrets) | indent 2 }}
 {{- end -}}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/servicemonitor.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/servicemonitor.yaml
@@ -9,13 +9,26 @@ metadata:
   {{- with .Values.prometheus.monitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.prometheus.monitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
+  {{- with .Values.prometheus.monitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+  {{- with .Values.prometheus.monitor.podTargetLabels }}
+  podTargetLabels:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+  {{- include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | indent 2 }}
   selector:
     matchLabels:
-    {{- if .Values.prometheus.monitor.selectorOverride -}}
-      {{ toYaml .Values.prometheus.monitor.selectorOverride | nindent 6 }}
-    {{ else }}
+    {{- with .Values.prometheus.monitor.selectorOverride }}
+      {{- toYaml . | nindent 6 }}
+    {{- else }}
       {{- include "kube-state-metrics.selectorLabels" . | indent 6 }}
     {{- end }}
   endpoints:
@@ -47,6 +60,13 @@ spec:
       tlsConfig:
         {{- toYaml .Values.prometheus.monitor.tlsConfig | nindent 8 }}
     {{- end }}
+    {{- if .Values.prometheus.monitor.bearerTokenFile }}
+      bearerTokenFile: {{ .Values.prometheus.monitor.bearerTokenFile }}
+    {{- end }}
+    {{- with .Values.prometheus.monitor.bearerTokenSecret }}
+      bearerTokenSecret:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
   {{- if .Values.selfMonitor.enabled }}
     - port: metrics
     {{- if .Values.prometheus.monitor.interval }}
@@ -75,6 +95,13 @@ spec:
     {{- if .Values.prometheus.monitor.tlsConfig }}
       tlsConfig:
         {{- toYaml .Values.prometheus.monitor.tlsConfig | nindent 8 }}
+    {{- end }}
+    {{- if .Values.prometheus.monitor.bearerTokenFile }}
+      bearerTokenFile: {{ .Values.prometheus.monitor.bearerTokenFile }}
+    {{- end }}
+    {{- with .Values.prometheus.monitor.bearerTokenSecret }}
+      bearerTokenSecret:
+        {{- toYaml . | nindent 8 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/verticalpodautoscaler.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/templates/verticalpodautoscaler.yaml
@@ -23,7 +23,11 @@ spec:
       {{- end }}
   targetRef:
     apiVersion: apps/v1
+    {{- if .Values.autosharding.enabled }}
+    kind: StatefulSet
+    {{- else }}
     kind: Deployment
+    {{- end }}
     name:  {{ template "kube-state-metrics.fullname" . }}
   {{- if .Values.verticalPodAutoscaler.updatePolicy }}
   updatePolicy:

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/values.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics/values.yaml
@@ -1,13 +1,32 @@
 # Default values for kube-state-metrics.
 prometheusScrape: true
 image:
-  repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-  tag: v2.6.0
+  registry: registry.k8s.io
+  repository: kube-state-metrics/kube-state-metrics
+  # If unset use v + .Charts.appVersion
+  tag: ""
   sha: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 # - name: "image-pull-secret"
+
+global:
+  # To help compatibility with other charts which use global.imagePullSecrets.
+  # Allow either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).
+  # global:
+  #   imagePullSecrets:
+  #   - name: pullSecret1
+  #   - name: pullSecret2
+  # or
+  # global:
+  #   imagePullSecrets:
+  #   - pullSecret1
+  #   - pullSecret2
+  imagePullSecrets: []
+  #
+  # Allow parent charts to override registry hostname
+  imageRegistry: ""
 
 # If set to true, this will deploy kube-state-metrics as a StatefulSet and the data
 # will be automatically sharded across <.Values.replicas> pods using the built-in
@@ -29,12 +48,17 @@ service:
   type: ClusterIP
   nodePort: 0
   loadBalancerIP: ""
+  # Only allow access to the loadBalancerIP from these IPs
+  loadBalancerSourceRanges: []
   clusterIP: ""
   annotations: {}
 
 ## Additional labels to add to all resources
 customLabels: {}
   # app: kube-state-metrics
+
+## Override selector labels
+selectorOverride: {}
 
 ## set to true to add the release label so scraping of the servicemonitor with kube-prometheus-stack works out of the box
 releaseLabel: false
@@ -58,6 +82,46 @@ rbac:
   #   verbs: ["list", "watch"]
   extraRules: []
 
+# Configure kube-rbac-proxy. When enabled, creates one kube-rbac-proxy container per exposed HTTP endpoint (metrics and telemetry if enabled).
+# The requests are served through the same service but requests are then HTTPS.
+kubeRBACProxy:
+  enabled: false
+  image:
+    registry: quay.io
+    repository: brancz/kube-rbac-proxy
+    tag: v0.14.0
+    sha: ""
+    pullPolicy: IfNotPresent
+
+  # List of additional cli arguments to configure kube-rbac-prxy
+  # for example: --tls-cipher-suites, --log-file, etc.
+  # all the possible args can be found here: https://github.com/brancz/kube-rbac-proxy#usage
+  extraArgs: []
+
+  ## Specify security settings for a Container
+  ## Allows overrides and additional options compared to (Pod) securityContext
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  containerSecurityContext: {}
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 64Mi
+    # requests:
+    #  cpu: 10m
+    #  memory: 32Mi
+
+  ## volumeMounts enables mounting custom volumes in rbac-proxy containers
+  ## Useful for TLS certificates and keys
+  volumeMounts: []
+    # - mountPath: /etc/tls
+    #   name: kube-rbac-proxy-tls
+    #   readOnly: true
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created, require rbac true
   create: true
@@ -75,10 +139,32 @@ serviceAccount:
 prometheus:
   monitor:
     enabled: false
+    annotations: {}
     additionalLabels: {}
     namespace: ""
     jobLabel: ""
+    targetLabels: []
+    podTargetLabels: []
     interval: ""
+    ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: 0
+
+    ## TargetLimit defines a limit on the number of scraped targets that will be accepted.
+    ##
+    targetLimit: 0
+
+    ## Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelLimit: 0
+
+    ## Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelNameLengthLimit: 0
+
+    ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelValueLengthLimit: 0
     scrapeTimeout: ""
     proxyUrl: ""
     selectorOverride: {}
@@ -86,6 +172,14 @@ prometheus:
     metricRelabelings: []
     relabelings: []
     scheme: ""
+    ## File to read bearer token for scraping targets
+    bearerTokenFile: ""
+    ## Secret to mount to read bearer token for scraping targets. The secret needs
+    ## to be in the same namespace as the service monitor and accessible by the
+    ## Prometheus Operator
+    bearerTokenSecret: {}
+      # name: secret-name
+      # key:  key-name
     tlsConfig: {}
 
 ## Specify if a Pod Security Policy for kube-state-metrics must be created
@@ -105,16 +199,46 @@ podSecurityPolicy:
 
   additionalVolumes: []
 
+## Configure network policy for kube-state-metrics
+networkPolicy:
+  enabled: false
+  # networkPolicy.flavor -- Flavor of the network policy to use.
+  # Can be:
+  # * kubernetes for networking.k8s.io/v1/NetworkPolicy
+  # * cilium     for cilium.io/v2/CiliumNetworkPolicy
+  flavor: kubernetes
+
+  ## Configure the cilium network policy kube-apiserver selector
+  # cilium:
+    # kubeApiServerSelector:
+      # - toEntities:
+      #   - kube-apiserver
+
+  # egress:
+  # - {}
+  # ingress:
+  # - {}
+  # podSelector:
+  #   matchLabels:
+  #     app.kubernetes.io/name: kube-state-metrics
+
 securityContext:
   enabled: true
   runAsGroup: 65534
   runAsUser: 65534
   fsGroup: 65534
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 ## Specify security settings for a Container
 ## Allows overrides and additional options compared to (Pod) securityContext
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-containerSecurityContext: {}
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -184,6 +308,7 @@ collectors:
   - horizontalpodautoscalers
   - ingresses
   - jobs
+  - leases
   - limitranges
   - mutatingwebhookconfigurations
   - namespaces
@@ -214,7 +339,7 @@ kubeconfig:
 # If releaseNamespace and namespaces are both set a merged list will be collected.
 releaseNamespace: false
 
-# Comma-separated list of namespaces to be enabled for collecting resources. By default all namespaces are collected.
+# Comma-separated list(string) or yaml list of namespaces to be enabled for collecting resources. By default all namespaces are collected.
 namespaces: ""
 
 # Comma-separated list of namespaces not to be enabled. If namespaces and namespaces-denylist are both set,

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -631,7 +631,8 @@
           "images": [
             {
               "image": "kube-state-metrics",
-              "tag": "v2.6.0-20230524165333-36212f20",
+              "tag": "v2.8.2-20230531155057-c4a3ac95",
+              "helmRegKey": "image.registry",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
This PR upgrades the kube-state-metrics image to version 2.8.2 and also upgrades the kube-state-metrics Helm chart to 5.6.4.

Note that the new Helm chart splits the registry from the repository and thus requires a new Helm key in the BOM for the registry. This same change was made to the Prometheus Operator images when upgrading the kube-prometheus-stack Helm chart recently.