### PR TITLE
Make cluster issuer namespace configurable in a-la-carte pipeline

### DIFF
--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -263,6 +263,7 @@ pipeline {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
+                CLUSTER_RESOURCE_NAMESPACE = "${params.CLUSTER_RESOURCE_NAMESPACE}"
             }
             steps {
                 sh """

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -28,14 +28,18 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "1.25", "1.24", "1.23", "1.22" ])
         string (name: 'GIT_COMMIT_TO_USE',
-                        defaultValue: 'NONE',
-                        description: 'This is the full git commit hash from the source build to be used for all jobs',
-                        trim: true)
+                defaultValue: 'NONE',
+                description: 'This is the full git commit hash from the source build to be used for all jobs',
+                trim: true)
         string (name: 'VERRAZZANO_OPERATOR_IMAGE',
-                        defaultValue: 'NONE',
-                        description: 'Verrazzano platform operator image name (in ghcr.io repo).  If not specified, the operator.yaml from Verrazzano repo will be used to create Verrazzano platform operator',
+                defaultValue: 'NONE',
+                description: 'Verrazzano platform operator image name (in ghcr.io repo).  If not specified, the operator.yaml from Verrazzano repo will be used to create Verrazzano platform operator',
                 trim: true)
         booleanParam (description: 'Whether to capture full cluster snapshot on test failure', name: 'CAPTURE_FULL_CLUSTER', defaultValue: false)
+        string (name: 'CLUSTER_RESOURCE_NAMESPACE',
+                defaultValue: 'my-cert-manager',
+                description: 'The name of the namespace to install the cluster issuer into',
+                trim: true)
     }
 
     environment {
@@ -211,7 +215,7 @@ pipeline {
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
             }
             steps {
-                runGinkgoUpdate('update/a-la-carte', 'prom-edge-stack')
+                runGinkgoUpdate('update/a-la-carte', 'prom-edge-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")
             }
 
             post {
@@ -266,7 +270,7 @@ pipeline {
                     ci/scripts/install_third_party_components.sh
                 """
 
-                runGinkgoUpdate('update/a-la-carte', 'app-stack')
+                runGinkgoUpdate('update/a-la-carte', 'app-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")
             }
 
             post {
@@ -323,7 +327,7 @@ pipeline {
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
             }
             steps {
-                runGinkgoUpdate('update/a-la-carte', 'istio-app-stack')
+                runGinkgoUpdate('update/a-la-carte', 'istio-app-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")
             }
 
             post {
@@ -388,7 +392,7 @@ pipeline {
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
             }
             steps {
-                runGinkgoUpdate('update/a-la-carte', 'cluster-management-stack')
+                runGinkgoUpdate('update/a-la-carte', 'cluster-management-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")
             }
 
             post {
@@ -445,7 +449,7 @@ pipeline {
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
             }
             steps {
-                runGinkgoUpdate('update/a-la-carte', 'none-profile')
+                runGinkgoUpdate('update/a-la-carte', 'none-profile', "${params.CLUSTER_RESOURCE_NAMESPACE}")
             }
 
             post {
@@ -687,12 +691,12 @@ def runGinkgo(testSuitePath) {
     }
 }
 
-def runGinkgoUpdate(testSuitePath, updateTypeVal = '') {
+def runGinkgoUpdate(testSuitePath, updateTypeVal = '', clusterResourceNamespace = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             if [ -d "${testSuitePath}" ]; then
-                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file=".*" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --updateType="${updateTypeVal}"
+                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file=".*" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --updateType="${updateTypeVal}" --clusterResourceNamespace=""${clusterResourceNamespace}""
             fi
         """
     }

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
         booleanParam (description: 'Whether to capture full cluster snapshot on test failure', name: 'CAPTURE_FULL_CLUSTER', defaultValue: false)
         string (name: 'CLUSTER_RESOURCE_NAMESPACE',
                 defaultValue: 'my-cert-manager',
-                description: 'The name of the namespace to install the cluster issuer into',
+                description: 'The namespace for cluster-scoped Cert-Manager resources; defaults to where Cert-Manager is installed.',
                 trim: true)
     }
 

--- a/ci/scripts/install_third_party_components.sh
+++ b/ci/scripts/install_third_party_components.sh
@@ -8,7 +8,6 @@ echo "Installing cert-manager via helm chart"
 echo "Setting clusterResourceNamespace to ${CLUSTER_RESOURCE_NAMESPACE}"
 
 kubectl create ns my-cert-manager
-kubectl apply -f platform-operator/thirdparty/manifests/cert-manager
 
 controllerTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="cert-manager")' | jq '.subcomponents[0].images[] | select(.image=="cert-manager-controller")' | jq .tag -r)
 cainjectorTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="cert-manager")' | jq '.subcomponents[0].images[] | select(.image=="cert-manager-cainjector")' | jq .tag -r)
@@ -17,7 +16,8 @@ helm upgrade cert-manager -n my-cert-manager platform-operator/thirdparty/charts
 --set image.repository=ghcr.io/verrazzano/cert-manager-controller --set image.tag=${controllerTag}  \
 --set cainjector.image.repository=ghcr.io/verrazzano/cert-manager-cainjector --set cainjector.image.tag=${cainjectorTag}  \
 --set webhook.image.repository=ghcr.io/verrazzano/cert-manager-webhook --set webhook.image.tag=${webhookTag} \
---set startupapicheck.enabled=false --set clusterResourceNamespace=${CLUSTER_RESOURCE_NAMESPACE} --install
+--set startupapicheck.enabled=false --set clusterResourceNamespace=${CLUSTER_RESOURCE_NAMESPACE} \
+--set installCRDs=true --install
 
 echo "ensure cert-manager using ghcr.io images"
 if [ ! -z "$(kubectl get po -n my-cert-manager -o yaml | grep quay.io)" ]

--- a/ci/scripts/install_third_party_components.sh
+++ b/ci/scripts/install_third_party_components.sh
@@ -5,6 +5,7 @@
 #
 
 echo "Installing cert-manager via helm chart"
+echo "Setting clusterResourceNamespace to ${CLUSTER_RESOURCE_NAMESPACE}"
 
 kubectl create ns my-cert-manager
 kubectl apply -f platform-operator/thirdparty/manifests/cert-manager
@@ -16,7 +17,7 @@ helm upgrade cert-manager -n my-cert-manager platform-operator/thirdparty/charts
 --set image.repository=ghcr.io/verrazzano/cert-manager-controller --set image.tag=${controllerTag}  \
 --set cainjector.image.repository=ghcr.io/verrazzano/cert-manager-cainjector --set cainjector.image.tag=${cainjectorTag}  \
 --set webhook.image.repository=ghcr.io/verrazzano/cert-manager-webhook --set webhook.image.tag=${webhookTag} \
---set startupapicheck.enabled=false --install
+--set startupapicheck.enabled=false --set clusterResourceNamespace=${CLUSTER_RESOURCE_NAMESPACE} --install
 
 echo "ensure cert-manager using ghcr.io images"
 if [ ! -z "$(kubectl get po -n my-cert-manager -o yaml | grep quay.io)" ]

--- a/ci/scripts/install_third_party_components.sh
+++ b/ci/scripts/install_third_party_components.sh
@@ -6,26 +6,26 @@
 
 echo "Installing cert-manager via helm chart"
 
-kubectl create ns cert-manager
+kubectl create ns my-cert-manager
 kubectl apply -f platform-operator/thirdparty/manifests/cert-manager
 
 controllerTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="cert-manager")' | jq '.subcomponents[0].images[] | select(.image=="cert-manager-controller")' | jq .tag -r)
 cainjectorTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="cert-manager")' | jq '.subcomponents[0].images[] | select(.image=="cert-manager-cainjector")' | jq .tag -r)
 webhookTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="cert-manager")' | jq '.subcomponents[0].images[] | select(.image=="cert-manager-webhook")' | jq .tag -r)
-helm upgrade cert-manager -n cert-manager platform-operator/thirdparty/charts/cert-manager \
+helm upgrade cert-manager -n my-cert-manager platform-operator/thirdparty/charts/cert-manager \
 --set image.repository=ghcr.io/verrazzano/cert-manager-controller --set image.tag=${controllerTag}  \
 --set cainjector.image.repository=ghcr.io/verrazzano/cert-manager-cainjector --set cainjector.image.tag=${cainjectorTag}  \
 --set webhook.image.repository=ghcr.io/verrazzano/cert-manager-webhook --set webhook.image.tag=${webhookTag} \
 --set startupapicheck.enabled=false --install
 
 echo "ensure cert-manager using ghcr.io images"
-if [ ! -z "$(kubectl get po -n cert-manager -o yaml | grep quay.io)" ]
+if [ ! -z "$(kubectl get po -n my-cert-manager -o yaml | grep quay.io)" ]
 then
-  kubectl get po -n cert-manager -o yaml | grep quay.io
+  kubectl get po -n my-cert-manager -o yaml | grep quay.io
   exit 1
 fi
 
-kubectl get pods -n cert-manager
+kubectl get pods -n my-cert-manager
 
 echo "Installing ingress-nginx via helm chart"
 

--- a/ci/scripts/install_third_party_components.sh
+++ b/ci/scripts/install_third_party_components.sh
@@ -5,9 +5,13 @@
 #
 
 echo "Installing cert-manager via helm chart"
-echo "Setting clusterResourceNamespace to ${CLUSTER_RESOURCE_NAMESPACE}"
+echo "Setting clusterResourceNamespace to $CLUSTER_RESOURCE_NAMESPACE"
 
 kubectl create ns my-cert-manager
+if [ $CLUSTER_RESOURCE_NAMESPACE != my-cert-manager ]
+then
+  kubectl create ns $CLUSTER_RESOURCE_NAMESPACE
+fi
 
 controllerTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="cert-manager")' | jq '.subcomponents[0].images[] | select(.image=="cert-manager-controller")' | jq .tag -r)
 cainjectorTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="cert-manager")' | jq '.subcomponents[0].images[] | select(.image=="cert-manager-cainjector")' | jq .tag -r)

--- a/tests/e2e/update/a-la-carte/a_la_carte_suite_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_suite_test.go
@@ -12,9 +12,12 @@ import (
 )
 
 var updateType string
+var clusterResourceNamespace string
 
 func init() {
 	flag.StringVar(&updateType, "updateType", "", "updateType is the type of update to perform")
+	flag.StringVar(&clusterResourceNamespace, "clusterResourceNamespace", "my-cert-manager", "the cluster issuer namespace")
+
 }
 func TestALaCarte(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -70,7 +70,6 @@ func (m appStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
 
 	cr.Spec.Components.ApplicationOperator = &vzapi.ApplicationOperatorComponent{Enabled: &trueVal}
 	cr.Spec.Components.AuthProxy = &vzapi.AuthProxyComponent{Enabled: &trueVal}
-	cr.Spec.Components.CertManager = &vzapi.CertManagerComponent{Enabled: &falseVal}
 	cr.Spec.Components.ClusterIssuer = &vzapi.ClusterIssuerComponent{Enabled: &trueVal}
 	cr.Spec.Components.Fluentd = &vzapi.FluentdComponent{Enabled: &trueVal}
 	cr.Spec.Components.Grafana = &vzapi.GrafanaComponent{Enabled: &trueVal}
@@ -82,6 +81,11 @@ func (m appStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
 	cr.Spec.Components.OAM = &vzapi.OAMComponent{Enabled: &trueVal}
 	cr.Spec.Components.Verrazzano = &vzapi.VerrazzanoComponent{Enabled: &trueVal}
 	cr.Spec.Components.JaegerOperator = &vzapi.JaegerOperatorComponent{Enabled: &trueVal}
+
+	cr.Spec.Components.CertManager = &vzapi.CertManagerComponent{Enabled: &falseVal}
+	cr.Spec.Components.ClusterIssuer = &vzapi.ClusterIssuerComponent{
+		ClusterResourceNamespace: clusterResourceNamespace,
+	}
 }
 
 func (m istioAppStackModifier) ModifyCR(cr *vzapi.Verrazzano) {


### PR DESCRIPTION
This change makes the cluster issuer namespace configurable in the a-la-carte pipeline, but defaults it to my-cert-manager. It also changes the namespace for the third party cert-manager to my-cert-manager.