### PR TITLE
VZ-9959.  Backport fix to release-1.5

### DIFF
--- a/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt.go
@@ -72,7 +72,7 @@ func (c *certBuilder) buildLetsEncryptStagingChain() error {
 }
 
 func useAdditionalCAs(acme vzapi.Acme) bool {
-	return acme != vzapi.Acme{} && acme.Environment != "production"
+	return acme != vzapi.Acme{} && acme.Environment == "staging"
 }
 
 func ProcessAdditionalCertificates(log vzlog.VerrazzanoLogger, cli client.Client, vz *vzapi.Verrazzano) error {

--- a/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package common

--- a/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher_letsencrypt_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package common

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -230,7 +230,7 @@ var cattleClusterReposGVR = schema.GroupVersionResource{
 }
 
 func useAdditionalCAs(acme vzapi.Acme) bool {
-	return acme.Environment == "staging"
+	return acme.Environment == letsEncryptStaging
 }
 
 func getRancherHostname(c client.Client, vz *vzapi.Verrazzano) (string, error) {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -230,7 +230,7 @@ var cattleClusterReposGVR = schema.GroupVersionResource{
 }
 
 func useAdditionalCAs(acme vzapi.Acme) bool {
-	return acme.Environment != "production"
+	return acme.Environment == "staging"
 }
 
 func getRancherHostname(c client.Client, vz *vzapi.Verrazzano) (string, error) {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -62,6 +62,12 @@ const cattleShellImageName = "rancher-shell"
 // cattleUIEnvName is the environment variable name to set for the Rancher dashboard
 const cattleUIEnvName = "CATTLE_UI_OFFLINE_PREFERRED"
 
+const (
+	// Let's Encrypt environments
+	letsencryptProduction = "production"
+	letsEncryptStaging    = "staging"
+)
+
 // Environment variables for the Rancher images
 // format: imageName: baseEnvVar
 var imageEnvVars = map[string]string{
@@ -209,6 +215,10 @@ func appendCAOverrides(log vzlog.VerrazzanoLogger, kvs []bom.KeyValue, ctx spi.C
 
 	// Configure CA Issuer KVs
 	if (cm.Certificate.Acme != vzapi.Acme{}) {
+		letsEncryptEnv := cm.Certificate.Acme.Environment
+		if len(letsEncryptEnv) == 0 {
+			letsEncryptEnv = letsencryptProduction
+		}
 		kvs = append(kvs,
 			bom.KeyValue{
 				Key:   letsEncryptIngressClassKey,
@@ -218,7 +228,7 @@ func appendCAOverrides(log vzlog.VerrazzanoLogger, kvs []bom.KeyValue, ctx spi.C
 				Value: cm.Certificate.Acme.EmailAddress,
 			}, bom.KeyValue{
 				Key:   letsEncryptEnvironmentKey,
-				Value: cm.Certificate.Acme.Environment,
+				Value: letsEncryptEnv,
 			}, bom.KeyValue{
 				Key:   ingressTLSSourceKey,
 				Value: letsEncryptTLSSource,

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -51,7 +51,7 @@ var (
 						Acme: vzapi.Acme{
 							Provider:     "foobar",
 							EmailAddress: "foo@bar.com",
-							Environment:  "dev",
+							Environment:  letsEncryptStaging,
 						},
 					},
 				},
@@ -247,8 +247,9 @@ func TestUseAdditionalCAs(t *testing.T) {
 		in  vzapi.Acme
 		out bool
 	}{
-		{vzapi.Acme{Environment: "dev"}, true},
-		{vzapi.Acme{Environment: "production"}, false},
+		{vzapi.Acme{Environment: letsEncryptStaging}, true},
+		{vzapi.Acme{Environment: letsencryptProduction}, false},
+		{vzapi.Acme{Environment: "dev"}, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Handle LetsEncrypt/prod default case for rancher
- Fix Rancher Helm value override for default LE/prod scenario
- Do not create tls-ca-additional when LE staging is not in play
- add/update related unit tests

Not a strict backport per-se, but a re-implementation using the CM APIs.