### PR TITLE
VZ-9956 parameterized a-la-carte for certs and dns

### DIFF
--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -43,13 +43,16 @@ pipeline {
                 defaultValue: 'my-cert-manager',
                 description: 'The namespace for cluster-scoped Cert-Manager resources; defaults to where Cert-Manager is installed.',
                 trim: true)
-        // OKE_CLUSTER_REGION parameter will be ignored for private DNS tests. They get overwritten with runner region
+        choice (description: 'Whether to use wildcard DNS or OCIDNS', name: 'DNS_TYPE',
+            // 1st choice is the default value
+            choices: ["wildcard","ocidns"] )
         choice (description: 'OCI region to create the DNS Zone in', name: 'OKE_CLUSTER_REGION',
             // 1st choice is the default value
             choices: availableRegions )
         choice (description: 'Specifies  DNS scope. Values: GLOBAL, PRIVATE. Default: GLOBAL',name: 'DNS_SCOPE',
             // 1st choice is the default value
             choices: [ "GLOBAL","PRIVATE" ])
+
     }
 
     environment {
@@ -278,7 +281,7 @@ pipeline {
         }
 
 
-        stage('Install App stack with third party cert-manager and ingress-nginx') {
+        stage('Install App stack with external cert-manager and ingress-nginx') {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
@@ -292,15 +295,21 @@ pipeline {
                     ci/scripts/install_third_party_components.sh
                 """
 
-                sh """
-                    ${WORKSPACE}/tests/e2e/config/scripts/create-test-oci-config-secret.sh
-                """
-
                script {
-                    env.DNS_ZONE_OCID = sh(script: "${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o create -c ${OCI_ZONE_COMPARTMENT_ID} -s z${zoneId} -k ${params.DNS_SCOPE}", returnStdout: true)
+                    if (params.DNS_TYPE == "ocidns") {
+                        env.DNS_ZONE_OCID = sh(script: "${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o create -c ${OCI_ZONE_COMPARTMENT_ID} -s z${zoneId} -k ${params.DNS_SCOPE}", returnStdout: true)
+                    }
+
+                    sh """
+                        ${WORKSPACE}/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+                    """
                 }
 
                 runGinkgoUpdate('update/a-la-carte', 'app-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")
+
+                sh """
+                    kubectl get vz -A -o yaml
+                """
             }
 
             post {
@@ -314,7 +323,7 @@ pipeline {
             }
         }
 
-        stage('Verify App Stack') {
+        stage('Verify App stack with external cert-manager and ingress-nginx') {
             parallel {
                 stage('verify-install/promstack') {
                     environment {
@@ -554,6 +563,11 @@ pipeline {
             """
             archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*full-cluster*/**,**/*cluster-snapshot*/**,**/bug-report/**,**/Screenshot*.png,**/ConsoleLog*.log,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
+            if (params.DNS_TYPE == "ocidns") {
+                 sh """
+                    ${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o delete -s z${zoneId} -k ${params.DNS_SCOPE} || echo "Failed to delete DNS zone z${zoneId}"
+                 """
+            }
             deleteCluster()
         }
         failure {

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -47,6 +47,9 @@ pipeline {
         choice (description: 'OCI region to create the DNS Zone in', name: 'OKE_CLUSTER_REGION',
             // 1st choice is the default value
             choices: availableRegions )
+        choice (description: 'Specifies  DNS scope. Values: GLOBAL, PRIVATE. Default: GLOBAL',name: 'DNS_SCOPE',
+            // 1st choice is the default value
+            choices: [ "GLOBAL","PRIVATE" ])
     }
 
     environment {
@@ -293,7 +296,7 @@ pipeline {
                 """
 
                script {
-                    env.DNS_ZONE_OCID = sh(script: "${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o create -c ${OCI_ZONE_COMPARTMENT_ID} -s z${zoneId} -k PUBLIC", returnStdout: true)
+                    env.DNS_ZONE_OCID = sh(script: "${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o create -c ${OCI_ZONE_COMPARTMENT_ID} -s z${zoneId} -k ${params.DNS_SCOPE}", returnStdout: true)
                 }
 
                 runGinkgoUpdate('update/a-la-carte', 'app-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -303,13 +303,13 @@ pipeline {
                     oci setup repair-file-permissions --file /home/opc/.oci/config
                 """
 
-               script {
-                    env.DNS_ZONE_OCID = sh(script: "${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o create -c ${OCI_ZONE_COMPARTMENT_ID} -s z${zoneId} -k PUBLIC", returnStdout: true)
-                }
-
                 sh """
                     ${WORKSPACE}/tests/e2e/config/scripts/create-test-oci-config-secret.sh
                 """
+
+               script {
+                    env.DNS_ZONE_OCID = sh(script: "${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o create -c ${OCI_ZONE_COMPARTMENT_ID} -s z${zoneId} -k PUBLIC", returnStdout: true)
+                }
 
                 runGinkgoUpdate('update/a-la-carte', 'app-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")
             }

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -78,8 +78,9 @@ pipeline {
         OCI_CLI_USER = credentials('oci-user-ocid')
         OCI_CLI_FINGERPRINT = credentials('oci-api-key-fingerprint')
         OCI_CLI_KEY_FILE = credentials('oci-api-key')
-        OKE_CLUSTER_REGION = "${params.OKE_CLUSTER_REGION}"
+        OCI_CLI_REGION = "${params.OCI_CLI_REGION}"
         OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"
+        OCI_CLI_CONFIG_FILE = credentials('oci-dev-api-key-file')
 
 
         WEBLOGIC_PSW = credentials('weblogic-example-domain-password') // required by WebLogic application and console ingress test
@@ -287,6 +288,21 @@ pipeline {
                     # install third party cert-manager and nginx
                     cd ${GO_REPO_PATH}/verrazzano
                     ci/scripts/install_third_party_components.sh
+                """
+
+                sh """
+                    mkdir -p ~/.oci
+                    cp ${OCI_CLI_CONFIG_FILE} ~/.oci
+                    rm -rf ~/.oci/config
+                    {
+                      echo '[DEFAULT]'
+                      echo 'user=${OCI_CLI_USER}'
+                      echo 'fingerprint=${OCI_CLI_FINGERPRINT}'
+                      echo 'tenancy=${OCI_CLI_TENANCY}'
+                      echo 'region=${OCI_CLI_REGION}'
+                      echo 'key_file=~/.oci/alm.pem'
+                    } >> ~/.oci/config
+                    oci setup repair-file-permissions --file /home/opc/.oci/config
                 """
 
                script {

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                 defaultValue: 'my-cert-manager',
                 description: 'The namespace for cluster-scoped Cert-Manager resources; defaults to where Cert-Manager is installed.',
                 trim: true)
-        choice (description: 'Whether to use wildcard DNS or OCIDNS', name: 'DNS_TYPE',
+        choice (description: 'Specifies  DNS type. Values: wildcard, ocidns. Default: wildcard', name: 'DNS_TYPE',
             // 1st choice is the default value
             choices: ["wildcard","ocidns"] )
         choice (description: 'OCI region to create the DNS Zone in', name: 'OKE_CLUSTER_REGION',
@@ -52,6 +52,9 @@ pipeline {
         choice (description: 'Specifies  DNS scope. Values: GLOBAL, PRIVATE. Default: GLOBAL',name: 'DNS_SCOPE',
             // 1st choice is the default value
             choices: [ "GLOBAL","PRIVATE" ])
+        choice (description: 'Specifies certificate issuer. Values: default, letsEncrypt. Default: default', name: 'CERTIFICATE_TYPE',
+            // 1st choice is the default value
+            choices: [ "default", "letsEncrypt" ])
     }
 
     environment {
@@ -305,6 +308,11 @@ pipeline {
                 }
 
                 runGinkgoUpdate('update/a-la-carte', 'app-stack')
+
+                sh """
+                    kubectl get vz -A -o yaml
+                """
+
             }
 
             post {
@@ -738,7 +746,7 @@ def runGinkgoUpdate(testSuitePath, updateTypeVal = '') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             if [ -d "${testSuitePath}" ]; then
-                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file=".*" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --updateType="${updateTypeVal}" --clusterResourceNamespace="${params.CLUSTER_RESOURCE_NAMESPACE}" --dnsType="${params.DNS_TYPE}"
+                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file=".*" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --updateType="${updateTypeVal}" --clusterResourceNamespace="${params.CLUSTER_RESOURCE_NAMESPACE}" --dnsType="${params.DNS_TYPE}" --certificateType="${params.CERTIFICATE_TYPE}"
             fi
         """
     }

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -283,6 +283,7 @@ pipeline {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
                 CLUSTER_RESOURCE_NAMESPACE = "${params.CLUSTER_RESOURCE_NAMESPACE}"
+                OCI_CLI_AUTH="api_key"
             }
             steps {
                 sh """

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -289,21 +289,6 @@ pipeline {
                 """
 
                 sh """
-                    mkdir -p ~/.oci
-                    cp ${OCI_CLI_KEY_FILE} ~/.oci
-                    rm -rf ~/.oci/config
-                    {
-                      echo '[DEFAULT]'
-                      echo 'user=${OCI_CLI_USER}'
-                      echo 'fingerprint=${OCI_CLI_FINGERPRINT}'
-                      echo 'tenancy=${OCI_CLI_TENANCY}'
-                      echo 'region=${OCI_CLI_REGION}'
-                      echo 'key_file=~/.oci/oci-api-key.pem'
-                    } >> ~/.oci/config
-                    oci setup repair-file-permissions --file /home/opc/.oci/config
-                """
-
-                sh """
                     ${WORKSPACE}/tests/e2e/config/scripts/create-test-oci-config-secret.sh
                 """
 

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -237,7 +237,7 @@ pipeline {
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
             }
             steps {
-                runGinkgoUpdate('update/a-la-carte', 'prom-edge-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")
+                runGinkgoUpdate('update/a-la-carte', 'prom-edge-stack')
             }
 
             post {
@@ -305,7 +305,7 @@ pipeline {
                     """
                 }
 
-                runGinkgoUpdate('update/a-la-carte', 'app-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")
+                runGinkgoUpdate('update/a-la-carte', 'app-stack')
 
                 sh """
                     kubectl get vz -A -o yaml
@@ -366,7 +366,7 @@ pipeline {
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
             }
             steps {
-                runGinkgoUpdate('update/a-la-carte', 'istio-app-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")
+                runGinkgoUpdate('update/a-la-carte', 'istio-app-stack')
             }
 
             post {
@@ -431,7 +431,7 @@ pipeline {
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
             }
             steps {
-                runGinkgoUpdate('update/a-la-carte', 'cluster-management-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")
+                runGinkgoUpdate('update/a-la-carte', 'cluster-management-stack')
             }
 
             post {
@@ -488,7 +488,7 @@ pipeline {
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
             }
             steps {
-                runGinkgoUpdate('update/a-la-carte', 'none-profile', "${params.CLUSTER_RESOURCE_NAMESPACE}")
+                runGinkgoUpdate('update/a-la-carte', 'none-profile')
             }
 
             post {
@@ -735,12 +735,12 @@ def runGinkgo(testSuitePath) {
     }
 }
 
-def runGinkgoUpdate(testSuitePath, updateTypeVal = '', clusterResourceNamespace = '') {
+def runGinkgoUpdate(testSuitePath, updateTypeVal = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
             if [ -d "${testSuitePath}" ]; then
-                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file=".*" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --updateType="${updateTypeVal}" --clusterResourceNamespace=""${clusterResourceNamespace}""
+                ginkgo -p --randomize-all -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file=".*" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --updateType="${updateTypeVal}" --clusterResourceNamespace="${params.CLUSTER_RESOURCE_NAMESPACE}" --dnsType="${params.DNS_TYPE}"
             fi
         """
     }

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
         OCI_CLI_USER = credentials('oci-user-ocid')
         OCI_CLI_FINGERPRINT = credentials('oci-api-key-fingerprint')
         OCI_CLI_KEY_FILE = credentials('oci-api-key')
-        OCI_CLI_REGION = "${params.OCI_CLI_REGION}"
+        OCI_CLI_REGION = "${params.OKE_CLUSTER_REGION}"
         OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"
 
         WEBLOGIC_PSW = credentials('weblogic-example-domain-password') // required by WebLogic application and console ingress test

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -299,11 +299,11 @@ pipeline {
                     if (params.DNS_TYPE == "ocidns") {
                         env.DNS_ZONE_OCID = sh(script: "${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o create -c ${OCI_ZONE_COMPARTMENT_ID} -s z${zoneId} -k ${params.DNS_SCOPE}", returnStdout: true)
                     }
+               }
 
-                    sh """
-                        ${WORKSPACE}/tests/e2e/config/scripts/create-test-oci-config-secret.sh
-                    """
-                }
+                sh """
+                    ${WORKSPACE}/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+                """
 
                 runGinkgoUpdate('update/a-la-carte', 'app-stack')
 
@@ -563,11 +563,11 @@ pipeline {
             """
             archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*full-cluster*/**,**/*cluster-snapshot*/**,**/bug-report/**,**/Screenshot*.png,**/ConsoleLog*.log,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
-            if (params.DNS_TYPE == "ocidns") {
-                 sh """
-                    ${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o delete -s z${zoneId} -k ${params.DNS_SCOPE} || echo "Failed to delete DNS zone z${zoneId}"
-                 """
-            }
+//             if (params.DNS_TYPE == "ocidns") {
+//                  sh """
+//                     ${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o delete -s z${zoneId} -k ${params.DNS_SCOPE} || echo "Failed to delete DNS zone z${zoneId}"
+//                  """
+//             }
             deleteCluster()
         }
         failure {

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -80,8 +80,6 @@ pipeline {
         OCI_CLI_KEY_FILE = credentials('oci-api-key')
         OCI_CLI_REGION = "${params.OCI_CLI_REGION}"
         OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"
-        OCI_CLI_CONFIG_FILE = credentials('oci-dev-api-key-file')
-
 
         WEBLOGIC_PSW = credentials('weblogic-example-domain-password') // required by WebLogic application and console ingress test
         DATABASE_PSW = credentials('todo-mysql-password') // required by console ingress test
@@ -292,7 +290,7 @@ pipeline {
 
                 sh """
                     mkdir -p ~/.oci
-                    cp ${OCI_CLI_CONFIG_FILE} ~/.oci
+                    cp ${OCI_CLI_KEY_FILE} ~/.oci
                     rm -rf ~/.oci/config
                     {
                       echo '[DEFAULT]'
@@ -300,7 +298,7 @@ pipeline {
                       echo 'fingerprint=${OCI_CLI_FINGERPRINT}'
                       echo 'tenancy=${OCI_CLI_TENANCY}'
                       echo 'region=${OCI_CLI_REGION}'
-                      echo 'key_file=~/.oci/alm.pem'
+                      echo 'key_file=~/.oci/oci-api-key.pem'
                     } >> ~/.oci/config
                     oci setup repair-file-permissions --file /home/opc/.oci/config
                 """

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -4,6 +4,9 @@
 def DOCKER_IMAGE_TAG
 def agentLabel = env.JOB_NAME.contains('master') ? "phx-large" : "large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
+def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
+def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "uk-london-1" ]
+Collections.shuffle(availableRegions)
 
 pipeline {
     options {
@@ -40,6 +43,10 @@ pipeline {
                 defaultValue: 'my-cert-manager',
                 description: 'The namespace for cluster-scoped Cert-Manager resources; defaults to where Cert-Manager is installed.',
                 trim: true)
+        // OKE_CLUSTER_REGION parameter will be ignored for private DNS tests. They get overwritten with runner region
+        choice (description: 'OCI region to create the DNS Zone in', name: 'OKE_CLUSTER_REGION',
+            // 1st choice is the default value
+            choices: availableRegions )
     }
 
     environment {
@@ -64,6 +71,16 @@ pipeline {
         VZ_ENVIRONMENT_NAME = "default"
         TEST_SCRIPTS_DIR = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts"
         VERRAZZANO_OPERATOR_IMAGE="${params.VERRAZZANO_OPERATOR_IMAGE}"
+
+        // Environment variables required for OCIDNS
+        OCI_ZONE_COMPARTMENT_ID = credentials('oci-tiburon-dev-compartment-ocid')
+        OCI_CLI_TENANCY = credentials('oci-tenancy')
+        OCI_CLI_USER = credentials('oci-user-ocid')
+        OCI_CLI_FINGERPRINT = credentials('oci-api-key-fingerprint')
+        OCI_CLI_KEY_FILE = credentials('oci-api-key')
+        OKE_CLUSTER_REGION = "${params.OKE_CLUSTER_REGION}"
+        OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"
+
 
         WEBLOGIC_PSW = credentials('weblogic-example-domain-password') // required by WebLogic application and console ingress test
         DATABASE_PSW = credentials('todo-mysql-password') // required by console ingress test
@@ -267,8 +284,17 @@ pipeline {
             }
             steps {
                 sh """
+                    # install third party cert-manager and nginx
                     cd ${GO_REPO_PATH}/verrazzano
                     ci/scripts/install_third_party_components.sh
+                """
+
+               script {
+                    env.DNS_ZONE_OCID = sh(script: "${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o create -c ${OCI_ZONE_COMPARTMENT_ID} -s z${zoneId} -k PUBLIC", returnStdout: true)
+                }
+
+                sh """
+                    ${WORKSPACE}/tests/e2e/config/scripts/create-test-oci-config-secret.sh
                 """
 
                 runGinkgoUpdate('update/a-la-carte', 'app-stack', "${params.CLUSTER_RESOURCE_NAMESPACE}")

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -52,7 +52,6 @@ pipeline {
         choice (description: 'Specifies  DNS scope. Values: GLOBAL, PRIVATE. Default: GLOBAL',name: 'DNS_SCOPE',
             // 1st choice is the default value
             choices: [ "GLOBAL","PRIVATE" ])
-
     }
 
     environment {
@@ -281,7 +280,7 @@ pipeline {
         }
 
 
-        stage('Install App stack with external cert-manager and ingress-nginx') {
+        stage('Install app stack with external cert-manager and ingress-nginx') {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
@@ -295,21 +294,17 @@ pipeline {
                     ci/scripts/install_third_party_components.sh
                 """
 
-               script {
+                script {
                     if (params.DNS_TYPE == "ocidns") {
                         env.DNS_ZONE_OCID = sh(script: "${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o create -c ${OCI_ZONE_COMPARTMENT_ID} -s z${zoneId} -k ${params.DNS_SCOPE}", returnStdout: true)
                     }
-               }
 
-                sh """
-                    ${WORKSPACE}/tests/e2e/config/scripts/create-test-oci-config-secret.sh
-                """
+                    sh """
+                        ${WORKSPACE}/tests/e2e/config/scripts/create-test-oci-config-secret.sh
+                    """
+                }
 
                 runGinkgoUpdate('update/a-la-carte', 'app-stack')
-
-                sh """
-                    kubectl get vz -A -o yaml
-                """
             }
 
             post {
@@ -323,7 +318,7 @@ pipeline {
             }
         }
 
-        stage('Verify App stack with external cert-manager and ingress-nginx') {
+        stage('Verify app stack with external cert-manager and ingress-nginx') {
             parallel {
                 stage('verify-install/promstack') {
                     environment {
@@ -563,11 +558,14 @@ pipeline {
             """
             archiveArtifacts artifacts: "**/coverage.html,**/logs/**,**/verrazzano_images.txt,**/*full-cluster*/**,**/*cluster-snapshot*/**,**/bug-report/**,**/Screenshot*.png,**/ConsoleLog*.log,**/${TEST_REPORT}", allowEmptyArchive: true
             junit testResults: "**/${TEST_REPORT}", allowEmptyResults: true
-//             if (params.DNS_TYPE == "ocidns") {
-//                  sh """
-//                     ${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o delete -s z${zoneId} -k ${params.DNS_SCOPE} || echo "Failed to delete DNS zone z${zoneId}"
-//                  """
-//             }
+            script {
+                if (params.DNS_TYPE == "ocidns") {
+                     sh """
+                        ${WORKSPACE}/tests/e2e/config/scripts/oci_dns_ops.sh -o delete -s z${zoneId} -k ${params.DNS_SCOPE} || echo "Failed to delete DNS zone z${zoneId}"
+                     """
+                }
+            }
+
             deleteCluster()
         }
         failure {

--- a/tests/e2e/update/a-la-carte/a_la_carte_suite_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_suite_test.go
@@ -13,10 +13,12 @@ import (
 
 var updateType string
 var clusterResourceNamespace string
+var dnsType string
 
 func init() {
 	flag.StringVar(&updateType, "updateType", "", "updateType is the type of update to perform")
 	flag.StringVar(&clusterResourceNamespace, "clusterResourceNamespace", "my-cert-manager", "the cluster issuer namespace")
+	flag.StringVar(&dnsType, "dnsType", "wildcard", "the DNS type to configure")
 
 }
 func TestALaCarte(t *testing.T) {

--- a/tests/e2e/update/a-la-carte/a_la_carte_suite_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_suite_test.go
@@ -14,12 +14,13 @@ import (
 var updateType string
 var clusterResourceNamespace string
 var dnsType string
+var certificateType string
 
 func init() {
 	flag.StringVar(&updateType, "updateType", "", "updateType is the type of update to perform")
 	flag.StringVar(&clusterResourceNamespace, "clusterResourceNamespace", "my-cert-manager", "the cluster issuer namespace")
 	flag.StringVar(&dnsType, "dnsType", "wildcard", "the DNS type to configure")
-
+	flag.StringVar(&certificateType, "certificateType", "default", "the certificate issuer")
 }
 func TestALaCarte(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -120,8 +120,7 @@ func (m appStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
 			ValueOverrides: []vzapi.Overrides{
 				{
 					Values: &apiextensionsv1.JSON{
-						Raw: []byte(fmt.Sprintf(`
-certManager:
+						Raw: []byte(fmt.Sprintf(`certManager:
   namespace: my-cert-manager
   clusterResourceNamespace: %s`, clusterResourceNamespace)),
 					},

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -124,7 +124,6 @@ func (m noneModifier) ModifyCR(cr *vzapi.Verrazzano) {
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
 	Expect(getModifer(updateType)).ToNot(BeNil(), fmt.Sprintf("Provided update type %s was not a supported update type", updateType))
-	os.Getenv("")
 })
 
 var _ = BeforeSuite(beforeSuite)

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -120,9 +120,11 @@ func (m appStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
 			ValueOverrides: []vzapi.Overrides{
 				{
 					Values: &apiextensionsv1.JSON{
-						Raw: []byte(fmt.Sprintf(`certManager:
-  namespace: my-cert-manager
-  clusterResourceNamespace: %s`, clusterResourceNamespace)),
+						Raw: []byte(fmt.Sprintf(`{
+  "certManager": {
+    "namespace": "my-cert-manager",
+    "clusterResourceNamespace": "%s"
+  }}`, clusterResourceNamespace)),
 					},
 				},
 			},

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -5,6 +5,7 @@ package alacarte
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,6 +26,11 @@ const (
 	istioAppStack          = "istio-app-stack"
 	clusterManagementStack = "cluster-management-stack"
 	noneProfile            = "none-profile"
+
+	ociConfigSecretName          = "oci"
+	dnsZoneCompartmentOCIDEnvvar = "OCI_ZONE_COMPARTMENT_ID"
+	dnsZoneOCIDEnvvar            = "DNS_ZONE_OCID"
+	dnsZoneNameEnvvar            = "OCI_DNS_ZONE_NAME"
 )
 
 var (
@@ -81,6 +87,13 @@ func (m appStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
 	cr.Spec.Components.OAM = &vzapi.OAMComponent{Enabled: &trueVal}
 	cr.Spec.Components.Verrazzano = &vzapi.VerrazzanoComponent{Enabled: &trueVal}
 	cr.Spec.Components.JaegerOperator = &vzapi.JaegerOperatorComponent{Enabled: &trueVal}
+	cr.Spec.Components.DNS = &vzapi.DNSComponent{OCI: &vzapi.OCI{
+		DNSZoneCompartmentOCID: os.Getenv(dnsZoneCompartmentOCIDEnvvar),
+		DNSZoneOCID:            os.Getenv(dnsZoneOCIDEnvvar),
+		DNSZoneName:            os.Getenv(dnsZoneNameEnvvar),
+		OCIConfigSecret:        ociConfigSecretName,
+	}}
+
 
 	cr.Spec.Components.CertManager = &vzapi.CertManagerComponent{Enabled: &falseVal}
 	cr.Spec.Components.ClusterIssuer = &vzapi.ClusterIssuerComponent{
@@ -111,6 +124,7 @@ func (m noneModifier) ModifyCR(cr *vzapi.Verrazzano) {
 
 var beforeSuite = t.BeforeSuiteFunc(func() {
 	Expect(getModifer(updateType)).ToNot(BeNil(), fmt.Sprintf("Provided update type %s was not a supported update type", updateType))
+	os.Getenv("")
 })
 
 var _ = BeforeSuite(beforeSuite)

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -94,7 +94,6 @@ func (m appStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
 		OCIConfigSecret:        ociConfigSecretName,
 	}}
 
-
 	cr.Spec.Components.CertManager = &vzapi.CertManagerComponent{Enabled: &falseVal}
 	cr.Spec.Components.ClusterIssuer = &vzapi.ClusterIssuerComponent{
 		ClusterResourceNamespace: clusterResourceNamespace,

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -27,6 +27,8 @@ const (
 	clusterManagementStack = "cluster-management-stack"
 	noneProfile            = "none-profile"
 
+	ocidnsType = "ocidns"
+
 	ociConfigSecretName          = "oci"
 	dnsZoneCompartmentOCIDEnvvar = "OCI_ZONE_COMPARTMENT_ID"
 	dnsZoneOCIDEnvvar            = "DNS_ZONE_OCID"
@@ -87,12 +89,16 @@ func (m appStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
 	cr.Spec.Components.OAM = &vzapi.OAMComponent{Enabled: &trueVal}
 	cr.Spec.Components.Verrazzano = &vzapi.VerrazzanoComponent{Enabled: &trueVal}
 	cr.Spec.Components.JaegerOperator = &vzapi.JaegerOperatorComponent{Enabled: &trueVal}
-	cr.Spec.Components.DNS = &vzapi.DNSComponent{OCI: &vzapi.OCI{
-		DNSZoneCompartmentOCID: os.Getenv(dnsZoneCompartmentOCIDEnvvar),
-		DNSZoneOCID:            os.Getenv(dnsZoneOCIDEnvvar),
-		DNSZoneName:            os.Getenv(dnsZoneNameEnvvar),
-		OCIConfigSecret:        ociConfigSecretName,
-	}}
+	if dnsType == ocidnsType {
+		cr.Spec.Components.DNS = &vzapi.DNSComponent{
+			OCI: &vzapi.OCI{
+				DNSZoneCompartmentOCID: os.Getenv(dnsZoneCompartmentOCIDEnvvar),
+				DNSZoneOCID:            os.Getenv(dnsZoneOCIDEnvvar),
+				DNSZoneName:            os.Getenv(dnsZoneNameEnvvar),
+				OCIConfigSecret:        ociConfigSecretName,
+			},
+		}
+	}
 
 	cr.Spec.Components.CertManager = &vzapi.CertManagerComponent{Enabled: &falseVal}
 	cr.Spec.Components.ClusterIssuer = &vzapi.ClusterIssuerComponent{


### PR DESCRIPTION
Added support for OCIDNS and letsEncrypt in the a-la-carte pipeline.