### PR TITLE
VZ-9672 Update Rancher images (#6161)

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -131,13 +131,13 @@
             {
               "image": "rancher",
               "dashboard": "v2.7.2-20230509143745-870a44e17",
-              "tag": "v2.7.3-release-1.5-20230519203223-2ebc90456",
+              "tag": "v2.7.3-release-1.5-20230606110507-b9099842d",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-release-1.5-20230519203223-2ebc90456"
+              "tag": "v2.7.3-release-1.5-20230606110507-b9099842d"
             }
           ]
         },


### PR DESCRIPTION
This PR is to pickup the new Rancher images that has a fix to the rancher agent image path when using private registry. See https://github.com/verrazzano/rancher/pull/106 for details.
