### PR TITLE
VZ-9942 VZ-9721 Exclude VZ 1.3 release from upgrade testing

### DIFF
--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -33,7 +33,8 @@ pipeline {
                         description: 'This is the wildcard DNS domain',
                         trim: true)
         string (name: 'EXCLUDE_RELEASES',
-                defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4, v1.1.0, v1.1.1, v1.1.2, v1.2.0, v1.2.1, v1.2.2",
+                defaultValue: "v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4, v1.1.0, v1.1.1, v1.1.2, v1.2.0, v1.2.1, v1.2.2," +
+                        " v1.3.0, v1.3.1, v1.3.2, v1.3.3, v1.3.4, v1.3.5, v1.3.6, v1.3.7, v1.3.8",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)
         string (name: 'TAGGED_TESTS',
                 defaultValue: '',

--- a/ci/tools/derive_upgrade_version.go
+++ b/ci/tools/derive_upgrade_version.go
@@ -80,12 +80,14 @@ func parseCliArgs(args []string) {
 
 	if len(args) > 2 {
 		for index, arg := range args {
+			// Remove any ',' or ']' suffixes and remove any '[' prefix
+			trimArg := strings.TrimPrefix(strings.TrimSuffix(strings.TrimSuffix(arg, ","), "]"), "[")
 			if index > 1 {
 				if versionType == LatestVersionForCurrentBranch {
-					developmentVersion = arg
+					developmentVersion = trimArg
 					return
 				}
-				excludeReleaseTags = append(excludeReleaseTags, arg)
+				excludeReleaseTags = append(excludeReleaseTags, trimArg)
 			}
 		}
 	}
@@ -203,6 +205,17 @@ func getInstallRelease(releaseTags []string) string {
 	majorVersionValue := parseInt(latestReleaseTagSplit[0])
 	minorInstallVersionValue := parseInt(latestReleaseTagSplit[1]) - 2
 
+	// Handles the case where only two or less minor releases are available for upgrade
+	// E.g. where the latest version is 1.5.x and the first supported version for upgrade is 1.4.x
+	// Get the first supported release tag for upgrade
+	firstReleaseTag := releaseTags[0]
+	//Split the string excluding prefix 'v' into major and minor version values
+	firstReleaseTagSplit := strings.Split(strings.TrimPrefix(firstReleaseTag, "v"), ".")
+	firstMajorVersionValue := parseInt(firstReleaseTagSplit[0])
+	firstMinorVersionValue := parseInt(firstReleaseTagSplit[1])
+	if firstMajorVersionValue == majorVersionValue && minorInstallVersionValue < firstMinorVersionValue {
+		minorInstallVersionValue = firstMinorVersionValue
+	}
 	// Handles the major release case, e.g. where the latest version is 2.0.0 and the previous version is 1.4.2
 	if minorInstallVersionValue < 0 {
 		majorVersionValue = parseInt(latestReleaseTagSplit[0]) - 1

--- a/ci/tools/derive_upgrade_version.go
+++ b/ci/tools/derive_upgrade_version.go
@@ -166,6 +166,19 @@ func getInterimRelease(releaseTags []string) string {
 	majorVersionValue := parseInt(latestReleaseTagSplit[0])
 	minorInterimVersionValue := parseInt(latestReleaseTagSplit[1]) - 1
 
+	// Handles the case where only two or less minor releases are available for upgrade
+	// E.g. where the latest version is 1.5.x and the first supported version for upgrade is 1.4.x, then return 1.5.0
+	// as an interim release
+	firstReleaseTag := releaseTags[0]
+	//Split the string excluding prefix 'v' into major and minor version values
+	firstReleaseTagSplit := strings.Split(strings.TrimPrefix(firstReleaseTag, "v"), ".")
+	firstMajorVersionValue := parseInt(firstReleaseTagSplit[0])
+	firstMinorVersionValue := parseInt(firstReleaseTagSplit[1])
+	if firstMajorVersionValue == majorVersionValue && minorInterimVersionValue == firstMinorVersionValue {
+		minorInterimVersionValue = parseInt(latestReleaseTagSplit[1])
+		return fmt.Sprintf("v%d.%d.0\n", majorVersionValue, minorInterimVersionValue)
+	}
+
 	// Handles the major release case, e.g. where the latest version is 2.0.0 and the previous version is 1.4.2
 	if minorInterimVersionValue < 0 {
 		minorInterimVersionValue = 0

--- a/ci/tools/derive_upgrade_version_test.go
+++ b/ci/tools/derive_upgrade_version_test.go
@@ -58,6 +58,16 @@ func TestGetInterimReleaseWithMajorVersion(t *testing.T) {
 	assert.Equal(t, "v1.5.0\n", getInterimRelease(releaseTags))
 }
 
+// TestGetInterimReleaseNotMoreThanTwoMinorVersions Tests the getInterimRelease function
+// WHEN there are no more than two minor release tags
+// THEN interim release version with the first patch release of the last minor release is expected
+func TestGetInterimReleaseNotMoreThanTwoMinorVersions(t *testing.T) {
+	pwd, _ := os.Getwd()
+	parseCliArgs([]string{pwd, "install-version"})
+	releaseTags := []string{"v1.4.0", "v1.4.1", "v1.4.2", "v1.5.0", "v1.5.1"}
+	assert.Equal(t, "v1.5.0\n", getInterimRelease(releaseTags))
+}
+
 // TestGetLatestReleaseForBranch tests the getLatestReleaseForCurrentBranch function
 // WHEN Verrazzano development version input is given from a current branch
 // THEN latest release with one minor release difference is expected.

--- a/ci/tools/derive_upgrade_version_test.go
+++ b/ci/tools/derive_upgrade_version_test.go
@@ -28,6 +28,16 @@ func TestGetInstallReleaseWithMajorRelease(t *testing.T) {
 	assert.Equal(t, "v1.5.0\n", getInstallRelease(releaseTags))
 }
 
+// TestGetInstallReleaseNotMoreThanTwoMinorVersions Tests the getInstallRelease function
+// WHEN there are no more than two minor release tags
+// THEN install release version with the first minor release is expected
+func TestGetInstallReleaseNotMoreThanTwoMinorVersions(t *testing.T) {
+	pwd, _ := os.Getwd()
+	parseCliArgs([]string{pwd, "install-version"})
+	releaseTags := []string{"v1.4.0", "v1.4.1", "v1.4.2", "v1.5.0", "v1.5.1"}
+	assert.Equal(t, "v1.4.2\n", getInstallRelease(releaseTags))
+}
+
 // TestGetInterimReleaseWithoutMajorVersion Tests the getInterimRelease function
 // WHEN with git release tags major version change does not exist
 // THEN interim release version with one minor release difference is expected

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "1.24", "1.25", "1.26" ])
         string (name: 'VERSION_FOR_INSTALL',
-                defaultValue: 'v1.3.0',
+                defaultValue: 'v1.4.0',
                 description: 'This is the Verrazzano version for install before doing an upgrade.  By default, the v1.3.0 release will be installed',
                 trim: true)
         string (name: 'VERSION_FOR_UPGRADE',

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -45,7 +45,7 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "1.24", "1.25", "1.26" ])
         string (name: 'EXCLUDE_RELEASES',
-                defaultValue: "v1.0, v1.1, v1.2",
+                defaultValue: "v1.0, v1.1, v1.2, v1.3",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)
         string (name: 'VERRAZZANO_OPERATOR_IMAGE',
                         defaultValue: 'NONE',


### PR DESCRIPTION
Also, the following changes are done:
- Fix the logic in parsing `excludeReleaseTags` in the `derive_upgrade_version.go` code.
- Update the `derive_upgrade_version.go` code to handle the case where there are no more than two minor versions supported for the upgrade. 
- Do not run the VMI prometheus pre-upgrade tests for versions greater than or equal to vz 1.4 as VMI prometheus support has been moved to Prometheus operator in 1.4.