### PR TITLE
VZ-9923 Uptake new Rancher images

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,13 +151,13 @@
               "rancherUI": "v2.7.2-3/release-2.7.2",
               "ocneDriverVersion": "v0.4.0",
               "ocneDriverChecksum": "7088762cf8640ea8d7051b5ff1b028ff58743687e269bb2f210fe13c3f490c44",
-              "tag": "v2.7.3-20230606171358-9b3517ec7",
+              "tag": "v2.7.3-20230607043750-3f0079604",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-20230606171358-9b3517ec7"
+              "tag": "v2.7.3-20230607043750-3f0079604"
             }
           ]
         },


### PR DESCRIPTION
This PR is to pick up the new Rancher images that has a change to host the OKE driver on Rancher server and activate it from the same. See  https://github.com/verrazzano/rancher/pull/108 for details.