### PR TITLE
replace dots with underscore in opensearch output

### DIFF
--- a/platform-operator/helm_config/charts/fluentbit-opensearch-output/templates/application-clusteroutput.yaml
+++ b/platform-operator/helm_config/charts/fluentbit-opensearch-output/templates/application-clusteroutput.yaml
@@ -38,6 +38,7 @@ spec:
     httpPassword:
 {{ toYaml .Values.application.httpPassword | indent 6 }}
     {{- end}}
+    replaceDots: true
     suppressTypeName: true
     {{- if .Values.application.tls.enabled }}
     tls:

--- a/platform-operator/helm_config/charts/fluentbit-opensearch-output/templates/system-clusteroutput.yaml
+++ b/platform-operator/helm_config/charts/fluentbit-opensearch-output/templates/system-clusteroutput.yaml
@@ -39,6 +39,7 @@ spec:
 {{ toYaml .Values.system.httpPassword | indent 6 }}
     {{- end}}
     suppressTypeName: true
+    replaceDots: true
     {{- if .Values.system.tls.enabled }}
     tls:
       caFile: {{ .Values.system.tls.caFile }}


### PR DESCRIPTION
This PR is to fix mapping conflict with OS index template with labels such that data gets ingested properly.