### PR TITLE
VZ-10037: update internal CAPI templates with image tags from bom.

### DIFF
--- a/platform-operator/capi/bootstrap-ocne/v1.6.1/bootstrap-components.yaml
+++ b/platform-operator/capi/bootstrap-ocne/v1.6.1/bootstrap-components.yaml
@@ -2540,7 +2540,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         # This image will be overridden by the Verrazzano controller
-        image: ghcr.io/verrazzano/cluster-api-ocne-bootstrap-controller:v0.1.0-20230531223401-6824a09
+        image: ghcr.io/verrazzano/cluster-api-ocne-bootstrap-controller:v1.6.1-20230620181634-aebde3b
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/platform-operator/capi/cluster-api/v1.4.2/core-components.yaml
+++ b/platform-operator/capi/cluster-api/v1.4.2/core-components.yaml
@@ -11142,7 +11142,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.uid
-        image: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.2
+        image: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.2-20230601170413-d75d4df4d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/platform-operator/capi/control-plane-ocne/v1.6.1/control-plane-components.yaml
+++ b/platform-operator/capi/control-plane-ocne/v1.6.1/control-plane-components.yaml
@@ -3083,7 +3083,7 @@ spec:
             fieldRef:
               fieldPath: metadata.uid
         # This image will be overridden by the Verrazzano controller
-        image: ghcr.io/verrazzano/cluster-api-ocne-control-plane-controller:v0.1.0-20230531223401-6824a09
+        image: ghcr.io/verrazzano/cluster-api-ocne-control-plane-controller:v1.6.1-20230620181634-aebde3b
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
this is not a functionality change, but a change to maintain parity