### PR TITLE
fix space issue in chart path of fluent operator in comments

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_types.go
@@ -466,7 +466,7 @@ type FluentbitOpensearchOutputComponent struct {
 	// List of Overrides for the default `values.yaml` file for the component Helm chart. Overrides are merged together,
 	// but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
 	// find all possible values
-	// [here]( {{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml%}} )
+	// [here]( {{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml %}} )
 	// and invalid values will be ignored.
 	// +optional
 	InstallOverrides `json:",inline"`
@@ -1123,7 +1123,7 @@ type FluentOperatorComponent struct {
 	// List of Overrides for the default `values.yaml` file for the component Helm chart. Overrides are merged together,
 	// but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
 	// find all possible values
-	// [here]( {{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml%}} )
+	// [here]( {{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml %}} )
 	// and invalid values will be ignored.
 	// +optional
 	InstallOverrides `json:",inline"`

--- a/platform-operator/apis/verrazzano/v1beta1/verrazzano_types.go
+++ b/platform-operator/apis/verrazzano/v1beta1/verrazzano_types.go
@@ -456,7 +456,7 @@ type FluentbitOpensearchOutputComponent struct {
 	// List of Overrides for the default `values.yaml` file for the component Helm chart. Overrides are merged together,
 	// but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
 	// find all possible values
-	// [here]( {{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml%}} )
+	// [here]( {{% release_source_url path=platform-operator/helm_config/charts/fluentbit-opensearch-output/values.yaml %}} )
 	// and invalid values will be ignored.
 	// +optional
 	InstallOverrides `json:",inline"`
@@ -1045,7 +1045,7 @@ type FluentOperatorComponent struct {
 	// List of Overrides for the default `values.yaml` file for the component Helm chart. Overrides are merged together,
 	// but in the event of conflicting fields, the last override in the list takes precedence over any others. You can
 	// find all possible values
-	// [here]( {{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml%}} )
+	// [here]( {{% release_source_url path=platform-operator/thirdparty/charts/fluent-operator/values.yaml %}} )
 	// and invalid values will be ignored.
 	// +optional
 	InstallOverrides `json:",inline"`


### PR DESCRIPTION
fix space issue in chart path of fluent operator in comments