### PR TITLE
Fix the default value prompt for VZ uninstall command

### DIFF
--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -531,7 +531,7 @@ func continueUninstall(confirmUninstall bool) (bool, error) {
 	}
 	var response string
 	scanner := bufio.NewScanner(os.Stdin)
-	fmt.Print("Are you sure you want to uninstall Verrazzano? [Y/n]: ")
+	fmt.Print("Are you sure you want to uninstall Verrazzano? [y/N]: ")
 	if scanner.Scan() {
 		response = scanner.Text()
 	}


### PR DESCRIPTION
The default value for the VZ uninstall prompt should be "no" to match the behavior of the command.

