### PR TITLE
VZ-10137 capi init must not be called until cert-manager resources ca…

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -99,7 +99,7 @@ func (c clusterAPIComponent) ShouldInstallBeforeUpgrade() bool {
 
 // GetDependencies returns the dependencies of this component.
 func (c clusterAPIComponent) GetDependencies() []string {
-	return []string{cmconstants.CertManagerComponentName}
+	return []string{cmconstants.CertManagerComponentName, cmconstants.ClusterIssuerComponentName}
 }
 
 // IsReady indicates whether a component is Ready for dependency components.

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component_test.go
@@ -90,8 +90,9 @@ func TestShouldInstallBeforeUpgrade(t *testing.T) {
 func TestGetDependencies(t *testing.T) {
 	var comp clusterAPIComponent
 	dependencies := comp.GetDependencies()
-	assert.Len(t, dependencies, 1)
+	assert.Len(t, dependencies, 2)
 	assert.Equal(t, cmconstants.CertManagerComponentName, dependencies[0])
+	assert.Equal(t, cmconstants.ClusterIssuerComponentName, dependencies[1])
 }
 
 // TestIsReady tests the IsReady function


### PR DESCRIPTION



If CAPI init is called by VPO ClusterAPI component before cert manager validating webhook is ready, then the CAPI init code will install old cert manager.

When the VPO CAPI component does an install, it calls CAPI init to initialize the CAPI resources. The CAPI init code tries to create cert-manager test resources, and if it cannot, it installs cert-manager using different images and charts. The problem is that the VPO certManager component installs cert manager, but doesn't wait for the cert-manager-webhook validatingwebhook to have the caBundle bundle. Until that happens, you will get a webhook error when trying to create a cert manager resource.

The temp solution is to make ClusterAPI component depend on the certManagerClusterIssuer component to be ready, since certManagerClusterIssuer component creates a cert-manager resource (cluster-issuer) and retries until that succeeds.
