### PR TITLE
VZ-9912: pickup latest ocne providers with VPO changes and updated ocnecp API change

### DIFF
--- a/platform-operator/capi/control-plane-ocne/v0.1.0/control-plane-components.yaml
+++ b/platform-operator/capi/control-plane-ocne/v0.1.0/control-plane-components.yaml
@@ -1408,6 +1408,16 @@ spec:
                           type: string
                       type: object
                     type: array
+                  privateRegistry:
+                    description: PrivateRegistry sets the private registry settings
+                      for installing Verrazzano.
+                    properties:
+                      enabled:
+                        description: Enabled sets a flag to determine if a private
+                          registry will be used when installing Verrazzano. if not
+                          set, the Enabled is set to false.
+                        type: boolean
+                    type: object
                 type: object
               version:
                 description: 'Version defines the desired Kubernetes version. Please

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -235,11 +235,11 @@
           "images": [
             {
               "image": "cluster-api-ocne-bootstrap-controller",
-              "tag": "v0.1.0-20230606055007-314f118"
+              "tag": "v0.1.0-20230606212653-adc792c"
             },
             {
               "image": "cluster-api-ocne-control-plane-controller",
-              "tag": "v0.1.0-20230606055007-314f118"
+              "tag": "v0.1.0-20230606212653-adc792c"
             }
           ]
         }


### PR DESCRIPTION
This pull request picks up a new control plane ocne provider that has the remaining VPO helm chart install changes and a ocnecp API change to enable a private registry.