### PR TITLE
VZ-10158 install capi before upgrade (#6314)

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -94,7 +94,7 @@ func (c clusterAPIComponent) Namespace() string {
 
 // ShouldInstallBeforeUpgrade returns true if component can be installed before upgrade is done.
 func (c clusterAPIComponent) ShouldInstallBeforeUpgrade() bool {
-	return false
+	return true
 }
 
 // GetDependencies returns the dependencies of this component.

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component_test.go
@@ -75,11 +75,11 @@ func TestNamespace(t *testing.T) {
 // GIVEN a call to ShouldInstallBeforeUpgrade
 //
 //	WHEN ShouldInstallBeforeUpgrade is called
-//	THEN false is returned
+//	THEN true is returned
 func TestShouldInstallBeforeUpgrade(t *testing.T) {
 	var comp clusterAPIComponent
 	flag := comp.ShouldInstallBeforeUpgrade()
-	assert.Equal(t, false, flag)
+	assert.Equal(t, true, flag)
 }
 
 // TestGetDependencies tests the GetDependencies function


### PR DESCRIPTION
Install ClusterAPI component before upgrade, since Rancher will hang if CAPI is enabled but not installed.
