### PR TITLE
VZ-9919 - VMO does not need to be enabled when Prometheus is enabled e.g. managed clusters, plus uninstall-resiliency-test fix

### DIFF
--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -396,9 +396,10 @@ def runVerifyTests(stageName, iteration) {
 
 def generateVerifyUninstallStages() {
     boolean mySQLOperatorEnabled = params.INSTALL_PROFILE != 'managed-cluster'
+    boolean vmoEnabled = params.INSTALL_PROFILE != 'managed-cluster'
     uninstallTests = [
         "verifycrds": {
-            runGinkgoWithPassThroughs('uninstall/verifycrds', mySQLOperatorEnabled)
+            runGinkgoWithPassThroughs('uninstall/verifycrds', mySQLOperatorEnabled, vmoEnabled)
         },
         "verifyrancher": {
             runGinkgo('uninstall/verifyrancher')
@@ -587,7 +588,7 @@ def runGinkgo(testSuitePath, dumpDir = '', kubeconfig = '') {
     }
 }
 
-def runGinkgoWithPassThroughs(testSuitePath, mySQLOperatorEnabled, dumpDir = '', kubeconfig = '') {
+def runGinkgoWithPassThroughs(testSuitePath, mySQLOperatorEnabled, vmoEnabled, dumpDir = '', kubeconfig = '') {
     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         sh """
             if [ ! -z "${dumpDir}" ]; then
@@ -597,7 +598,7 @@ def runGinkgoWithPassThroughs(testSuitePath, mySQLOperatorEnabled, dumpDir = '',
                 export KUBECONFIG="${kubeConfig}"
             fi
             cd ${GO_REPO_PATH}/verrazzano/tests/e2e
-            ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --mySQLOperatorEnabled=${mySQLOperatorEnabled}
+            ginkgo -v --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --mySQLOperatorEnabled=${mySQLOperatorEnabled} --vmoEnabled=${vmoEnabled}
         """
     }
 }

--- a/pkg/vzcr/enabled.go
+++ b/pkg/vzcr/enabled.go
@@ -350,7 +350,7 @@ func IsOCIDNSEnabled(cr runtime.Object) bool {
 
 // IsVMOEnabled - Returns false if all VMO components are disabled
 func IsVMOEnabled(vz runtime.Object) bool {
-	return IsPrometheusEnabled(vz) || IsOpenSearchDashboardsEnabled(vz) || IsOpenSearchEnabled(vz) || IsGrafanaEnabled(vz)
+	return IsOpenSearchDashboardsEnabled(vz) || IsOpenSearchEnabled(vz) || IsGrafanaEnabled(vz)
 }
 
 // IsPrometheusOperatorEnabled returns false only if the Prometheus Operator is explicitly disabled in the CR

--- a/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_suite_test.go
@@ -11,9 +11,11 @@ import (
 )
 
 var mySQLOperatorEnabled bool
+var vmoEnabled bool
 
 func init() {
-	flag.BoolVar(&mySQLOperatorEnabled, "mySQLOperatorEnabled", true, "mySQLOperatorEnabled describes whether the mySQLOperator component is enabled")
+	flag.BoolVar(&mySQLOperatorEnabled, "mySQLOperatorEnabled", true, "mySQLOperatorEnabled indicates whether the mySQLOperator component is enabled")
+	flag.BoolVar(&vmoEnabled, "vmoEnabled", true, "vmoEnabled indicates whether the Verrazzano monitoring operator is enabled")
 }
 
 func TestVerifyCRDs(test *testing.T) {

--- a/tests/e2e/uninstall/verifycrds/verify_crds_test.go
+++ b/tests/e2e/uninstall/verifycrds/verify_crds_test.go
@@ -27,7 +27,6 @@ var verrazzanoiocrds = map[string]bool{
 	"multiclustersecrets.clusters.verrazzano.io":                   false,
 	"verrazzanocoherenceworkloads.oam.verrazzano.io":               false,
 	"verrazzanohelidonworkloads.oam.verrazzano.io":                 false,
-	"verrazzanomonitoringinstances.verrazzano.io":                  false,
 	"verrazzanoprojects.clusters.verrazzano.io":                    false,
 	"verrazzanoweblogicworkloads.oam.verrazzano.io":                false,
 }
@@ -99,6 +98,11 @@ var mysqloperatorcrds = map[string]bool{
 	"clusterkopfpeerings.zalando.org": false,
 	"kopfpeerings.zalando.org":        false,
 }
+
+var vmoCRDs = map[string]bool{
+	"verrazzanomonitoringinstances.verrazzano.io": false,
+}
+
 var t = framework.NewTestFramework("uninstall verify crds")
 
 // This test verifies the CRDs found after an uninstall of Verrazzano are what is expected
@@ -111,6 +115,12 @@ var _ = t.Describe("Verify CRDs after uninstall.", Label("f:platform-lcm.unnstal
 	t.It("Check for expected verrazzano.io CRDs", func() {
 		checkCrds(crds, verrazzanoiocrds, "verrazzano.io")
 	})
+
+	if vmoEnabled {
+		t.It("Check for expected Verrazzano monitoring operator CRDs", func() {
+			checkCrds(crds, vmoCRDs, "verrazzano.io")
+		})
+	}
 
 	t.It("Check for expected istio.io CRDs", func() {
 		checkCrds(crds, istioiocrds, "istio.io")
@@ -181,13 +191,7 @@ func checkCrds(crds *apiextv1.CustomResourceDefinitionList, expectdCrds map[stri
 			expectdCrds[crd.Name] = true
 		} else {
 			if strings.HasSuffix(crd.Name, suffix) {
-				optionalCrdFound := false
-				for _, optionalcrd := range optionalverrazzanoiocrds {
-					if crd.Name == optionalcrd {
-						optionalCrdFound = true
-						break
-					}
-				}
+				optionalCrdFound := crdExistsInList(crd.Name, optionalverrazzanoiocrds)
 				if optionalCrdFound {
 					continue
 				}
@@ -198,14 +202,25 @@ func checkCrds(crds *apiextv1.CustomResourceDefinitionList, expectdCrds map[stri
 	}
 
 	crdNotFound := false
-	for key, value := range expectdCrds {
-		if !value {
+	for crdName, wasFound := range expectdCrds {
+		if !wasFound {
 			crdNotFound = true
-			pkg.Log(pkg.Error, fmt.Sprintf("Expected CRD was not found: %s", key))
+			pkg.Log(pkg.Error, fmt.Sprintf("Expected CRD was not found: %s", crdName))
 		}
 	}
 
 	if unexpectedCrd || crdNotFound {
 		Fail(fmt.Sprintf("Failed to verify %s CRDs", suffix))
 	}
+}
+
+func crdExistsInList(crdNameToCheck string, listOfCrds []string) bool {
+	crdFound := false
+	for _, crdName := range listOfCrds {
+		if crdNameToCheck == crdName {
+			crdFound = true
+			break
+		}
+	}
+	return crdFound
 }


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
