### PR TITLE
VZ-9919 - VMO does not need to be enabled when Prometheus is enabled e.g. managed clusters

### DIFF
--- a/pkg/vzcr/enabled.go
+++ b/pkg/vzcr/enabled.go
@@ -350,7 +350,7 @@ func IsOCIDNSEnabled(cr runtime.Object) bool {
 
 // IsVMOEnabled - Returns false if all VMO components are disabled
 func IsVMOEnabled(vz runtime.Object) bool {
-	return IsPrometheusEnabled(vz) || IsOpenSearchDashboardsEnabled(vz) || IsOpenSearchEnabled(vz) || IsGrafanaEnabled(vz)
+	return IsOpenSearchDashboardsEnabled(vz) || IsOpenSearchEnabled(vz) || IsGrafanaEnabled(vz)
 }
 
 // IsPrometheusOperatorEnabled returns false only if the Prometheus Operator is explicitly disabled in the CR

--- a/tests/e2e/verify-install/kubernetes/kubernetes_test.go
+++ b/tests/e2e/verify-install/kubernetes/kubernetes_test.go
@@ -39,7 +39,7 @@ var expectedPodsIngressNginx = []string{
 	"ingress-controller-ingress-nginx-controller",
 	"ingress-controller-ingress-nginx-defaultbackend"}
 
-var expectedVMOPod string = "verrazzano-monitoring-operator"
+var expectedVMOPod = "verrazzano-monitoring-operator"
 
 // comment out while debugging so it does not break master
 // "vmi-system-prometheus",


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
