### PR TITLE
Fix network policies link in API docs

### DIFF
--- a/application-operator/apis/clusters/v1alpha1/verrazzanoproject_types.go
+++ b/application-operator/apis/clusters/v1alpha1/verrazzanoproject_types.go
@@ -25,7 +25,7 @@ type NamespaceTemplate struct {
 // NetworkPolicyTemplate contains the metadata and specification of a Kubernetes NetworkPolicy.
 // <div class="alert alert-warning" role="alert">
 // <h4 class="alert-heading">NOTE</h4>
-// To add an application NetworkPolicy, see <a href="../../../../docs/networking/security/net-security/#networkpolicies-for-applications">NetworkPolicies for applications</a>.
+// To add an application NetworkPolicy, see <a href="../../../docs/networking/security/#networkpolicies-for-applications">NetworkPolicies for applications</a>.
 // </div>
 type NetworkPolicyTemplate struct {
 	// +kubebuilder:pruning:PreserveUnknownFields

--- a/platform-operator/helm_config/charts/verrazzano-cluster-agent/crds/clusters.verrazzano.io_verrazzanoprojects.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-agent/crds/clusters.verrazzano.io_verrazzanoprojects.yaml
@@ -92,7 +92,7 @@ spec:
                       description: NetworkPolicyTemplate contains the metadata and
                         specification of a Kubernetes NetworkPolicy. <div class="alert
                         alert-warning" role="alert"> <h4 class="alert-heading">NOTE</h4>
-                        To add an application NetworkPolicy, see <a href="../../../../docs/networking/security/net-security/#networkpolicies-for-applications">NetworkPolicies
+                        To add an application NetworkPolicy, see <a href="../../../docs/networking/security/#networkpolicies-for-applications">NetworkPolicies
                         for applications</a>. </div>
                       properties:
                         metadata:


### PR DESCRIPTION
This pull request fixes a link to network policies in the API docs.