### PR TITLE
VZ-8933 Verify rootCA update works for ArgoCD (#6135)

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -455,6 +455,11 @@ pipeline {
                         runGinkgoRandomize('verify-install')
                     }
                 }
+                stage('verify-argocd') {
+                                    steps {
+                                        runGinkgo('multicluster/verify-argocd', '${TEST_DUMP_ROOT}/verify-argocd')
+                                    }
+                                }
                 stage('verify-rancher') {
                     steps {
                         runGinkgo('multicluster/verify-rancher', '${TEST_DUMP_ROOT}/verify-rancher')


### PR DESCRIPTION
This PR moves the `verify-argocd` stage to after we update the DNS zone and rootCA cert on the managed cluster. This makes sure that our multicluster tests support ArgoCD after certs have been updated.