### PR TITLE
VZ-9889.  Updated validators for customer-managed Cert-Manager

### DIFF
--- a/platform-operator/controllers/verrazzano/component/argocd/argocd_component.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/argocd_component.go
@@ -5,6 +5,7 @@ package argocd
 
 import (
 	"fmt"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
@@ -13,7 +14,6 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
@@ -61,7 +61,7 @@ func NewComponent() spi.Component {
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "argocd-values.yaml"),
 			AppendOverridesFunc:       AppendOverrides,
 			Certificates:              certificates,
-			Dependencies:              []string{networkpolicies.ComponentName, istio.ComponentName, nginx.ComponentName, cmcommon.CertManagerComponentName, keycloak.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, istio.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName, keycloak.ComponentName},
 			AvailabilityObjects: &ready.AvailabilityObjects{
 				DeploymentNames: []types.NamespacedName{
 					{

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager_component.go
@@ -6,6 +6,7 @@ package certmanager
 import (
 	"context"
 	"fmt"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"path/filepath"
 
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
@@ -15,7 +16,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
@@ -30,13 +30,13 @@ import (
 )
 
 // ComponentName is the name of the component
-const ComponentName = cmcommon.CertManagerComponentName
+const ComponentName = cmconstants.CertManagerComponentName
 
 // ComponentNamespace is the namespace of the component
 const ComponentNamespace = vzconst.CertManagerNamespace
 
 // ComponentJSONName is the JSON name of the verrazzano component in CRD
-const ComponentJSONName = cmcommon.CertManagerComponentJSONName
+const ComponentJSONName = cmconstants.CertManagerComponentJSONName
 
 // ExternalDNSComponentJSONName is the JSON name of the verrazzano component in CRD
 //const ExternalDNSComponentJSONName = cmcommon.ExternalDNSComponentJSONName

--- a/platform-operator/controllers/verrazzano/component/certmanager/common/acme_utils.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/common/acme_utils.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"strings"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -24,7 +25,7 @@ func IsLetsEncryptProductionEnv(acme interface{}) bool {
 	if v1beta1ACME, ok := acme.(v1beta1.Acme); ok {
 		envName = v1beta1ACME.Environment
 	}
-	return strings.ToLower(envName) == LetsEncryptProduction
+	return strings.ToLower(envName) == cmconstants.LetsEncryptProduction
 }
 
 func IsLetsEncryptStagingEnv(acme interface{}) bool {
@@ -41,7 +42,7 @@ func IsLetsEncryptStagingEnv(acme interface{}) bool {
 	if v1beta1ACME, ok := acme.(v1beta1.Acme); ok {
 		envName = v1beta1ACME.Environment
 	}
-	return strings.ToLower(envName) == LetsEncryptStaging
+	return strings.ToLower(envName) == cmconstants.LetsEncryptStaging
 }
 
 func IsLetsEncryptProvider(acme interface{}) bool {

--- a/platform-operator/controllers/verrazzano/component/certmanager/common/acme_utils_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/common/acme_utils_test.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,14 +17,14 @@ import (
 // WHEN an LetsEncrypt configuration is passed in
 // THEN the function returns true if the LetsEncrypt environment is for the LE production env
 func TestIsLetsEncryptProductionEnv(t *testing.T) {
-	assert.True(t, IsLetsEncryptProductionEnv(v1alpha1.LetsEncryptACMEIssuer{Environment: LetsEncryptProduction}))
-	assert.False(t, IsLetsEncryptProductionEnv(v1alpha1.LetsEncryptACMEIssuer{Environment: LetsEncryptStaging}))
-	assert.True(t, IsLetsEncryptProductionEnv(v1beta1.LetsEncryptACMEIssuer{Environment: LetsEncryptProduction}))
-	assert.False(t, IsLetsEncryptProductionEnv(v1beta1.LetsEncryptACMEIssuer{Environment: LetsEncryptStaging}))
-	assert.True(t, IsLetsEncryptProductionEnv(v1alpha1.Acme{Environment: LetsEncryptProduction}))
-	assert.False(t, IsLetsEncryptProductionEnv(v1alpha1.Acme{Environment: LetsEncryptStaging}))
-	assert.True(t, IsLetsEncryptProductionEnv(v1beta1.Acme{Environment: LetsEncryptProduction}))
-	assert.False(t, IsLetsEncryptProductionEnv(v1beta1.Acme{Environment: LetsEncryptStaging}))
+	assert.True(t, IsLetsEncryptProductionEnv(v1alpha1.LetsEncryptACMEIssuer{Environment: cmconstants.LetsEncryptProduction}))
+	assert.False(t, IsLetsEncryptProductionEnv(v1alpha1.LetsEncryptACMEIssuer{Environment: cmconstants.LetsEncryptStaging}))
+	assert.True(t, IsLetsEncryptProductionEnv(v1beta1.LetsEncryptACMEIssuer{Environment: cmconstants.LetsEncryptProduction}))
+	assert.False(t, IsLetsEncryptProductionEnv(v1beta1.LetsEncryptACMEIssuer{Environment: cmconstants.LetsEncryptStaging}))
+	assert.True(t, IsLetsEncryptProductionEnv(v1alpha1.Acme{Environment: cmconstants.LetsEncryptProduction}))
+	assert.False(t, IsLetsEncryptProductionEnv(v1alpha1.Acme{Environment: cmconstants.LetsEncryptStaging}))
+	assert.True(t, IsLetsEncryptProductionEnv(v1beta1.Acme{Environment: cmconstants.LetsEncryptProduction}))
+	assert.False(t, IsLetsEncryptProductionEnv(v1beta1.Acme{Environment: cmconstants.LetsEncryptStaging}))
 }
 
 // TestIsLetsEncryptStagingEnv tests the IsLetsEncryptStagingEnv functions
@@ -33,12 +34,12 @@ func TestIsLetsEncryptProductionEnv(t *testing.T) {
 func TestIsLetsEncryptStagingEnv(t *testing.T) {
 	assert.True(t, IsLetsEncryptStagingEnv(
 		v1alpha1.LetsEncryptACMEIssuer{
-			Environment: LetsEncryptStaging,
+			Environment: cmconstants.LetsEncryptStaging,
 		},
 	))
 	assert.False(t, IsLetsEncryptStagingEnv(
 		v1alpha1.LetsEncryptACMEIssuer{
-			Environment: LetsEncryptProduction,
+			Environment: cmconstants.LetsEncryptProduction,
 		},
 	))
 	assert.False(t, IsLetsEncryptStagingEnv(
@@ -53,12 +54,12 @@ func TestIsLetsEncryptStagingEnv(t *testing.T) {
 	))
 	assert.True(t, IsLetsEncryptStagingEnv(
 		v1alpha1.Acme{
-			Environment: LetsEncryptStaging,
+			Environment: cmconstants.LetsEncryptStaging,
 		},
 	))
 	assert.False(t, IsLetsEncryptStagingEnv(
 		v1alpha1.Acme{
-			Environment: LetsEncryptProduction,
+			Environment: cmconstants.LetsEncryptProduction,
 		},
 	))
 	assert.False(t, IsLetsEncryptStagingEnv(

--- a/platform-operator/controllers/verrazzano/component/certmanager/common/config_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/common/config_test.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"testing"
 
 	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -39,7 +40,7 @@ var defaultCA = vzapi.CA{
 var acmeTestConfig = vzapi.Acme{
 	Provider:     vzapi.LetsEncrypt,
 	EmailAddress: "testEmail@foo.com",
-	Environment:  LetsEncryptStaging,
+	Environment:  cmconstants.LetsEncryptStaging,
 }
 
 // Default Verrazzano object

--- a/platform-operator/controllers/verrazzano/component/certmanager/common/crdchecks.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/common/crdchecks.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package common
+
+import (
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
+)
+
+var certManagerCRDNames = []string{
+	"certificaterequests.cert-manager.io",
+	"orders.acme.cert-manager.io",
+	"certificates.cert-manager.io",
+	"clusterissuers.cert-manager.io",
+	"issuers.cert-manager.io",
+}
+
+// GetRequiredCertManagerCRDNames returns a list of required/expected Cert-Manager CRDs
+func GetRequiredCertManagerCRDNames() []string {
+	return certManagerCRDNames
+}
+
+// CertManagerCRDsExist returns true if the Cert-Manager CRDs exist in the cluster, false otherwise
+func CertManagerCRDsExist() (bool, error) {
+	crdsExist, err := common.CheckCRDsExist(GetRequiredCertManagerCRDNames())
+	if err != nil {
+		return false, err
+	}
+	// Found required CRDs
+	return crdsExist, nil
+}

--- a/platform-operator/controllers/verrazzano/component/certmanager/common/crdchecks_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/common/crdchecks_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package common
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+// TestGetRequiredCertManagerCRDNames tests the GetRequiredCertManagerCRDNames function
+// GIVEN a call to GetRequiredCertManagerCRDNames
+// THEN the correct number of strings are returned
+func TestGetRequiredCertManagerCRDNames(t *testing.T) {
+	crdNames := GetRequiredCertManagerCRDNames()
+	assert.Len(t, crdNames, 5)
+}
+
+// TestCertManagerCrdsExist tests the CertManagerCRDsExist function
+// GIVEN a call to CertManagerCRDsExist
+// THEN false is returned if the CRDs do not exist, true otherwise
+func TestCertManagerCrdsExist(t *testing.T) {
+	asserts := assert.New(t)
+
+	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
+	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1.ApiextensionsV1Interface, error) {
+		return nil, fmt.Errorf("unexpected error")
+	}
+
+	crdsExist, err := CertManagerCRDsExist()
+	asserts.False(crdsExist)
+	asserts.Error(err)
+
+	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1.ApiextensionsV1Interface, error) {
+		return apiextv1fake.NewSimpleClientset().ApiextensionsV1(), nil
+	}
+
+	crdsExist, err = CertManagerCRDsExist()
+	asserts.False(crdsExist)
+	asserts.NoError(err)
+
+	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1.ApiextensionsV1Interface, error) {
+		return apiextv1fake.NewSimpleClientset(createCertManagerCRDs()...).ApiextensionsV1(), nil
+	}
+
+	crdsExist, err = CertManagerCRDsExist()
+	asserts.True(crdsExist)
+	asserts.NoError(err)
+}
+
+func createCertManagerCRDs() []runtime.Object {
+	var runtimeObjs []runtime.Object
+	for _, crd := range GetRequiredCertManagerCRDNames() {
+		runtimeObjs = append(runtimeObjs, newCRD(crd))
+	}
+	return runtimeObjs
+}
+
+func newCRD(name string) clipkg.Object {
+	crd := &v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	return crd
+}

--- a/platform-operator/controllers/verrazzano/component/certmanager/constants/constants.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/constants/constants.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-package common
+package constants
 
 const (
 	// ClusterIssuerComponentName is the name of the CertManager config component
@@ -12,6 +12,9 @@ const (
 
 	// CertManagerComponentJSONName is the JSON name of the verrazzano component in CRD
 	CertManagerComponentJSONName = "certManager"
+
+	// ClusterIssuerComponentJSONName - this is not a real component but declare it for compatibility
+	ClusterIssuerComponentJSONName = "clusterIssuer"
 
 	// CertManagerWebhookOCIComponentName is the name of the OCI DNS webhook component
 	CertManagerWebhookOCIComponentName = "cert-manager-webhook-oci"

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component.go
@@ -9,7 +9,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -18,13 +18,13 @@ import (
 )
 
 // ComponentName is the name of the component
-const ComponentName = cmcommon.ClusterIssuerComponentName
+const ComponentName = cmconstants.ClusterIssuerComponentName
 
 // ComponentNamespace is the namespace of the component
 const ComponentNamespace = vzconst.CertManagerNamespace
 
 // ComponentJSONName - this is not a real component but declare it for compatibility
-const ComponentJSONName = "clusterIssuer"
+const ComponentJSONName = cmconstants.ClusterIssuerComponentJSONName
 
 // clusterIssuerComponent represents an CertManager component
 type clusterIssuerComponent struct{}
@@ -187,7 +187,7 @@ func (c clusterIssuerComponent) ShouldInstallBeforeUpgrade() bool {
 }
 
 func (c clusterIssuerComponent) GetDependencies() []string {
-	return []string{networkpolicies.ComponentName, cmcommon.CertManagerComponentName}
+	return []string{networkpolicies.ComponentName, cmconstants.CertManagerComponentName}
 }
 
 func (c clusterIssuerComponent) IsAvailable(context spi.ComponentContext) (string, v1alpha1.ComponentAvailability) {

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component_test.go
@@ -653,28 +653,3 @@ func createCertSecretNoParent(name string, namespace string, cn string) (*corev1
 	}
 	return secret, nil
 }
-
-//func crtObjectToRuntimeObject(objs ...clipkg.Object) []runtime.Object {
-//	var runtimeObjs []runtime.Object
-//	for _, obj := range objs {
-//		runtimeObjs = append(runtimeObjs, obj)
-//	}
-//	return runtimeObjs
-//}
-//
-//func createCertManagerCRDs() []clipkg.Object {
-//	var cmCRDs []clipkg.Object
-//	for _, crd := range cmcommon.GetRequiredCertManagerCRDNames() {
-//		cmCRDs = append(cmCRDs, newCRD(crd))
-//	}
-//	return cmCRDs
-//}
-//
-//func newCRD(name string) clipkg.Object {
-//	crd := &apiextv1.CustomResourceDefinition{
-//		ObjectMeta: metav1.ObjectMeta{
-//			Name: name,
-//		},
-//	}
-//	return crd
-//}

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component_test.go
@@ -5,6 +5,7 @@ package issuer
 
 import (
 	"context"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"testing"
 
 	cmutil "github.com/cert-manager/cert-manager/pkg/api/util"
@@ -49,7 +50,7 @@ func TestSimpleMethods(t *testing.T) {
 	asserts.Equal(ComponentNamespace, c.Namespace())
 	asserts.Equal(ComponentJSONName, c.GetJSONName())
 	asserts.False(c.ShouldInstallBeforeUpgrade())
-	asserts.ElementsMatch([]string{networkpolicies.ComponentName, cmcommon.CertManagerComponentName}, c.GetDependencies())
+	asserts.ElementsMatch([]string{networkpolicies.ComponentName, cmconstants.CertManagerComponentName}, c.GetDependencies())
 	asserts.Equal(constants.VerrazzanoVersion1_0_0, c.GetMinVerrazzanoVersion())
 	asserts.ElementsMatch([]types.NamespacedName{}, c.GetIngressNames(nil))
 	asserts.ElementsMatch([]types.NamespacedName{}, c.GetCertificateNames(nil))

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	apiextv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -91,7 +91,7 @@ func runIsInstalledTest(t *testing.T, expectInstalled bool, expectErr bool, objs
 	}
 	client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(clientObjs...).Build()
 	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
-	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1.ApiextensionsV1Interface, error) {
+	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
 		return apiextv1fake.NewSimpleClientset().ApiextensionsV1(), nil
 	}
 
@@ -142,7 +142,7 @@ func runIsReadyTest(t *testing.T, expectedReady bool, objs ...clipkg.Object) {
 	}
 	client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(clientObjs...).Build()
 	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
-	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1.ApiextensionsV1Interface, error) {
+	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
 		return apiextv1fake.NewSimpleClientset().ApiextensionsV1(), nil
 	}
 
@@ -156,24 +156,6 @@ func runIsReadyTest(t *testing.T, expectedReady bool, objs ...clipkg.Object) {
 		_, availability := fakeComponent.IsAvailable(fakeContext)
 		assert.Equal(t, vzapi.ComponentAvailability(vzapi.ComponentUnavailable), availability)
 	}
-}
-
-// TestValidateInstall tests the ValidateInstall function
-// GIVEN a call to ValidateInstall
-//
-//	WHEN for various Issuer configurations
-//	THEN an error is returned if anything is misconfigured
-func TestValidateInstall(t *testing.T) {
-	validationTests(t, false)
-}
-
-// TestValidateUpdate tests the ValidateInstall function
-// GIVEN a call to ValidateInstall
-//
-//	WHEN for various Issuer configurations
-//	THEN an error is returned if anything is misconfigured
-func TestValidateUpdate(t *testing.T) {
-	validationTests(t, true)
 }
 
 // TestPostInstallCA tests the PostInstall function
@@ -600,7 +582,7 @@ func runUninstallTest(t *testing.T, objs ...clipkg.Object) {
 	client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objs...).Build()
 
 	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
-	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1.ApiextensionsV1Interface, error) {
+	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
 		return apiextv1fake.NewSimpleClientset().ApiextensionsV1(), nil
 	}
 
@@ -670,3 +652,28 @@ func createCertSecretNoParent(name string, namespace string, cn string) (*corev1
 	}
 	return secret, nil
 }
+
+//func crtObjectToRuntimeObject(objs ...clipkg.Object) []runtime.Object {
+//	var runtimeObjs []runtime.Object
+//	for _, obj := range objs {
+//		runtimeObjs = append(runtimeObjs, obj)
+//	}
+//	return runtimeObjs
+//}
+//
+//func createCertManagerCRDs() []clipkg.Object {
+//	var cmCRDs []clipkg.Object
+//	for _, crd := range cmcommon.GetRequiredCertManagerCRDNames() {
+//		cmCRDs = append(cmCRDs, newCRD(crd))
+//	}
+//	return cmCRDs
+//}
+//
+//func newCRD(name string) clipkg.Object {
+//	crd := &apiextv1.CustomResourceDefinition{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Name: name,
+//		},
+//	}
+//	return crd
+//}

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/validate_issuer.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/validate_issuer.go
@@ -88,7 +88,7 @@ func getDNSSuffix(effectiveCR runtime.Object) (string, bool) {
 // - Validates the CA or LetsEncrypt configurations if necessary
 // - returns an error if anything is misconfigured
 func validateConfiguration(vz *v1beta1.Verrazzano) (err error) {
-	if err := validateComponentConfigurationV1Beta1(vz); err != nil {
+	if err := validateCertificate(vz.Spec.Components.CertManager); err != nil {
 		return err
 	}
 	return validateIssuerConfig(vz.Spec.Components.ClusterIssuer)
@@ -159,30 +159,6 @@ func validateCertManagerTypesExist() error {
 		return fmt.Errorf("%s component is enabled but could not detect the presence of Cert-Manager", ComponentJSONName)
 	}
 	return nil
-}
-
-// validateComponentConfigurationV1Beta1 validates that only one of either the ClusterIssuerComponent or the
-// CertManager.Certificate field can be configured with non-defaults at the same time.
-func validateComponentConfigurationV1Beta1(vz *v1beta1.Verrazzano) error {
-
-	//certManagerComp := vz.Spec.Components.CertManager
-	//clusterIssuerComp := vz.Spec.Components.ClusterIssuer
-
-	// NOTE: Disable this for now, since we can't distinguish between a user edit and the merged profile settings;
-	// we may have to do this validation in the ComponentValidatorImpl before the EffectiveCR is generated
-	//
-	// We only allow configuring either the deprecated CertManager Certificate field, or the ClusterIssuerComponent
-	//if certManagerComp != nil && clusterIssuerComp != nil {
-	//	isDefaultIssuer, err := clusterIssuerComp.IsDefaultIssuer()
-	//	if err != nil {
-	//		return err
-	//	}
-	//	if !isDefaultIssuer && !isDefaultCertificateConfiguration(certManagerComp.Certificate) {
-	//		return fmt.Errorf("Can not simultaneously configure both the CertManager and ClusterIssuer components")
-	//	}
-	//}
-
-	return validateCertificate(vz.Spec.Components.CertManager)
 }
 
 func validateCertificate(comp *v1beta1.CertManagerComponent) error {

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/validate_issuer_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/validate_issuer_test.go
@@ -205,46 +205,46 @@ var simpleValidationTests = []validationTestStruct{
 		wantErr:     false,
 		crdsPresent: false,
 	},
-	//{
-	//	name: "CertManager and ClusterIssuer both explicitly configured",
-	//	old:  &vzapi.Verrazzano{},
-	//	new: &vzapi.Verrazzano{
-	//		Spec: vzapi.VerrazzanoSpec{
-	//			Components: vzapi.ComponentSpec{
-	//				CertManager: &vzapi.CertManagerComponent{
-	//					Enabled: getBoolPtr(false),
-	//					Certificate: vzapi.Certificate{
-	//						CA: vzapi.CA{
-	//							ClusterResourceNamespace: secretNamespace,
-	//							SecretName:               secretName,
-	//						},
-	//					},
-	//				},
-	//				ClusterIssuer: &vzapi.ClusterIssuerComponent{
-	//					IssuerConfig: vzapi.IssuerConfig{
-	//						LetsEncrypt: &vzapi.LetsEncryptACMEIssuer{
-	//							EmailAddress: emailAddress,
-	//							Environment:  letsEncryptStaging,
-	//						},
-	//					},
-	//				},
-	//				DNS: &vzapi.DNSComponent{
-	//					OCI: &vzapi.OCI{
-	//						DNSScope:               "GLOBAL",
-	//						DNSZoneCompartmentOCID: "ocid",
-	//						DNSZoneOCID:            "zoneOcid",
-	//						DNSZoneName:            "zoneName",
-	//						OCIConfigSecret:        "oci",
-	//					},
-	//				},
-	//			},
-	//		},
-	//	},
-	//	caSecret: &corev1.Secret{
-	//		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: secretNamespace},
-	//	},
-	//	wantErr: true,
-	//},
+	{
+		name: "CertManager and ClusterIssuer both explicitly configured",
+		old:  &vzapi.Verrazzano{},
+		new: &vzapi.Verrazzano{
+			Spec: vzapi.VerrazzanoSpec{
+				Components: vzapi.ComponentSpec{
+					CertManager: &vzapi.CertManagerComponent{
+						Enabled: getBoolPtr(false),
+						Certificate: vzapi.Certificate{
+							CA: vzapi.CA{
+								ClusterResourceNamespace: secretNamespace,
+								SecretName:               secretName,
+							},
+						},
+					},
+					ClusterIssuer: &vzapi.ClusterIssuerComponent{
+						IssuerConfig: vzapi.IssuerConfig{
+							LetsEncrypt: &vzapi.LetsEncryptACMEIssuer{
+								EmailAddress: emailAddress,
+								Environment:  letsEncryptStaging,
+							},
+						},
+					},
+					DNS: &vzapi.DNSComponent{
+						OCI: &vzapi.OCI{
+							DNSScope:               "GLOBAL",
+							DNSZoneCompartmentOCID: "ocid",
+							DNSZoneOCID:            "zoneOcid",
+							DNSZoneName:            "zoneName",
+							OCIConfigSecret:        "oci",
+						},
+					},
+				},
+			},
+		},
+		caSecret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: secretNamespace},
+		},
+		wantErr: true,
+	},
 	{
 		name: "CertManager Component Custom CA",
 		old:  &vzapi.Verrazzano{},

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/validate_issuer_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/validate_issuer_test.go
@@ -4,6 +4,8 @@
 package issuer
 
 import (
+	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +30,72 @@ const emailAddress = "joeblow@foo.com"
 const secretName = "newsecret"
 const secretNamespace = "ns"
 
+// TestValidateClusterResourceNamespace tests the checkClusterResourceNamespaceExists function
+// GIVEN a call to checkClusterResourceNamespaceExists
+//
+//	THEN an error is returned if the clusterResourceNamespace doesn't exist, or an unxpected client error occurs
+func TestValidateClusterResourceNamespace(t *testing.T) {
+	defer cmcommon.ResetCoreV1ClientFunc()
+
+	namespace := "myns"
+	issuerConfig := v1beta1.ClusterIssuerComponent{ClusterResourceNamespace: namespace}
+
+	assert.Error(t, checkClusterResourceNamespaceExists(&issuerConfig))
+
+	errMsg := "Test client error"
+	cmcommon.GetClientFunc = func(log ...vzlog.VerrazzanoLogger) (v1.CoreV1Interface, error) {
+		return nil, fmt.Errorf(errMsg)
+	}
+	assert.EqualError(t, checkClusterResourceNamespaceExists(&issuerConfig), errMsg)
+
+	cmcommon.GetClientFunc = func(log ...vzlog.VerrazzanoLogger) (v1.CoreV1Interface, error) {
+		return createFakeClient(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}).CoreV1(), nil
+	}
+	assert.NoError(t, checkClusterResourceNamespaceExists(&issuerConfig))
+}
+
+// TestValidateCertManagerTypesExist tests the validateCertManagerTypesExist function
+// GIVEN a call to validateCertManagerTypesExist
+// THEN true is returned when the CRDs exist, or an error otherwise
+func TestValidateCertManagerTypesExist(t *testing.T) {
+	defer resetCheckCertManagerCRDsFunc()
+
+	checkCertManagerCRDFunc = func() (bool, error) {
+		return false, nil
+	}
+	assert.EqualError(t, validateCertManagerTypesExist(),
+		"clusterIssuer component is enabled but could not detect the presence of Cert-Manager")
+
+	unexpectedErrMsg := "unexpected error"
+	checkCertManagerCRDFunc = func() (bool, error) {
+		return false, fmt.Errorf(unexpectedErrMsg)
+	}
+	assert.EqualError(t, validateCertManagerTypesExist(), unexpectedErrMsg)
+
+	checkCertManagerCRDFunc = func() (bool, error) {
+		return true, nil
+	}
+	assert.NoError(t, validateCertManagerTypesExist())
+}
+
+// TestValidateInstall tests the ValidateInstall function
+// GIVEN a call to ValidateInstall
+//
+//	WHEN for various Issuer configurations
+//	THEN an error is returned if anything is misconfigured
+func TestValidateInstall(t *testing.T) {
+	validationTests(t, false)
+}
+
+// TestValidateUpdate tests the ValidateInstall function
+// GIVEN a call to ValidateInstall
+//
+//	WHEN for various Issuer configurations
+//	THEN an error is returned if anything is misconfigured
+func TestValidateUpdate(t *testing.T) {
+	validationTests(t, true)
+}
+
 var simpleValidationTests = []validationTestStruct{
 	{
 		name:    "No OCI DNS or CertManager present",
@@ -45,6 +113,7 @@ var simpleValidationTests = []validationTestStruct{
 						Enabled: getBoolPtr(true),
 					},
 					ClusterIssuer: &vzapi.ClusterIssuerComponent{
+						ClusterResourceNamespace: constants.CertManagerNamespace,
 						IssuerConfig: vzapi.IssuerConfig{
 							LetsEncrypt: &vzapi.LetsEncryptACMEIssuer{
 								EmailAddress: emailAddress,
@@ -76,6 +145,7 @@ var simpleValidationTests = []validationTestStruct{
 						Enabled: getBoolPtr(false),
 					},
 					ClusterIssuer: &vzapi.ClusterIssuerComponent{
+						ClusterResourceNamespace: secretNamespace,
 						IssuerConfig: vzapi.IssuerConfig{
 							LetsEncrypt: &vzapi.LetsEncryptACMEIssuer{
 								EmailAddress: emailAddress,
@@ -98,7 +168,42 @@ var simpleValidationTests = []validationTestStruct{
 		caSecret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: secretNamespace},
 		},
-		wantErr: false,
+		expectedClusterResourceNamespace: secretNamespace,
+		wantErr:                          false,
+		crdsPresent:                      true,
+	},
+	{
+		name: "CertManager Disabled Issuer Enabled No CRDs present",
+		old:  &vzapi.Verrazzano{},
+		new: &vzapi.Verrazzano{
+			Spec: vzapi.VerrazzanoSpec{
+				Components: vzapi.ComponentSpec{
+					CertManager: &vzapi.CertManagerComponent{
+						Enabled: getBoolPtr(false),
+					},
+					ClusterIssuer: vzapi.NewDefaultClusterIssuer(),
+				},
+			},
+		},
+		wantErr:     true,
+		crdsPresent: false,
+	},
+	{
+		// Case where CM is enabled, and the issuer is enabled, but before CM is installed
+		name: "CertManager Enabled Issuer Enabled No CRDs present",
+		old:  &vzapi.Verrazzano{},
+		new: &vzapi.Verrazzano{
+			Spec: vzapi.VerrazzanoSpec{
+				Components: vzapi.ComponentSpec{
+					CertManager: &vzapi.CertManagerComponent{
+						Enabled: getBoolPtr(true),
+					},
+					ClusterIssuer: vzapi.NewDefaultClusterIssuer(),
+				},
+			},
+		},
+		wantErr:     false,
+		crdsPresent: false,
 	},
 	//{
 	//	name: "CertManager and ClusterIssuer both explicitly configured",
@@ -147,7 +252,8 @@ var simpleValidationTests = []validationTestStruct{
 		caSecret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: secretNamespace},
 		},
-		wantErr: false,
+		expectedClusterResourceNamespace: secretNamespace,
+		wantErr:                          false,
 	},
 }
 
@@ -159,13 +265,15 @@ var issuerConfigurationTests = []validationTestStruct{
 		caSecret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: secretNamespace},
 		},
-		wantErr: false,
+		wantErr:                          false,
+		expectedClusterResourceNamespace: secretNamespace,
 	},
 	{
-		name:    "updateCustomCASecretNotFound",
-		old:     &vzapi.Verrazzano{},
-		new:     getCaSecretCR(),
-		wantErr: true,
+		name:                             "updateCustomCASecretNotFound",
+		old:                              &vzapi.Verrazzano{},
+		new:                              getCaSecretCR(),
+		wantErr:                          true,
+		expectedClusterResourceNamespace: secretNamespace,
 	},
 	{
 		name:    "no change",
@@ -283,25 +391,32 @@ var issuerConfigurationTests = []validationTestStruct{
 
 // All of this below is to make Sonar happy
 type validationTestStruct struct {
-	name      string
-	old       *vzapi.Verrazzano
-	new       *vzapi.Verrazzano
-	coreV1Cli func(_ ...vzlog.VerrazzanoLogger) (v1.CoreV1Interface, error)
-	caSecret  *corev1.Secret
-	wantErr   bool
+	name                             string
+	old                              *vzapi.Verrazzano
+	new                              *vzapi.Verrazzano
+	expectedClusterResourceNamespace string
+	coreV1Cli                        func(_ ...vzlog.VerrazzanoLogger) (v1.CoreV1Interface, error)
+	caSecret                         *corev1.Secret
+	crdsPresent                      bool
+	wantErr                          bool
 }
 
 func validationTests(t *testing.T, isUpdate bool) {
 	defer func() { k8sutil.ResetGetAPIExtV1ClientFunc() }()
+	defer resetCheckCertManagerCRDsFunc()
 
 	tests := simpleValidationTests
 	tests = append(tests, issuerConfigurationTests...)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Logf("Running test %s", tt.name)
 			if tt.name == "Cert Manager Namespace already exists" && isUpdate { // will throw error only during installation
 				tt.wantErr = false
 			}
 			c := NewComponent()
+			checkCertManagerCRDFunc = func() (bool, error) {
+				return tt.crdsPresent, nil
+			}
 			cmcommon.GetClientFunc = getTestClient(tt)
 			runValidationTest(t, tt, isUpdate, c)
 		})
@@ -342,11 +457,19 @@ func runValidationTest(t *testing.T, tt validationTestStruct, isUpdate bool, c s
 }
 
 func getTestClient(tt validationTestStruct) func(log ...vzlog.VerrazzanoLogger) (v1.CoreV1Interface, error) {
+	crNamespace := tt.expectedClusterResourceNamespace
+	if len(crNamespace) == 0 {
+		crNamespace = "cert-manager"
+	}
 	return func(log ...vzlog.VerrazzanoLogger) (v1.CoreV1Interface, error) {
-		if tt.caSecret != nil {
-			return createFakeClient(tt.caSecret).CoreV1(), nil
+		objs := []runtime.Object{
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: crNamespace}},
 		}
-		return createFakeClient().CoreV1(), nil
+		if tt.caSecret != nil {
+			objs = append(objs, tt.caSecret)
+		}
+		return createFakeClient(objs...).CoreV1(), nil
+		//		return createFakeClient().CoreV1(), nil
 	}
 }
 

--- a/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/webhook_oci_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/webhook_oci_component.go
@@ -31,10 +31,10 @@ const (
 	ComponentNamespace = constants.VerrazzanoSystemNamespace
 
 	// componentChartName is the Webhook Chart name
-	componentChartName = "cert-manager-webhook-oci"
+	componentChartName = cmcommon.CertManagerWebhookOCIComponentName
 
 	// webhookDeploymentName is the Webhook deployment object name
-	webhookDeploymentName = "cert-manager-webhook-oci"
+	webhookDeploymentName = cmcommon.CertManagerWebhookOCIComponentName
 )
 
 // certManagerOciDnsComponent represents an CertManager component
@@ -52,7 +52,7 @@ func NewComponent() spi.Component {
 			ReleaseName:               ComponentName,
 			JSONName:                  ComponentJSONName,
 			ChartDir:                  filepath.Join(config.GetThirdPartyDir(), componentChartName),
-			ChartNamespace:            ComponentNamespace,
+			ChartNamespace:            constants.VerrazzanoSystemNamespace,
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,

--- a/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/webhook_oci_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/webhook_oci_component.go
@@ -9,7 +9,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
@@ -22,7 +22,7 @@ import (
 
 const (
 	// ComponentName is the name of the component
-	ComponentName = cmcommon.CertManagerWebhookOCIComponentName
+	ComponentName = cmconstants.CertManagerWebhookOCIComponentName
 
 	// ComponentJSONName is the Webhook component JSON name in the Verrazzano CR
 	ComponentJSONName = "certManagerOCIWebhook"
@@ -31,10 +31,10 @@ const (
 	ComponentNamespace = constants.VerrazzanoSystemNamespace
 
 	// componentChartName is the Webhook Chart name
-	componentChartName = cmcommon.CertManagerWebhookOCIComponentName
+	componentChartName = cmconstants.CertManagerWebhookOCIComponentName
 
 	// webhookDeploymentName is the Webhook deployment object name
-	webhookDeploymentName = cmcommon.CertManagerWebhookOCIComponentName
+	webhookDeploymentName = cmconstants.CertManagerWebhookOCIComponentName
 )
 
 // certManagerOciDnsComponent represents an CertManager component
@@ -60,7 +60,7 @@ func NewComponent() spi.Component {
 			GetInstallOverridesFunc:   GetOverrides,
 			AppendOverridesFunc:       appendOCIDNSOverrides,
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0].name",
-			Dependencies:              []string{networkpolicies.ComponentName, cmcommon.CertManagerComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, cmconstants.CertManagerComponentName},
 			AvailabilityObjects: &ready.AvailabilityObjects{
 				DeploymentNames: []types.NamespacedName{
 					{

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -6,6 +6,7 @@ package clusterapi
 import (
 	"context"
 	"fmt"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
@@ -13,7 +14,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	vpoconstants "github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	appsv1 "k8s.io/api/apps/v1"
@@ -99,7 +99,7 @@ func (c clusterAPIComponent) ShouldInstallBeforeUpgrade() bool {
 
 // GetDependencies returns the dependencies of this component.
 func (c clusterAPIComponent) GetDependencies() []string {
-	return []string{cmcommon.CertManagerComponentName}
+	return []string{cmconstants.CertManagerComponentName}
 }
 
 // IsReady indicates whether a component is Ready for dependency components.

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
@@ -90,7 +90,7 @@ func TestGetDependencies(t *testing.T) {
 	var comp clusterAPIComponent
 	dependencies := comp.GetDependencies()
 	assert.Len(t, dependencies, 1)
-	assert.Equal(t, cmcommon.CertManagerComponentName, dependencies[0])
+	assert.Equal(t, cmconstants.CertManagerComponentName, dependencies[0])
 }
 
 // TestIsReady tests the IsReady function

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/jaeger_operator_component.go
@@ -6,6 +6,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"path/filepath"
 
 	globalconst "github.com/verrazzano/verrazzano/pkg/constants"
@@ -15,7 +16,6 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
@@ -87,7 +87,7 @@ func NewComponent() spi.Component {
 			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_3_0,
 			ImagePullSecretKeyname:    "image.imagePullSecrets[0]",
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "jaeger-operator-values.yaml"),
-			Dependencies:              []string{networkpolicies.ComponentName, cmcommon.CertManagerComponentName, opensearch.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, cmconstants.CertManagerComponentName, opensearch.ComponentName},
 			AppendOverridesFunc:       AppendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
 		},

--- a/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/keycloak_component.go
@@ -6,6 +6,7 @@ package keycloak
 import (
 	"context"
 	"fmt"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
@@ -16,7 +17,6 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
@@ -65,7 +65,7 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride:   true,
 			ImagePullSecretKeyname:    secret.DefaultImagePullSecretKeyName,
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "keycloak-values.yaml"),
-			Dependencies:              []string{networkpolicies.ComponentName, istio.ComponentName, nginx.ComponentName, cmcommon.CertManagerComponentName, mysql.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, istio.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName, mysql.ComponentName},
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
 			AppendOverridesFunc:       AppendKeycloakOverrides,

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali_component.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali_component.go
@@ -6,6 +6,7 @@ package kiali
 import (
 	"context"
 	"fmt"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
@@ -17,7 +18,6 @@ import (
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
@@ -62,7 +62,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorUninstall: true,
 			ImagePullSecretKeyname:    secret.DefaultImagePullSecretKeyName,
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), kialiOverridesFile),
-			Dependencies:              []string{networkpolicies.ComponentName, istio.ComponentName, nginx.ComponentName, cmcommon.CertManagerComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, istio.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName},
 			AppendOverridesFunc:       AppendOverrides,
 			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_1_0,
 			AvailabilityObjects: &ready.AvailabilityObjects{

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_component.go
@@ -5,30 +5,29 @@ package operator
 
 import (
 	"context"
-	networkv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
-	"github.com/verrazzano/verrazzano/pkg/vzcr"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
-	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/authproxy"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/vmo"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	networkv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"path/filepath"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ComponentName is the name of the component
@@ -68,7 +67,7 @@ func NewComponent() spi.Component {
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "prometheus-operator-values.yaml"),
 			// the dependency on the VMO is to ensure that a persistent volume is retained and the claim is released
 			// so that persistent storage can be migrated to the new Prometheus
-			Dependencies:            []string{networkpolicies.ComponentName, nginx.ComponentName, cmcommon.CertManagerComponentName, vmo.ComponentName},
+			Dependencies:            []string{networkpolicies.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName, vmo.ComponentName},
 			AppendOverridesFunc:     AppendOverrides,
 			GetInstallOverridesFunc: GetOverrides,
 		},

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -6,6 +6,7 @@ package rancher
 import (
 	"context"
 	"fmt"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -21,7 +22,6 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/clusterapi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
@@ -122,7 +122,7 @@ func NewComponent() spi.Component {
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "rancher-values.yaml"),
 			AppendOverridesFunc:       AppendOverrides,
 			Certificates:              certificates,
-			Dependencies:              []string{networkpolicies.ComponentName, nginx.ComponentName, cmcommon.CertManagerComponentName, clusterapi.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName, clusterapi.ComponentName},
 			AvailabilityObjects: &ready.AvailabilityObjects{
 				DeploymentNames: []types.NamespacedName{
 					{

--- a/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/verrazzano_component.go
@@ -5,6 +5,7 @@ package verrazzano
 
 import (
 	"fmt"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -13,7 +14,6 @@ import (
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/authproxy"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentd"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
@@ -62,7 +62,7 @@ func NewComponent() spi.Component {
 			ImagePullSecretKeyname:    vzImagePullSecretKeyName,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
-			Dependencies:              []string{istio.ComponentName, nginx.ComponentName, cmcommon.CertManagerComponentName, authproxy.ComponentName},
+			Dependencies:              []string{istio.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName, authproxy.ComponentName},
 			GetInstallOverridesFunc:   GetOverrides,
 		},
 	}

--- a/platform-operator/controllers/verrazzano/transform/convert_certificate.go
+++ b/platform-operator/controllers/verrazzano/transform/convert_certificate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 )
 
 var (
@@ -177,7 +178,8 @@ func isCAConfig(certConfig interface{}) (isCAConfig bool, err error) {
 func convertCertificateConfiguration(cmCertificateConfig interface{}, clusterIssuerConfig interface{}, isDefaultIssuer bool) error {
 	isDefaultCertificateConfig := isDefaultCertificateConfig(cmCertificateConfig)
 	if !isDefaultCertificateConfig && !isDefaultIssuer {
-		return fmt.Errorf("Illegal state, both CertManager Certificate and ClusterIssuer components are configured")
+		return fmt.Errorf("update conflict, can not configure Verrazzano ClusterIssuer from both the %s and %s components, %s.certificate is deprecated",
+			cmconstants.ClusterIssuerComponentJSONName, cmconstants.CertManagerComponentJSONName, cmconstants.CertManagerComponentJSONName)
 	}
 
 	if !isDefaultIssuer {

--- a/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
+++ b/tests/e2e/upgrade/post-upgrade/verify/verify_restart_test.go
@@ -5,6 +5,7 @@ package verify
 
 import (
 	"fmt"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"strings"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/appoper"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/authproxy"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/coherence"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/externaldns"
 	compistio "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
@@ -210,9 +210,9 @@ var _ = t.Describe("Checking if Verrazzano system components are ready, post-upg
 			t.Entry("Checking Deployment prometheus-operator-kube-p-operator", vzconst.PrometheusOperatorNamespace, promoperator.ComponentName, "prometheus-operator-kube-p-operator"),
 			t.Entry("Checking Deployment weblogic-operator", constants.VerrazzanoSystemNamespace, weblogic.ComponentName, "weblogic-operator"),
 
-			t.Entry("Checking Deployment cert-manager", vzconst.CertManagerNamespace, cmcommon.CertManagerComponentName, "cert-manager"),
-			t.Entry("Checking Deployment cert-manager-cainjector", vzconst.CertManagerNamespace, cmcommon.CertManagerComponentName, "cert-manager-cainjector"),
-			t.Entry("Checking Deployment cert-manager-webhook", vzconst.CertManagerNamespace, cmcommon.CertManagerComponentName, "cert-manager-webhook"),
+			t.Entry("Checking Deployment cert-manager", vzconst.CertManagerNamespace, cmconstants.CertManagerComponentName, "cert-manager"),
+			t.Entry("Checking Deployment cert-manager-cainjector", vzconst.CertManagerNamespace, cmconstants.CertManagerComponentName, "cert-manager-cainjector"),
+			t.Entry("Checking Deployment cert-manager-webhook", vzconst.CertManagerNamespace, cmconstants.CertManagerComponentName, "cert-manager-webhook"),
 
 			t.Entry("Checking Deployment external-dns", externaldns.ResolveExernalDNSNamespace(), externaldns.ComponentName, "external-dns"),
 

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"io"
 	"net/http"
 	"os"
@@ -21,7 +22,6 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	vzalpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmcommon "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/grafana"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/keycloak"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/kiali"
@@ -739,7 +739,7 @@ func getExpectedThanosReplicaCount(kubeconfig string) (int32, error) {
 
 func ingressEnabled(vz *vzalpha1.Verrazzano) bool {
 	return vzcr.IsComponentStatusEnabled(vz, nginx.ComponentName) &&
-		vzcr.IsComponentStatusEnabled(vz, cmcommon.CertManagerComponentName) &&
+		vzcr.IsComponentStatusEnabled(vz, cmconstants.CertManagerComponentName) &&
 		vzcr.IsComponentStatusEnabled(vz, keycloak.ComponentName)
 }
 


### PR DESCRIPTION
Introduces some additional validators for some new cases for the new Cert-Manager component suite.

If the ClusterIssuer is enabled, and the Verrazzano `certManager` component is disabled:
- validate that the `clusterResourceNamespace` exists
- validate that Cert-Manager CRDs are present in the cluster

The above are only checked for the case where the Verrazzano `certManager` component is disabled; in that case, if the `clusterIssuer` is enabled we expect Cert-Manager types and the expected namespace to be active.

Other changes:
- refactor some common CM component constants into a `platform-operator/controllers/verrazzano/components/certmanager/constants` package to avoid import cycles
- Update the corresponding components and e2e tests for the above change
- Update the `platform-operator/controllers/verrazzano/validator` unit tests

Automated test runs include
- Triggered tests
- Dynamic-config suite
- a-la-carte

In addition to the automated regression testing, I've been running a number of configurations that exercise the validators in `--dry-run=server` mode for
- Default Verrazzano-managed CM configurations
- Customer-managed CM configurations
- Invalid configurations (user has made edits to issuer configurations in both the deprecated `certManger.certificate` and `clusterIssuer` components)

I will update the ticket with the manual testing configurations and steps above

### Validation examples

- Cert-manager disabled (ext CM expected), but no CM installed:
```
apiVersion: install.verrazzano.io/v1beta1
kind: Verrazzano
metadata:
 name: my-verrazzano
spec:
  profile: prod
  environmentName: extcm
  components:
    certManager:
      enabled: false
    clusterIssuer:
      clusterResourceNamespace: mycm-res
```

```
+ kubectl apply --dry-run=server -f vz_all_extcm_custom_ns.yaml
Error from server (clusterIssuer component is enabled but could not detect the presence of Cert-Manager): error when creating "vz_all_extcm_custom_ns.yaml": admission webhook "install.verrazzano.io.v1beta1" denied the request: clusterIssuer component is enabled but could not detect the presence of Cert-Manager
```

- External CM case with a custom `clusterIssuerNamespace`, but that namespace does not exist:
```
apiVersion: install.verrazzano.io/v1beta1
kind: Verrazzano
metadata:
 name: my-verrazzano
spec:
  profile: prod
  environmentName: dwlextcmle3
  components:
    certManager:
      enabled: false
    clusterIssuer:
      clusterResourceNamespace: mycm-res
      letsEncrypt:
        environment: staging
        emailAddress: michael.cico@oracle.com
    certManagerWebhookOCI:
      overrides:
      - values:
          certManager:
            namespace: mycm
            clusterResourceNamespace: mycm-res
    dns:
      oci:
        ociConfigSecret: oci
        dnsZoneCompartmentOCID: ocid1.compartment.oc1..aaaaaaaa7cfqxbsnon63unlmm5z63zidx5wvq4gieuc5kixemfitzliwvxeq
        dnsZoneOCID: ocid1.dns-zone.oc1..aaaaaaaaq5wazpdo4kybkjkgapqhlmlatemszttel7paybbg54qnsgk6mf5a
        dnsZoneName: cico.v8odev.io
```


```
+ kubectl apply --dry-run=server -f vz_all_ocidns_le_extcm_custom_cm_cres_ns.yaml
Error from server (configured clusterResourceNamespace "mycm-res" for clusterIssuer component does not exist): error when creating "vz_all_ocidns_le_extcm_custom_cm_cres_ns.yaml": admission webhook "install.verrazzano.io.v1beta1" denied the request: configured clusterResourceNamespace "mycm-res" for clusterIssuer component does not exist
```

- Invalid configuration, both the `certManager.certificate` and `clusterIssuer.IssuerConfig` fields configured with non-default values:

```
apiVersion: install.verrazzano.io/v1beta1
kind: Verrazzano
metadata:
  name: verrazzano
spec:
  profile: none
  components:
    certManager:
      certificate:
        ca:
          secretName: mysecret
          clusterResourceNamespace: resns
    clusterIssuer:
      clusterResourceNamespace: mycm
      ca:
        secretName: foo
```

```
+ kubectl apply --dry-run=server -f invalid.yaml
Error from server (update conflict, can not configure Verrazzano ClusterIssuer from both the clusterIssuer and certManager components, certManager.certificate is deprecated): error when creating "invalid.yaml": admission webhook "install.verrazzano.io.v1beta1" denied the request: update conflict, can not configure Verrazzano ClusterIssuer from both the clusterIssuer and certManager components, certManager.certificate is deprecated
```

- Simple cases, basic dev/prod/managed-cluster/none profiles:

```
+ kubectl apply --dry-run=server -f dev.yaml
verrazzano.install.verrazzano.io/verrazzano created (server dry run)
+ kubectl apply --dry-run=server -f mgdcluster.yaml
verrazzano.install.verrazzano.io/verrazzano created (server dry run)
+ kubectl apply --dry-run=server -f none.yaml
verrazzano.install.verrazzano.io/verrazzano created (server dry run)
+ kubectl apply --dry-run=server -f prod.yaml
verrazzano.install.verrazzano.io/verrazzano created (server dry run)
```