### PR TITLE
Fix CAPI upgrade for DEVLRE

### DIFF
--- a/platform-operator/capi/bootstrap-ocne/v0.1.0/bootstrap-components.yaml
+++ b/platform-operator/capi/bootstrap-ocne/v0.1.0/bootstrap-components.yaml
@@ -1,0 +1,2710 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+    control-plane: controller-manager
+  name: capi-ocne-bootstrap-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-ocne-bootstrap-system/capi-ocne-bootstrap-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+    cluster.x-k8s.io/v1beta1: v1alpha1
+  name: ocneconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-ocne-bootstrap-webhook-service
+          namespace: capi-ocne-bootstrap-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OCNEConfig
+    listKind: OCNEConfigList
+    plural: ocneconfigs
+    singular: ocneconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Time duration since creation of OCNEConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OCNEConfig is the Schema for the ocneconfigs API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCNEConfigSpec defines the desired state of OCNEConfig. Either
+              ClusterConfiguration and InitConfiguration should be defined or the
+              JoinConfiguration should be defined.
+            properties:
+              clusterConfiguration:
+                description: ClusterConfiguration along with InitConfiguration are
+                  the configurations necessary for the init command
+                properties:
+                  apiServer:
+                    description: APIServer contains extra settings for the API server
+                      control plane component
+                    properties:
+                      certSANs:
+                        description: CertSANs sets extra Subject Alternative Names
+                          for the API Server signing cert.
+                        items:
+                          type: string
+                        type: array
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to
+                          the control plane component. TODO: This is temporary and
+                          ideally we would like to switch all components to use ComponentConfig
+                          + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing
+                            volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will
+                                be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      timeoutForControlPlane:
+                        description: TimeoutForControlPlane controls the timeout that
+                          we use for API server to appear
+                        type: string
+                    type: object
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  certificatesDir:
+                    description: 'CertificatesDir specifies where to store or look
+                      for all required certificates. NB: if not provided, this will
+                      default to `/etc/kubernetes/pki`'
+                    type: string
+                  clusterName:
+                    description: The cluster name
+                    type: string
+                  controlPlaneEndpoint:
+                    description: 'ControlPlaneEndpoint sets a stable IP address or
+                      DNS name for the control plane; it can be a valid IP address
+                      or a RFC-1123 DNS subdomain, both with optional TCP port. In
+                      case the ControlPlaneEndpoint is not specified, the AdvertiseAddress
+                      + BindPort are used; in case the ControlPlaneEndpoint is specified
+                      but without a TCP port, the BindPort is used. Possible usages
+                      are: e.g. In a cluster with more than one control plane instances,
+                      this field should be assigned the address of the external load
+                      balancer in front of the control plane instances. e.g.  in environments
+                      with enforced node recycling, the ControlPlaneEndpoint could
+                      be used for assigning a stable DNS to the control plane. NB:
+                      This value defaults to the first value in the Cluster object
+                      status.apiEndpoints array.'
+                    type: string
+                  controllerManager:
+                    description: ControllerManager contains extra settings for the
+                      controller manager control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to
+                          the control plane component. TODO: This is temporary and
+                          ideally we would like to switch all components to use ComponentConfig
+                          + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing
+                            volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will
+                                be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  dns:
+                    description: DNS defines the options for the DNS add-on installed
+                      in the cluster.
+                    properties:
+                      imageRepository:
+                        description: ImageRepository sets the container registry to
+                          pull images from. if not set, the ImageRepository defined
+                          in ClusterConfiguration will be used instead.
+                        type: string
+                      imageTag:
+                        description: ImageTag allows to specify a tag for the image.
+                          In case this value is set, kubeadm does not change automatically
+                          the version of the above components during upgrades.
+                        type: string
+                    type: object
+                  etcd:
+                    description: 'Etcd holds configuration for etcd. NB: This value
+                      defaults to a Local (stacked) etcd'
+                    properties:
+                      external:
+                        description: External describes how to connect to an external
+                          etcd cluster Local and External are mutually exclusive
+                        properties:
+                          caFile:
+                            description: CAFile is an SSL Certificate Authority file
+                              used to secure etcd communication. Required if using
+                              a TLS connection.
+                            type: string
+                          certFile:
+                            description: CertFile is an SSL certification file used
+                              to secure etcd communication. Required if using a TLS
+                              connection.
+                            type: string
+                          endpoints:
+                            description: Endpoints of etcd members. Required for ExternalEtcd.
+                            items:
+                              type: string
+                            type: array
+                          keyFile:
+                            description: KeyFile is an SSL key file used to secure
+                              etcd communication. Required if using a TLS connection.
+                            type: string
+                        required:
+                        - caFile
+                        - certFile
+                        - endpoints
+                        - keyFile
+                        type: object
+                      local:
+                        description: Local provides configuration knobs for configuring
+                          the local etcd instance Local and External are mutually
+                          exclusive
+                        properties:
+                          dataDir:
+                            description: DataDir is the directory etcd will place
+                              its data. Defaults to "/var/lib/etcd".
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraArgs are extra arguments provided to
+                              the etcd binary when run inside a static pod.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry
+                              to pull images from. if not set, the ImageRepository
+                              defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the
+                              image. In case this value is set, kubeadm does not change
+                              automatically the version of the above components during
+                              upgrades.
+                            type: string
+                          peerCertSANs:
+                            description: PeerCertSANs sets extra Subject Alternative
+                              Names for the etcd peer signing cert.
+                            items:
+                              type: string
+                            type: array
+                          serverCertSANs:
+                            description: ServerCertSANs sets extra Subject Alternative
+                              Names for the etcd server signing cert.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: FeatureGates enabled by the user.
+                    type: object
+                  imageRepository:
+                    description: 'ImageRepository sets the container registry to pull
+                      images from. * If not set, the default registry of kubeadm will
+                      be used, i.e. * registry.k8s.io (new registry): >= v1.22.17,
+                      >= v1.23.15, >= v1.24.9, >= v1.25.0 * k8s.gcr.io (old registry):
+                      all older versions Please note that when imageRepository is
+                      not set we don''t allow upgrades to versions >= v1.22.0 which
+                      use the old registry (k8s.gcr.io). Please use a newer patch
+                      version with the new registry instead (i.e. >= v1.22.17, >=
+                      v1.23.15, >= v1.24.9, >= v1.25.0). * If the version is a CI
+                      build (kubernetes version starts with `ci/` or `ci-cross/`)
+                      `gcr.io/k8s-staging-ci-images` will be used as a default for
+                      control plane components and for kube-proxy, while `registry.k8s.io`
+                      will be used for all the other images.'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  kubernetesVersion:
+                    description: 'KubernetesVersion is the target version of the control
+                      plane. NB: This value defaults to the Machine object spec.version'
+                    type: string
+                  networking:
+                    description: 'Networking holds configuration for the networking
+                      topology of the cluster. NB: This value defaults to the Cluster
+                      object spec.clusterNetwork.'
+                    properties:
+                      dnsDomain:
+                        description: DNSDomain is the dns domain used by k8s services.
+                          Defaults to "cluster.local".
+                        type: string
+                      podSubnet:
+                        description: PodSubnet is the subnet used by pods. If unset,
+                          the API server will not allocate CIDR ranges for every node.
+                          Defaults to a comma-delimited string of the Cluster object's
+                          spec.clusterNetwork.services.cidrBlocks if that is set
+                        type: string
+                      serviceSubnet:
+                        description: ServiceSubnet is the subnet used by k8s services.
+                          Defaults to a comma-delimited string of the Cluster object's
+                          spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12"
+                          if that's unset.
+                        type: string
+                    type: object
+                  scheduler:
+                    description: Scheduler contains extra settings for the scheduler
+                      control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to
+                          the control plane component. TODO: This is temporary and
+                          ideally we would like to switch all components to use ComponentConfig
+                          + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing
+                            volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will
+                                be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              diskSetup:
+                description: DiskSetup specifies options for the creation of partition
+                  tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: Filesystems specifies the list of file systems to
+                      setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: Device specifies the device name
+                          type: string
+                        extraOpts:
+                          description: ExtraOpts defined extra options to add to the
+                            command for creating the file system.
+                          items:
+                            type: string
+                          type: array
+                        filesystem:
+                          description: Filesystem specifies the file system type.
+                          type: string
+                        label:
+                          description: Label specifies the file system label to be
+                            used. If set to None, no label is used.
+                          type: string
+                        overwrite:
+                          description: Overwrite defines whether or not to overwrite
+                            any existing filesystem. If true, any pre-existing file
+                            system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'Partition specifies the partition to use.
+                            The valid options are: "auto|any", "auto", "any", "none",
+                            and <NUM>, where NUM is the actual partition number.'
+                          type: string
+                        replaceFS:
+                          description: 'ReplaceFS is a special directive, used for
+                            Microsoft Azure that instructs cloud-init to replace a
+                            file system of <FS_TYPE>. NOTE: unless you define a label,
+                            this requires the use of the ''any'' partition directive.'
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      - label
+                      type: object
+                    type: array
+                  partitions:
+                    description: Partitions specifies the list of the partitions to
+                      setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: Device is the name of the device.
+                          type: string
+                        layout:
+                          description: Layout specifies the device layout. If it is
+                            true, a single partition will be created for the entire
+                            device. When layout is false, it means don't partition
+                            or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: Overwrite describes whether to skip checks
+                            and create the partition if a partition or filesystem
+                            is found on the device. Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: 'TableType specifies the tupe of partition
+                            table. The following are supported: ''mbr'': default and
+                            setups a MS-DOS partition table ''gpt'': setups a GPT
+                            partition table'
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    type: array
+                type: object
+              files:
+                description: Files specifies extra files to be passed to user_data
+                  upon creation.
+                items:
+                  description: File defines the input for generating write_files in
+                    cloud-init.
+                  properties:
+                    append:
+                      description: Append specifies whether to append Content to existing
+                        file if Path exists.
+                      type: boolean
+                    content:
+                      description: Content is the actual content of the file.
+                      type: string
+                    contentFrom:
+                      description: ContentFrom is a referenced source of content to
+                        populate the file.
+                      properties:
+                        secret:
+                          description: Secret represents a secret that should populate
+                            this file.
+                          properties:
+                            key:
+                              description: Key is the key in the secret's data map
+                                for this value.
+                              type: string
+                            name:
+                              description: Name of the secret in the KubeadmBootstrapConfig's
+                                namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: Encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: Owner specifies the ownership of the file, e.g.
+                        "root:root".
+                      type: string
+                    path:
+                      description: Path specifies the full path on disk where to store
+                        the file.
+                      type: string
+                    permissions:
+                      description: Permissions specifies the permissions to assign
+                        to the file, e.g. "0640".
+                      type: string
+                  required:
+                  - path
+                  type: object
+                type: array
+              format:
+                description: Format specifies the output format of the bootstrap data
+                enum:
+                - cloud-config
+                - ignition
+                type: string
+              ignition:
+                description: Ignition contains Ignition specific configuration.
+                properties:
+                  containerLinuxConfig:
+                    description: ContainerLinuxConfig contains CLC specific configuration.
+                    properties:
+                      additionalConfig:
+                        description: "AdditionalConfig contains additional configuration
+                          to be merged with the Ignition configuration generated by
+                          the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+                          \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/"
+                        type: string
+                      strict:
+                        description: Strict controls if AdditionalConfig should be
+                          strictly parsed. If so, warnings are treated as errors.
+                        type: boolean
+                    type: object
+                type: object
+              imageConfiguration:
+                description: ImageConfiguration contains configuration required for
+                  the base image.
+                properties:
+                  dependencies:
+                    description: Dependencies contains details about dependencies
+                      on the image that can be configured at boot time.
+                    properties:
+                      skipInstall:
+                        description: SkipInstall is the flag that can be used to tell
+                          the provider to skip install of OCNE dependencies. The value,
+                          if set to true, will be used to skip the overrides installation
+                          on OCNEConfigSpec. By default, this value is false.
+                        type: boolean
+                    type: object
+                  proxy:
+                    description: Proxy contains proxy server info that may be required
+                      for installing dependencies. The value, if specified is used
+                      in conjunction with preOCNECommands to install and configure
+                      repositories.
+                    properties:
+                      httpProxy:
+                        description: HttpProxy contains http proxy server info that
+                          may be required for installing dependencies. The value,
+                          if specified is used in conjunction with preOCNECommands
+                          to install and configure repositories.
+                        type: string
+                      httpsProxy:
+                        description: HttpsProxy contains https proxy server info that
+                          may be required for installing dependencies. The value,
+                          if specified is used in conjunction with preOCNECommands
+                          to install and configure repositories.
+                        type: string
+                      noProxy:
+                        description: NoProxy contains addresses that needs to be skipped
+                          when proxy server is being used. The value, if specified
+                          is used in conjunction with preOCNECommands to install and
+                          configure repositories.
+                        type: string
+                    type: object
+                type: object
+              initConfiguration:
+                description: InitConfiguration along with ClusterConfiguration are
+                  the configurations necessary for the init command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  bootstrapTokens:
+                    description: BootstrapTokens is respected at `kubeadm init` time
+                      and describes a set of Bootstrap Tokens to create. This information
+                      IS NOT uploaded to the kubeadm cluster configmap, partly because
+                      of its sensitive nature
+                    items:
+                      description: BootstrapToken describes one bootstrap token, stored
+                        as a Secret in the cluster.
+                      properties:
+                        description:
+                          description: Description sets a human-friendly message why
+                            this token exists and what it's used for, so other administrators
+                            can know its purpose.
+                          type: string
+                        expires:
+                          description: Expires specifies the timestamp when this token
+                            expires. Defaults to being set dynamically at runtime
+                            based on the TTL. Expires and TTL are mutually exclusive.
+                          format: date-time
+                          type: string
+                        groups:
+                          description: Groups specifies the extra groups that this
+                            token will authenticate as when/if used for authentication
+                          items:
+                            type: string
+                          type: array
+                        token:
+                          description: Token is used for establishing bidirectional
+                            trust between nodes and control-planes. Used for joining
+                            nodes in the cluster.
+                          type: string
+                        ttl:
+                          description: TTL defines the time to live for this token.
+                            Defaults to 24h. Expires and TTL are mutually exclusive.
+                          type: string
+                        usages:
+                          description: Usages describes the ways in which this token
+                            can be used. Can by default be used for establishing bidirectional
+                            trust, but that can be changed here.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - token
+                      type: object
+                    type: array
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  localAPIEndpoint:
+                    description: LocalAPIEndpoint represents the endpoint of the API
+                      server instance that's deployed on this control plane node In
+                      HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint
+                      in the sense that ControlPlaneEndpoint is the global endpoint
+                      for the cluster, which then loadbalances the requests to each
+                      individual API server. This configuration object lets you customize
+                      what IP/DNS name and port the local API server advertises it's
+                      accessible on. By default, kubeadm tries to auto-detect the
+                      IP of the default interface and use that, but in case that process
+                      fails you may set the desired value here.
+                    properties:
+                      advertiseAddress:
+                        description: AdvertiseAddress sets the IP address for the
+                          API server to advertise.
+                        type: string
+                      bindPort:
+                        description: BindPort sets the secure port for the API Server
+                          to bind to. Defaults to 6443.
+                        format: int32
+                        type: integer
+                    type: object
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering
+                      the new control-plane node to the cluster. When used in the
+                      context of control plane nodes, NodeRegistration should remain
+                      consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime
+                          info. This information will be annotated to the Node API
+                          object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: IgnorePreflightErrors provides a slice of pre-flight
+                          errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments
+                          to the kubelet. The arguments here are passed to the kubelet
+                          command line via the environment file kubeadm writes at
+                          runtime for the kubelet to source. This overrides the generic
+                          base-level configuration in the kubelet-config-1.X ConfigMap
+                          Flags have higher priority when parsing. These values are
+                          local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node
+                          API object that will be created in this `kubeadm init` or
+                          `kubeadm join` operation. This field is also used in the
+                          CommonName field of the kubelet's client certificate to
+                          the API server. Defaults to the hostname of the node if
+                          not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object
+                          should be registered with. If this field is unset, i.e.
+                          nil, in the `kubeadm init` process it will be defaulted
+                          to []v1.Taint{''node-role.kubernetes.io/master=""''}. If
+                          you don''t want to taint your control-plane node, set this
+                          field to an empty slice, i.e. `taints: []` in the YAML file.
+                          This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the
+                            "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods
+                                that do not tolerate the taint. Valid effects are
+                                NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which
+                                the taint was added. It is only written for NoExecute
+                                taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                  patches:
+                    description: Patches contains options related to applying patches
+                      to components deployed by kubeadm during "kubeadm init". The
+                      minimum kubernetes version needed to support Patches is v1.22
+                    properties:
+                      directory:
+                        description: Directory is a path to a directory that contains
+                          files named "target[suffix][+patchtype].extension". For
+                          example, "kube-apiserver0+merge.yaml" or just "etcd.json".
+                          "target" can be one of "kube-apiserver", "kube-controller-manager",
+                          "kube-scheduler", "etcd". "patchtype" can be one of "strategic"
+                          "merge" or "json" and they match the patch formats supported
+                          by kubectl. The default "patchtype" is "strategic". "extension"
+                          must be either "json" or "yaml". "suffix" is an optional
+                          string that can be used to determine which patches are applied
+                          first alpha-numerically. These files can be written into
+                          the target directory via OCNEConfig.Files which specifies
+                          additional files to be created on the machine, either with
+                          content inline or by referencing a secret.
+                        type: string
+                    type: object
+                  skipPhases:
+                    description: SkipPhases is a list of phases to skip during command
+                      execution. The list of phases can be obtained with the "kubeadm
+                      init --help" command. This option takes effect only on Kubernetes
+                      >=1.22.0.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              joinConfiguration:
+                description: JoinConfiguration is the kubeadm configuration for the
+                  join command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  caCertPath:
+                    description: 'CACertPath is the path to the SSL certificate authority
+                      used to secure comunications between node and control-plane.
+                      Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when
+                      there is defaulting from k/k'
+                    type: string
+                  controlPlane:
+                    description: ControlPlane defines the additional control plane
+                      instance to be deployed on the joining node. If nil, no additional
+                      control plane instance will be deployed.
+                    properties:
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the
+                          API server instance to be deployed on this node.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for
+                              the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API
+                              Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  discovery:
+                    description: 'Discovery specifies the options for the kubelet
+                      to use during the TLS Bootstrap process TODO: revisit when there
+                      is defaulting from k/k'
+                    properties:
+                      bootstrapToken:
+                        description: BootstrapToken is used to set the options for
+                          bootstrap token based discovery BootstrapToken and File
+                          are mutually exclusive
+                        properties:
+                          apiServerEndpoint:
+                            description: APIServerEndpoint is an IP or domain name
+                              to the API server from which info will be fetched.
+                            type: string
+                          caCertHashes:
+                            description: 'CACertHashes specifies a set of public key
+                              pins to verify when token-based discovery is used. The
+                              root CA found during discovery must match one of these
+                              values. Specifying an empty set disables root CA pinning,
+                              which can be unsafe. Each hash is specified as "<type>:<value>",
+                              where the only currently supported type is "sha256".
+                              This is a hex-encoded SHA-256 hash of the Subject Public
+                              Key Info (SPKI) object in DER-encoded ASN.1. These hashes
+                              can be calculated using, for example, OpenSSL: openssl
+                              x509 -pubkey -in ca.crt openssl rsa -pubin -outform
+                              der 2>&/dev/null | openssl dgst -sha256 -hex'
+                            items:
+                              type: string
+                            type: array
+                          token:
+                            description: Token is a token used to validate cluster
+                              information fetched from the control-plane.
+                            type: string
+                          unsafeSkipCAVerification:
+                            description: UnsafeSkipCAVerification allows token-based
+                              discovery without CA verification via CACertHashes.
+                              This can weaken the security of kubeadm since other
+                              nodes can impersonate the control-plane.
+                            type: boolean
+                        required:
+                        - token
+                        type: object
+                      file:
+                        description: File is used to specify a file or URL to a kubeconfig
+                          file from which to load cluster information BootstrapToken
+                          and File are mutually exclusive
+                        properties:
+                          kubeConfigPath:
+                            description: KubeConfigPath is used to specify the actual
+                              file path or URL to the kubeconfig file from which to
+                              load cluster information
+                            type: string
+                        required:
+                        - kubeConfigPath
+                        type: object
+                      timeout:
+                        description: Timeout modifies the discovery timeout
+                        type: string
+                      tlsBootstrapToken:
+                        description: TLSBootstrapToken is a token used for TLS bootstrapping.
+                          If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token,
+                          but can be overridden. If .File is set, this field **must
+                          be set** in case the KubeConfigFile does not contain any
+                          other authentication information
+                        type: string
+                    type: object
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering
+                      the new control-plane node to the cluster. When used in the
+                      context of control plane nodes, NodeRegistration should remain
+                      consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime
+                          info. This information will be annotated to the Node API
+                          object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: IgnorePreflightErrors provides a slice of pre-flight
+                          errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments
+                          to the kubelet. The arguments here are passed to the kubelet
+                          command line via the environment file kubeadm writes at
+                          runtime for the kubelet to source. This overrides the generic
+                          base-level configuration in the kubelet-config-1.X ConfigMap
+                          Flags have higher priority when parsing. These values are
+                          local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node
+                          API object that will be created in this `kubeadm init` or
+                          `kubeadm join` operation. This field is also used in the
+                          CommonName field of the kubelet's client certificate to
+                          the API server. Defaults to the hostname of the node if
+                          not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object
+                          should be registered with. If this field is unset, i.e.
+                          nil, in the `kubeadm init` process it will be defaulted
+                          to []v1.Taint{''node-role.kubernetes.io/master=""''}. If
+                          you don''t want to taint your control-plane node, set this
+                          field to an empty slice, i.e. `taints: []` in the YAML file.
+                          This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the
+                            "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods
+                                that do not tolerate the taint. Valid effects are
+                                NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which
+                                the taint was added. It is only written for NoExecute
+                                taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                  patches:
+                    description: Patches contains options related to applying patches
+                      to components deployed by kubeadm during "kubeadm join". The
+                      minimum kubernetes version needed to support Patches is v1.22
+                    properties:
+                      directory:
+                        description: Directory is a path to a directory that contains
+                          files named "target[suffix][+patchtype].extension". For
+                          example, "kube-apiserver0+merge.yaml" or just "etcd.json".
+                          "target" can be one of "kube-apiserver", "kube-controller-manager",
+                          "kube-scheduler", "etcd". "patchtype" can be one of "strategic"
+                          "merge" or "json" and they match the patch formats supported
+                          by kubectl. The default "patchtype" is "strategic". "extension"
+                          must be either "json" or "yaml". "suffix" is an optional
+                          string that can be used to determine which patches are applied
+                          first alpha-numerically. These files can be written into
+                          the target directory via OCNEConfig.Files which specifies
+                          additional files to be created on the machine, either with
+                          content inline or by referencing a secret.
+                        type: string
+                    type: object
+                  skipPhases:
+                    description: SkipPhases is a list of phases to skip during command
+                      execution. The list of phases can be obtained with the "kubeadm
+                      init --help" command. This option takes effect only on Kubernetes
+                      >=1.22.0.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              mounts:
+                description: Mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    type: string
+                  type: array
+                type: array
+              ntp:
+                description: NTP specifies NTP configuration
+                properties:
+                  enabled:
+                    description: Enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: Servers specifies which NTP servers to use
+                    items:
+                      type: string
+                    type: array
+                type: object
+              postOCNECommands:
+                description: PostOCNECommands specifies extra commands to run after
+                  kubeadm runs
+                items:
+                  type: string
+                type: array
+              preOCNECommands:
+                description: PreOCNECommands specifies extra commands to run before
+                  kubeadm runs
+                items:
+                  type: string
+                type: array
+              useExperimentalRetryJoin:
+                description: "UseExperimentalRetryJoin replaces a basic kubeadm command
+                  with a shell script with retries for joins. \n This is meant to
+                  be an experimental temporary workaround on some environments where
+                  joins fail due to timing (and other issues). The long term goal
+                  is to add retries to kubeadm proper and use that functionality.
+                  \n This will add about 40KB to userdata \n For more information,
+                  refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                  \n Deprecated: This experimental fix is no longer needed and this
+                  field will be removed in a future release. When removing also remove
+                  from staticcheck exclude-rules for SA1019 in golangci.yml"
+                type: boolean
+              users:
+                description: Users specifies extra users to add
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: Gecos specifies the gecos to use for the user
+                      type: string
+                    groups:
+                      description: Groups specifies the additional groups for the
+                        user
+                      type: string
+                    homeDir:
+                      description: HomeDir specifies the home directory to use for
+                        the user
+                      type: string
+                    inactive:
+                      description: Inactive specifies whether to mark the user as
+                        inactive
+                      type: boolean
+                    lockPassword:
+                      description: LockPassword specifies if password login should
+                        be disabled
+                      type: boolean
+                    name:
+                      description: Name specifies the user name
+                      type: string
+                    passwd:
+                      description: Passwd specifies a hashed password for the user
+                      type: string
+                    passwdFrom:
+                      description: PasswdFrom is a referenced source of passwd to
+                        populate the passwd.
+                      properties:
+                        secret:
+                          description: Secret represents a secret that should populate
+                            this password.
+                          properties:
+                            key:
+                              description: Key is the key in the secret's data map
+                                for this value.
+                              type: string
+                            name:
+                              description: Name of the secret in the KubeadmBootstrapConfig's
+                                namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    primaryGroup:
+                      description: PrimaryGroup specifies the primary group for the
+                        user
+                      type: string
+                    shell:
+                      description: Shell specifies the user's shell
+                      type: string
+                    sshAuthorizedKeys:
+                      description: SSHAuthorizedKeys specifies a list of ssh authorized
+                        keys for the user
+                      items:
+                        type: string
+                      type: array
+                    sudo:
+                      description: Sudo specifies a sudo role for the user
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              verbosity:
+                description: Verbosity is the number for the kubeadm log level verbosity.
+                  It overrides the `--v` flag in kubeadm commands.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: OCNEConfigStatus defines the observed state of OCNEConfig.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the OCNEConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores
+                  the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData field is ready to be
+                  consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-ocne-bootstrap-system/capi-ocne-bootstrap-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+    cluster.x-k8s.io/v1beta1: v1alpha1
+  name: ocneconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-ocne-bootstrap-webhook-service
+          namespace: capi-ocne-bootstrap-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OCNEConfigTemplate
+    listKind: OCNEConfigTemplateList
+    plural: ocneconfigtemplates
+    singular: ocneconfigtemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of OCNEConfigTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OCNEConfigTemplate is the Schema for the ocneconfigtemplates
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCNEConfigTemplateSpec defines the desired state of OCNEConfigTemplate.
+            properties:
+              template:
+                description: OCNEConfigTemplateResource defines the Template structure.
+                properties:
+                  spec:
+                    description: OCNEConfigSpec defines the desired state of OCNEConfig.
+                      Either ClusterConfiguration and InitConfiguration should be
+                      defined or the JoinConfiguration should be defined.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the
+                              API server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative
+                                  Names for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to
+                                  pass to the control plane component. TODO: This
+                                  is temporary and ideally we would like to switch
+                                  all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing
+                                    volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host
+                                        that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema
+                              of this representation of an object. Servers should
+                              convert recognized schemas to the latest internal value,
+                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          certificatesDir:
+                            description: 'CertificatesDir specifies where to store
+                              or look for all required certificates. NB: if not provided,
+                              this will default to `/etc/kubernetes/pki`'
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: 'ControlPlaneEndpoint sets a stable IP address
+                              or DNS name for the control plane; it can be a valid
+                              IP address or a RFC-1123 DNS subdomain, both with optional
+                              TCP port. In case the ControlPlaneEndpoint is not specified,
+                              the AdvertiseAddress + BindPort are used; in case the
+                              ControlPlaneEndpoint is specified but without a TCP
+                              port, the BindPort is used. Possible usages are: e.g.
+                              In a cluster with more than one control plane instances,
+                              this field should be assigned the address of the external
+                              load balancer in front of the control plane instances.
+                              e.g.  in environments with enforced node recycling,
+                              the ControlPlaneEndpoint could be used for assigning
+                              a stable DNS to the control plane. NB: This value defaults
+                              to the first value in the Cluster object status.apiEndpoints
+                              array.'
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings
+                              for the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to
+                                  pass to the control plane component. TODO: This
+                                  is temporary and ideally we would like to switch
+                                  all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing
+                                    volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host
+                                        that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on
+                              installed in the cluster.
+                            properties:
+                              imageRepository:
+                                description: ImageRepository sets the container registry
+                                  to pull images from. if not set, the ImageRepository
+                                  defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for
+                                  the image. In case this value is set, kubeadm does
+                                  not change automatically the version of the above
+                                  components during upgrades.
+                                type: string
+                            type: object
+                          etcd:
+                            description: 'Etcd holds configuration for etcd. NB: This
+                              value defaults to a Local (stacked) etcd'
+                            properties:
+                              external:
+                                description: External describes how to connect to
+                                  an external etcd cluster Local and External are
+                                  mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: CAFile is an SSL Certificate Authority
+                                      file used to secure etcd communication. Required
+                                      if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: CertFile is an SSL certification
+                                      file used to secure etcd communication. Required
+                                      if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required
+                                      for ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: KeyFile is an SSL key file used to
+                                      secure etcd communication. Required if using
+                                      a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: Local provides configuration knobs for
+                                  configuring the local etcd instance Local and External
+                                  are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: DataDir is the directory etcd will
+                                      place its data. Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: ExtraArgs are extra arguments provided
+                                      to the etcd binary when run inside a static
+                                      pod.
+                                    type: object
+                                  imageRepository:
+                                    description: ImageRepository sets the container
+                                      registry to pull images from. if not set, the
+                                      ImageRepository defined in ClusterConfiguration
+                                      will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: ImageTag allows to specify a tag
+                                      for the image. In case this value is set, kubeadm
+                                      does not change automatically the version of
+                                      the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject
+                                      Alternative Names for the etcd server signing
+                                      cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: 'ImageRepository sets the container registry
+                              to pull images from. * If not set, the default registry
+                              of kubeadm will be used, i.e. * registry.k8s.io (new
+                              registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >=
+                              v1.25.0 * k8s.gcr.io (old registry): all older versions
+                              Please note that when imageRepository is not set we
+                              don''t allow upgrades to versions >= v1.22.0 which use
+                              the old registry (k8s.gcr.io). Please use a newer patch
+                              version with the new registry instead (i.e. >= v1.22.17,
+                              >= v1.23.15, >= v1.24.9, >= v1.25.0). * If the version
+                              is a CI build (kubernetes version starts with `ci/`
+                              or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will
+                              be used as a default for control plane components and
+                              for kube-proxy, while `registry.k8s.io` will be used
+                              for all the other images.'
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the
+                              REST resource this object represents. Servers may infer
+                              this from the endpoint the client submits requests to.
+                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          kubernetesVersion:
+                            description: 'KubernetesVersion is the target version
+                              of the control plane. NB: This value defaults to the
+                              Machine object spec.version'
+                            type: string
+                          networking:
+                            description: 'Networking holds configuration for the networking
+                              topology of the cluster. NB: This value defaults to
+                              the Cluster object spec.clusterNetwork.'
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s
+                                  services. Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: PodSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR
+                                  ranges for every node. Defaults to a comma-delimited
+                                  string of the Cluster object's spec.clusterNetwork.services.cidrBlocks
+                                  if that is set
+                                type: string
+                              serviceSubnet:
+                                description: ServiceSubnet is the subnet used by k8s
+                                  services. Defaults to a comma-delimited string of
+                                  the Cluster object's spec.clusterNetwork.pods.cidrBlocks,
+                                  or to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the
+                              scheduler control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to
+                                  pass to the control plane component. TODO: This
+                                  is temporary and ideally we would like to switch
+                                  all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing
+                                    volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host
+                                        that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod
+                                        template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation
+                          of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to
+                                be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to
+                                    add to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system
+                                    type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label
+                                    to be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: Overwrite defines whether or not to
+                                    overwrite any existing filesystem. If true, any
+                                    pre-existing file system will be destroyed. Use
+                                    with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition
+                                    to use. The valid options are: "auto|any", "auto",
+                                    "any", "none", and <NUM>, where NUM is the actual
+                                    partition number.'
+                                  type: string
+                                replaceFS:
+                                  description: 'ReplaceFS is a special directive,
+                                    used for Microsoft Azure that instructs cloud-init
+                                    to replace a file system of <FS_TYPE>. NOTE: unless
+                                    you define a label, this requires the use of the
+                                    ''any'' partition directive.'
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: Layout specifies the device layout.
+                                    If it is true, a single partition will be created
+                                    for the entire device. When layout is false, it
+                                    means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: Overwrite describes whether to skip
+                                    checks and create the partition if a partition
+                                    or filesystem is found on the device. Use with
+                                    caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: 'TableType specifies the tupe of partition
+                                    table. The following are supported: ''mbr'': default
+                                    and setups a MS-DOS partition table ''gpt'': setups
+                                    a GPT partition table'
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            append:
+                              description: Append specifies whether to append Content
+                                to existing file if Path exists.
+                              type: boolean
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's
+                                        data map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the
+                                file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to
+                                assign to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        - ignition
+                        type: string
+                      ignition:
+                        description: Ignition contains Ignition specific configuration.
+                        properties:
+                          containerLinuxConfig:
+                            description: ContainerLinuxConfig contains CLC specific
+                              configuration.
+                            properties:
+                              additionalConfig:
+                                description: "AdditionalConfig contains additional
+                                  configuration to be merged with the Ignition configuration
+                                  generated by the bootstrapper controller. More info:
+                                  https://coreos.github.io/ignition/operator-notes/#config-merging
+                                  \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/"
+                                type: string
+                              strict:
+                                description: Strict controls if AdditionalConfig should
+                                  be strictly parsed. If so, warnings are treated
+                                  as errors.
+                                type: boolean
+                            type: object
+                        type: object
+                      imageConfiguration:
+                        description: ImageConfiguration contains configuration required
+                          for the base image.
+                        properties:
+                          dependencies:
+                            description: Dependencies contains details about dependencies
+                              on the image that can be configured at boot time.
+                            properties:
+                              skipInstall:
+                                description: SkipInstall is the flag that can be used
+                                  to tell the provider to skip install of OCNE dependencies.
+                                  The value, if set to true, will be used to skip
+                                  the overrides installation on OCNEConfigSpec. By
+                                  default, this value is false.
+                                type: boolean
+                            type: object
+                          proxy:
+                            description: Proxy contains proxy server info that may
+                              be required for installing dependencies. The value,
+                              if specified is used in conjunction with preOCNECommands
+                              to install and configure repositories.
+                            properties:
+                              httpProxy:
+                                description: HttpProxy contains http proxy server
+                                  info that may be required for installing dependencies.
+                                  The value, if specified is used in conjunction with
+                                  preOCNECommands to install and configure repositories.
+                                type: string
+                              httpsProxy:
+                                description: HttpsProxy contains https proxy server
+                                  info that may be required for installing dependencies.
+                                  The value, if specified is used in conjunction with
+                                  preOCNECommands to install and configure repositories.
+                                type: string
+                              noProxy:
+                                description: NoProxy contains addresses that needs
+                                  to be skipped when proxy server is being used. The
+                                  value, if specified is used in conjunction with
+                                  preOCNECommands to install and configure repositories.
+                                type: string
+                            type: object
+                        type: object
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema
+                              of this representation of an object. Servers should
+                              convert recognized schemas to the latest internal value,
+                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          bootstrapTokens:
+                            description: BootstrapTokens is respected at `kubeadm
+                              init` time and describes a set of Bootstrap Tokens to
+                              create. This information IS NOT uploaded to the kubeadm
+                              cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap
+                                token, stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: Description sets a human-friendly message
+                                    why this token exists and what it's used for,
+                                    so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: Expires specifies the timestamp when
+                                    this token expires. Defaults to being set dynamically
+                                    at runtime based on the TTL. Expires and TTL are
+                                    mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: Groups specifies the extra groups that
+                                    this token will authenticate as when/if used for
+                                    authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: Token is used for establishing bidirectional
+                                    trust between nodes and control-planes. Used for
+                                    joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: TTL defines the time to live for this
+                                    token. Defaults to 24h. Expires and TTL are mutually
+                                    exclusive.
+                                  type: string
+                                usages:
+                                  description: Usages describes the ways in which
+                                    this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that
+                                    can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: 'Kind is a string value representing the
+                              REST resource this object represents. Servers may infer
+                              this from the endpoint the client submits requests to.
+                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint
+                              of the API server instance that's deployed on this control
+                              plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint
+                              in the sense that ControlPlaneEndpoint is the global
+                              endpoint for the cluster, which then loadbalances the
+                              requests to each individual API server. This configuration
+                              object lets you customize what IP/DNS name and port
+                              the local API server advertises it's accessible on.
+                              By default, kubeadm tries to auto-detect the IP of the
+                              default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address
+                                  for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the
+                                  API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate
+                              to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration
+                              should remain consistent across both InitConfiguration
+                              and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container
+                                  runtime info. This information will be annotated
+                                  to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice
+                                  of pre-flight errors to be ignored when the current
+                                  node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra
+                                  arguments to the kubelet. The arguments here are
+                                  passed to the kubelet command line via the environment
+                                  file kubeadm writes at runtime for the kubelet to
+                                  source. This overrides the generic base-level configuration
+                                  in the kubelet-config-1.X ConfigMap Flags have higher
+                                  priority when parsing. These values are local and
+                                  specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of
+                                  the Node API object that will be created in this
+                                  `kubeadm init` or `kubeadm join` operation. This
+                                  field is also used in the CommonName field of the
+                                  kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node
+                                  API object should be registered with. If this field
+                                  is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}.
+                                  If you don''t want to taint your control-plane node,
+                                  set this field to an empty slice, i.e. `taints:
+                                  []` in the YAML file. This field is solely used
+                                  for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to
+                                    has the "effect" on any pod that does not tolerate
+                                    the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint
+                                        on pods that do not tolerate the taint. Valid
+                                        effects are NoSchedule, PreferNoSchedule and
+                                        NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at
+                                        which the taint was added. It is only written
+                                        for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                          patches:
+                            description: Patches contains options related to applying
+                              patches to components deployed by kubeadm during "kubeadm
+                              init". The minimum kubernetes version needed to support
+                              Patches is v1.22
+                            properties:
+                              directory:
+                                description: Directory is a path to a directory that
+                                  contains files named "target[suffix][+patchtype].extension".
+                                  For example, "kube-apiserver0+merge.yaml" or just
+                                  "etcd.json". "target" can be one of "kube-apiserver",
+                                  "kube-controller-manager", "kube-scheduler", "etcd".
+                                  "patchtype" can be one of "strategic" "merge" or
+                                  "json" and they match the patch formats supported
+                                  by kubectl. The default "patchtype" is "strategic".
+                                  "extension" must be either "json" or "yaml". "suffix"
+                                  is an optional string that can be used to determine
+                                  which patches are applied first alpha-numerically.
+                                  These files can be written into the target directory
+                                  via OCNEConfig.Files which specifies additional
+                                  files to be created on the machine, either with
+                                  content inline or by referencing a secret.
+                                type: string
+                            type: object
+                          skipPhases:
+                            description: SkipPhases is a list of phases to skip during
+                              command execution. The list of phases can be obtained
+                              with the "kubeadm init --help" command. This option
+                              takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration
+                          for the join command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema
+                              of this representation of an object. Servers should
+                              convert recognized schemas to the latest internal value,
+                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          caCertPath:
+                            description: 'CACertPath is the path to the SSL certificate
+                              authority used to secure comunications between node
+                              and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt".
+                              TODO: revisit when there is defaulting from k/k'
+                            type: string
+                          controlPlane:
+                            description: ControlPlane defines the additional control
+                              plane instance to be deployed on the joining node. If
+                              nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this
+                                  node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: BindPort sets the secure port for
+                                      the API Server to bind to. Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: 'Discovery specifies the options for the
+                              kubelet to use during the TLS Bootstrap process TODO:
+                              revisit when there is defaulting from k/k'
+                            properties:
+                              bootstrapToken:
+                                description: BootstrapToken is used to set the options
+                                  for bootstrap token based discovery BootstrapToken
+                                  and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain
+                                      name to the API server from which info will
+                                      be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: 'CACertHashes specifies a set of
+                                      public key pins to verify when token-based discovery
+                                      is used. The root CA found during discovery
+                                      must match one of these values. Specifying an
+                                      empty set disables root CA pinning, which can
+                                      be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256".
+                                      This is a hex-encoded SHA-256 hash of the Subject
+                                      Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using,
+                                      for example, OpenSSL: openssl x509 -pubkey -in
+                                      ca.crt openssl rsa -pubin -outform der 2>&/dev/null
+                                      | openssl dgst -sha256 -hex'
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: Token is a token used to validate
+                                      cluster information fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: UnsafeSkipCAVerification allows token-based
+                                      discovery without CA verification via CACertHashes.
+                                      This can weaken the security of kubeadm since
+                                      other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                type: object
+                              file:
+                                description: File is used to specify a file or URL
+                                  to a kubeconfig file from which to load cluster
+                                  information BootstrapToken and File are mutually
+                                  exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify
+                                      the actual file path or URL to the kubeconfig
+                                      file from which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: TLSBootstrapToken is a token used for
+                                  TLS bootstrapping. If .BootstrapToken is set, this
+                                  field is defaulted to .BootstrapToken.Token, but
+                                  can be overridden. If .File is set, this field **must
+                                  be set** in case the KubeConfigFile does not contain
+                                  any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: 'Kind is a string value representing the
+                              REST resource this object represents. Servers may infer
+                              this from the endpoint the client submits requests to.
+                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate
+                              to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration
+                              should remain consistent across both InitConfiguration
+                              and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container
+                                  runtime info. This information will be annotated
+                                  to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice
+                                  of pre-flight errors to be ignored when the current
+                                  node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra
+                                  arguments to the kubelet. The arguments here are
+                                  passed to the kubelet command line via the environment
+                                  file kubeadm writes at runtime for the kubelet to
+                                  source. This overrides the generic base-level configuration
+                                  in the kubelet-config-1.X ConfigMap Flags have higher
+                                  priority when parsing. These values are local and
+                                  specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of
+                                  the Node API object that will be created in this
+                                  `kubeadm init` or `kubeadm join` operation. This
+                                  field is also used in the CommonName field of the
+                                  kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node
+                                  API object should be registered with. If this field
+                                  is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}.
+                                  If you don''t want to taint your control-plane node,
+                                  set this field to an empty slice, i.e. `taints:
+                                  []` in the YAML file. This field is solely used
+                                  for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to
+                                    has the "effect" on any pod that does not tolerate
+                                    the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint
+                                        on pods that do not tolerate the taint. Valid
+                                        effects are NoSchedule, PreferNoSchedule and
+                                        NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at
+                                        which the taint was added. It is only written
+                                        for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                          patches:
+                            description: Patches contains options related to applying
+                              patches to components deployed by kubeadm during "kubeadm
+                              join". The minimum kubernetes version needed to support
+                              Patches is v1.22
+                            properties:
+                              directory:
+                                description: Directory is a path to a directory that
+                                  contains files named "target[suffix][+patchtype].extension".
+                                  For example, "kube-apiserver0+merge.yaml" or just
+                                  "etcd.json". "target" can be one of "kube-apiserver",
+                                  "kube-controller-manager", "kube-scheduler", "etcd".
+                                  "patchtype" can be one of "strategic" "merge" or
+                                  "json" and they match the patch formats supported
+                                  by kubectl. The default "patchtype" is "strategic".
+                                  "extension" must be either "json" or "yaml". "suffix"
+                                  is an optional string that can be used to determine
+                                  which patches are applied first alpha-numerically.
+                                  These files can be written into the target directory
+                                  via OCNEConfig.Files which specifies additional
+                                  files to be created on the machine, either with
+                                  content inline or by referencing a secret.
+                                type: string
+                            type: object
+                          skipPhases:
+                            description: SkipPhases is a list of phases to skip during
+                              command execution. The list of phases can be obtained
+                              with the "kubeadm init --help" command. This option
+                              takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be
+                          setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postOCNECommands:
+                        description: PostOCNECommands specifies extra commands to
+                          run after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preOCNECommands:
+                        description: PreOCNECommands specifies extra commands to run
+                          before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: "UseExperimentalRetryJoin replaces a basic kubeadm
+                          command with a shell script with retries for joins. \n This
+                          is meant to be an experimental temporary workaround on some
+                          environments where joins fail due to timing (and other issues).
+                          The long term goal is to add retries to kubeadm proper and
+                          use that functionality. \n This will add about 40KB to userdata
+                          \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                          \n Deprecated: This experimental fix is no longer needed
+                          and this field will be removed in a future release. When
+                          removing also remove from staticcheck exclude-rules for
+                          SA1019 in golangci.yml"
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user
+                            in cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the
+                                user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups
+                                for the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to
+                                use for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the
+                                user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login
+                                should be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for
+                                the user
+                              type: string
+                            passwdFrom:
+                              description: PasswdFrom is a referenced source of passwd
+                                to populate the passwd.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this password.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's
+                                        data map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group
+                                for the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh
+                                authorized keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: Verbosity is the number for the kubeadm log level
+                          verbosity. It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+  name: capi-ocne-bootstrap-manager
+  namespace: capi-ocne-bootstrap-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+  name: capi-ocne-bootstrap-leader-election-role
+  namespace: capi-ocne-bootstrap-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+  name: capi-ocne-bootstrap-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - ocneconfigs
+  - ocneconfigs/finalizers
+  - ocneconfigs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  - machinepools
+  - machinepools/status
+  - machines
+  - machines/status
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+  name: capi-ocne-bootstrap-leader-election-rolebinding
+  namespace: capi-ocne-bootstrap-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-ocne-bootstrap-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-ocne-bootstrap-manager
+  namespace: capi-ocne-bootstrap-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+  name: capi-ocne-bootstrap-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-ocne-bootstrap-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-ocne-bootstrap-manager
+  namespace: capi-ocne-bootstrap-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+  name: capi-ocne-bootstrap-webhook-service
+  namespace: capi-ocne-bootstrap-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+    control-plane: controller-manager
+  name: capi-ocne-bootstrap-controller-manager
+  namespace: capi-ocne-bootstrap-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: bootstrap-ocne
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-ocne
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --metrics-bind-addr=localhost:8080
+        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}
+        - --bootstrap-token-ttl=${KUBEADM_BOOTSTRAP_TOKEN_TTL:=15m}
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        # This image will be overridden by the Verrazzano controller
+        image: ghcr.io/verrazzano/cluster-api-ocne-bootstrap-controller:v0.1.0-20230531223401-6824a09
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: capi-ocne-bootstrap-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capi-ocne-bootstrap-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+  name: capi-ocne-bootstrap-serving-cert
+  namespace: capi-ocne-bootstrap-system
+spec:
+  dnsNames:
+  - capi-ocne-bootstrap-webhook-service.capi-ocne-bootstrap-system.svc
+  - capi-ocne-bootstrap-webhook-service.capi-ocne-bootstrap-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capi-ocne-bootstrap-selfsigned-issuer
+  secretName: capi-ocne-bootstrap-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+  name: capi-ocne-bootstrap-selfsigned-issuer
+  namespace: capi-ocne-bootstrap-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-ocne-bootstrap-system/capi-ocne-bootstrap-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+  name: capi-ocne-bootstrap-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: capi-ocne-bootstrap-webhook-service
+      namespace: capi-ocne-bootstrap-system
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1alpha1-ocneconfig
+  failurePolicy: Fail
+  name: default.ocneconfig.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocneconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: capi-ocne-bootstrap-webhook-service
+      namespace: capi-ocne-bootstrap-system
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1alpha1-ocneconfigtemplate
+  failurePolicy: Fail
+  name: default.ocneconfigtemplate.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocneconfigtemplates
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-ocne-bootstrap-system/capi-ocne-bootstrap-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-ocne
+  name: capi-ocne-bootstrap-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: capi-ocne-bootstrap-webhook-service
+      namespace: capi-ocne-bootstrap-system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1alpha1-ocneconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ocneconfig.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocneconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: capi-ocne-bootstrap-webhook-service
+      namespace: capi-ocne-bootstrap-system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1alpha1-ocneconfigtemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ocneconfigtemplate.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocneconfigtemplates
+  sideEffects: None

--- a/platform-operator/capi/bootstrap-ocne/v0.1.0/metadata.yaml
+++ b/platform-operator/capi/bootstrap-ocne/v0.1.0/metadata.yaml
@@ -15,6 +15,3 @@ releaseSeries:
   - major: 0
     minor: 1
     contract: v1beta1
-  - major: 1
-    minor: 6
-    contract: v1beta1

--- a/platform-operator/capi/control-plane-ocne/v0.1.0/control-plane-components.yaml
+++ b/platform-operator/capi/control-plane-ocne/v0.1.0/control-plane-components.yaml
@@ -1,0 +1,3274 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+    control-plane: controller-manager
+  name: capi-ocne-control-plane-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-ocne-control-plane-system/capi-ocne-control-plane-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+    cluster.x-k8s.io/v1beta1: v1alpha1
+  name: ocnecontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-ocne-control-plane-webhook-service
+          namespace: capi-ocne-control-plane-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OCNEControlPlane
+    listKind: OCNEControlPlaneList
+    plural: ocnecontrolplanes
+    shortNames:
+    - ocnecp
+    singular: ocnecontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: This denotes whether or not the control plane has the uploaded
+        kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: OCNEControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Total number of machines desired by this control plane
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: Time duration since creation of OCNEControlPlane
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OCNEControlPlane is the Schema for the OCNEControlPlane API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCNEControlPlaneSpec defines the desired state of OCNEControlPlane.
+            properties:
+              controlPlaneConfig:
+                description: ControlPlaneConfig is a bootstrap OCNEConfigSpec to use
+                  for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration
+                      are the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API
+                          server control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass
+                              to the control plane component. TODO: This is temporary
+                              and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing
+                                volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that
+                                    will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout
+                              that we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this
+                          representation of an object. Servers should convert recognized
+                          schemas to the latest internal value, and may reject unrecognized
+                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      certificatesDir:
+                        description: 'CertificatesDir specifies where to store or
+                          look for all required certificates. NB: if not provided,
+                          this will default to `/etc/kubernetes/pki`'
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: 'ControlPlaneEndpoint sets a stable IP address
+                          or DNS name for the control plane; it can be a valid IP
+                          address or a RFC-1123 DNS subdomain, both with optional
+                          TCP port. In case the ControlPlaneEndpoint is not specified,
+                          the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint
+                          is specified but without a TCP port, the BindPort is used.
+                          Possible usages are: e.g. In a cluster with more than one
+                          control plane instances, this field should be assigned the
+                          address of the external load balancer in front of the control
+                          plane instances. e.g.  in environments with enforced node
+                          recycling, the ControlPlaneEndpoint could be used for assigning
+                          a stable DNS to the control plane. NB: This value defaults
+                          to the first value in the Cluster object status.apiEndpoints
+                          array.'
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for
+                          the controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass
+                              to the control plane component. TODO: This is temporary
+                              and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing
+                                volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that
+                                    will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: ImageRepository sets the container registry
+                              to pull images from. if not set, the ImageRepository
+                              defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the
+                              image. In case this value is set, kubeadm does not change
+                              automatically the version of the above components during
+                              upgrades.
+                            type: string
+                        type: object
+                      etcd:
+                        description: 'Etcd holds configuration for etcd. NB: This
+                          value defaults to a Local (stacked) etcd'
+                        properties:
+                          external:
+                            description: External describes how to connect to an external
+                              etcd cluster Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: CAFile is an SSL Certificate Authority
+                                  file used to secure etcd communication. Required
+                                  if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: CertFile is an SSL certification file
+                                  used to secure etcd communication. Required if using
+                                  a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for
+                                  ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: KeyFile is an SSL key file used to secure
+                                  etcd communication. Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: Local provides configuration knobs for configuring
+                              the local etcd instance Local and External are mutually
+                              exclusive
+                            properties:
+                              dataDir:
+                                description: DataDir is the directory etcd will place
+                                  its data. Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraArgs are extra arguments provided
+                                  to the etcd binary when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: ImageRepository sets the container registry
+                                  to pull images from. if not set, the ImageRepository
+                                  defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for
+                                  the image. In case this value is set, kubeadm does
+                                  not change automatically the version of the above
+                                  components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: 'ImageRepository sets the container registry
+                          to pull images from. * If not set, the default registry
+                          of kubeadm will be used, i.e. * registry.k8s.io (new registry):
+                          >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0 * k8s.gcr.io
+                          (old registry): all older versions Please note that when
+                          imageRepository is not set we don''t allow upgrades to versions
+                          >= v1.22.0 which use the old registry (k8s.gcr.io). Please
+                          use a newer patch version with the new registry instead
+                          (i.e. >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                          * If the version is a CI build (kubernetes version starts
+                          with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images`
+                          will be used as a default for control plane components and
+                          for kube-proxy, while `registry.k8s.io` will be used for
+                          all the other images.'
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST
+                          resource this object represents. Servers may infer this
+                          from the endpoint the client submits requests to. Cannot
+                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      kubernetesVersion:
+                        description: 'KubernetesVersion is the target version of the
+                          control plane. NB: This value defaults to the Machine object
+                          spec.version'
+                        type: string
+                      networking:
+                        description: 'Networking holds configuration for the networking
+                          topology of the cluster. NB: This value defaults to the
+                          Cluster object spec.clusterNetwork.'
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: PodSubnet is the subnet used by pods. If
+                              unset, the API server will not allocate CIDR ranges
+                              for every node. Defaults to a comma-delimited string
+                              of the Cluster object's spec.clusterNetwork.services.cidrBlocks
+                              if that is set
+                            type: string
+                          serviceSubnet:
+                            description: ServiceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster
+                              object's spec.clusterNetwork.pods.cidrBlocks, or to
+                              "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass
+                              to the control plane component. TODO: This is temporary
+                              and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing
+                                volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that
+                                    will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems
+                          to setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add
+                                to the command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to
+                                be used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: Overwrite defines whether or not to overwrite
+                                any existing filesystem. If true, any pre-existing
+                                file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any",
+                                "none", and <NUM>, where NUM is the actual partition
+                                number.'
+                              type: string
+                            replaceFS:
+                              description: 'ReplaceFS is a special directive, used
+                                for Microsoft Azure that instructs cloud-init to replace
+                                a file system of <FS_TYPE>. NOTE: unless you define
+                                a label, this requires the use of the ''any'' partition
+                                directive.'
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions
+                          to setup.
+                        items:
+                          description: Partition defines how to create and layout
+                            a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: Layout specifies the device layout. If
+                                it is true, a single partition will be created for
+                                the entire device. When layout is false, it means
+                                don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: Overwrite describes whether to skip checks
+                                and create the partition if a partition or filesystem
+                                is found on the device. Use with caution. Default
+                                is 'false'.
+                              type: boolean
+                            tableType:
+                              description: 'TableType specifies the tupe of partition
+                                table. The following are supported: ''mbr'': default
+                                and setups a MS-DOS partition table ''gpt'': setups
+                                a GPT partition table'
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files
+                        in cloud-init.
+                      properties:
+                        append:
+                          description: Append specifies whether to append Content
+                            to existing file if Path exists.
+                          type: boolean
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content
+                            to populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should
+                                populate this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data
+                                    map for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file
+                            contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file,
+                            e.g. "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where
+                            to store the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap
+                      data
+                    enum:
+                    - cloud-config
+                    - ignition
+                    type: string
+                  ignition:
+                    description: Ignition contains Ignition specific configuration.
+                    properties:
+                      containerLinuxConfig:
+                        description: ContainerLinuxConfig contains CLC specific configuration.
+                        properties:
+                          additionalConfig:
+                            description: "AdditionalConfig contains additional configuration
+                              to be merged with the Ignition configuration generated
+                              by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+                              \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/"
+                            type: string
+                          strict:
+                            description: Strict controls if AdditionalConfig should
+                              be strictly parsed. If so, warnings are treated as errors.
+                            type: boolean
+                        type: object
+                    type: object
+                  imageConfiguration:
+                    description: ImageConfiguration contains configuration required
+                      for the base image.
+                    properties:
+                      dependencies:
+                        description: Dependencies contains details about dependencies
+                          on the image that can be configured at boot time.
+                        properties:
+                          skipInstall:
+                            description: SkipInstall is the flag that can be used
+                              to tell the provider to skip install of OCNE dependencies.
+                              The value, if set to true, will be used to skip the
+                              overrides installation on OCNEConfigSpec. By default,
+                              this value is false.
+                            type: boolean
+                        type: object
+                      proxy:
+                        description: Proxy contains proxy server info that may be
+                          required for installing dependencies. The value, if specified
+                          is used in conjunction with preOCNECommands to install and
+                          configure repositories.
+                        properties:
+                          httpProxy:
+                            description: HttpProxy contains http proxy server info
+                              that may be required for installing dependencies. The
+                              value, if specified is used in conjunction with preOCNECommands
+                              to install and configure repositories.
+                            type: string
+                          httpsProxy:
+                            description: HttpsProxy contains https proxy server info
+                              that may be required for installing dependencies. The
+                              value, if specified is used in conjunction with preOCNECommands
+                              to install and configure repositories.
+                            type: string
+                          noProxy:
+                            description: NoProxy contains addresses that needs to
+                              be skipped when proxy server is being used. The value,
+                              if specified is used in conjunction with preOCNECommands
+                              to install and configure repositories.
+                            type: string
+                        type: object
+                    type: object
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration
+                      are the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this
+                          representation of an object. Servers should convert recognized
+                          schemas to the latest internal value, and may reject unrecognized
+                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      bootstrapTokens:
+                        description: BootstrapTokens is respected at `kubeadm init`
+                          time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster
+                          configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token,
+                            stored as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: Description sets a human-friendly message
+                                why this token exists and what it's used for, so other
+                                administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: Expires specifies the timestamp when this
+                                token expires. Defaults to being set dynamically at
+                                runtime based on the TTL. Expires and TTL are mutually
+                                exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: Groups specifies the extra groups that
+                                this token will authenticate as when/if used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: Token is used for establishing bidirectional
+                                trust between nodes and control-planes. Used for joining
+                                nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: TTL defines the time to live for this token.
+                                Defaults to 24h. Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: Usages describes the ways in which this
+                                token can be used. Can by default be used for establishing
+                                bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: 'Kind is a string value representing the REST
+                          resource this object represents. Servers may infer this
+                          from the endpoint the client submits requests to. Cannot
+                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the
+                          API server instance that's deployed on this control plane
+                          node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint
+                          in the sense that ControlPlaneEndpoint is the global endpoint
+                          for the cluster, which then loadbalances the requests to
+                          each individual API server. This configuration object lets
+                          you customize what IP/DNS name and port the local API server
+                          advertises it's accessible on. By default, kubeadm tries
+                          to auto-detect the IP of the default interface and use that,
+                          but in case that process fails you may set the desired value
+                          here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for
+                              the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API
+                              Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to
+                          registering the new control-plane node to the cluster. When
+                          used in the context of control plane nodes, NodeRegistration
+                          should remain consistent across both InitConfiguration and
+                          JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node
+                              API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of
+                              pre-flight errors to be ignored when the current node
+                              is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments
+                              to the kubelet. The arguments here are passed to the
+                              kubelet command line via the environment file kubeadm
+                              writes at runtime for the kubelet to source. This overrides
+                              the generic base-level configuration in the kubelet-config-1.X
+                              ConfigMap Flags have higher priority when parsing. These
+                              values are local and specific to the node kubeadm is
+                              executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the
+                              Node API object that will be created in this `kubeadm
+                              init` or `kubeadm join` operation. This field is also
+                              used in the CommonName field of the kubelet's client
+                              certificate to the API server. Defaults to the hostname
+                              of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API
+                              object should be registered with. If this field is unset,
+                              i.e. nil, in the `kubeadm init` process it will be defaulted
+                              to []v1.Taint{''node-role.kubernetes.io/master=""''}.
+                              If you don''t want to taint your control-plane node,
+                              set this field to an empty slice, i.e. `taints: []`
+                              in the YAML file. This field is solely used for Node
+                              registration.'
+                            items:
+                              description: The node this Taint is attached to has
+                                the "effect" on any pod that does not tolerate the
+                                Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on
+                                    pods that do not tolerate the taint. Valid effects
+                                    are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which
+                                    the taint was added. It is only written for NoExecute
+                                    taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                      patches:
+                        description: Patches contains options related to applying
+                          patches to components deployed by kubeadm during "kubeadm
+                          init". The minimum kubernetes version needed to support
+                          Patches is v1.22
+                        properties:
+                          directory:
+                            description: Directory is a path to a directory that contains
+                              files named "target[suffix][+patchtype].extension".
+                              For example, "kube-apiserver0+merge.yaml" or just "etcd.json".
+                              "target" can be one of "kube-apiserver", "kube-controller-manager",
+                              "kube-scheduler", "etcd". "patchtype" can be one of
+                              "strategic" "merge" or "json" and they match the patch
+                              formats supported by kubectl. The default "patchtype"
+                              is "strategic". "extension" must be either "json" or
+                              "yaml". "suffix" is an optional string that can be used
+                              to determine which patches are applied first alpha-numerically.
+                              These files can be written into the target directory
+                              via OCNEConfig.Files which specifies additional files
+                              to be created on the machine, either with content inline
+                              or by referencing a secret.
+                            type: string
+                        type: object
+                      skipPhases:
+                        description: SkipPhases is a list of phases to skip during
+                          command execution. The list of phases can be obtained with
+                          the "kubeadm init --help" command. This option takes effect
+                          only on Kubernetes >=1.22.0.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for
+                      the join command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this
+                          representation of an object. Servers should convert recognized
+                          schemas to the latest internal value, and may reject unrecognized
+                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      caCertPath:
+                        description: 'CACertPath is the path to the SSL certificate
+                          authority used to secure comunications between node and
+                          control-plane. Defaults to "/etc/kubernetes/pki/ca.crt".
+                          TODO: revisit when there is defaulting from k/k'
+                        type: string
+                      controlPlane:
+                        description: ControlPlane defines the additional control plane
+                          instance to be deployed on the joining node. If nil, no
+                          additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint
+                              of the API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address
+                                  for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the
+                                  API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: 'Discovery specifies the options for the kubelet
+                          to use during the TLS Bootstrap process TODO: revisit when
+                          there is defaulting from k/k'
+                        properties:
+                          bootstrapToken:
+                            description: BootstrapToken is used to set the options
+                              for bootstrap token based discovery BootstrapToken and
+                              File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain
+                                  name to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: 'CACertHashes specifies a set of public
+                                  key pins to verify when token-based discovery is
+                                  used. The root CA found during discovery must match
+                                  one of these values. Specifying an empty set disables
+                                  root CA pinning, which can be unsafe. Each hash
+                                  is specified as "<type>:<value>", where the only
+                                  currently supported type is "sha256". This is a
+                                  hex-encoded SHA-256 hash of the Subject Public Key
+                                  Info (SPKI) object in DER-encoded ASN.1. These hashes
+                                  can be calculated using, for example, OpenSSL: openssl
+                                  x509 -pubkey -in ca.crt openssl rsa -pubin -outform
+                                  der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: Token is a token used to validate cluster
+                                  information fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: UnsafeSkipCAVerification allows token-based
+                                  discovery without CA verification via CACertHashes.
+                                  This can weaken the security of kubeadm since other
+                                  nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            type: object
+                          file:
+                            description: File is used to specify a file or URL to
+                              a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the
+                                  actual file path or URL to the kubeconfig file from
+                                  which to load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: TLSBootstrapToken is a token used for TLS
+                              bootstrapping. If .BootstrapToken is set, this field
+                              is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case
+                              the KubeConfigFile does not contain any other authentication
+                              information
+                            type: string
+                        type: object
+                      kind:
+                        description: 'Kind is a string value representing the REST
+                          resource this object represents. Servers may infer this
+                          from the endpoint the client submits requests to. Cannot
+                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to
+                          registering the new control-plane node to the cluster. When
+                          used in the context of control plane nodes, NodeRegistration
+                          should remain consistent across both InitConfiguration and
+                          JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node
+                              API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of
+                              pre-flight errors to be ignored when the current node
+                              is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments
+                              to the kubelet. The arguments here are passed to the
+                              kubelet command line via the environment file kubeadm
+                              writes at runtime for the kubelet to source. This overrides
+                              the generic base-level configuration in the kubelet-config-1.X
+                              ConfigMap Flags have higher priority when parsing. These
+                              values are local and specific to the node kubeadm is
+                              executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the
+                              Node API object that will be created in this `kubeadm
+                              init` or `kubeadm join` operation. This field is also
+                              used in the CommonName field of the kubelet's client
+                              certificate to the API server. Defaults to the hostname
+                              of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API
+                              object should be registered with. If this field is unset,
+                              i.e. nil, in the `kubeadm init` process it will be defaulted
+                              to []v1.Taint{''node-role.kubernetes.io/master=""''}.
+                              If you don''t want to taint your control-plane node,
+                              set this field to an empty slice, i.e. `taints: []`
+                              in the YAML file. This field is solely used for Node
+                              registration.'
+                            items:
+                              description: The node this Taint is attached to has
+                                the "effect" on any pod that does not tolerate the
+                                Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on
+                                    pods that do not tolerate the taint. Valid effects
+                                    are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which
+                                    the taint was added. It is only written for NoExecute
+                                    taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                      patches:
+                        description: Patches contains options related to applying
+                          patches to components deployed by kubeadm during "kubeadm
+                          join". The minimum kubernetes version needed to support
+                          Patches is v1.22
+                        properties:
+                          directory:
+                            description: Directory is a path to a directory that contains
+                              files named "target[suffix][+patchtype].extension".
+                              For example, "kube-apiserver0+merge.yaml" or just "etcd.json".
+                              "target" can be one of "kube-apiserver", "kube-controller-manager",
+                              "kube-scheduler", "etcd". "patchtype" can be one of
+                              "strategic" "merge" or "json" and they match the patch
+                              formats supported by kubectl. The default "patchtype"
+                              is "strategic". "extension" must be either "json" or
+                              "yaml". "suffix" is an optional string that can be used
+                              to determine which patches are applied first alpha-numerically.
+                              These files can be written into the target directory
+                              via OCNEConfig.Files which specifies additional files
+                              to be created on the machine, either with content inline
+                              or by referencing a secret.
+                            type: string
+                        type: object
+                      skipPhases:
+                        description: SkipPhases is a list of phases to skip during
+                          command execution. The list of phases can be obtained with
+                          the "kubeadm init --help" command. This option takes effect
+                          only on Kubernetes >=1.22.0.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts
+                        in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postOCNECommands:
+                    description: PostOCNECommands specifies extra commands to run
+                      after kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preOCNECommands:
+                    description: PreOCNECommands specifies extra commands to run before
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: "UseExperimentalRetryJoin replaces a basic kubeadm
+                      command with a shell script with retries for joins. \n This
+                      is meant to be an experimental temporary workaround on some
+                      environments where joins fail due to timing (and other issues).
+                      The long term goal is to add retries to kubeadm proper and use
+                      that functionality. \n This will add about 40KB to userdata
+                      \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                      \n Deprecated: This experimental fix is no longer needed and
+                      this field will be removed in a future release. When removing
+                      also remove from staticcheck exclude-rules for SA1019 in golangci.yml"
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in
+                        cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for
+                            the user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use
+                            for the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user
+                            as inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the
+                            user
+                          type: string
+                        passwdFrom:
+                          description: PasswdFrom is a referenced source of passwd
+                            to populate the passwd.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should
+                                populate this password.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data
+                                    map for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for
+                            the user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: Verbosity is the number for the kubeadm log level
+                      verbosity. It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              machineTemplate:
+                description: MachineTemplate contains information about how machines
+                  should be shaped when creating or updating a control plane.
+                properties:
+                  infrastructureRef:
+                    description: InfrastructureRef is a required reference to a custom
+                      resource offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object. TODO: this design is not final and this field
+                          is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  nodeDeletionTimeout:
+                    description: NodeDeletionTimeout defines how long the machine
+                      controller will attempt to delete the Node that the Machine
+                      hosts after the Machine is marked for deletion. A duration of
+                      0 will retry deletion indefinitely. If no value is provided,
+                      the default value for this property of the Machine resource
+                      will be used.
+                    type: string
+                  nodeDrainTimeout:
+                    description: 'NodeDrainTimeout is the total amount of time that
+                      the controller will spend on draining a controlplane node The
+                      default value is 0, meaning that the node can be drained without
+                      any time limitations. NOTE: NodeDrainTimeout is different from
+                      `kubectl drain --timeout`'
+                    type: string
+                  nodeVolumeDetachTimeout:
+                    description: NodeVolumeDetachTimeout is the total amount of time
+                      that the controller will spend on waiting for all volumes to
+                      be detached. The default value is 0, meaning that the volumes
+                      can be detached without any time limitations.
+                    type: string
+                required:
+                - infrastructureRef
+                type: object
+              moduleOperator:
+                description: ModuleOperator deploys the OCNE module operator to the
+                  worker cluster post installation.
+                properties:
+                  enabled:
+                    description: Enabled sets the operational mode for a specific
+                      module. if not set, the Enabled is set to false.
+                    type: boolean
+                  image:
+                    description: Image is used to set various attributes regarding
+                      a specific module. If not set, they are set as per the ImageMeta
+                      definitions.
+                    properties:
+                      pullPolicy:
+                        description: PullPolicy allows to specify an image pull policy
+                          for the container images. if not set, the PullPolicy is
+                          IfNotPresent.
+                        type: string
+                      repository:
+                        description: Repository sets the container registry to pull
+                          images from. if not set, the Repository defined in OCNEMeta
+                          will be used instead.
+                        type: string
+                      tag:
+                        description: Tag allows to specify a tag for the image. if
+                          not set, the Tag defined in OCNEMeta will be used instead.
+                        type: string
+                    type: object
+                  imagePullSecrets:
+                    description: ImagePullSecrets allows to specify secrets if the
+                      image is being pulled from an authenticated private registry.
+                      if not set, it will be assumed the images are public.
+                    items:
+                      properties:
+                        name:
+                          description: Name is name of the secret to be used as image
+                            pull secret
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              replicas:
+                description: Number of desired machines. Defaults to 1. When stacked
+                  etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: RolloutAfter is a field to indicate a rollout should
+                  be performed after the specified time even if no changes have been
+                  made to the OCNEControlPlane.
+                format: date-time
+                type: string
+              rolloutBefore:
+                description: RolloutBefore is a field to indicate a rollout should
+                  be performed if the specified criteria is met.
+                properties:
+                  certificatesExpiryDays:
+                    description: CertificatesExpiryDays indicates a rollout needs
+                      to be performed if the certificates of the machine will expire
+                      within the specified days.
+                    format: int32
+                    type: integer
+                type: object
+              rolloutStrategy:
+                default:
+                  rollingUpdate:
+                    maxSurge: 1
+                  type: RollingUpdate
+                description: The RolloutStrategy to use to replace control plane machines
+                  with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if RolloutStrategyType
+                      = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of control planes that can
+                          be scheduled above or under the desired number of control
+                          planes. Value can be an absolute number 1 or 0. Defaults
+                          to 1. Example: when this is set to 1, the control plane
+                          can be scaled up immediately when the rolling update starts.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of rollout. Currently the only supported strategy
+                      is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              verrazzanoPlatformOperator:
+                description: VerrazzanoPlatformOperator deploys the Verrazzano Platform
+                  operator to the worker cluster post installation.
+                properties:
+                  enabled:
+                    description: Enabled sets the operational mode for a specific
+                      module. if not set, the Enabled is set to false.
+                    type: boolean
+                  image:
+                    description: Image is used to set various attributes regarding
+                      a specific module. If not set, they are set as per the ImageMeta
+                      definitions.
+                    properties:
+                      pullPolicy:
+                        description: PullPolicy allows to specify an image pull policy
+                          for the container images. if not set, the PullPolicy is
+                          IfNotPresent.
+                        type: string
+                      repository:
+                        description: Repository sets the container registry to pull
+                          images from. if not set, the Repository defined in OCNEMeta
+                          will be used instead.
+                        type: string
+                      tag:
+                        description: Tag allows to specify a tag for the image. if
+                          not set, the Tag defined in OCNEMeta will be used instead.
+                        type: string
+                    type: object
+                  imagePullSecrets:
+                    description: ImagePullSecrets allows to specify secrets if the
+                      image is being pulled from an authenticated private registry.
+                      if not set, it will be assumed the images are public.
+                    items:
+                      properties:
+                        name:
+                          description: Name is name of the secret to be used as image
+                            pull secret
+                          type: string
+                      type: object
+                    type: array
+                  privateRegistry:
+                    description: PrivateRegistry sets the private registry settings
+                      for installing Verrazzano.
+                    properties:
+                      enabled:
+                        description: Enabled sets a flag to determine if a private
+                          registry will be used when installing Verrazzano. if not
+                          set, the Enabled is set to false.
+                        type: boolean
+                    type: object
+                type: object
+              version:
+                description: 'Version defines the desired Kubernetes version. Please
+                  note that if controlPlaneConfig.ClusterConfiguration.imageRepository
+                  is not set we don''t allow upgrades to versions >= v1.22.0 for which
+                  kubeadm uses the old registry (k8s.gcr.io). Please use a newer patch
+                  version with the new registry instead. The default registries of
+                  kubeadm are: * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15,
+                  >= v1.24.9, >= v1.25.0 * k8s.gcr.io (old registry): all older versions'
+                type: string
+            required:
+            - controlPlaneConfig
+            - machineTemplate
+            - version
+            type: object
+          status:
+            description: OCNEControlPlaneStatus defines the observed state of OCNEControlPlane.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the OCNEControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: ErrorMessage indicates that there is a terminal problem
+                  reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a terminal problem
+                  reconciling the state, and will be set to a token value suitable
+                  for programmatic interpretation.
+                type: string
+              initialized:
+                description: Initialized denotes whether or not the control plane
+                  has the uploaded kubeadm-config configmap.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the OCNEControlPlane API Server is
+                  ready to receive requests.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane
+                  machines.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this
+                  control plane (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the label selector in string format to avoid
+                  introspection by clients, and is used to provide the CRD-based integration
+                  for the scale subresource and additional integrations for things
+                  like kubectl describe.. The string will be in the same format as
+                  the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this
+                  control plane. This is the total number of machines that are still
+                  required for the deployment to have 100% available capacity. They
+                  may either be machines that are running but not yet ready or machines
+                  that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this
+                  control plane that have the desired template spec.
+                format: int32
+                type: integer
+              version:
+                description: Version represents the minimum Kubernetes version for
+                  the control plane machines in the cluster.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-ocne-control-plane-system/capi-ocne-control-plane-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+    cluster.x-k8s.io/v1beta1: v1alpha1
+  name: ocnecontrolplanetemplates.controlplane.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-ocne-control-plane-webhook-service
+          namespace: capi-ocne-control-plane-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OCNEControlPlaneTemplate
+    listKind: OCNEControlPlaneTemplateList
+    plural: ocnecontrolplanetemplates
+    singular: ocnecontrolplanetemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of OCNEControlPlaneTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OCNEControlPlaneTemplate is the Schema for the ocnecontrolplanetemplates
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCNEControlPlaneTemplateSpec defines the desired state of
+              OCNEControlPlaneTemplate.
+            properties:
+              template:
+                description: OCNEControlPlaneTemplateResource describes the data needed
+                  to create a OCNEControlPlane from a template.
+                properties:
+                  spec:
+                    description: 'OCNEControlPlaneTemplateResourceSpec defines the
+                      desired state of OCNEControlPlane. NOTE: OCNEControlPlaneTemplateResourceSpec
+                      is similar to OCNEControlPlaneSpec but omits Replicas and Version
+                      fields. These fields do not make sense on the OCNEControlPlaneTemplate,
+                      because they are calculated by the Cluster topology reconciler
+                      during reconciliation and thus cannot be configured on the OCNEControlPlaneTemplate.'
+                    properties:
+                      controlPlaneConfig:
+                        description: OCNEConfigSpec is a OCNEConfigSpec to use for
+                          initializing and joining machines to the control plane.
+                        properties:
+                          clusterConfiguration:
+                            description: ClusterConfiguration along with InitConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: APIServer contains extra settings for
+                                  the API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: CertSANs sets extra Subject Alternative
+                                      Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags
+                                      to pass to the control plane component. TODO:
+                                      This is temporary and ideally we would like
+                                      to switch all components to use ComponentConfig
+                                      + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements
+                                        describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the
+                                            host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the
+                                            pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: TimeoutForControlPlane controls the
+                                      timeout that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema
+                                  of this representation of an object. Servers should
+                                  convert recognized schemas to the latest internal
+                                  value, and may reject unrecognized values. More
+                                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              certificatesDir:
+                                description: 'CertificatesDir specifies where to store
+                                  or look for all required certificates. NB: if not
+                                  provided, this will default to `/etc/kubernetes/pki`'
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: 'ControlPlaneEndpoint sets a stable IP
+                                  address or DNS name for the control plane; it can
+                                  be a valid IP address or a RFC-1123 DNS subdomain,
+                                  both with optional TCP port. In case the ControlPlaneEndpoint
+                                  is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified
+                                  but without a TCP port, the BindPort is used. Possible
+                                  usages are: e.g. In a cluster with more than one
+                                  control plane instances, this field should be assigned
+                                  the address of the external load balancer in front
+                                  of the control plane instances. e.g.  in environments
+                                  with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the
+                                  control plane. NB: This value defaults to the first
+                                  value in the Cluster object status.apiEndpoints
+                                  array.'
+                                type: string
+                              controllerManager:
+                                description: ControllerManager contains extra settings
+                                  for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags
+                                      to pass to the control plane component. TODO:
+                                      This is temporary and ideally we would like
+                                      to switch all components to use ComponentConfig
+                                      + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements
+                                        describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the
+                                            host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the
+                                            pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: DNS defines the options for the DNS add-on
+                                  installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: ImageRepository sets the container
+                                      registry to pull images from. if not set, the
+                                      ImageRepository defined in ClusterConfiguration
+                                      will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: ImageTag allows to specify a tag
+                                      for the image. In case this value is set, kubeadm
+                                      does not change automatically the version of
+                                      the above components during upgrades.
+                                    type: string
+                                type: object
+                              etcd:
+                                description: 'Etcd holds configuration for etcd. NB:
+                                  This value defaults to a Local (stacked) etcd'
+                                properties:
+                                  external:
+                                    description: External describes how to connect
+                                      to an external etcd cluster Local and External
+                                      are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: CAFile is an SSL Certificate
+                                          Authority file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: CertFile is an SSL certification
+                                          file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: Endpoints of etcd members. Required
+                                          for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: KeyFile is an SSL key file used
+                                          to secure etcd communication. Required if
+                                          using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: Local provides configuration knobs
+                                      for configuring the local etcd instance Local
+                                      and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: DataDir is the directory etcd
+                                          will place its data. Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: ExtraArgs are extra arguments
+                                          provided to the etcd binary when run inside
+                                          a static pod.
+                                        type: object
+                                      imageRepository:
+                                        description: ImageRepository sets the container
+                                          registry to pull images from. if not set,
+                                          the ImageRepository defined in ClusterConfiguration
+                                          will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: ImageTag allows to specify a
+                                          tag for the image. In case this value is
+                                          set, kubeadm does not change automatically
+                                          the version of the above components during
+                                          upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: PeerCertSANs sets extra Subject
+                                          Alternative Names for the etcd peer signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: ServerCertSANs sets extra Subject
+                                          Alternative Names for the etcd server signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: FeatureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: 'ImageRepository sets the container registry
+                                  to pull images from. * If not set, the default registry
+                                  of kubeadm will be used, i.e. * registry.k8s.io
+                                  (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9,
+                                  >= v1.25.0 * k8s.gcr.io (old registry): all older
+                                  versions Please note that when imageRepository is
+                                  not set we don''t allow upgrades to versions >=
+                                  v1.22.0 which use the old registry (k8s.gcr.io).
+                                  Please use a newer patch version with the new registry
+                                  instead (i.e. >= v1.22.17, >= v1.23.15, >= v1.24.9,
+                                  >= v1.25.0). * If the version is a CI build (kubernetes
+                                  version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images`
+                                  will be used as a default for control plane components
+                                  and for kube-proxy, while `registry.k8s.io` will
+                                  be used for all the other images.'
+                                type: string
+                              kind:
+                                description: 'Kind is a string value representing
+                                  the REST resource this object represents. Servers
+                                  may infer this from the endpoint the client submits
+                                  requests to. Cannot be updated. In CamelCase. More
+                                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              kubernetesVersion:
+                                description: 'KubernetesVersion is the target version
+                                  of the control plane. NB: This value defaults to
+                                  the Machine object spec.version'
+                                type: string
+                              networking:
+                                description: 'Networking holds configuration for the
+                                  networking topology of the cluster. NB: This value
+                                  defaults to the Cluster object spec.clusterNetwork.'
+                                properties:
+                                  dnsDomain:
+                                    description: DNSDomain is the dns domain used
+                                      by k8s services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: PodSubnet is the subnet used by pods.
+                                      If unset, the API server will not allocate CIDR
+                                      ranges for every node. Defaults to a comma-delimited
+                                      string of the Cluster object's spec.clusterNetwork.services.cidrBlocks
+                                      if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: ServiceSubnet is the subnet used
+                                      by k8s services. Defaults to a comma-delimited
+                                      string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks,
+                                      or to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: Scheduler contains extra settings for
+                                  the scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags
+                                      to pass to the control plane component. TODO:
+                                      This is temporary and ideally we would like
+                                      to switch all components to use ComponentConfig
+                                      + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements
+                                        describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the
+                                            host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the
+                                            pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: DiskSetup specifies options for the creation
+                              of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: Filesystems specifies the list of file
+                                  systems to setup.
+                                items:
+                                  description: Filesystem defines the file systems
+                                    to be created.
+                                  properties:
+                                    device:
+                                      description: Device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: ExtraOpts defined extra options
+                                        to add to the command for creating the file
+                                        system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: Filesystem specifies the file system
+                                        type.
+                                      type: string
+                                    label:
+                                      description: Label specifies the file system
+                                        label to be used. If set to None, no label
+                                        is used.
+                                      type: string
+                                    overwrite:
+                                      description: Overwrite defines whether or not
+                                        to overwrite any existing filesystem. If true,
+                                        any pre-existing file system will be destroyed.
+                                        Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'Partition specifies the partition
+                                        to use. The valid options are: "auto|any",
+                                        "auto", "any", "none", and <NUM>, where NUM
+                                        is the actual partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: 'ReplaceFS is a special directive,
+                                        used for Microsoft Azure that instructs cloud-init
+                                        to replace a file system of <FS_TYPE>. NOTE:
+                                        unless you define a label, this requires the
+                                        use of the ''any'' partition directive.'
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: Partitions specifies the list of the
+                                  partitions to setup.
+                                items:
+                                  description: Partition defines how to create and
+                                    layout a partition.
+                                  properties:
+                                    device:
+                                      description: Device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: Layout specifies the device layout.
+                                        If it is true, a single partition will be
+                                        created for the entire device. When layout
+                                        is false, it means don't partition or ignore
+                                        existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: Overwrite describes whether to
+                                        skip checks and create the partition if a
+                                        partition or filesystem is found on the device.
+                                        Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: 'TableType specifies the tupe of
+                                        partition table. The following are supported:
+                                        ''mbr'': default and setups a MS-DOS partition
+                                        table ''gpt'': setups a GPT partition table'
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: Files specifies extra files to be passed
+                              to user_data upon creation.
+                            items:
+                              description: File defines the input for generating write_files
+                                in cloud-init.
+                              properties:
+                                append:
+                                  description: Append specifies whether to append
+                                    Content to existing file if Path exists.
+                                  type: boolean
+                                content:
+                                  description: Content is the actual content of the
+                                    file.
+                                  type: string
+                                contentFrom:
+                                  description: ContentFrom is a referenced source
+                                    of content to populate the file.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that
+                                        should populate this file.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: Encoding specifies the encoding of
+                                    the file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: Owner specifies the ownership of the
+                                    file, e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: Path specifies the full path on disk
+                                    where to store the file.
+                                  type: string
+                                permissions:
+                                  description: Permissions specifies the permissions
+                                    to assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: Format specifies the output format of the
+                              bootstrap data
+                            enum:
+                            - cloud-config
+                            - ignition
+                            type: string
+                          ignition:
+                            description: Ignition contains Ignition specific configuration.
+                            properties:
+                              containerLinuxConfig:
+                                description: ContainerLinuxConfig contains CLC specific
+                                  configuration.
+                                properties:
+                                  additionalConfig:
+                                    description: "AdditionalConfig contains additional
+                                      configuration to be merged with the Ignition
+                                      configuration generated by the bootstrapper
+                                      controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+                                      \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/"
+                                    type: string
+                                  strict:
+                                    description: Strict controls if AdditionalConfig
+                                      should be strictly parsed. If so, warnings are
+                                      treated as errors.
+                                    type: boolean
+                                type: object
+                            type: object
+                          imageConfiguration:
+                            description: ImageConfiguration contains configuration
+                              required for the base image.
+                            properties:
+                              dependencies:
+                                description: Dependencies contains details about dependencies
+                                  on the image that can be configured at boot time.
+                                properties:
+                                  skipInstall:
+                                    description: SkipInstall is the flag that can
+                                      be used to tell the provider to skip install
+                                      of OCNE dependencies. The value, if set to true,
+                                      will be used to skip the overrides installation
+                                      on OCNEConfigSpec. By default, this value is
+                                      false.
+                                    type: boolean
+                                type: object
+                              proxy:
+                                description: Proxy contains proxy server info that
+                                  may be required for installing dependencies. The
+                                  value, if specified is used in conjunction with
+                                  preOCNECommands to install and configure repositories.
+                                properties:
+                                  httpProxy:
+                                    description: HttpProxy contains http proxy server
+                                      info that may be required for installing dependencies.
+                                      The value, if specified is used in conjunction
+                                      with preOCNECommands to install and configure
+                                      repositories.
+                                    type: string
+                                  httpsProxy:
+                                    description: HttpsProxy contains https proxy server
+                                      info that may be required for installing dependencies.
+                                      The value, if specified is used in conjunction
+                                      with preOCNECommands to install and configure
+                                      repositories.
+                                    type: string
+                                  noProxy:
+                                    description: NoProxy contains addresses that needs
+                                      to be skipped when proxy server is being used.
+                                      The value, if specified is used in conjunction
+                                      with preOCNECommands to install and configure
+                                      repositories.
+                                    type: string
+                                type: object
+                            type: object
+                          initConfiguration:
+                            description: InitConfiguration along with ClusterConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema
+                                  of this representation of an object. Servers should
+                                  convert recognized schemas to the latest internal
+                                  value, and may reject unrecognized values. More
+                                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              bootstrapTokens:
+                                description: BootstrapTokens is respected at `kubeadm
+                                  init` time and describes a set of Bootstrap Tokens
+                                  to create. This information IS NOT uploaded to the
+                                  kubeadm cluster configmap, partly because of its
+                                  sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap
+                                    token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: Description sets a human-friendly
+                                        message why this token exists and what it's
+                                        used for, so other administrators can know
+                                        its purpose.
+                                      type: string
+                                    expires:
+                                      description: Expires specifies the timestamp
+                                        when this token expires. Defaults to being
+                                        set dynamically at runtime based on the TTL.
+                                        Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: Groups specifies the extra groups
+                                        that this token will authenticate as when/if
+                                        used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: Token is used for establishing
+                                        bidirectional trust between nodes and control-planes.
+                                        Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: TTL defines the time to live for
+                                        this token. Defaults to 24h. Expires and TTL
+                                        are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: Usages describes the ways in which
+                                        this token can be used. Can by default be
+                                        used for establishing bidirectional trust,
+                                        but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: 'Kind is a string value representing
+                                  the REST resource this object represents. Servers
+                                  may infer this from the endpoint the client submits
+                                  requests to. Cannot be updated. In CamelCase. More
+                                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint
+                                  of the API server instance that's deployed on this
+                                  control plane node In HA setups, this differs from
+                                  ClusterConfiguration.ControlPlaneEndpoint in the
+                                  sense that ControlPlaneEndpoint is the global endpoint
+                                  for the cluster, which then loadbalances the requests
+                                  to each individual API server. This configuration
+                                  object lets you customize what IP/DNS name and port
+                                  the local API server advertises it's accessible
+                                  on. By default, kubeadm tries to auto-detect the
+                                  IP of the default interface and use that, but in
+                                  case that process fails you may set the desired
+                                  value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: BindPort sets the secure port for
+                                      the API Server to bind to. Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: NodeRegistration holds fields that relate
+                                  to registering the new control-plane node to the
+                                  cluster. When used in the context of control plane
+                                  nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a
+                                      slice of pre-flight errors to be ignored when
+                                      the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: KubeletExtraArgs passes through extra
+                                      arguments to the kubelet. The arguments here
+                                      are passed to the kubelet command line via the
+                                      environment file kubeadm writes at runtime for
+                                      the kubelet to source. This overrides the generic
+                                      base-level configuration in the kubelet-config-1.X
+                                      ConfigMap Flags have higher priority when parsing.
+                                      These values are local and specific to the node
+                                      kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: Name is the `.Metadata.Name` field
+                                      of the Node API object that will be created
+                                      in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field
+                                      of the kubelet's client certificate to the API
+                                      server. Defaults to the hostname of the node
+                                      if not provided.
+                                    type: string
+                                  taints:
+                                    description: 'Taints specifies the taints the
+                                      Node API object should be registered with. If
+                                      this field is unset, i.e. nil, in the `kubeadm
+                                      init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}.
+                                      If you don''t want to taint your control-plane
+                                      node, set this field to an empty slice, i.e.
+                                      `taints: []` in the YAML file. This field is
+                                      solely used for Node registration.'
+                                    items:
+                                      description: The node this Taint is attached
+                                        to has the "effect" on any pod that does not
+                                        tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: Required. The effect of the
+                                            taint on pods that do not tolerate the
+                                            taint. Valid effects are NoSchedule, PreferNoSchedule
+                                            and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to
+                                            be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: TimeAdded represents the time
+                                            at which the taint was added. It is only
+                                            written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding
+                                            to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                              patches:
+                                description: Patches contains options related to applying
+                                  patches to components deployed by kubeadm during
+                                  "kubeadm init". The minimum kubernetes version needed
+                                  to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: Directory is a path to a directory
+                                      that contains files named "target[suffix][+patchtype].extension".
+                                      For example, "kube-apiserver0+merge.yaml" or
+                                      just "etcd.json". "target" can be one of "kube-apiserver",
+                                      "kube-controller-manager", "kube-scheduler",
+                                      "etcd". "patchtype" can be one of "strategic"
+                                      "merge" or "json" and they match the patch formats
+                                      supported by kubectl. The default "patchtype"
+                                      is "strategic". "extension" must be either "json"
+                                      or "yaml". "suffix" is an optional string that
+                                      can be used to determine which patches are applied
+                                      first alpha-numerically. These files can be
+                                      written into the target directory via OCNEConfig.Files
+                                      which specifies additional files to be created
+                                      on the machine, either with content inline or
+                                      by referencing a secret.
+                                    type: string
+                                type: object
+                              skipPhases:
+                                description: SkipPhases is a list of phases to skip
+                                  during command execution. The list of phases can
+                                  be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          joinConfiguration:
+                            description: JoinConfiguration is the kubeadm configuration
+                              for the join command
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema
+                                  of this representation of an object. Servers should
+                                  convert recognized schemas to the latest internal
+                                  value, and may reject unrecognized values. More
+                                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              caCertPath:
+                                description: 'CACertPath is the path to the SSL certificate
+                                  authority used to secure comunications between node
+                                  and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt".
+                                  TODO: revisit when there is defaulting from k/k'
+                                type: string
+                              controlPlane:
+                                description: ControlPlane defines the additional control
+                                  plane instance to be deployed on the joining node.
+                                  If nil, no additional control plane instance will
+                                  be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: LocalAPIEndpoint represents the endpoint
+                                      of the API server instance to be deployed on
+                                      this node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP
+                                          address for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: BindPort sets the secure port
+                                          for the API Server to bind to. Defaults
+                                          to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: 'Discovery specifies the options for
+                                  the kubelet to use during the TLS Bootstrap process
+                                  TODO: revisit when there is defaulting from k/k'
+                                properties:
+                                  bootstrapToken:
+                                    description: BootstrapToken is used to set the
+                                      options for bootstrap token based discovery
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: APIServerEndpoint is an IP or
+                                          domain name to the API server from which
+                                          info will be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: 'CACertHashes specifies a set
+                                          of public key pins to verify when token-based
+                                          discovery is used. The root CA found during
+                                          discovery must match one of these values.
+                                          Specifying an empty set disables root CA
+                                          pinning, which can be unsafe. Each hash
+                                          is specified as "<type>:<value>", where
+                                          the only currently supported type is "sha256".
+                                          This is a hex-encoded SHA-256 hash of the
+                                          Subject Public Key Info (SPKI) object in
+                                          DER-encoded ASN.1. These hashes can be calculated
+                                          using, for example, OpenSSL: openssl x509
+                                          -pubkey -in ca.crt openssl rsa -pubin -outform
+                                          der 2>&/dev/null | openssl dgst -sha256
+                                          -hex'
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: Token is a token used to validate
+                                          cluster information fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: UnsafeSkipCAVerification allows
+                                          token-based discovery without CA verification
+                                          via CACertHashes. This can weaken the security
+                                          of kubeadm since other nodes can impersonate
+                                          the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    type: object
+                                  file:
+                                    description: File is used to specify a file or
+                                      URL to a kubeconfig file from which to load
+                                      cluster information BootstrapToken and File
+                                      are mutually exclusive
+                                    properties:
+                                      kubeConfigPath:
+                                        description: KubeConfigPath is used to specify
+                                          the actual file path or URL to the kubeconfig
+                                          file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: Timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: TLSBootstrapToken is a token used
+                                      for TLS bootstrapping. If .BootstrapToken is
+                                      set, this field is defaulted to .BootstrapToken.Token,
+                                      but can be overridden. If .File is set, this
+                                      field **must be set** in case the KubeConfigFile
+                                      does not contain any other authentication information
+                                    type: string
+                                type: object
+                              kind:
+                                description: 'Kind is a string value representing
+                                  the REST resource this object represents. Servers
+                                  may infer this from the endpoint the client submits
+                                  requests to. Cannot be updated. In CamelCase. More
+                                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              nodeRegistration:
+                                description: NodeRegistration holds fields that relate
+                                  to registering the new control-plane node to the
+                                  cluster. When used in the context of control plane
+                                  nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a
+                                      slice of pre-flight errors to be ignored when
+                                      the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: KubeletExtraArgs passes through extra
+                                      arguments to the kubelet. The arguments here
+                                      are passed to the kubelet command line via the
+                                      environment file kubeadm writes at runtime for
+                                      the kubelet to source. This overrides the generic
+                                      base-level configuration in the kubelet-config-1.X
+                                      ConfigMap Flags have higher priority when parsing.
+                                      These values are local and specific to the node
+                                      kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: Name is the `.Metadata.Name` field
+                                      of the Node API object that will be created
+                                      in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field
+                                      of the kubelet's client certificate to the API
+                                      server. Defaults to the hostname of the node
+                                      if not provided.
+                                    type: string
+                                  taints:
+                                    description: 'Taints specifies the taints the
+                                      Node API object should be registered with. If
+                                      this field is unset, i.e. nil, in the `kubeadm
+                                      init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}.
+                                      If you don''t want to taint your control-plane
+                                      node, set this field to an empty slice, i.e.
+                                      `taints: []` in the YAML file. This field is
+                                      solely used for Node registration.'
+                                    items:
+                                      description: The node this Taint is attached
+                                        to has the "effect" on any pod that does not
+                                        tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: Required. The effect of the
+                                            taint on pods that do not tolerate the
+                                            taint. Valid effects are NoSchedule, PreferNoSchedule
+                                            and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to
+                                            be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: TimeAdded represents the time
+                                            at which the taint was added. It is only
+                                            written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding
+                                            to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                              patches:
+                                description: Patches contains options related to applying
+                                  patches to components deployed by kubeadm during
+                                  "kubeadm join". The minimum kubernetes version needed
+                                  to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: Directory is a path to a directory
+                                      that contains files named "target[suffix][+patchtype].extension".
+                                      For example, "kube-apiserver0+merge.yaml" or
+                                      just "etcd.json". "target" can be one of "kube-apiserver",
+                                      "kube-controller-manager", "kube-scheduler",
+                                      "etcd". "patchtype" can be one of "strategic"
+                                      "merge" or "json" and they match the patch formats
+                                      supported by kubectl. The default "patchtype"
+                                      is "strategic". "extension" must be either "json"
+                                      or "yaml". "suffix" is an optional string that
+                                      can be used to determine which patches are applied
+                                      first alpha-numerically. These files can be
+                                      written into the target directory via OCNEConfig.Files
+                                      which specifies additional files to be created
+                                      on the machine, either with content inline or
+                                      by referencing a secret.
+                                    type: string
+                                type: object
+                              skipPhases:
+                                description: SkipPhases is a list of phases to skip
+                                  during command execution. The list of phases can
+                                  be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          mounts:
+                            description: Mounts specifies a list of mount points to
+                              be setup.
+                            items:
+                              description: MountPoints defines input for generated
+                                mounts in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: NTP specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether NTP should
+                                  be enabled
+                                type: boolean
+                              servers:
+                                description: Servers specifies which NTP servers to
+                                  use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postOCNECommands:
+                            description: PostOCNECommands specifies extra commands
+                              to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preOCNECommands:
+                            description: PreOCNECommands specifies extra commands
+                              to run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: "UseExperimentalRetryJoin replaces a basic
+                              kubeadm command with a shell script with retries for
+                              joins. \n This is meant to be an experimental temporary
+                              workaround on some environments where joins fail due
+                              to timing (and other issues). The long term goal is
+                              to add retries to kubeadm proper and use that functionality.
+                              \n This will add about 40KB to userdata \n For more
+                              information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                              \n Deprecated: This experimental fix is no longer needed
+                              and this field will be removed in a future release.
+                              When removing also remove from staticcheck exclude-rules
+                              for SA1019 in golangci.yml"
+                            type: boolean
+                          users:
+                            description: Users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated
+                                user in cloud-init.
+                              properties:
+                                gecos:
+                                  description: Gecos specifies the gecos to use for
+                                    the user
+                                  type: string
+                                groups:
+                                  description: Groups specifies the additional groups
+                                    for the user
+                                  type: string
+                                homeDir:
+                                  description: HomeDir specifies the home directory
+                                    to use for the user
+                                  type: string
+                                inactive:
+                                  description: Inactive specifies whether to mark
+                                    the user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: LockPassword specifies if password
+                                    login should be disabled
+                                  type: boolean
+                                name:
+                                  description: Name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: Passwd specifies a hashed password
+                                    for the user
+                                  type: string
+                                passwdFrom:
+                                  description: PasswdFrom is a referenced source of
+                                    passwd to populate the passwd.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that
+                                        should populate this password.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                primaryGroup:
+                                  description: PrimaryGroup specifies the primary
+                                    group for the user
+                                  type: string
+                                shell:
+                                  description: Shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: SSHAuthorizedKeys specifies a list
+                                    of ssh authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: Sudo specifies a sudo role for the
+                                    user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: Verbosity is the number for the kubeadm log
+                              level verbosity. It overrides the `--v` flag in kubeadm
+                              commands.
+                            format: int32
+                            type: integer
+                        type: object
+                      machineTemplate:
+                        description: MachineTemplate contains information about how
+                          machines should be shaped when creating or updating a control
+                          plane.
+                        properties:
+                          nodeDeletionTimeout:
+                            description: NodeDeletionTimeout defines how long the
+                              machine controller will attempt to delete the Node that
+                              the Machine hosts after the Machine is marked for deletion.
+                              A duration of 0 will retry deletion indefinitely. If
+                              no value is provided, the default value for this property
+                              of the Machine resource will be used.
+                            type: string
+                          nodeDrainTimeout:
+                            description: 'NodeDrainTimeout is the total amount of
+                              time that the controller will spend on draining a controlplane
+                              node The default value is 0, meaning that the node can
+                              be drained without any time limitations. NOTE: NodeDrainTimeout
+                              is different from `kubectl drain --timeout`'
+                            type: string
+                          nodeVolumeDetachTimeout:
+                            description: NodeVolumeDetachTimeout is the total amount
+                              of time that the controller will spend on waiting for
+                              all volumes to be detached. The default value is 0,
+                              meaning that the volumes can be detached without any
+                              time limitations.
+                            type: string
+                        type: object
+                      rolloutAfter:
+                        description: RolloutAfter is a field to indicate a rollout
+                          should be performed after the specified time even if no
+                          changes have been made to the OCNEControlPlane.
+                        format: date-time
+                        type: string
+                      rolloutBefore:
+                        description: RolloutBefore is a field to indicate a rollout
+                          should be performed if the specified criteria is met.
+                        properties:
+                          certificatesExpiryDays:
+                            description: CertificatesExpiryDays indicates a rollout
+                              needs to be performed if the certificates of the machine
+                              will expire within the specified days.
+                            format: int32
+                            type: integer
+                        type: object
+                      rolloutStrategy:
+                        default:
+                          rollingUpdate:
+                            maxSurge: 1
+                          type: RollingUpdate
+                        description: The RolloutStrategy to use to replace control
+                          plane machines with new ones.
+                        properties:
+                          rollingUpdate:
+                            description: Rolling update config params. Present only
+                              if RolloutStrategyType = RollingUpdate.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of control planes
+                                  that can be scheduled above or under the desired
+                                  number of control planes. Value can be an absolute
+                                  number 1 or 0. Defaults to 1. Example: when this
+                                  is set to 1, the control plane can be scaled up
+                                  immediately when the rolling update starts.'
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of rollout. Currently the only supported
+                              strategy is "RollingUpdate". Default is RollingUpdate.
+                            type: string
+                        type: object
+                    required:
+                    - controlPlaneConfig
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+  name: capi-ocne-control-plane-manager
+  namespace: capi-ocne-control-plane-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+  name: capi-ocne-control-plane-leader-election-role
+  namespace: capi-ocne-control-plane-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      ocne.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+  name: capi-ocne-control-plane-aggregated-manager-role
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+    ocne.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+  name: capi-ocne-control-plane-manager-role
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+  name: capi-ocne-control-plane-leader-election-rolebinding
+  namespace: capi-ocne-control-plane-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-ocne-control-plane-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-ocne-control-plane-manager
+  namespace: capi-ocne-control-plane-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+  name: capi-ocne-control-plane-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-ocne-control-plane-aggregated-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-ocne-control-plane-manager
+  namespace: capi-ocne-control-plane-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+  name: capi-ocne-control-plane-webhook-service
+  namespace: capi-ocne-control-plane-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: control-plane-ocne
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+    control-plane: controller-manager
+  name: capi-ocne-control-plane-controller-manager
+  namespace: capi-ocne-control-plane-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: control-plane-ocne
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-ocne
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --metrics-bind-addr=localhost:8080
+        - --feature-gates=ClusterTopology=${CLUSTER_TOPOLOGY:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        # This image will be overridden by the Verrazzano controller
+        image: ghcr.io/verrazzano/cluster-api-ocne-control-plane-controller:v0.1.0-20230531223401-6824a09
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: capi-ocne-control-plane-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capi-ocne-control-plane-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+  name: capi-ocne-control-plane-serving-cert
+  namespace: capi-ocne-control-plane-system
+spec:
+  dnsNames:
+  - capi-ocne-control-plane-webhook-service.capi-ocne-control-plane-system.svc
+  - capi-ocne-control-plane-webhook-service.capi-ocne-control-plane-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capi-ocne-control-plane-selfsigned-issuer
+  secretName: capi-ocne-control-plane-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+  name: capi-ocne-control-plane-selfsigned-issuer
+  namespace: capi-ocne-control-plane-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-ocne-control-plane-system/capi-ocne-control-plane-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+  name: capi-ocne-control-plane-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: capi-ocne-control-plane-webhook-service
+      namespace: capi-ocne-control-plane-system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1alpha1-ocnecontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.ocnecontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocnecontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: capi-ocne-control-plane-webhook-service
+      namespace: capi-ocne-control-plane-system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1alpha1-ocnecontrolplanetemplate
+  failurePolicy: Fail
+  name: default.ocnecontrolplanetemplate.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocnecontrolplanetemplates
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-ocne-control-plane-system/capi-ocne-control-plane-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: control-plane-ocne
+  name: capi-ocne-control-plane-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: capi-ocne-control-plane-webhook-service
+      namespace: capi-ocne-control-plane-system
+      path: /validate-controlplane-cluster-x-k8s-io-v1alpha1-ocnecontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.ocnecontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocnecontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: capi-ocne-control-plane-webhook-service
+      namespace: capi-ocne-control-plane-system
+      path: /validate-controlplane-cluster-x-k8s-io-v1alpha1-ocnecontrolplanetemplate
+  failurePolicy: Fail
+  name: validation.ocnecontrolplanetemplate.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ocnecontrolplanetemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-ocne-control-plane-webhook-service
+      namespace: capi-ocne-control-plane-system
+      path: /validate-scale-controlplane-cluster-x-k8s-io-v1beta1-ocnecontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation-scale.ocnecontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - UPDATE
+    resources:
+    - ocnecontrolplanes/scale
+  sideEffects: None

--- a/platform-operator/capi/control-plane-ocne/v0.1.0/metadata.yaml
+++ b/platform-operator/capi/control-plane-ocne/v0.1.0/metadata.yaml
@@ -15,6 +15,3 @@ releaseSeries:
   - major: 0
     minor: 1
     contract: v1beta1
-  - major: 1
-    minor: 6
-    contract: v1beta1

--- a/platform-operator/capi/control-plane-ocne/v1.6.1/metadata.yaml
+++ b/platform-operator/capi/control-plane-ocne/v1.6.1/metadata.yaml
@@ -12,6 +12,9 @@
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
+  - major: 0
+    minor: 1
+    contract: v1beta1
   - major: 1
     minor: 6
     contract: v1beta1


### PR DESCRIPTION
This PR will fix CAPI upgrades for dev setups which had version 0.1.0 running. Since this is not a release version, once devLRE is updated 0.1.0 will be removed with a follow up PR. 