### PR TITLE
Remove prerequisite checks

### DIFF
--- a/tools/vz/pkg/bugreport/reportgen.go
+++ b/tools/vz/pkg/bugreport/reportgen.go
@@ -6,7 +6,6 @@ package bugreport
 import (
 	"fmt"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
-	"github.com/verrazzano/verrazzano/pkg/vzchecks"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	pkghelpers "github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
@@ -86,10 +85,6 @@ func CaptureClusterSnapshot(kubeClient kubernetes.Interface, dynamicClient dynam
 	err = captureResources(client, kubeClient, bugReportDir, vz, vzHelper, nsList)
 	if err != nil {
 		pkghelpers.LogError(fmt.Sprintf("There is an error with capturing the Verrazzano resources: %s", err.Error()))
-	}
-
-	for _, e := range vzchecks.PrerequisiteCheck(client, vzchecks.ProfileType(vz.Spec.Profile)) {
-		fmt.Fprintf(vzHelper.GetOutputStream(), "Warning: "+e.Error()+"\n")
 	}
 
 	// Capture OAM resources from the namespaces specified using --include-namespaces


### PR DESCRIPTION
This pull request removes prerequisite checks that were generating the following misleading warning when running **vz analyze**:

Warning: minimum required ephemeral storage is 100G but the ephemeral storage on node 10.196.3.107 is 34.262890849G

These checks had been removed from v1.6 but not v1.5