### PR TITLE
Certificate ready-checks, Prometheus operator webhook certs with customer-managed CertManager

### DIFF
--- a/pkg/k8s/ready/certificates.go
+++ b/pkg/k8s/ready/certificates.go
@@ -4,6 +4,7 @@ package ready
 
 import (
 	"context"
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"sort"
 
 	certapiv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -28,11 +29,9 @@ func CertificatesAreReady(client clipkg.Client, log vzlog.VerrazzanoLogger, vz *
 		return true, []types.NamespacedName{}
 	}
 
-	if vz != nil && vz.Spec.Components.CertManager != nil && vz.Spec.Components.CertManager.Enabled != nil {
-		if !*vz.Spec.Components.CertManager.Enabled {
-			log.Oncef("Cert-Manager disabled, skipping certificates check")
-			return true, []types.NamespacedName{}
-		}
+	if !vzcr.IsClusterIssuerEnabled(vz) {
+		log.Oncef("Cert-Manager ClusterIssuer disabled, skipping certificates check")
+		return true, []types.NamespacedName{}
 	}
 
 	log.Oncef("Checking certificates status for %v", certificates)

--- a/pkg/k8s/ready/certificates_test.go
+++ b/pkg/k8s/ready/certificates_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package ready
 
@@ -42,12 +42,14 @@ func TestCheckCertificatesReady(t *testing.T) {
 		{Name: "mycert", Namespace: "verrazzano-system"},
 		{Name: "mycert2", Namespace: "verrazzano-system"},
 	}
-	cmEnabled := true
+	cmDisabled := false // Validate this for the customer-managed-CM case to ensure we
+	issuerEnabled := true
 	vz := &v1alpha1.Verrazzano{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "foo"},
 		Spec: v1alpha1.VerrazzanoSpec{
 			Components: v1alpha1.ComponentSpec{
-				CertManager: &v1alpha1.CertManagerComponent{Enabled: &cmEnabled},
+				CertManager:   &v1alpha1.CertManagerComponent{Enabled: &cmDisabled},
+				ClusterIssuer: &v1alpha1.ClusterIssuerComponent{Enabled: &issuerEnabled},
 			},
 		},
 	}
@@ -97,12 +99,14 @@ func TestCheckCertificatesNotReady(t *testing.T) {
 	notReadyExpected := []types.NamespacedName{
 		certNames[1],
 	}
-	cmEnabled := true
+	cmDisabled := false // Validate this for the customer-managed-CM case to ensure we
+	issuerEnabled := true
 	vz := &v1alpha1.Verrazzano{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "foo"},
 		Spec: v1alpha1.VerrazzanoSpec{
 			Components: v1alpha1.ComponentSpec{
-				CertManager: &v1alpha1.CertManagerComponent{Enabled: &cmEnabled},
+				CertManager:   &v1alpha1.CertManagerComponent{Enabled: &cmDisabled},
+				ClusterIssuer: &v1alpha1.ClusterIssuerComponent{Enabled: &issuerEnabled},
 			},
 		},
 	}
@@ -147,15 +151,26 @@ func TestCheckCertificatesNotReadyCertManagerDisabled(t *testing.T) {
 		{Name: "mycert2", Namespace: "verrazzano-system"},
 	}
 
-	cmEnabled := false
+	disabled := false // Validate this for the customer-managed-CM case to ensure we
 	vz := &v1alpha1.Verrazzano{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "foo"},
 		Spec: v1alpha1.VerrazzanoSpec{
 			Components: v1alpha1.ComponentSpec{
-				CertManager: &v1alpha1.CertManagerComponent{Enabled: &cmEnabled},
+				CertManager:   &v1alpha1.CertManagerComponent{Enabled: &disabled},
+				ClusterIssuer: &v1alpha1.ClusterIssuerComponent{Enabled: &disabled},
 			},
 		},
 	}
+
+	//cmEnabled := false
+	//vz := &v1alpha1.Verrazzano{
+	//	ObjectMeta: metav1.ObjectMeta{Namespace: "foo"},
+	//	Spec: v1alpha1.VerrazzanoSpec{
+	//		Components: v1alpha1.ComponentSpec{
+	//			CertManager: &v1alpha1.CertManagerComponent{Enabled: &cmEnabled},
+	//		},
+	//	},
+	//}
 
 	client := fake.NewClientBuilder().WithScheme(getScheme()).Build()
 	allReady, notReadyActual := CertificatesAreReady(client, vzlog.DefaultLogger(), vz, certNames)
@@ -168,12 +183,14 @@ func TestCheckCertificatesNotReadyCertManagerDisabled(t *testing.T) {
 // WHEN I call CertificatesAreReady with an empty certs list
 // THEN true and an empty list of names is returned
 func TestCheckCertificatesNotReadyNoCertsPassed(t *testing.T) {
-	cmEnabled := true
+	cmDisabled := false // Validate this for the customer-managed-CM case to ensure we
+	issuerEnabled := true
 	vz := &v1alpha1.Verrazzano{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "foo"},
 		Spec: v1alpha1.VerrazzanoSpec{
 			Components: v1alpha1.ComponentSpec{
-				CertManager: &v1alpha1.CertManagerComponent{Enabled: &cmEnabled},
+				CertManager:   &v1alpha1.CertManagerComponent{Enabled: &cmDisabled},
+				ClusterIssuer: &v1alpha1.ClusterIssuerComponent{Enabled: &issuerEnabled},
 			},
 		},
 	}

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component_test.go
@@ -1224,6 +1224,9 @@ func getIngressTests(isUpgradeOperation bool) []ingressTestStruct {
 						CertManager: &vzapi.CertManagerComponent{
 							Enabled: &falseValue,
 						},
+						ClusterIssuer: &vzapi.ClusterIssuerComponent{
+							Enabled: &falseValue,
+						},
 					},
 				},
 			},
@@ -1240,6 +1243,9 @@ func getIngressTests(isUpgradeOperation bool) []ingressTestStruct {
 				Spec: vzapi.VerrazzanoSpec{
 					Components: vzapi.ComponentSpec{
 						CertManager: &vzapi.CertManagerComponent{
+							Enabled: &falseValue,
+						},
+						ClusterIssuer: &vzapi.ClusterIssuerComponent{
 							Enabled: &falseValue,
 						},
 						DNS: &vzapi.DNSComponent{

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -302,7 +302,7 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 	// will use the kube-webhook-certgen image
 	kvs = append(kvs, bom.KeyValue{
 		Key:   "prometheusOperator.admissionWebhooks.certManager.enabled",
-		Value: strconv.FormatBool(vzcr.IsCertManagerEnabled(ctx.EffectiveCR())),
+		Value: strconv.FormatBool(vzcr.IsClusterIssuerEnabled(ctx.EffectiveCR())),
 	})
 
 	if vzcr.IsPrometheusEnabled(ctx.EffectiveCR()) {


### PR DESCRIPTION
The VPO currently does checks on Certificate status when the CertManager component is enabled; however this breaks when using a customer-managed Cert-Manager instance.

Additionally, the Prometheus Operator uses Cert-Manager certs if it is available, however it can no longer rely on checking if the Verrazzano `certManager` component is enabled.

In both cases we shift to using the `clusterIssuer` component to check for these behaviors.  The `clusterIssuer` is what unifies both cases, the Verrazzano-managed and customer-managed Cert-Manager instances.

Also fixes up related unit tests.

Manually verified the behavior in the debugger for the customer-managed CM case, and examined the VPO logs for the default case.