### PR TITLE
VZ-10070: fix bug where VPO restarted when first creating the verrazzano-meta cm

### DIFF
--- a/platform-operator/internal/operatorinit/versions.go
+++ b/platform-operator/internal/operatorinit/versions.go
@@ -43,9 +43,7 @@ func CreateVerrazzanoVersionsConfigMap(ctx context.Context) error {
 				},
 				Data: cmData,
 			}, metav1.CreateOptions{})
-			if err != nil {
-				return err
-			}
+			return err
 		}
 		return err
 	}


### PR DESCRIPTION
 Fixed bug where VPO restarted when first creating the verrazzano-meta cm.