### PR TITLE
VZ-9933 Periodics Dry Run will fail in Release Candidate Validation Checks

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -592,6 +592,11 @@ pipeline {
             }
         }
         stage('Release Candidate Validation Checks') {
+            when {
+                allOf {
+                    expression { return runTests() }
+                }
+            }
             steps {
                 script {
                     releaseValidationChecks()
@@ -601,6 +606,11 @@ pipeline {
         stage('Update Last Clean Periodic Test') {
             environment {
                 GIT_COMMIT_USED = "${env.GIT_COMMIT}"
+            }
+            when {
+                allOf {
+                    expression { return runTests() }
+                }
             }
             steps {
                 script {


### PR DESCRIPTION
Fix periodics to not run prerelease validation when DRY_RUN=TRUE