### PR TITLE
VZ-10007: Update CAPI with simplified api change

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -235,11 +235,11 @@
           "images": [
             {
               "image": "cluster-api-ocne-bootstrap-controller",
-              "tag": "v0.1.0-20230608160926-a0abe23"
+              "tag": "v0.1.0-20230608223935-e34e5b0"
             },
             {
               "image": "cluster-api-ocne-control-plane-controller",
-              "tag": "v0.1.0-20230608160926-a0abe23"
+              "tag": "v0.1.0-20230608223935-e34e5b0"
             }
           ]
         }


### PR DESCRIPTION
A previous change implemented the simplified API

https://github.com/verrazzano/cluster-api-provider-ocne/pull/19

where API was updated if input was simple.

This PR will prevent the API from getting updated and just update necessary configurations for bootstrap functionality