### PR TITLE
VZ-9965: Fix clusterAPI component to use REGISTRY environment variable for global override

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzyaml "github.com/verrazzano/verrazzano/pkg/yaml"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/override"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -246,7 +247,10 @@ func mergeBOMOverrides(ctx spi.ComponentContext, overrides *capiOverrides) error
 	}
 
 	// Populate global values
-	overrides.Global.Registry = bomFile.GetRegistry()
+	overrides.Global.Registry = os.Getenv(constants.RegistryOverrideEnvVar)
+	if len(overrides.Global.Registry) == 0 {
+		overrides.Global.Registry = bomFile.GetRegistry()
+	}
 
 	// Populate core provider values
 	core := &overrides.DefaultProviders.Core.Image

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
@@ -342,28 +342,24 @@ func getImageOverride(ctx spi.ComponentContext, bomFile bom.Bom, component strin
 		return nil, err
 	}
 
-	subComp, err := bomFile.GetSubcomponent(component)
-	if err != nil {
-		return nil, err
-	}
-
+	var repository string
 	var tag string
 	for _, image := range images {
 		if len(imageName) == 0 || strings.Contains(image, imageName) {
 			imageSplit := strings.Split(image, ":")
 			tag = imageSplit[1]
+			index := strings.LastIndex(imageSplit[0], "/")
+			repository = imageSplit[0][:index]
+			repoSplit := strings.Split(repository, "/")
+			repository = strings.TrimPrefix(repository, repoSplit[0])
+			repository = strings.TrimPrefix(repository, "/")
 			break
 		}
 	}
 
-	if len(subComp.Repository) == 0 || len(tag) == 0 {
+	if len(repository) == 0 || len(tag) == 0 {
 		return nil, ctx.Log().ErrorNewErr("Failed to find image override for %s/%s", component, imageName)
 	}
 
-	repo := os.Getenv(constants.ImageRepoOverrideEnvVar)
-	if len(repo) == 0 {
-		repo = subComp.Repository
-	}
-
-	return &ImageConfig{Version: version, Repository: repo, Tag: tag}, nil
+	return &ImageConfig{Version: version, Repository: repository, Tag: tag}, nil
 }

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
@@ -348,7 +348,6 @@ func getImageOverride(ctx spi.ComponentContext, bomFile bom.Bom, component strin
 	}
 
 	var tag string
-
 	for _, image := range images {
 		if len(imageName) == 0 || strings.Contains(image, imageName) {
 			imageSplit := strings.Split(image, ":")
@@ -361,5 +360,10 @@ func getImageOverride(ctx spi.ComponentContext, bomFile bom.Bom, component strin
 		return nil, ctx.Log().ErrorNewErr("Failed to find image override for %s/%s", component, imageName)
 	}
 
-	return &ImageConfig{Version: version, Repository: subComp.Repository, Tag: tag}, nil
+	repo := os.Getenv(constants.ImageRepoOverrideEnvVar)
+	if len(repo) == 0 {
+		repo = subComp.Repository
+	}
+
+	return &ImageConfig{Version: version, Repository: repo, Tag: tag}, nil
 }

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides_test.go
@@ -4,10 +4,13 @@
 package clusterapi
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -323,4 +326,34 @@ func TestOverridesInterface(t *testing.T) {
 	assert.Equal(t, "v0.8.2", tc.GetOCITag())
 	assert.Equal(t, "https://github.com/oci-repo/cluster-api-provider-oci/releases/v0.8.2/infrastructure-components.yaml", tc.GetOCIURL())
 
+}
+
+// TestOverridesPrivateRegistry tests the OverridesInterface
+// GIVEN a set OverridesInput
+//
+//	WHEN the user sets private registry image override variables
+//	THEN verify the OverridesInterface returns the expected values
+func TestOverridesPrivateRegistry(t *testing.T) {
+	const privateRegistry = "myreg.io"
+	const privateRepo = "private-repo"
+	config.SetDefaultBomFilePath(testBomFilePath)
+	os.Setenv(vzconst.RegistryOverrideEnvVar, privateRegistry)
+	defer func() { os.Unsetenv(vzconst.RegistryOverrideEnvVar) }()
+	os.Setenv(vzconst.ImageRepoOverrideEnvVar, privateRepo)
+	defer func() { os.Unsetenv(vzconst.ImageRepoOverrideEnvVar) }()
+
+	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects().Build()
+	compContext := spi.NewFakeContext(fakeClient, &v1alpha1.Verrazzano{}, nil, false)
+	config.TestHelmConfigDir = TestHelmConfigDir
+
+	overrides, err := createOverrides(compContext)
+	assert.NoError(t, err)
+	assert.NotNil(t, overrides)
+	tc := newOverridesContext(overrides)
+
+	expectedRepo := fmt.Sprintf("%s/%s", privateRegistry, privateRepo)
+	assert.Equal(t, expectedRepo, tc.GetOCNEBootstrapRepository())
+	assert.Equal(t, expectedRepo, tc.GetOCNEControlPlaneRepository())
+	assert.Equal(t, expectedRepo, tc.GetClusterAPIRepository())
+	assert.Equal(t, expectedRepo, tc.GetOCIRepository())
 }

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides_test.go
@@ -351,9 +351,10 @@ func TestOverridesPrivateRegistry(t *testing.T) {
 	assert.NotNil(t, overrides)
 	tc := newOverridesContext(overrides)
 
-	expectedRepo := fmt.Sprintf("%s/%s", privateRegistry, privateRepo)
+	expectedRepo := fmt.Sprintf("%s/%s/verrazzano", privateRegistry, privateRepo)
 	assert.Equal(t, expectedRepo, tc.GetOCNEBootstrapRepository())
 	assert.Equal(t, expectedRepo, tc.GetOCNEControlPlaneRepository())
 	assert.Equal(t, expectedRepo, tc.GetClusterAPIRepository())
+	expectedRepo = fmt.Sprintf("%s/%s/oracle", privateRegistry, privateRepo)
 	assert.Equal(t, expectedRepo, tc.GetOCIRepository())
 }


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
