### PR TITLE
New OCNE Driver, UI

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -148,16 +148,16 @@
             {
               "image": "rancher",
               "dashboard": "v2.7.2-20230606170311-f093c099b",
-              "rancherUI": "v2.7.2-3/release-2.7.2",
-              "ocneDriverVersion": "v0.4.0",
-              "ocneDriverChecksum": "7088762cf8640ea8d7051b5ff1b028ff58743687e269bb2f210fe13c3f490c44",
-              "tag": "v2.7.3-20230607043750-3f0079604",
+              "rancherUI": "v2.7.2-4/release-2.7.2",
+              "ocneDriverVersion": "v0.6.0",
+              "ocneDriverChecksum": "40ad9926fadd8e35b4954f5b1cd0a45a5d11226404b62e09108f8ce98f822f91",
+              "tag": "v2.7.3-20230607144740-3f0079604",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-20230607043750-3f0079604"
+              "tag": "v2.7.3-20230607144740-3f0079604"
             }
           ]
         },


### PR DESCRIPTION
Take new OCNE Driver, UI versions that support installation and upgrade of Verrazzano, as well as module naming conventions for `oci-ccm`.