### PR TITLE
VZ-10041: Add Pod Security for Fluent Operator

### DIFF
--- a/platform-operator/helm_config/overrides/fluent-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/fluent-operator-values.yaml
@@ -61,10 +61,5 @@ operator:
     runAsGroup: 1025
     runAsNonRoot: true
     runAsUser: 1025
-    privileged: false
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
     seccompProfile:
       type: RuntimeDefault

--- a/platform-operator/helm_config/overrides/fluent-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/fluent-operator-values.yaml
@@ -50,3 +50,19 @@ fluentbit:
   envVars:
     - name: CLUSTER_NAME
       value: {{ .clusterName }}
+  # Pod security context for Fluentbit Pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  podSecurityContext:
+    runAsGroup: 1024
+    runAsNonRoot: true
+    runAsUser: 1024
+    seccompProfile:
+      type: RuntimeDefault
+
+operator:
+  # Pod security context for Fluent Operator pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  podSecurityContext:
+    runAsGroup: 1025
+    runAsNonRoot: true
+    runAsUser: 1025
+    seccompProfile:
+      type: RuntimeDefault

--- a/platform-operator/helm_config/overrides/fluent-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/fluent-operator-values.yaml
@@ -63,3 +63,9 @@ operator:
     runAsUser: 1025
     seccompProfile:
       type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    capabilities:
+      drop:
+        - ALL

--- a/platform-operator/helm_config/overrides/fluent-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/fluent-operator-values.yaml
@@ -52,9 +52,6 @@ fluentbit:
       value: {{ .clusterName }}
   # Pod security context for Fluentbit Pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   podSecurityContext:
-    runAsGroup: 1024
-    runAsNonRoot: true
-    runAsUser: 1024
     seccompProfile:
       type: RuntimeDefault
 
@@ -64,5 +61,10 @@ operator:
     runAsGroup: 1025
     runAsNonRoot: true
     runAsUser: 1025
+    privileged: false
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
     seccompProfile:
       type: RuntimeDefault

--- a/platform-operator/thirdparty/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/platform-operator/thirdparty/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -80,6 +80,10 @@ spec:
       containers:
       - name: fluent-operator
         image: {{ .Values.operator.container.repository }}:{{ .Values.operator.container.tag }}
+        {{- if .Values.operator.securityContext }}
+        securityContext:
+          {{ toYaml .Values.operator.securityContext | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.operator.resources | nindent 10 }}
         env:

--- a/platform-operator/thirdparty/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/platform-operator/thirdparty/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -99,3 +99,7 @@ spec:
       imagePullSecrets:
       {{- toYaml .Values.operator.imagePullSecrets | nindent 8 }}
       {{- end }}
+      {{- if .Values.operator.podSecurityContext }}
+      securityContext:
+        {{ toYaml .Values.operator.podSecurityContext | nindent 8 }}
+      {{- end }}

--- a/platform-operator/thirdparty/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/platform-operator/thirdparty/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -60,5 +60,9 @@ spec:
   labels:
 {{ toYaml .Values.fluentbit.labels | indent 4 }}
   {{- end }}
+  {{- if .Values.fluentbit.podSecurityContext }}
+  securityContext:
+{{ toYaml .Values.fluentbit.podSecurityContext | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/fluent-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/fluent-operator/values.yaml
@@ -17,7 +17,9 @@ operator:
   container:
     repository: "kubesphere/fluent-operator"
     tag: "v2.2.0"
-    # FluentBit operator resources. Usually user needn't to adjust these.
+  # Pod security context for Fluent Operator. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  podSecurityContext: {}
+  # FluentBit operator resources. Usually user needn't to adjust these.
   resources:
     limits:
       cpu: 100m
@@ -79,6 +81,8 @@ fluentbit:
   imagePullSecrets: []
   # - name: "image-pull-secret"
   secrets: []
+  # Pod security context for Fluent Bit pods. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  podSecurityContext: {}
   # List of volumes that can be mounted by containers belonging to the pod.
   additionalVolumes: []
   # Pod volumes to mount into the container's filesystem.

--- a/platform-operator/thirdparty/charts/fluent-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/fluent-operator/values.yaml
@@ -19,7 +19,9 @@ operator:
     tag: "v2.2.0"
   # Pod security context for Fluent Operator. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   podSecurityContext: {}
-  # FluentBit operator resources. Usually user needn't to adjust these.
+  # Container security context for Fluent Operator container. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  securityContext: {}
+  # Fluent Operator resources. Usually user needn't to adjust these.
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
Add Pod Security for Fluent Operator and Fluentbit pods.

- No container level security context for Fluentbit. As it is missing in fluentbit CRD in flunet Operator Helmchart.
- kept running Fluentbit as root user because it requires write access to the directory /fluent-bit/etc/tail that has write access to root only.