### PR TITLE
VZ-10104 Enable kube-state-metrics and node-exporter in minimal managed cluster profiles that have monitoring

### DIFF
--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -153,7 +153,7 @@ pipeline {
         INSTALL_CONFIG_FILE_KIND = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1beta1/install-vz-prod-kind-multicluster.yaml"
         INSTALL_CONFIG_FILE_OCIDNS = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1beta1/install-verrazzano-ocidns.yaml"
         INSTALL_CONFIG_FILE_NIPIO = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1beta1/install-verrazzano-nipio.yaml"
-        INSTALL_CONFIG_FILE_MINIMAL = "${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/v1beta1/install-verrazzano-minimal.yaml"
+        INSTALL_CONFIG_FILE_MINIMAL = "${WORKSPACE}/install-verrazzano-minimal.yaml"
         OCI_DNS_ZONE_NAME="z${zoneId}.v8o.io"
         ACME_ENVIRONMENT="${params.ACME_ENVIRONMENT}"
 
@@ -362,6 +362,7 @@ pipeline {
                                     steps {
                                         script {
                                             configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_OCIDNS, "./tests/e2e/config/scripts/process_oci_dns_install_yaml.sh", "acme", params.ACME_ENVIRONMENT)
+                                            downloadMinimalVerrazzanoYaml()
                                             configureManagedInstallers(env.INSTALL_CONFIG_FILE_MINIMAL, "./tests/e2e/config/scripts/process_oci_dns_install_yaml.sh", minimalFileName, params.ACME_ENVIRONMENT)
                                         }
                                     }
@@ -372,6 +373,7 @@ pipeline {
                             when { expression { return params.TEST_ENV == 'KIND' } }
                             steps {
                                 configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_KIND,"./tests/e2e/config/scripts/process_kind_install_yaml.sh", params.WILDCARD_DNS_DOMAIN)
+                                downloadMinimalVerrazzanoYaml()
                                 configureManagedInstallers(env.INSTALL_CONFIG_FILE_MINIMAL, "./tests/e2e/config/scripts/process_kind_install_yaml.sh", minimalFileName, params.WILDCARD_DNS_DOMAIN)
                             }
                         }
@@ -379,6 +381,7 @@ pipeline {
                             when { expression { return params.TEST_ENV == 'magicdns_oke' } }
                             steps {
                                 configureVerrazzanoInstallers(env.INSTALL_CONFIG_FILE_NIPIO, "./tests/e2e/config/scripts/process_nipio_install_yaml.sh", params.WILDCARD_DNS_DOMAIN)
+                                downloadMinimalVerrazzanoYaml()
                                 configureManagedInstallers(env.INSTALL_CONFIG_FILE_MINIMAL, "./tests/e2e/config/scripts/process_nipio_install_yaml.sh", minimalFileName, params.WILDCARD_DNS_DOMAIN)
                             }
                         }
@@ -837,6 +840,16 @@ def getVerrazzanoOperatorYaml() {
                 echo "Generating operator.yaml based on image name provided: ${params.VERRAZZANO_OPERATOR_IMAGE}"
                 env IMAGE_PULL_SECRETS=verrazzano-container-registry DOCKER_IMAGE=${params.VERRAZZANO_OPERATOR_IMAGE} ./tools/scripts/generate_operator_yaml.sh > ${OPERATOR_YAML_FILE}
             fi
+        """
+    }
+}
+
+// download the file for the minimal verrazzano install
+def downloadMinimalVerrazzanoYaml() {
+    script {
+        sh """
+            echo "Downloading minimal-thanos.yaml from branch ${env.BRANCH_NAME} to ${env.INSTALL_CONFIG_FILE_MINIMAL}"
+            wget -O ${env.INSTALL_CONFIG_FILE_MINIMAL} https://raw.githubusercontent.com/verrazzano/verrazzano/${env.BRANCH_NAME}/examples/multicluster/managed-clusters/minimal-thanos.yaml
         """
     }
 }

--- a/examples/multicluster/managed-clusters/minimal-prometheus.yaml
+++ b/examples/multicluster/managed-clusters/minimal-prometheus.yaml
@@ -13,6 +13,8 @@ spec:
       enabled: true
     prometheusOperator:
       enabled: true
+    kubeStateMetrics:
+      enabled: true
     authProxy:
       enabled: true
     certManager:

--- a/examples/multicluster/managed-clusters/minimal-prometheus.yaml
+++ b/examples/multicluster/managed-clusters/minimal-prometheus.yaml
@@ -15,6 +15,8 @@ spec:
       enabled: true
     kubeStateMetrics:
       enabled: true
+    prometheusNodeExporter:
+      enabled: true
     authProxy:
       enabled: true
     certManager:

--- a/examples/multicluster/managed-clusters/minimal-thanos.yaml
+++ b/examples/multicluster/managed-clusters/minimal-thanos.yaml
@@ -18,6 +18,8 @@ spec:
             prometheus:
               thanos:
                 integration: sidecar
+    kubeStateMetrics:
+      enabled: true
     authProxy:
       enabled: true
     thanos:

--- a/examples/multicluster/managed-clusters/minimal-thanos.yaml
+++ b/examples/multicluster/managed-clusters/minimal-thanos.yaml
@@ -20,6 +20,8 @@ spec:
                 integration: sidecar
     kubeStateMetrics:
       enabled: true
+    prometheusNodeExporter:
+      enabled: true
     authProxy:
       enabled: true
     thanos:


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
