### PR TITLE
VZ-8902: Refresh component images in release-1.4

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -28,13 +28,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.1.1-20221205221956-31c1f6101",
+              "tag": "v1.1.1-20230530095547-31c1f6101",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "v1.1.1-20221205221956-31c1f6101",
+              "tag": "v1.1.1-20230530095547-31c1f6101",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -52,24 +52,24 @@
           "images": [
             {
               "image": "cert-manager-controller",
-              "tag": "v1.7.1-20221212223004-d7589309",
+              "tag": "v1.7.1-20230531063350-d7589309",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "cert-manager-acmesolver",
-              "tag": "v1.7.1-20221212223004-d7589309",
+              "tag": "v1.7.1-20230531063350-d7589309",
               "helmFullImageKey": "extraArgs[0]"
             },
             {
               "image": "cert-manager-cainjector",
-              "tag": "v1.7.1-20221212223004-d7589309",
+              "tag": "v1.7.1-20230531063350-d7589309",
               "helmFullImageKey": "cainjector.image.repository",
               "helmTagKey": "cainjector.image.tag"
             },
             {
               "image": "cert-manager-webhook",
-              "tag": "v1.7.1-20221212223004-d7589309",
+              "tag": "v1.7.1-20230531063350-d7589309",
               "helmFullImageKey": "webhook.image.repository",
               "helmTagKey": "webhook.image.tag"
             }
@@ -87,7 +87,7 @@
           "images": [
             {
               "image": "external-dns",
-              "tag": "v0.10.2-20221116113317-462c11cc",
+              "tag": "v0.10.2-20230530115445-62c9ebcc",
               "helmFullImageKey": "image.repository",
               "helmRegKey": "image.registry",
               "helmTagKey": "image.tag"
@@ -200,13 +200,13 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.1.1-20221205221956-31c1f6101",
+              "tag": "v1.1.1-20230530095547-31c1f6101",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "v0.10.0-20230207180014-7cf62c11",
+              "tag": "v0.10.0-20230524141908-7cf62c11",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }
@@ -235,7 +235,7 @@
             },
             {
               "image": "grafana",
-              "tag": "v7.5.17-20230127201512-328e2599",
+              "tag": "v7.5.17-20230524152354-7afbf50a",
               "helmFullImageKey": "monitoringOperator.grafanaImage"
             },
             {
@@ -245,12 +245,12 @@
             },
             {
               "image": "opensearch-dashboards",
-              "tag": "1.2.0-20221011085109-c206c8b25f",
+              "tag": "1.2.0-20230531105547-b536bb1a5d",
               "helmFullImageKey": "monitoringOperator.kibanaImage"
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.1.1-20221205221956-31c1f6101",
+              "tag": "v1.1.1-20230530095547-31c1f6101",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]
@@ -362,7 +362,7 @@
           "images": [
             {
               "image": "kiali",
-              "tag": "v1.42.0-20221203021205-80d3a112",
+              "tag": "v1.42.0-20230531103153-80d3a112",
               "helmFullImageKey": "deployment.image_name",
               "helmTagKey": "deployment.image_version"
             }
@@ -422,7 +422,7 @@
           "images": [
             {
               "image": "keycloak-oracle-theme",
-              "tag": "v1.4.0-20220803133014-7b829cf"
+              "tag": "v1.4.0-20230530122556-0739720"
             }
           ]
         }
@@ -438,13 +438,13 @@
           "images": [
             {
               "image": "prometheus-operator",
-              "tag": "v0.55.1-20221205224323-3af6e09b",
+              "tag": "v0.55.1-20230531103428-3af6e09b",
               "helmFullImageKey": "prometheusOperator.image.repository",
               "helmTagKey": "prometheusOperator.image.tag"
             },
             {
               "image": "kube-webhook-certgen",
-              "tag": "v1.1.1-20221205221956-31c1f6101",
+              "tag": "v1.1.1-20230530095547-31c1f6101",
               "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
               "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"
             }
@@ -456,7 +456,7 @@
           "images": [
             {
               "image": "prometheus-config-reloader",
-              "tag": "v0.55.1-20221205224323-3af6e09b",
+              "tag": "v0.55.1-20230531103428-3af6e09b",
               "helmFullImageKey": "prometheusOperator.prometheusConfigReloader.image.repository",
               "helmTagKey": "prometheusOperator.prometheusConfigReloader.image.tag"
             }
@@ -468,7 +468,7 @@
           "images": [
             {
               "image": "alertmanager",
-              "tag": "v0.24.0-20221206192620-fb73d30f",
+              "tag": "v0.24.0-20230524114801-18128160",
               "helmFullImageKey": "alertmanager.alertmanagerSpec.image.repository",
               "helmTagKey": "alertmanager.alertmanagerSpec.image.tag"
             }
@@ -480,7 +480,7 @@
           "images": [
             {
               "image": "prometheus",
-              "tag": "v2.34.0-20221205144021-d0a9304a",
+              "tag": "v2.34.0-20230531104141-d0a9304a",
               "helmFullImageKey": "prometheus.prometheusSpec.image.repository",
               "helmTagKey": "prometheus.prometheusSpec.image.tag"
             }
@@ -497,7 +497,7 @@
           "images": [
             {
               "image": "prometheus-adapter",
-              "tag": "v0.9.1-20221205223816-ed53ffa2",
+              "tag": "v0.9.1-20230531102121-ed53ffa2",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -514,7 +514,7 @@
           "images": [
             {
               "image": "kube-state-metrics",
-              "tag": "v2.4.2-20221206161215-cd4d6126",
+              "tag": "v2.4.2-20230531062301-cd4d6126",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -531,7 +531,7 @@
           "images": [
             {
               "image": "prometheus-pushgateway",
-              "tag": "v1.4.2-20221130235227-3af6d83b",
+              "tag": "v1.4.2-20230524143811-3af6d83b",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -548,7 +548,7 @@
           "images": [
             {
               "image": "node-exporter",
-              "tag": "v1.3.1-20221130233213-2bb925b2",
+              "tag": "v1.3.1-20230530111359-b7f69924",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -566,7 +566,7 @@
           "images": [
             {
               "image": "jaeger-operator",
-              "tag": "1.34.1-20221208172914-c16c4aea",
+              "tag": "1.34.1-20230531063248-c16c4aea",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -578,7 +578,7 @@
           "images": [
             {
               "image": "jaeger-agent",
-              "tag": "1.34.1-20221208173501-7da07ddc",
+              "tag": "1.34.1-20230531065745-7da07ddc",
               "helmFullImageKey": "jaegerAgentImage"
             }
           ]
@@ -589,7 +589,7 @@
           "images": [
             {
               "image": "jaeger-collector",
-              "tag": "1.34.1-20221208173501-7da07ddc",
+              "tag": "1.34.1-20230531065745-7da07ddc",
               "helmFullImageKey": "jaegerCollectorImage"
             }
           ]
@@ -600,7 +600,7 @@
           "images": [
             {
               "image": "jaeger-query",
-              "tag": "1.34.1-20221208173501-7da07ddc",
+              "tag": "1.34.1-20230531065745-7da07ddc",
               "helmFullImageKey": "jaegerQueryImage"
             }
           ]
@@ -611,7 +611,7 @@
           "images": [
             {
               "image": "jaeger-ingester",
-              "tag": "1.34.1-20221208173501-7da07ddc",
+              "tag": "1.34.1-20230531065745-7da07ddc",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -622,7 +622,7 @@
           "images": [
             {
               "image": "jaeger-es-index-cleaner",
-              "tag": "1.34.1-20221208173501-7da07ddc",
+              "tag": "1.34.1-20230531065745-7da07ddc",
               "helmFullImageKey": "jaegerESIndexCleanerImage"
             }
           ]
@@ -633,7 +633,7 @@
           "images": [
             {
               "image": "jaeger-es-rollover",
-              "tag": "1.34.1-20221208173501-7da07ddc",
+              "tag": "1.34.1-20230531065745-7da07ddc",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]
@@ -644,7 +644,7 @@
           "images": [
             {
               "image": "jaeger-all-in-one",
-              "tag": "1.34.1-20221208173501-7da07ddc",
+              "tag": "1.34.1-20230531065745-7da07ddc",
               "helmFullImageKey": "jaegerAllInOneImage"
             }
           ]
@@ -661,18 +661,18 @@
           "images": [
             {
               "image": "velero",
-              "tag": "v1.9.1-20220928065349-147272cf",
+              "tag": "v1.9.1-20230524144448-edba946d",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "velero-plugin-for-aws",
-              "tag": "v1.5.0-20220924005304-4a142d0a",
+              "tag": "v1.5.0-20230524144106-9b26984f",
               "helmFullImageKey": "initContainers[0].image"
             },
             {
               "image": "velero-restic-restore-helper",
-              "tag": "v1.9.1-20230119225818-edba946d",
+              "tag": "v1.9.1-20230524144448-edba946d",
               "helmFullImageKey": "configMaps.restic-restore-action-config.data.image"
             }
           ]
@@ -689,7 +689,7 @@
           "images": [
             {
               "image": "backup-restore-operator",
-              "tag": "v2.1.3-20220827005326-bc2c3c4",
+              "tag": "v2.1.3-20230530115740-0977be7",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/tests/testdata/jaeger/hotrod/hotrod-tracing-comp.yaml
+++ b/tests/testdata/jaeger/hotrod/hotrod-tracing-comp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: hotrod-container
-          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.34.1-20220819074556-e69d6b9b"
+          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.34.1-20230531065745-7da07ddc"
           env:
             - name: JAEGER_AGENT_HOST
               value: "localhost"

--- a/tests/testdata/jaeger/hotrod/multicluster/hotrod-tracing-comp.yaml
+++ b/tests/testdata/jaeger/hotrod/multicluster/hotrod-tracing-comp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: hotrod-container
-          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.34.1-20220819074556-e69d6b9b"
+          image: "ghcr.io/verrazzano/jaeger-example-hotrod:1.34.1-20230531065745-7da07ddc"
           env:
             - name: JAEGER_AGENT_HOST
               value: "localhost"


### PR DESCRIPTION
This change refreshes component images in release-1.4. In some cases, there are issues in the build pipelines to build the components with the same commit, so those components are built with the latest commit after going through the list of changes.
