### PR TITLE
VZ-10180: Fix initialization of ociocne driver on upgrade (forward port from release-1.6)

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -14,7 +14,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	vpoconstants "github.com/verrazzano/verrazzano/platform-operator/constants"
 	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -233,7 +232,7 @@ func (c clusterAPIComponent) Install(ctx spi.ComponentContext) error {
 }
 
 func (c clusterAPIComponent) PostInstall(ctx spi.ComponentContext) error {
-	return common.ActivateKontainerDriver(ctx)
+	return nil
 }
 
 func (c clusterAPIComponent) IsOperatorUninstallSupported() bool {
@@ -301,7 +300,7 @@ func (c clusterAPIComponent) Upgrade(ctx spi.ComponentContext) error {
 }
 
 func (c clusterAPIComponent) PostUpgrade(ctx spi.ComponentContext) error {
-	return common.ActivateKontainerDriver(ctx)
+	return nil
 }
 
 func (c clusterAPIComponent) ValidateInstall(vz *v1alpha1.Verrazzano) error {

--- a/platform-operator/controllers/verrazzano/component/common/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher.go
@@ -184,9 +184,7 @@ func ActivateKontainerDriver(ctx spi.ComponentContext) error {
 	gvr := GetRancherMgmtAPIGVRForResource("kontainerdrivers")
 	driverObj, err = dynClient.Resource(gvr).Get(context.TODO(), kontainerDriverObjectName, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
+		// Keep trying until the resource is found
 		return fmt.Errorf("Failed to get %s/%s/%s %s: %v", gvr.Resource, gvr.Group, gvr.Version, kontainerDriverObjectName, err)
 	}
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -556,7 +556,7 @@ func (r rancherComponent) PostUpgrade(ctx spi.ComponentContext) error {
 		return err
 	}
 	if err := common.ActivateKontainerDriver(ctx); err != nil {
-		return err
+		return log.ErrorfThrottledNewErr("Failed to activate kontainerdriver post upgrade: %s", err.Error())
 	}
 	return cleanupRancherResources(context.TODO(), ctx.Client())
 }


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
