### PR TITLE
VZ-10076 fix the PV Grafana expression to adapt to multiple replicas

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/Verrazzano System/resource_usage_summary_dashboard.json
+++ b/platform-operator/helm_config/charts/verrazzano-grafana-dashboards/dashboards/Verrazzano System/resource_usage_summary_dashboard.json
@@ -667,7 +667,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "sum(kube_pod_spec_volumes_persistentvolumeclaims_info{verrazzano_component=~\"$component\",verrazzano_cluster=\"$cluster\"} * on(persistentvolumeclaim, namespace) group_right(verrazzano_component) kubelet_volume_stats_used_bytes{verrazzano_cluster=\"$cluster\"}) by (verrazzano_component)",
+          "expr": "sum(sum(kube_pod_spec_volumes_persistentvolumeclaims_info{verrazzano_component=~\"$component\",verrazzano_cluster=\"$cluster\"}) by(persistentvolumeclaim, namespace, verrazzano_component, verrazzano_cluster) * on(persistentvolumeclaim, namespace) group_right(verrazzano_component) kubelet_volume_stats_used_bytes{verrazzano_cluster=\"$cluster\"}) by (verrazzano_component)",
           "format": "time_series",
           "instant": false,
           "interval": "",


### PR DESCRIPTION
The PV expression was failing if the OS pods restarted because there would be a duplicate pod name. This new expression sums across the values we do not use to select (like pod name). This prevents an error in the Grafana dashboards if the pods restart.
