### PR TITLE
VZ-9994 Add optional external cert-manager to dynamic update pipeline

### DIFF
--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -517,6 +517,9 @@ pipeline {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/env-dns-cm-update"
                     }
                     steps {
+                        sh """
+                            ${WORKSPACE}/ci/scripts/install_third_party_components.sh
+                        """
                         runGinkgo('update/env-dns-cm')
                     }
                     post {

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -63,9 +63,9 @@ pipeline {
                 description: 'A regex matching any fully qualified test file that should not be executed (e.g. multicluster/|_excluded_test). Default: _excluded_test',
                 trim: true)
         booleanParam (description: 'Whether to capture full cluster snapshot on test failure', name: 'CAPTURE_FULL_CLUSTER', defaultValue: false)
-        booleanParam (description: 'Whether to run Install Tests', name: 'RUN_INSTALL_TESTS', defaultValue: false)
+        booleanParam (description: 'Whether to Post-Update1 Verify, Infra, and Acceptance Tests', name: 'RUN_POST_UPDATE1', defaultValue: false)
+        booleanParam (description: 'Whether to Post-Update2 Verify, Infra, and Acceptance Tests', name: 'RUN_POST_UPDATE2', defaultValue: false)
         booleanParam (description: 'Whether to run Infra Tests', name: 'RUN_INFRA_TESTS', defaultValue: false)
-        booleanParam (description: 'Whether to run App Tests', name: 'RUN_APP_TESTS', defaultValue: false)
         booleanParam (description: 'Whether to run Availability Status Updates', name: 'RUN_AVAILABILITY_STATUS', defaultValue: false)
         booleanParam (description: 'Whether to run API Conversion Update Tests', name: 'RUN_API_CONVERSION', defaultValue: false)
         booleanParam (description: 'Whether to run AuthProxy Update Tests', name: 'RUN_AUTHPROXY', defaultValue: false)
@@ -367,16 +367,13 @@ pipeline {
                     }
                 }
 
-                stage('Post-Update1 Install Tests') {
-                    when { expression {params.RUN_INSTALL_TESTS} }
+                stage('Post-Update1 Verify Tests') {
+                    when { expression {params.RUN_POST_UPDATE1} }
                     environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-verify-install"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-verify-infra"
                     }
                     steps {
                         runGinkgoRandomize('verify-install')
-                        script {
-                            parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update1-security-tests", 'false', 'true')
-                        }
                     }
                     post {
                         always {
@@ -394,6 +391,25 @@ pipeline {
                     steps {
                         script {
                             parallel generateVerifyInfraStages("${TEST_DUMP_ROOT}/post-update1-infra-tests")
+                        }
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
+                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                        }
+                    }
+                }
+
+                stage('Post-Update1 Acceptance Tests') {
+                    when { expression {params.RUN_POST_UPDATE1} }
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-infra-tests"
+                    }
+                    steps {
+                        script {
+                            // Run all but the WLS tests, and skip the undeploy step to leave the apps running
+                            parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update1-acceptance-tests", 'false', 'true')
                         }
                     }
                     post {
@@ -424,10 +440,10 @@ pipeline {
                     }
                 }
 
-                stage('Install Apps and run tests') {
-                    when { expression {params.RUN_APP_TESTS} }
+                stage('WLS/COH Post-Update2 Acceptance Tests') {
+                    when { expression {params.RUN_POST_UPDATE2} }
                     environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/install-app-tests"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-update"
                     }
                     steps {
                         // Run initial WLS/COH acceptance tests, and leave the apps running
@@ -597,16 +613,13 @@ pipeline {
                     }
                 }
 
-                stage('Post-Update2 Install Tests') {
-                    when { expression {params.RUN_INSTALL_TESTS} }
+                stage('Post-update2 Verify Tests') {
+                    when { expression {params.RUN_POST_UPDATE2} }
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update2-verify-install"
                     }
                     steps {
                         runGinkgoRandomize('verify-install')
-                        script {
-                            parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update2-security-tests", 'false', 'true')
-                        }
                     }
                     post {
                         always {
@@ -634,15 +647,15 @@ pipeline {
                     }
                 }
 
-                stage('Post-Update2 App Tests') {
-                    when { expression {params.RUN_APP_TESTS} }
+                stage('Post-update2 Acceptance Tests') {
+                    when { expression {params.RUN_POST_UPDATE2} }
                     environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update2-app-tests"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-update"
                     }
                     steps {
-                        // Run WLS/COH acceptance tests again, and delete the apps
+                        // Run all acceptance tests after the sequence of updates including CM and DNS; undeploy apps after
                         script {
-                            parallel generate_wls_tests("${TEST_DUMP_ROOT}/install-app-tests", 'true', 'false')
+                            parallel generateAllAcceptanceTestStages("${TEST_DUMP_ROOT}/post-cm-dns-acceptance-tests", 'true', 'false')
                         }
                     }
                     post {

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -252,13 +252,6 @@ pipeline {
                     }
                     steps {
                         sh """
-                            if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
-                              echo "Configuring installation with external cert-manger and NGINX"
-                              ci/scripts/install_third_party_components.sh
-                            fi
-                        """
-
-                        sh """
                             cd ${GO_REPO_PATH}/verrazzano
                             yq -i eval '.spec.components.weblogicOperator.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.coherenceOperator.enabled = false' ${INSTALL_CONFIG_FILE_KIND}

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -364,7 +364,9 @@ pipeline {
                     }
                     steps {
                         runGinkgoRandomize('verify-install')
-                        parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update1-security-tests", 'false', 'true')
+                        script {
+                            parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update1-security-tests", 'false', 'true')
+                        }
                     }
                     post {
                         always {
@@ -592,7 +594,9 @@ pipeline {
                     }
                     steps {
                         runGinkgoRandomize('verify-install')
-                        parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update2-security-tests", 'false', 'true')
+                        script {
+                            parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update2-security-tests", 'false', 'true')
+                        }
                     }
                     post {
                         always {

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -273,10 +273,15 @@ pipeline {
                             yq -i eval '.spec.components.grafana.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.console.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.verrazzano.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
+
+                            if [ ${params.EXTERNAL_CERT_MANAGER} == true ]; then
+                              yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
+                              yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = "${CLUSTER_RESOURCE_NAMESPACE}"' ${INSTALL_CONFIG_FILE_KIND}
+                            else
+                              yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
+                            fi
                         """
                         script {
-                            installExternalComponents()
-
                             if(params.CRD_API_VERSION == "v1alpha1"){
                                 scriptForPrepareATEnvironmentV1alpha1()
                             }else{
@@ -338,10 +343,15 @@ pipeline {
                             yq -i eval '.spec.components.console.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.verrazzano.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.argoCD.enabled = true' ${WORKSPACE}/vz-update1.yaml
+
+                            if [ ${params.EXTERNAL_CERT_MANAGER} == true ]; then
+                              yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
+                              yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = "${CLUSTER_RESOURCE_NAMESPACE}"' ${INSTALL_CONFIG_FILE_KIND}
+                            else
+                              yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
+                            fi
                         """
                         script {
-                            installExternalComponents()
-
                             if(params.CRD_API_VERSION == "v1alpha1"){
                                 vzUpdateComponentsV1alpha1()
                             }else{
@@ -1023,16 +1033,5 @@ def runCustomResourceValidation(){
        ci/scripts/prepare_jenkins_at_environment.sh ${params.CREATE_CLUSTER_USE_CALICO} ${params.WILDCARD_DNS_DOMAIN}
        oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/operator.yaml --file ${WORKSPACE}/downloaded-vpo.yaml
        ci/scripts/validate_custom_resource.sh ${WORKSPACE}/ci/dynamic-updates/invalidCR.yaml ${WORKSPACE}/downloaded-vpo.yaml
-    """
-}
-
-func installExternalComponents(){
-    sh """
-        if [ ${params.EXTERNAL_CERT_MANAGER} == true ]; then
-          yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
-          yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = "${CLUSTER_RESOURCE_NAMESPACE}"' ${INSTALL_CONFIG_FILE_KIND}
-        else
-          yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
-        fi
     """
 }

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -76,6 +76,10 @@ pipeline {
         booleanParam (description: 'Whether to run Post-install overrides Tests', name: 'RUN_POST_INSTALL_OVERRIDES', defaultValue: false)
         booleanParam (description: 'Whether to skip the VZ install in the prepare environment script', name: 'SKIP_VERRAZZANO_INSTALL_PARAM', defaultValue: false)
         booleanParam (description: 'Whether to run with an external cert-manager and NGINX installed', name: 'EXTERNAL_CERT_MANAGER', defaultValue: false)
+        string (name: 'CLUSTER_RESOURCE_NAMESPACE',
+                defaultValue: 'my-cert-manager',
+                description: 'The namespace for cluster-scoped Cert-Manager resources; defaults to where Cert-Manager is installed.',
+                trim: true)
     }
 
     environment {
@@ -143,6 +147,10 @@ pipeline {
         KIND_NODE_COUNT = 3
 
         SKIP_VERRAZZANO_INSTALL = "${params.SKIP_VERRAZZANO_INSTALL_PARAM}"
+
+        // external cert-manager
+        INSTALL_EXTERNAL_CERT_MANAGER = "${params.EXTERNAL_CERT_MANAGER}"
+        CLUSTER_RESOURCE_NAMESPACE = "${params.CLUSTER_RESOURCE_NAMESPACE}"
     }
 
     stages {
@@ -247,11 +255,12 @@ pipeline {
                         KIND_KUBERNETES_CLUSTER_VERSION="${params.KUBERNETES_CLUSTER_VERSION}"
                         OCI_OS_LOCATION="ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
                         SKIP_VERRAZZANO_INSTALL = false
-                        CLUSTER_RESOURCE_NAMESPACE="my-cert-manager"
-                        INSTALL_EXTERNAL_CERT_MANAGER = "${params.EXTERNAL_CERT_MANAGER}"
                     }
                     steps {
                         sh """
+                            echo "External cert-manager is ${params.EXTERNAL_CERT_MANAGER}"
+                            echo "External cert-manager is ${INSTALL_EXTERNAL_CERT_MANAGER}"
+
                             cd ${GO_REPO_PATH}/verrazzano
                             yq -i eval '.spec.components.weblogicOperator.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.coherenceOperator.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
@@ -270,6 +279,7 @@ pipeline {
                             if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
                               echo "Installing with external cert-manager and NGINX"
                               yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
+                              yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = ${CLUSTER_RESOURCE_NAMESPACE}' ${INSTALL_CONFIG_FILE_KIND}
                             else
                               echo "Installing with verrazzano cert-manager and NGINX"
                               yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
@@ -340,6 +350,7 @@ pipeline {
 
                             if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
                               yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
+                              yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = ${CLUSTER_RESOURCE_NAMESPACE}' ${INSTALL_CONFIG_FILE_KIND}
                             else
                               yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             fi

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -515,7 +515,6 @@ pipeline {
                     environment {
                         TEST_ENV = "KIND"
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/env-dns-cm-update"
-                        CLUSTER_RESOURCE_NAMESPACE = "test-namespace"
                     }
                     steps {
                         sh """

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -313,11 +313,11 @@ pipeline {
                                         else
                                           kubectl exec \$vz_api_pod -c istio-proxy -n verrazzano-system -- curl -X POST http://localhost:15000/logging?level=debug
                                         fi
-                                        nginx_ing_pod=\$(kubectl get pod -n ingress-nginx -l app.kubernetes.io/component=controller --no-headers -o custom-columns=\":metadata.name\")
+                                        nginx_ing_pod=\$(kubectl get pod -n verrazzano-ingress-nginx -l app.kubernetes.io/component=controller --no-headers -o custom-columns=\":metadata.name\")
                                         if [ -z "\$nginx_ing_pod" ]; then
                                           echo "Could not find nginx ingress controller pod, not enabling debug logging"
                                         else
-                                          kubectl exec \$nginx_ing_pod -c istio-proxy -n ingress-nginx -- curl -X POST http://localhost:15000/logging?level=debug
+                                          kubectl exec \$nginx_ing_pod -c istio-proxy -n verrazzano-ingress-nginx -- curl -X POST http://localhost:15000/logging?level=debug
                                         fi
                                     '''
                                 }

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -248,6 +248,7 @@ pipeline {
                         OCI_OS_LOCATION="ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
                         SKIP_VERRAZZANO_INSTALL = false
                         CLUSTER_RESOURCE_NAMESPACE="my-cert-manager"
+                        INSTALL_EXTERNAL_CERT_MANAGER = "${params.EXTERNAL_CERT_MANAGER}"
                     }
                     steps {
                         sh """

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -63,8 +63,10 @@ pipeline {
                 description: 'A regex matching any fully qualified test file that should not be executed (e.g. multicluster/|_excluded_test). Default: _excluded_test',
                 trim: true)
         booleanParam (description: 'Whether to capture full cluster snapshot on test failure', name: 'CAPTURE_FULL_CLUSTER', defaultValue: false)
-        booleanParam (description: 'Whether to Post-Update1 Verify, Infra, and Acceptance Tests', name: 'RUN_POST_UPDATE1', defaultValue: false)
-        booleanParam (description: 'Whether to Post-Update2 Verify, Infra, and Acceptance Tests', name: 'RUN_POST_UPDATE2', defaultValue: false)
+        booleanParam (description: 'Whether to run Install Tests', name: 'RUN_INSTALL_TESTS', defaultValue: false)
+        booleanParam (description: 'Whether to run Infra Tests', name: 'RUN_INFRA_TESTS', defaultValue: false)
+        booleanParam (description: 'Whether to run Security Tests', name: 'RUN_SECURITY_TESTS', defaultValue: false)
+        booleanParam (description: 'Whether to run App Tests', name: 'RUN_APP_TESTS', defaultValue: false)
         booleanParam (description: 'Whether to run Availability Status Updates', name: 'RUN_AVAILABILITY_STATUS', defaultValue: false)
         booleanParam (description: 'Whether to run API Conversion Update Tests', name: 'RUN_API_CONVERSION', defaultValue: false)
         booleanParam (description: 'Whether to run AuthProxy Update Tests', name: 'RUN_AUTHPROXY', defaultValue: false)
@@ -368,10 +370,10 @@ pipeline {
                     }
                 }
 
-                stage('Post-Update1 Verify Tests') {
-                    when { expression {params.RUN_POST_UPDATE1} }
+                stage('Post-Update1 Install Tests') {
+                    when { expression {params.RUN_INSTALL_TESTS} }
                     environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-verify-infra"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-verify-install"
                     }
                     steps {
                         runGinkgoRandomize('verify-install')
@@ -385,7 +387,7 @@ pipeline {
                 }
 
                 stage('Post-Update1 Infra Tests') {
-                    when { expression {params.RUN_POST_UPDATE1} }
+                    when { expression {params.RUN_INFRA_TESTS_TESTS} }
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-infra-tests"
                     }
@@ -402,15 +404,33 @@ pipeline {
                     }
                 }
 
-                stage('Post-Update1 Acceptance Tests') {
-                    when { expression {params.RUN_POST_UPDATE1} }
+                stage('Post-Update1 Security Tests') {
+                    when { expression {params.RUN_SECURITY_TESTS} }
                     environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-infra-tests"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-security-tests"
                     }
                     steps {
                         script {
                             // Run all but the WLS tests, and skip the undeploy step to leave the apps running
-                            parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update1-acceptance-tests", 'false', 'true')
+                            parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update1-security-tests", 'false', 'true')
+                        }
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
+                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                        }
+                    }
+                }
+                stage('Post-Update1 App Tests') {
+                    when { expression {params.RUN_APP_TESTS} }
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-app-tests"
+                    }
+                    steps {
+                        // Run initial WLS/COH acceptance tests, and leave the apps running
+                        script {
+                            parallel generate_wls_tests("${TEST_DUMP_ROOT}/wls-coh-update2-tests", 'false', 'true')
                         }
                     }
                     post {
@@ -437,25 +457,6 @@ pipeline {
                         always {
                             dumpVerrazzanoPlatformOperatorLogs("update-verrazzano")
                             archiveArtifacts artifacts: "vz-update2.yaml,**/logs/**", allowEmptyArchive: true
-                        }
-                    }
-                }
-
-                stage('WLS/COH Post-Update2 Acceptance Tests') {
-                    when { expression {params.RUN_POST_UPDATE2} }
-                    environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-update"
-                    }
-                    steps {
-                        // Run initial WLS/COH acceptance tests, and leave the apps running
-                        script {
-                            parallel generate_wls_tests("${TEST_DUMP_ROOT}/wls-coh-update2-tests", 'false', 'true')
-                        }
-                    }
-                    post {
-                        always {
-                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
-                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
                         }
                     }
                 }
@@ -614,8 +615,8 @@ pipeline {
                     }
                 }
 
-                stage('Post-update2 Verify Tests') {
-                    when { expression {params.RUN_POST_UPDATE2} }
+                stage('Post-Update2 Install Tests') {
+                    when { expression {params.RUN_INSTALL_TESTS} }
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update2-verify-install"
                     }
@@ -631,7 +632,7 @@ pipeline {
                 }
 
                 stage('Post-Update2 Infra Tests') {
-                    when { expression {params.RUN_POST_UPDATE2} }
+                    when { expression {params.RUN_INFRA_TESTS_TESTS} }
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update2-infra-tests"
                     }
@@ -648,15 +649,15 @@ pipeline {
                     }
                 }
 
-                stage('Post-update2 Acceptance Tests') {
-                    when { expression {params.RUN_POST_UPDATE2} }
+                stage('Post-Update2 Security Tests') {
+                    when { expression {params.RUN_SECURITY_TESTS} }
                     environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/verify-update"
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update2-security-tests"
                     }
                     steps {
-                        // Run all acceptance tests after the sequence of updates including CM and DNS; undeploy apps after
                         script {
-                            parallel generateAllAcceptanceTestStages("${TEST_DUMP_ROOT}/post-cm-dns-acceptance-tests", 'true', 'false')
+                            // Run all but the WLS tests, and skip the undeploy step to leave the apps running
+                            parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update2-security-tests", 'false', 'true')
                         }
                     }
                     post {
@@ -664,6 +665,23 @@ pipeline {
                             archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
                             junit testResults: '**/*test-result.xml', allowEmptyResults: true
                         }
+                    }
+                }
+            stage('Post-Update2 App Tests') {
+                when { expression {params.RUN_APP_TESTS} }
+                environment {
+                    DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update2-app-tests"
+                }
+                steps {
+                    // Run WLS/COH acceptance tests again, and delete the apps
+                    script {
+                        parallel generate_wls_tests("${TEST_DUMP_ROOT}/wls-coh-update2-tests", 'true', 'false')
+                    }
+                }
+                post {
+                    always {
+                        archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
+                        junit testResults: '**/*test-result.xml', allowEmptyResults: true
                     }
                 }
             }
@@ -757,6 +775,9 @@ def generateVerifyInfraStages(dumpRoot) {
         },
         "console": {
             acceptanceTestsConsole("${dumpRoot}")
+        },
+        "verify-infra vmi": {
+            runGinkgoRandomize('verify-infra/vmi', "${dumpRoot}/verify-infra-vmi")
         },
     ]
 }

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -668,21 +668,22 @@ pipeline {
                         }
                     }
                 }
-            stage('Post-Update2 App Tests') {
-                when { expression {params.RUN_APP_TESTS} }
-                environment {
-                    DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update2-app-tests"
-                }
-                steps {
-                    // Run WLS/COH acceptance tests again, and delete the apps
-                    script {
-                        parallel generate_wls_tests("${TEST_DUMP_ROOT}/install-app-tests", 'true', 'false')
+                stage('Post-Update2 App Tests') {
+                    when { expression {params.RUN_APP_TESTS} }
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update2-app-tests"
                     }
-                }
-                post {
-                    always {
-                        archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
-                        junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                    steps {
+                        // Run WLS/COH acceptance tests again, and delete the apps
+                        script {
+                            parallel generate_wls_tests("${TEST_DUMP_ROOT}/install-app-tests", 'true', 'false')
+                        }
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
+                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
+                        }
                     }
                 }
             }

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -741,9 +741,6 @@ def generateVerifyInfraStages(dumpRoot) {
         "system component metrics": {
             runGinkgoRandomize('metrics/syscomponents', "${dumpRoot}/system-component-metrics")
         },
-        "console": {
-            acceptanceTestsConsole("${dumpRoot}")
-        },
         "verify-infra vmi": {
             runGinkgoRandomize('verify-infra/vmi', "${dumpRoot}/verify-infra-vmi")
         },

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -250,6 +250,13 @@ pipeline {
                     }
                     steps {
                         sh """
+                            if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
+                              echo "Configuring installation with external cert-manger and NGINX"
+                              ci/scripts/install_third_party_components.sh
+                            fi
+                        """
+
+                        sh """
                             cd ${GO_REPO_PATH}/verrazzano
                             yq -i eval '.spec.components.weblogicOperator.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.coherenceOperator.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
@@ -272,7 +279,6 @@ pipeline {
                               echo "Installing with verrazzano cert-manager and NGINX"
                               yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             fi
-
                         """
                         script {
                             if(params.CRD_API_VERSION == "v1alpha1"){
@@ -350,13 +356,6 @@ pipeline {
                                 vzUpdateComponentsV1beta1()
                             }
                         }
-                        sh """
-                            if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
-                              echo "Configuring installation with external cert-manger and NGINX"
-                              ci/scripts/install_third_party_components.sh
-                            fi
-                        """
-
                     }
                     post {
                         always {

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -387,7 +387,7 @@ pipeline {
                 }
 
                 stage('Post-Update1 Infra Tests') {
-                    when { expression {params.RUN_INFRA_TESTS_TESTS} }
+                    when { expression {params.RUN_INFRA_TESTS} }
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-infra-tests"
                     }
@@ -422,24 +422,6 @@ pipeline {
                         }
                     }
                 }
-                stage('Post-Update1 App Tests') {
-                    when { expression {params.RUN_APP_TESTS} }
-                    environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-app-tests"
-                    }
-                    steps {
-                        // Run initial WLS/COH acceptance tests, and leave the apps running
-                        script {
-                            parallel generate_wls_tests("${TEST_DUMP_ROOT}/wls-coh-update2-tests", 'false', 'true')
-                        }
-                    }
-                    post {
-                        always {
-                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
-                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
-                        }
-                    }
-                }
 
                 // Update2 enables COH/WLS operators
                 stage('Verrazzano Update2') {
@@ -457,6 +439,25 @@ pipeline {
                         always {
                             dumpVerrazzanoPlatformOperatorLogs("update-verrazzano")
                             archiveArtifacts artifacts: "vz-update2.yaml,**/logs/**", allowEmptyArchive: true
+                        }
+                    }
+                }
+
+                stage('Install Apps and run tests') {
+                    when { expression {params.RUN_APP_TESTS} }
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/install-app-tests"
+                    }
+                    steps {
+                        // Run initial WLS/COH acceptance tests, and leave the apps running
+                        script {
+                            parallel generate_wls_tests("${TEST_DUMP_ROOT}/wls-coh-update2-tests", 'false', 'true')
+                        }
+                    }
+                    post {
+                        always {
+                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
+                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
                         }
                     }
                 }
@@ -632,7 +633,7 @@ pipeline {
                 }
 
                 stage('Post-Update2 Infra Tests') {
-                    when { expression {params.RUN_INFRA_TESTS_TESTS} }
+                    when { expression {params.RUN_INFRA_TESTS} }
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update2-infra-tests"
                     }
@@ -675,7 +676,7 @@ pipeline {
                 steps {
                     // Run WLS/COH acceptance tests again, and delete the apps
                     script {
-                        parallel generate_wls_tests("${TEST_DUMP_ROOT}/wls-coh-update2-tests", 'true', 'false')
+                        parallel generate_wls_tests("${TEST_DUMP_ROOT}/install-app-tests", 'true', 'false')
                     }
                 }
                 post {

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -247,7 +247,7 @@ pipeline {
                         KIND_KUBERNETES_CLUSTER_VERSION="${params.KUBERNETES_CLUSTER_VERSION}"
                         OCI_OS_LOCATION="ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
                         SKIP_VERRAZZANO_INSTALL = false
-                        CLUSTER_RESOURCE_NAMESPACE=my-cert-manager
+                        CLUSTER_RESOURCE_NAMESPACE="my-cert-manager"
                     }
                     steps {
                         sh """

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -65,7 +65,6 @@ pipeline {
         booleanParam (description: 'Whether to capture full cluster snapshot on test failure', name: 'CAPTURE_FULL_CLUSTER', defaultValue: false)
         booleanParam (description: 'Whether to run Install Tests', name: 'RUN_INSTALL_TESTS', defaultValue: false)
         booleanParam (description: 'Whether to run Infra Tests', name: 'RUN_INFRA_TESTS', defaultValue: false)
-        booleanParam (description: 'Whether to run Security Tests', name: 'RUN_SECURITY_TESTS', defaultValue: false)
         booleanParam (description: 'Whether to run App Tests', name: 'RUN_APP_TESTS', defaultValue: false)
         booleanParam (description: 'Whether to run Availability Status Updates', name: 'RUN_AVAILABILITY_STATUS', defaultValue: false)
         booleanParam (description: 'Whether to run API Conversion Update Tests', name: 'RUN_API_CONVERSION', defaultValue: false)
@@ -274,17 +273,10 @@ pipeline {
                             yq -i eval '.spec.components.grafana.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.console.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.verrazzano.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
-
-                            if [ ${params.EXTERNAL_CERT_MANAGER} == true ]; then
-                              echo "Installing with external cert-manager and NGINX"
-                              yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
-                              yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = "${CLUSTER_RESOURCE_NAMESPACE}"' ${INSTALL_CONFIG_FILE_KIND}
-                            else
-                              echo "Installing with verrazzano cert-manager and NGINX"
-                              yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
-                            fi
                         """
                         script {
+                            installExternalComponents()
+
                             if(params.CRD_API_VERSION == "v1alpha1"){
                                 scriptForPrepareATEnvironmentV1alpha1()
                             }else{
@@ -346,15 +338,10 @@ pipeline {
                             yq -i eval '.spec.components.console.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.verrazzano.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.argoCD.enabled = true' ${WORKSPACE}/vz-update1.yaml
-
-                            if [ ${params.EXTERNAL_CERT_MANAGER} == true ]; then
-                              yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
-                              yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = "${CLUSTER_RESOURCE_NAMESPACE}"' ${INSTALL_CONFIG_FILE_KIND}
-                            else
-                              yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
-                            fi
                         """
                         script {
+                            installExternalComponents()
+
                             if(params.CRD_API_VERSION == "v1alpha1"){
                                 vzUpdateComponentsV1alpha1()
                             }else{
@@ -377,6 +364,7 @@ pipeline {
                     }
                     steps {
                         runGinkgoRandomize('verify-install')
+                        parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update1-security-tests", 'false', 'true')
                     }
                     post {
                         always {
@@ -402,26 +390,7 @@ pipeline {
                             junit testResults: '**/*test-result.xml', allowEmptyResults: true
                         }
                     }
-                }
-
-                stage('Post-Update1 Security Tests') {
-                    when { expression {params.RUN_SECURITY_TESTS} }
-                    environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update1-security-tests"
-                    }
-                    steps {
-                        script {
-                            // Run all but the WLS tests, and skip the undeploy step to leave the apps running
-                            parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update1-security-tests", 'false', 'true')
-                        }
-                    }
-                    post {
-                        always {
-                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
-                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
-                        }
-                    }
-                }
+                }                }
 
                 // Update2 enables COH/WLS operators
                 stage('Verrazzano Update2') {
@@ -623,6 +592,7 @@ pipeline {
                     }
                     steps {
                         runGinkgoRandomize('verify-install')
+                        parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update2-security-tests", 'false', 'true')
                     }
                     post {
                         always {
@@ -650,24 +620,6 @@ pipeline {
                     }
                 }
 
-                stage('Post-Update2 Security Tests') {
-                    when { expression {params.RUN_SECURITY_TESTS} }
-                    environment {
-                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/post-update2-security-tests"
-                    }
-                    steps {
-                        script {
-                            // Run all but the WLS tests, and skip the undeploy step to leave the apps running
-                            parallel generateNonWLSAcceptanceTestStages("${TEST_DUMP_ROOT}/post-update2-security-tests", 'false', 'true')
-                        }
-                    }
-                    post {
-                        always {
-                            archiveArtifacts artifacts: '**/coverage.html,**/logs/*,**/test-cluster-snapshots/**', allowEmptyArchive: true
-                            junit testResults: '**/*test-result.xml', allowEmptyResults: true
-                        }
-                    }
-                }
                 stage('Post-Update2 App Tests') {
                     when { expression {params.RUN_APP_TESTS} }
                     environment {
@@ -1070,3 +1022,13 @@ def runCustomResourceValidation(){
     """
 }
 
+func installExternalComponents(){
+    sh """
+        if [ ${params.EXTERNAL_CERT_MANAGER} == true ]; then
+          yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
+          yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = "${CLUSTER_RESOURCE_NAMESPACE}"' ${INSTALL_CONFIG_FILE_KIND}
+        else
+          yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
+        fi
+    """
+}

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -390,7 +390,7 @@ pipeline {
                             junit testResults: '**/*test-result.xml', allowEmptyResults: true
                         }
                     }
-                }                }
+                }
 
                 // Update2 enables COH/WLS operators
                 stage('Verrazzano Update2') {

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -253,7 +253,6 @@ pipeline {
                         sh """
                             if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
                               echo "Configuring installation with external cert-manger and NGINX"
-
                               ci/scripts/install_third_party_components.sh
                             fi
                         """

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -515,6 +515,7 @@ pipeline {
                     environment {
                         TEST_ENV = "KIND"
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/env-dns-cm-update"
+                        CLUSTER_RESOURCE_NAMESPACE = "test-namespace"
                     }
                     steps {
                         sh """

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -279,7 +279,7 @@ pipeline {
                             if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
                               echo "Installing with external cert-manager and NGINX"
                               yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
-                              yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = ${CLUSTER_RESOURCE_NAMESPACE}' ${INSTALL_CONFIG_FILE_KIND}
+                              yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = "${CLUSTER_RESOURCE_NAMESPACE}"' ${INSTALL_CONFIG_FILE_KIND}
                             else
                               echo "Installing with verrazzano cert-manager and NGINX"
                               yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
@@ -350,7 +350,7 @@ pipeline {
 
                             if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
                               yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
-                              yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = ${CLUSTER_RESOURCE_NAMESPACE}' ${INSTALL_CONFIG_FILE_KIND}
+                              yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = "${CLUSTER_RESOURCE_NAMESPACE}"' ${INSTALL_CONFIG_FILE_KIND}
                             else
                               yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             fi

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -258,9 +258,6 @@ pipeline {
                     }
                     steps {
                         sh """
-                            echo "External cert-manager is ${params.EXTERNAL_CERT_MANAGER}"
-                            echo "External cert-manager is ${INSTALL_EXTERNAL_CERT_MANAGER}"
-
                             cd ${GO_REPO_PATH}/verrazzano
                             yq -i eval '.spec.components.weblogicOperator.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.coherenceOperator.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
@@ -276,7 +273,7 @@ pipeline {
                             yq -i eval '.spec.components.console.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.verrazzano.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
 
-                            if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
+                            if [ ${params.EXTERNAL_CERT_MANAGER} == true ]; then
                               echo "Installing with external cert-manager and NGINX"
                               yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
                               yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = "${CLUSTER_RESOURCE_NAMESPACE}"' ${INSTALL_CONFIG_FILE_KIND}
@@ -348,7 +345,7 @@ pipeline {
                             yq -i eval '.spec.components.verrazzano.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.argoCD.enabled = true' ${WORKSPACE}/vz-update1.yaml
 
-                            if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
+                            if [ ${params.EXTERNAL_CERT_MANAGER} == true ]; then
                               yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
                               yq -i eval '.spec.components.clusterIssuer.clusterResourceNamespace = "${CLUSTER_RESOURCE_NAMESPACE}"' ${INSTALL_CONFIG_FILE_KIND}
                             else

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -75,6 +75,7 @@ pipeline {
         booleanParam (description: 'Whether to run Jaeger Update Tests', name: 'RUN_JAEGER', defaultValue: false)
         booleanParam (description: 'Whether to run Post-install overrides Tests', name: 'RUN_POST_INSTALL_OVERRIDES', defaultValue: false)
         booleanParam (description: 'Whether to skip the VZ install in the prepare environment script', name: 'SKIP_VERRAZZANO_INSTALL_PARAM', defaultValue: false)
+        booleanParam (description: 'Whether to run with an external cert-manager and NGINX installed', name: 'EXTERNAL_CERT_MANAGER', defaultValue: false)
     }
 
     environment {
@@ -254,7 +255,6 @@ pipeline {
                             yq -i eval '.spec.components.coherenceOperator.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.kiali.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.rancher.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
-                            yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.istio.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.keycloak.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.applicationOperator.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
@@ -264,6 +264,15 @@ pipeline {
                             yq -i eval '.spec.components.grafana.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.console.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
                             yq -i eval '.spec.components.verrazzano.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
+
+                            if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
+                              echo "Installing with external cert-manager and NGINX"
+                              yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
+                            else
+                              echo "Installing with verrazzano cert-manager and NGINX"
+                              yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
+                            fi
+
                         """
                         script {
                             if(params.CRD_API_VERSION == "v1alpha1"){
@@ -317,7 +326,6 @@ pipeline {
                             cp ${INSTALL_CONFIG_FILE_KIND} ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.kiali.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.rancher.enabled = true' ${WORKSPACE}/vz-update1.yaml
-                            yq -i eval '.spec.components.certManager.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.istio.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.keycloak.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.applicationOperator.enabled = true' ${WORKSPACE}/vz-update1.yaml
@@ -328,6 +336,12 @@ pipeline {
                             yq -i eval '.spec.components.console.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.verrazzano.enabled = true' ${WORKSPACE}/vz-update1.yaml
                             yq -i eval '.spec.components.argoCD.enabled = true' ${WORKSPACE}/vz-update1.yaml
+
+                            if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
+                              yq -i eval '.spec.components.certManager.enabled = false' ${INSTALL_CONFIG_FILE_KIND}
+                            else
+                              yq -i eval '.spec.components.certManager.enabled = true' ${INSTALL_CONFIG_FILE_KIND}
+                            fi
                         """
                         script {
                             if(params.CRD_API_VERSION == "v1alpha1"){
@@ -336,6 +350,13 @@ pipeline {
                                 vzUpdateComponentsV1beta1()
                             }
                         }
+                        sh """
+                            if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
+                              echo "Configuring installation with external cert-manger and NGINX"
+                              ci/scripts/install_third_party_components.sh
+                            fi
+                        """
+
                     }
                     post {
                         always {

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -247,11 +247,13 @@ pipeline {
                         KIND_KUBERNETES_CLUSTER_VERSION="${params.KUBERNETES_CLUSTER_VERSION}"
                         OCI_OS_LOCATION="ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
                         SKIP_VERRAZZANO_INSTALL = false
+                        CLUSTER_RESOURCE_NAMESPACE=my-cert-manager
                     }
                     steps {
                         sh """
                             if [ ${params.EXTERNAL_CERT_MANAGER} ]; then
                               echo "Configuring installation with external cert-manger and NGINX"
+
                               ci/scripts/install_third_party_components.sh
                             fi
                         """

--- a/ci/dynamic-updates/JenkinsfileTrigger
+++ b/ci/dynamic-updates/JenkinsfileTrigger
@@ -116,10 +116,9 @@ pipeline {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
-                                startDCTestJob([booleanParam(name: 'RUN_INSTALL_TESTS', value: true),
+                                startDCTestJob([booleanParam(name: 'RUN_POST_UPDATE1', value: true),
+                                                booleanParam(name: 'RUN_POST_UPDATE2', value: true),
                                                 booleanParam(name: 'RUN_INFRA_TESTS', value: true),
-                                                booleanParam(name: 'RUN_SECURITY_TESTS', value: true),
-                                                booleanParam(name: 'RUN_APP_TESTS', value: true),
                                                 booleanParam(name: 'RUN_NGINX_ISTIO', value: true)])
                             }
                         }
@@ -129,10 +128,7 @@ pipeline {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
-                                startDCTestJob([booleanParam(name: 'RUN_INSTALL_TESTS', value: true),
-                                                booleanParam(name: 'RUN_INFRA_TESTS', value: true),
-                                                booleanParam(name: 'RUN_SECURITY_TESTS', value: true),
-                                                booleanParam(name: 'RUN_APP_TESTS', value: true),
+                                startDCTestJob([booleanParam(name: 'RUN_INFRA_TESTS', value: true),
                                                 booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
                                                 booleanParam(name: 'RUN_AUTHPROXY', value: true),
                                                 booleanParam(name: 'RUN_CERT_MANAGER', value: true),
@@ -146,8 +142,6 @@ pipeline {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
                                 startDCTestJob([booleanParam(name: 'RUN_INFRA_TESTS', value: true),
-                                                booleanParam(name: 'RUN_SECURITY_TESTS', value: true),
-                                                booleanParam(name: 'RUN_APP_TESTS', value: true),
                                                 booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
                                                 booleanParam(name: 'RUN_AUTHPROXY', value: true),
                                                 booleanParam(name: 'RUN_CERT_MANAGER', value: true),
@@ -161,10 +155,7 @@ pipeline {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
-                                startDCTestJob([booleanParam(name: 'RUN_INSTALL_TESTS', value: true),
-                                                booleanParam(name: 'RUN_INFRA_TESTS', value: true),
-                                                booleanParam(name: 'RUN_SECURITY_TESTS', value: true),
-                                                booleanParam(name: 'RUN_APP_TESTS', value: true),
+                                startDCTestJob([booleanParam(name: 'RUN_INFRA_TESTS', value: true),
                                                 booleanParam(name: 'RUN_API_CONVERSION', value: true),
                                                 booleanParam(name: 'RUN_OPENSEARCH', value: true),
                                                 booleanParam(name: 'RUN_JAEGER', value: true),

--- a/ci/dynamic-updates/JenkinsfileTrigger
+++ b/ci/dynamic-updates/JenkinsfileTrigger
@@ -142,7 +142,7 @@ pipeline {
                                 startDCTestJob([booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
                                                 booleanParam(name: 'RUN_AUTHPROXY', value: true),
                                                 booleanParam(name: 'RUN_CERT_MANAGER', value: true),
-                                                booleanParam(name: 'RUN_FLUENTD', value: true)])
+                                                booleanParam(name: 'RUN_FLUENTD', value: true)]),
                                                 booleanParam(name: 'EXTERNAL_CERT_MANAGER', value: true)])
                             }
                         }

--- a/ci/dynamic-updates/JenkinsfileTrigger
+++ b/ci/dynamic-updates/JenkinsfileTrigger
@@ -116,8 +116,10 @@ pipeline {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
-                                startDCTestJob([booleanParam(name: 'RUN_POST_UPDATE1', value: true),
-                                                booleanParam(name: 'RUN_POST_UPDATE2', value: true),
+                                startDCTestJob([booleanParam(name: 'RUN_INSTALL_TESTS', value: true),
+                                                booleanParam(name: 'RUN_INFRA_TESTS', value: true),
+                                                booleanParam(name: 'RUN_SECURITY_TESTS', value: true),
+                                                booleanParam(name: 'RUN_APP_TESTS', value: true),
                                                 booleanParam(name: 'RUN_NGINX_ISTIO', value: true)])
                             }
                         }
@@ -127,8 +129,10 @@ pipeline {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
-                                startDCTestJob([booleanParam(name: 'RUN_POST_UPDATE1', value: true),
-                                                booleanParam(name: 'RUN_POST_UPDATE2', value: true),
+                                startDCTestJob([booleanParam(name: 'RUN_INSTALL_TESTS', value: true),
+                                                booleanParam(name: 'RUN_INFRA_TESTS', value: true),
+                                                booleanParam(name: 'RUN_SECURITY_TESTS', value: true),
+                                                booleanParam(name: 'RUN_APP_TESTS', value: true),
                                                 booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
                                                 booleanParam(name: 'RUN_AUTHPROXY', value: true),
                                                 booleanParam(name: 'RUN_CERT_MANAGER', value: true),
@@ -141,8 +145,9 @@ pipeline {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
-                                startDCTestJob([booleanParam(name: 'RUN_POST_UPDATE1', value: true),
-                                                booleanParam(name: 'RUN_POST_UPDATE2', value: true),
+                                startDCTestJob([booleanParam(name: 'RUN_INFRA_TESTS', value: true),
+                                                booleanParam(name: 'RUN_SECURITY_TESTS', value: true),
+                                                booleanParam(name: 'RUN_APP_TESTS', value: true),
                                                 booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
                                                 booleanParam(name: 'RUN_AUTHPROXY', value: true),
                                                 booleanParam(name: 'RUN_CERT_MANAGER', value: true),
@@ -156,8 +161,10 @@ pipeline {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
-                                startDCTestJob([booleanParam(name: 'RUN_POST_UPDATE1', value: true),
-                                                booleanParam(name: 'RUN_POST_UPDATE2', value: true),
+                                startDCTestJob([booleanParam(name: 'RUN_INSTALL_TESTS', value: true),
+                                                booleanParam(name: 'RUN_INFRA_TESTS', value: true),
+                                                booleanParam(name: 'RUN_SECURITY_TESTS', value: true),
+                                                booleanParam(name: 'RUN_APP_TESTS', value: true),
                                                 booleanParam(name: 'RUN_API_CONVERSION', value: true),
                                                 booleanParam(name: 'RUN_OPENSEARCH', value: true),
                                                 booleanParam(name: 'RUN_JAEGER', value: true),

--- a/ci/dynamic-updates/JenkinsfileTrigger
+++ b/ci/dynamic-updates/JenkinsfileTrigger
@@ -127,7 +127,9 @@ pipeline {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
-                                startDCTestJob([booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
+                                startDCTestJob([booleanParam(name: 'RUN_POST_UPDATE1', value: true),
+                                                booleanParam(name: 'RUN_POST_UPDATE2', value: true),
+                                                booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
                                                 booleanParam(name: 'RUN_AUTHPROXY', value: true),
                                                 booleanParam(name: 'RUN_CERT_MANAGER', value: true),
                                                 booleanParam(name: 'RUN_FLUENTD', value: true)])
@@ -139,7 +141,9 @@ pipeline {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
-                                startDCTestJob([booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
+                                startDCTestJob([booleanParam(name: 'RUN_POST_UPDATE1', value: true),
+                                                booleanParam(name: 'RUN_POST_UPDATE2', value: true),
+                                                booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
                                                 booleanParam(name: 'RUN_AUTHPROXY', value: true),
                                                 booleanParam(name: 'RUN_CERT_MANAGER', value: true),
                                                 booleanParam(name: 'RUN_FLUENTD', value: true),
@@ -152,7 +156,9 @@ pipeline {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {
                             script {
-                                startDCTestJob([booleanParam(name: 'RUN_API_CONVERSION', value: true),
+                                startDCTestJob([booleanParam(name: 'RUN_POST_UPDATE1', value: true),
+                                                booleanParam(name: 'RUN_POST_UPDATE2', value: true),
+                                                booleanParam(name: 'RUN_API_CONVERSION', value: true),
                                                 booleanParam(name: 'RUN_OPENSEARCH', value: true),
                                                 booleanParam(name: 'RUN_JAEGER', value: true),
                                                 booleanParam(name: 'RUN_POST_INSTALL_OVERRIDES', value: true)])

--- a/ci/dynamic-updates/JenkinsfileTrigger
+++ b/ci/dynamic-updates/JenkinsfileTrigger
@@ -147,6 +147,7 @@ pipeline {
                                                 booleanParam(name: 'RUN_CERT_MANAGER', value: true),
                                                 booleanParam(name: 'RUN_FLUENTD', value: true),
                                                 booleanParam(name: 'EXTERNAL_CERT_MANAGER', value: true)])
+                                                string(name: 'CLUSTER_RESOURCE_NAMESPACE', value: "test-namespace"),
                             }
                         }
                     }

--- a/ci/dynamic-updates/JenkinsfileTrigger
+++ b/ci/dynamic-updates/JenkinsfileTrigger
@@ -135,6 +135,19 @@ pipeline {
                         }
                     }
                 }
+                stage ('Availability Status, AuthProxy, CertManager, and Fluentd Update Tests With External cert-manager') {
+                    steps {
+                        retry (count: JOB_PROMOTION_RETRIES) {
+                            script {
+                                startDCTestJob([booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
+                                                booleanParam(name: 'RUN_AUTHPROXY', value: true),
+                                                booleanParam(name: 'RUN_CERT_MANAGER', value: true),
+                                                booleanParam(name: 'RUN_FLUENTD', value: true)])
+                                                booleanParam(name: 'EXTERNAL_CERT_MANAGER', value: true)])
+                            }
+                        }
+                    }
+                }
                 stage ('API Conversion Update, Opensearch Update, Jaeger Update, and Post-install Overrides Tests') {
                     steps {
                         retry (count: JOB_PROMOTION_RETRIES) {

--- a/ci/dynamic-updates/JenkinsfileTrigger
+++ b/ci/dynamic-updates/JenkinsfileTrigger
@@ -146,8 +146,8 @@ pipeline {
                                                 booleanParam(name: 'RUN_AUTHPROXY', value: true),
                                                 booleanParam(name: 'RUN_CERT_MANAGER', value: true),
                                                 booleanParam(name: 'RUN_FLUENTD', value: true),
-                                                booleanParam(name: 'EXTERNAL_CERT_MANAGER', value: true)])
-                                                string(name: 'CLUSTER_RESOURCE_NAMESPACE', value: "test-namespace"),
+                                                booleanParam(name: 'EXTERNAL_CERT_MANAGER', value: true),
+                                                string(name: 'CLUSTER_RESOURCE_NAMESPACE', value: "test-namespace")])
                             }
                         }
                     }

--- a/ci/dynamic-updates/JenkinsfileTrigger
+++ b/ci/dynamic-updates/JenkinsfileTrigger
@@ -142,7 +142,7 @@ pipeline {
                                 startDCTestJob([booleanParam(name: 'RUN_AVAILABILITY_STATUS', value: true),
                                                 booleanParam(name: 'RUN_AUTHPROXY', value: true),
                                                 booleanParam(name: 'RUN_CERT_MANAGER', value: true),
-                                                booleanParam(name: 'RUN_FLUENTD', value: true)]),
+                                                booleanParam(name: 'RUN_FLUENTD', value: true),
                                                 booleanParam(name: 'EXTERNAL_CERT_MANAGER', value: true)])
                             }
                         }

--- a/ci/scripts/install_third_party_components.sh
+++ b/ci/scripts/install_third_party_components.sh
@@ -7,10 +7,12 @@
 echo "Installing cert-manager via helm chart"
 echo "Setting clusterResourceNamespace to $CLUSTER_RESOURCE_NAMESPACE"
 
-kubectl create ns my-cert-manager
 if [ $CLUSTER_RESOURCE_NAMESPACE != my-cert-manager ]
 then
-  kubectl create ns $CLUSTER_RESOURCE_NAMESPACE
+  if [ -z "$(kubectl get ns | grep $CLUSTER_RESOURCE_NAMESPACE)" ]
+  then
+    kubectl create ns $CLUSTER_RESOURCE_NAMESPACE
+  fi
 fi
 
 controllerTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="cert-manager")' | jq '.subcomponents[0].images[] | select(.image=="cert-manager-controller")' | jq .tag -r)
@@ -21,7 +23,7 @@ helm upgrade cert-manager -n my-cert-manager platform-operator/thirdparty/charts
 --set cainjector.image.repository=ghcr.io/verrazzano/cert-manager-cainjector --set cainjector.image.tag=${cainjectorTag}  \
 --set webhook.image.repository=ghcr.io/verrazzano/cert-manager-webhook --set webhook.image.tag=${webhookTag} \
 --set startupapicheck.enabled=false --set clusterResourceNamespace=${CLUSTER_RESOURCE_NAMESPACE} \
---set installCRDs=true --install
+--set installCRDs=true --install --create-namespace
 
 echo "ensure cert-manager using ghcr.io images"
 if [ ! -z "$(kubectl get po -n my-cert-manager -o yaml | grep quay.io)" ]
@@ -34,7 +36,6 @@ kubectl get pods -n my-cert-manager
 
 echo "Installing ingress-nginx via helm chart"
 
-kubectl create ns ingress-nginx
 
 controllerTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="ingress-nginx")' | jq '.subcomponents[0].images[] | select(.image=="nginx-ingress-controller")' | jq .tag -r)
 defaultBackendTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="ingress-nginx")' | jq '.subcomponents[0].images[] | select(.image=="nginx-ingress-default-backend")' | jq .tag -r)
@@ -42,7 +43,7 @@ defaultBackendTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[
 helm upgrade ingress-controller -n ingress-nginx platform-operator/thirdparty/charts/ingress-nginx \
 --set controller.image.digest="" --set controller.image.repository=ghcr.io/verrazzano/nginx-ingress-controller --set controller.image.tag=${controllerTag}  \
 --set defaultBackend.image.repository=ghcr.io/verrazzano/nginx-ingress-default-backend --set defaultBackend.image.tag=${defaultBackendTag} \
---set defaultBackend.enabled=true --install
+--set defaultBackend.enabled=true --install  --create-namespace
 
 echo "ensure cert-manager using ghcr.io images"
 if [ ! -z "$(kubectl get po -n cert-manager -o yaml | grep registry.k8s.io)" ]

--- a/ci/scripts/install_third_party_components.sh
+++ b/ci/scripts/install_third_party_components.sh
@@ -7,6 +7,11 @@
 echo "Installing cert-manager via helm chart"
 echo "Setting clusterResourceNamespace to $CLUSTER_RESOURCE_NAMESPACE"
 
+if [ -z "$(kubectl get ns | grep my-cert-manager)" ]
+then
+  kubectl create ns my-cert-manager
+fi
+
 if [ $CLUSTER_RESOURCE_NAMESPACE != my-cert-manager ]
 then
   if [ -z "$(kubectl get ns | grep $CLUSTER_RESOURCE_NAMESPACE)" ]
@@ -23,7 +28,7 @@ helm upgrade cert-manager -n my-cert-manager platform-operator/thirdparty/charts
 --set cainjector.image.repository=ghcr.io/verrazzano/cert-manager-cainjector --set cainjector.image.tag=${cainjectorTag}  \
 --set webhook.image.repository=ghcr.io/verrazzano/cert-manager-webhook --set webhook.image.tag=${webhookTag} \
 --set startupapicheck.enabled=false --set clusterResourceNamespace=${CLUSTER_RESOURCE_NAMESPACE} \
---set installCRDs=true --install --create-namespace
+--set installCRDs=true --install
 
 echo "ensure cert-manager using ghcr.io images"
 if [ ! -z "$(kubectl get po -n my-cert-manager -o yaml | grep quay.io)" ]
@@ -36,6 +41,10 @@ kubectl get pods -n my-cert-manager
 
 echo "Installing ingress-nginx via helm chart"
 
+if [ -z "$(kubectl get ns | grep ingress-nginx)" ]
+then
+  kubectl create ns ingress-nginx
+fi
 
 controllerTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="ingress-nginx")' | jq '.subcomponents[0].images[] | select(.image=="nginx-ingress-controller")' | jq .tag -r)
 defaultBackendTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[] | select(.name=="ingress-nginx")' | jq '.subcomponents[0].images[] | select(.image=="nginx-ingress-default-backend")' | jq .tag -r)
@@ -43,7 +52,7 @@ defaultBackendTag=$(cat platform-operator/verrazzano-bom.json | jq '.components[
 helm upgrade ingress-controller -n ingress-nginx platform-operator/thirdparty/charts/ingress-nginx \
 --set controller.image.digest="" --set controller.image.repository=ghcr.io/verrazzano/nginx-ingress-controller --set controller.image.tag=${controllerTag}  \
 --set defaultBackend.image.repository=ghcr.io/verrazzano/nginx-ingress-default-backend --set defaultBackend.image.tag=${defaultBackendTag} \
---set defaultBackend.enabled=true --install  --create-namespace
+--set defaultBackend.enabled=true --install
 
 echo "ensure cert-manager using ghcr.io images"
 if [ ! -z "$(kubectl get po -n cert-manager -o yaml | grep registry.k8s.io)" ]

--- a/ci/scripts/prepare_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_jenkins_at_environment.sh
@@ -28,6 +28,7 @@ TEST_OVERRIDE_CONFIGMAP_FILE="./tests/e2e/config/scripts/pre-install-overrides/t
 TEST_OVERRIDE_SECRET_FILE="./tests/e2e/config/scripts/pre-install-overrides/test-overrides-secret.yaml"
 INSTALL_TIMEOUT_VALUE=${INSTALL_TIMEOUT:-30m}
 ENABLE_THANOS_STORE_GATEWAY=${ENABLE_THANOS_STORE_GATEWAY:-false}
+INSTALL_EXTERNAL_CERT_MANAGER=${INSTALL_EXTERNAL_CERT_MANAGER:-false}
 
 clusterNames=$(kind get clusters)
 if [[ $clusterNames == *"${CLUSTER_NAME}"* ]]; then
@@ -137,6 +138,10 @@ EOF
     exit 1
   fi
 
+  if [ $INSTALL_EXTERNAL_CERT_MANAGER == true ]; then
+    echo "Configuring installation with external cert-manger and NGINX"
+    ./ci/scripts/install_third_party_components.sh
+  fi
 fi
 
 # Configure the custom resource to install Verrazzano on Kind

--- a/tests/e2e/update/env-dns-cm/env_dns_cert_update_test.go
+++ b/tests/e2e/update/env-dns-cm/env_dns_cert_update_test.go
@@ -15,7 +15,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/pkg/constants"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	constants2 "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
@@ -58,11 +57,11 @@ func (u WildcardDNSModifier) ModifyCR(cr *vzapi.Verrazzano) {
 }
 
 func (u CustomCACertificateModifier) ModifyCR(cr *vzapi.Verrazzano) {
-	if cr.Spec.Components.CertManager == nil {
-		cr.Spec.Components.CertManager = &vzapi.CertManagerComponent{}
+	if cr.Spec.Components.ClusterIssuer == nil {
+		cr.Spec.Components.ClusterIssuer = &vzapi.ClusterIssuerComponent{}
 	}
-	cr.Spec.Components.CertManager.Certificate.CA.ClusterResourceNamespace = u.ClusterResourceNamespace
-	cr.Spec.Components.CertManager.Certificate.CA.SecretName = u.SecretName
+	cr.Spec.Components.ClusterIssuer.ClusterResourceNamespace = u.ClusterResourceNamespace
+	cr.Spec.Components.ClusterIssuer.CA.SecretName = u.SecretName
 }
 
 var (
@@ -85,21 +84,11 @@ var (
 	currentCertSecretName = "verrazzano-ca-certificate-secret"
 )
 
-var beforeSuite = t.BeforeSuiteFunc(func() {
-	kubeConfigPath, err := k8sutil.GetKubeConfigLocation()
-	Expect(err).ToNot(HaveOccurred())
-
-	if !pkg.IsCertManagerEnabled(kubeConfigPath) {
-		Skip("CertManager is not enabled, skipping test")
-	}
-})
-
 var afterSuite = t.AfterSuiteFunc(func() {
 	files := []string{testCertName + ".crt", testCertName + ".key"}
 	cleanupTemporaryFiles(files)
 })
 
-var _ = BeforeSuite(beforeSuite)
 var _ = AfterSuite(afterSuite)
 
 var _ = t.Describe("Test updates to environment name, dns domain and cert-manager CA certificates", func() {

--- a/tests/e2e/update/env-dns-cm/env_dns_cert_update_test.go
+++ b/tests/e2e/update/env-dns-cm/env_dns_cert_update_test.go
@@ -103,22 +103,22 @@ var _ = t.Describe("Test updates to environment name, dns domain and cert-manage
 		ItvalidateIngressList(currentEnvironmentName, currentDNSDomain)
 		ItvalidateVirtualServiceList(currentDNSDomain)
 	})
-	//
-	//t.Context("Update and verify environment name", func() {
-	//	m := EnvironmentNameModifier{testEnvironmentName}
-	//	ItupdateCR(m)
-	//	ItvalidateIngressList(testEnvironmentName, currentDNSDomain)
-	//	ItvalidateVirtualServiceList(currentDNSDomain)
-	//	ItverifyIngressAccess(t.Logs)
-	//})
-	//
-	//t.Context("Update and verify dns domain", func() {
-	//	m := WildcardDNSModifier{testDNSDomain}
-	//	ItupdateCR(m)
-	//	ItvalidateIngressList(testEnvironmentName, testDNSDomain)
-	//	ItvalidateVirtualServiceList(testDNSDomain)
-	//	ItverifyIngressAccess(t.Logs)
-	//})
+
+	t.Context("Update and verify environment name", func() {
+		m := EnvironmentNameModifier{testEnvironmentName}
+		ItupdateCR(m)
+		ItvalidateIngressList(testEnvironmentName, currentDNSDomain)
+		ItvalidateVirtualServiceList(currentDNSDomain)
+		ItverifyIngressAccess(t.Logs)
+	})
+
+	t.Context("Update and verify dns domain", func() {
+		m := WildcardDNSModifier{testDNSDomain}
+		ItupdateCR(m)
+		ItvalidateIngressList(testEnvironmentName, testDNSDomain)
+		ItvalidateVirtualServiceList(testDNSDomain)
+		ItverifyIngressAccess(t.Logs)
+	})
 
 	t.Context("Update and verify CA certificate", func() {
 		createCustomCACertificate(testCertName, testCertSecretNamespace, testCertSecretName)

--- a/tests/e2e/update/env-dns-cm/env_dns_cert_update_test.go
+++ b/tests/e2e/update/env-dns-cm/env_dns_cert_update_test.go
@@ -60,6 +60,9 @@ func (u CustomCACertificateModifier) ModifyCR(cr *vzapi.Verrazzano) {
 	if cr.Spec.Components.ClusterIssuer == nil {
 		cr.Spec.Components.ClusterIssuer = &vzapi.ClusterIssuerComponent{}
 	}
+	if cr.Spec.Components.ClusterIssuer.CA == nil {
+		cr.Spec.Components.ClusterIssuer.CA = &vzapi.CAIssuer{}
+	}
 	cr.Spec.Components.ClusterIssuer.ClusterResourceNamespace = u.ClusterResourceNamespace
 	cr.Spec.Components.ClusterIssuer.CA.SecretName = u.SecretName
 }
@@ -100,22 +103,22 @@ var _ = t.Describe("Test updates to environment name, dns domain and cert-manage
 		ItvalidateIngressList(currentEnvironmentName, currentDNSDomain)
 		ItvalidateVirtualServiceList(currentDNSDomain)
 	})
-
-	t.Context("Update and verify environment name", func() {
-		m := EnvironmentNameModifier{testEnvironmentName}
-		ItupdateCR(m)
-		ItvalidateIngressList(testEnvironmentName, currentDNSDomain)
-		ItvalidateVirtualServiceList(currentDNSDomain)
-		ItverifyIngressAccess(t.Logs)
-	})
-
-	t.Context("Update and verify dns domain", func() {
-		m := WildcardDNSModifier{testDNSDomain}
-		ItupdateCR(m)
-		ItvalidateIngressList(testEnvironmentName, testDNSDomain)
-		ItvalidateVirtualServiceList(testDNSDomain)
-		ItverifyIngressAccess(t.Logs)
-	})
+	//
+	//t.Context("Update and verify environment name", func() {
+	//	m := EnvironmentNameModifier{testEnvironmentName}
+	//	ItupdateCR(m)
+	//	ItvalidateIngressList(testEnvironmentName, currentDNSDomain)
+	//	ItvalidateVirtualServiceList(currentDNSDomain)
+	//	ItverifyIngressAccess(t.Logs)
+	//})
+	//
+	//t.Context("Update and verify dns domain", func() {
+	//	m := WildcardDNSModifier{testDNSDomain}
+	//	ItupdateCR(m)
+	//	ItvalidateIngressList(testEnvironmentName, testDNSDomain)
+	//	ItvalidateVirtualServiceList(testDNSDomain)
+	//	ItverifyIngressAccess(t.Logs)
+	//})
 
 	t.Context("Update and verify CA certificate", func() {
 		createCustomCACertificate(testCertName, testCertSecretNamespace, testCertSecretName)


### PR DESCRIPTION
This adds external cert-manager as an option to the dynamic update pipeline. It also includes it as a configuration of the dynamic updates suite that runs from the periodics.