### PR TITLE
VZ-10131: Uptake latest Rancher images

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,13 +151,13 @@
               "rancherUI": "v2.7.2-7/release-2.7.2",
               "ocneDriverVersion": "v0.14.0",
               "ocneDriverChecksum": "c10f757291664ae041569934951ae42d2d4021d4031f6ba009370cb92b7173fe",
-              "tag": "v2.7.3-20230626201408-a56717991",
+              "tag": "v2.7.3-20230628173719-72ada53b0",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-20230626201408-a56717991"
+              "tag": "v2.7.3-20230628173719-72ada53b0"
             }
           ]
         },


### PR DESCRIPTION
These latest Rancher images contain a bug fix for the Rancher cleanup image when using a private registry and a fix to return additional cloud credential fields in the OCI handler.