### PR TITLE
VZ-9959.  Backport to release-1.6 (#6333)

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"text/template"
 
 	cmutil "github.com/cert-manager/cert-manager/pkg/api/util"
@@ -381,7 +382,7 @@ func createACMEIssuerObject(log vzlog.VerrazzanoLogger, client crtclient.Client,
 
 	// Verify the acme environment and set the server
 	acmeServer := letsEncryptProdEndpoint
-	if cmcommon.IsLetsEncryptStagingEnv(*vzCertAcme) {
+	if common.IsLetsEncryptStagingEnv(*vzCertAcme) {
 		acmeServer = letsEncryptStageEndpoint
 	}
 
@@ -543,7 +544,7 @@ func getACMEIssuerName(acme *vzapi.LetsEncryptACMEIssuer) ([]string, error) {
 	if acme == nil {
 		return []string{}, fmt.Errorf("Illegal state, LetsEncrypt issuer not configured")
 	}
-	if cmcommon.IsLetsEncryptProductionEnv(*acme) {
+	if common.IsLetsEncryptProductionEnv(*acme) {
 		return letsEncryptProductionCACommonNames, nil
 	}
 	return letsEncryptStagingCACommonNames, nil

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/validate_issuer.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/validate_issuer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/mail"
@@ -141,7 +142,7 @@ func validateCAConfiguration(ca *v1beta1.CAIssuer, clusterResourceNamespace stri
 
 // validateAcmeConfiguration Validate the LetsEncrypt/LetsEncrypt values
 func validateAcmeConfiguration(acme v1beta1.LetsEncryptACMEIssuer) error {
-	if len(acme.Environment) > 0 && !cmcommon.IsLetsEncryptProductionEnv(acme) && !cmcommon.IsLetsEncryptStagingEnv(acme) {
+	if len(acme.Environment) > 0 && !common.IsLetsEncryptProductionEnv(acme) && !common.IsLetsEncryptStagingEnv(acme) {
 		return fmt.Errorf("Invalid Let's Encrypt environment: %s", acme.Environment)
 	}
 	if _, err := mail.ParseAddress(acme.EmailAddress); err != nil {
@@ -197,10 +198,10 @@ func validateCertificateCAConfiguration(ca v1beta1.CA) error {
 
 // validateAcmeConfiguration Validate the ACME/LetsEncrypt values
 func validateCertificateAcmeConfiguration(acme v1beta1.Acme) error {
-	if !cmcommon.IsLetsEncryptProvider(acme) {
+	if !common.IsLetsEncryptProvider(acme) {
 		return fmt.Errorf("Invalid ACME certificate provider %v", acme.Provider)
 	}
-	if len(acme.Environment) > 0 && !cmcommon.IsLetsEncryptProductionEnv(acme) && !cmcommon.IsLetsEncryptStagingEnv(acme) {
+	if len(acme.Environment) > 0 && !common.IsLetsEncryptProductionEnv(acme) && !common.IsLetsEncryptStagingEnv(acme) {
 		return fmt.Errorf("Invalid Let's Encrypt environment: %s", acme.Environment)
 	}
 	if _, err := mail.ParseAddress(acme.EmailAddress); err != nil {

--- a/platform-operator/controllers/verrazzano/component/common/acme_utils.go
+++ b/platform-operator/controllers/verrazzano/component/common/acme_utils.go
@@ -25,6 +25,10 @@ func IsLetsEncryptProductionEnv(acme interface{}) bool {
 	if v1beta1ACME, ok := acme.(v1beta1.Acme); ok {
 		envName = v1beta1ACME.Environment
 	}
+	if len(envName) == 0 {
+		// the default if not specified
+		return true
+	}
 	return strings.ToLower(envName) == cmconstants.LetsEncryptProduction
 }
 

--- a/platform-operator/controllers/verrazzano/component/common/acme_utils_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/acme_utils_test.go
@@ -18,13 +18,17 @@ import (
 // THEN the function returns true if the LetsEncrypt environment is for the LE production env
 func TestIsLetsEncryptProductionEnv(t *testing.T) {
 	assert.True(t, IsLetsEncryptProductionEnv(v1alpha1.LetsEncryptACMEIssuer{Environment: cmconstants.LetsEncryptProduction}))
+	assert.True(t, IsLetsEncryptProductionEnv(v1alpha1.LetsEncryptACMEIssuer{}))
 	assert.False(t, IsLetsEncryptProductionEnv(v1alpha1.LetsEncryptACMEIssuer{Environment: cmconstants.LetsEncryptStaging}))
 	assert.True(t, IsLetsEncryptProductionEnv(v1beta1.LetsEncryptACMEIssuer{Environment: cmconstants.LetsEncryptProduction}))
+	assert.True(t, IsLetsEncryptProductionEnv(v1beta1.LetsEncryptACMEIssuer{}))
 	assert.False(t, IsLetsEncryptProductionEnv(v1beta1.LetsEncryptACMEIssuer{Environment: cmconstants.LetsEncryptStaging}))
 	assert.True(t, IsLetsEncryptProductionEnv(v1alpha1.Acme{Environment: cmconstants.LetsEncryptProduction}))
+	assert.True(t, IsLetsEncryptProductionEnv(v1alpha1.Acme{}))
 	assert.False(t, IsLetsEncryptProductionEnv(v1alpha1.Acme{Environment: cmconstants.LetsEncryptStaging}))
 	assert.True(t, IsLetsEncryptProductionEnv(v1beta1.Acme{Environment: cmconstants.LetsEncryptProduction}))
 	assert.False(t, IsLetsEncryptProductionEnv(v1beta1.Acme{Environment: cmconstants.LetsEncryptStaging}))
+	assert.True(t, IsLetsEncryptProductionEnv(v1beta1.Acme{}))
 }
 
 // TestIsLetsEncryptStagingEnv tests the IsLetsEncryptStagingEnv functions
@@ -72,6 +76,11 @@ func TestIsLetsEncryptStagingEnv(t *testing.T) {
 			Environment: "",
 		},
 	))
+
+	assert.False(t, IsLetsEncryptStagingEnv(v1alpha1.LetsEncryptACMEIssuer{}))
+	assert.False(t, IsLetsEncryptStagingEnv(v1beta1.LetsEncryptACMEIssuer{}))
+	assert.False(t, IsLetsEncryptStagingEnv(v1alpha1.Acme{}))
+	assert.False(t, IsLetsEncryptStagingEnv(v1beta1.Acme{}))
 }
 
 // TestIsLetsEncryptProvider tests the IsLetsEncryptProvider functions

--- a/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt.go
@@ -6,12 +6,12 @@ package common
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"io"
 	"net/http"
 
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -78,7 +78,7 @@ func useAdditionalCAs(issuerConfig *vzapi.ClusterIssuerComponent) bool {
 	if isLetsEncrypt, err := issuerConfig.IsLetsEncryptIssuer(); err != nil || !isLetsEncrypt {
 		return false
 	}
-	return issuerConfig.LetsEncrypt.Environment != "production"
+	return IsLetsEncryptStagingEnv(*issuerConfig.LetsEncrypt)
 }
 
 func ProcessAdditionalCertificates(log vzlog.VerrazzanoLogger, cli client.Client, vz *vzapi.Verrazzano) error {

--- a/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt_test.go
@@ -6,10 +6,13 @@ package common
 import (
 	"errors"
 	"github.com/golang/mock/gomock"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
 	"io"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"strings"
 	"testing"
@@ -122,13 +125,60 @@ func TestProcessAdditionalCertificates(t *testing.T) {
 			Components: v1alpha1.ComponentSpec{
 				CertManager: &v1alpha1.CertManagerComponent{
 					Enabled:     &a,
-					Certificate: v1alpha1.Certificate{Acme: v1alpha1.Acme{Environment: "dev"}},
+					Certificate: v1alpha1.Certificate{Acme: v1alpha1.Acme{Environment: "staging"}},
 				},
 			},
 		},
 	}
+
+	tlsAdditionalSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: CattleSystem,
+			Name:      constants.AdditionalTLS,
+		}}
+
 	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).Return(nil).AnyTimes()
 	client.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	client.EXPECT().Delete(gomock.Any(), tlsAdditionalSecret, gomock.Any()).Times(0)
+
+	// Create a fake ComponentContext with the profiles dir to create an EffectiveCR; this is required to
+	// convert the CertManager config to the ClusterIssuer config
+	ctx := spi.NewFakeContext(client, &vz, nil, false, profileDir)
+	err := ProcessAdditionalCertificates(ctx.Log(), client, ctx.EffectiveCR())
+	assert.Nil(t, err)
+}
+
+// TestProcessAdditionalCertificatesLetsEncryptDefaultProdEnv verifies building the LetsEncrypt staging certificate chain
+// GIVEN a call to ProcessAdditionalCertificates
+//
+//	WHEN  is LetsEncrypt production env is enabled implicitly
+//	THEN ProcessAdditionalCertificates should process the additional certs successfully with no error
+func TestProcessAdditionalCertificatesLetsEncryptDefaultProdEnv(t *testing.T) {
+	mock := gomock.NewController(t)
+	client := mocks.NewMockClient(mock)
+	a := true
+	vz := v1alpha1.Verrazzano{
+		Spec: v1alpha1.VerrazzanoSpec{
+			Components: v1alpha1.ComponentSpec{
+				CertManager: &v1alpha1.CertManagerComponent{
+					Enabled: &a,
+					Certificate: v1alpha1.Certificate{Acme: v1alpha1.Acme{
+						Provider: v1alpha1.LetsEncrypt,
+					}},
+				},
+			},
+		},
+	}
+
+	tlsAdditionalSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: CattleSystem,
+			Name:      constants.AdditionalTLS,
+		}}
+
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).Return(nil).Times(0)
+	client.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).Times(0)
+	client.EXPECT().Delete(gomock.Any(), tlsAdditionalSecret, gomock.Not(gomock.Nil())).Return(nil)
 
 	// Create a fake ComponentContext with the profiles dir to create an EffectiveCR; this is required to
 	// convert the CertManager config to the ClusterIssuer config
@@ -141,14 +191,19 @@ func TestProcessAdditionalCertificates(t *testing.T) {
 // GIVEN a logger, client and vz instance with no Certmanager spec defined
 //
 //	WHEN ProcessAdditionalCertificates is called
-//	THEN ProcessAdditionalCertificates function call fails and returns error
+//	THEN ProcessAdditionalCertificates function call does not fail and attempts to clean up the tls-ca-additional secret
 func TestProcessAdditionalCertificatesFailure(t *testing.T) {
 	mock := gomock.NewController(t)
 	client := mocks.NewMockClient(mock)
 	vz := v1alpha1.Verrazzano{}
-	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).Return(nil).AnyTimes()
-	client.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).Return(nil).AnyTimes()
-	client.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	client.EXPECT().Delete(gomock.Any(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: CattleSystem,
+			Name:      constants.AdditionalTLS,
+		},
+	}, gomock.Not(gomock.Nil())).Return(nil)
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).Return(nil).Times(0)
+	client.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).Times(0)
 
 	// Create a fake ComponentContext with the profiles dir to create an EffectiveCR; this is required to
 	// convert the CertManager config to the ClusterIssuer config

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -225,6 +225,10 @@ func appendCAOverrides(log vzlog.VerrazzanoLogger, kvs []bom.KeyValue, ctx spi.C
 
 	// Configure CA Issuer KVs
 	if (cm.LetsEncrypt != nil && *cm.LetsEncrypt != vzapi.LetsEncryptACMEIssuer{}) {
+		letsEncryptEnv := cm.LetsEncrypt.Environment
+		if len(letsEncryptEnv) == 0 {
+			letsEncryptEnv = cmconstants.LetsEncryptProduction
+		}
 		kvs = append(kvs,
 			bom.KeyValue{
 				Key:   letsEncryptIngressClassKey,
@@ -234,13 +238,13 @@ func appendCAOverrides(log vzlog.VerrazzanoLogger, kvs []bom.KeyValue, ctx spi.C
 				Value: cm.LetsEncrypt.EmailAddress,
 			}, bom.KeyValue{
 				Key:   letsEncryptEnvironmentKey,
-				Value: cm.LetsEncrypt.Environment,
+				Value: letsEncryptEnv,
 			}, bom.KeyValue{
 				Key:   ingressTLSSourceKey,
 				Value: letsEncryptTLSSource,
 			}, bom.KeyValue{
 				Key:   additionalTrustedCAsKey,
-				Value: strconv.FormatBool(useAdditionalCAs(*cm.LetsEncrypt)),
+				Value: strconv.FormatBool(common.IsLetsEncryptStagingEnv(*cm.LetsEncrypt)),
 			})
 	} else { // Certificate issuer type is CA
 		kvs = append(kvs, bom.KeyValue{

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -51,7 +51,7 @@ var (
 						Acme: vzapi.Acme{
 							Provider:     "foobar",
 							EmailAddress: "foo@bar.com",
-							Environment:  "dev",
+							Environment:  "staging",
 						},
 					},
 				},


### PR DESCRIPTION
Handle LetsEncrypt/prod default case for rancher 
- Fix Rancher Helm value override for default LE/prod scenario
- Do not create tls-ca-additional when LE staging is not in play
- refactor LE utils from cert-manager common to component common
- add/update related unit tests

