### PR TITLE
VZ-9939: Update backup restore operator image in BOM

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -684,11 +684,11 @@
       "version": "2.1.3",
       "subcomponents": [
         {
-          "repository": "verrazzano/rancher",
+          "repository": "verrazzano",
           "name": "rancher-backup",
           "images": [
             {
-              "image": "backup-restore-operator",
+              "image": "rancher-backup-restore-operator",
               "tag": "v2.1.3-20230530115740-0977be7",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"

--- a/tests/testdata/grafana/grafana-mysql.yaml
+++ b/tests/testdata/grafana/grafana-mysql.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: v1
@@ -82,7 +82,7 @@ spec:
               name: data
       containers:
         - name: mysql
-          image: "ghcr.io/verrazzano/mysql:8.0.29"
+          image: "ghcr.io/verrazzano/community-server:8.0.33"
           imagePullPolicy: "IfNotPresent"
           resources:
             requests:


### PR DESCRIPTION
This change updates BOM with the correct image name for backup-restore-operator.