### PR TITLE
VZ-10131: Uptake latest Rancher images (#6357)

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -147,7 +147,7 @@
           "images": [
             {
               "image": "rancher",
-              "dashboard": "v2.7.2-20230613145236-da921e6fd",
+              "dashboard": "v2.7.2-20230615210154-513bc4d98",
               "rancherUI": "v2.7.2-7/release-2.7.2",
               "ocneDriverVersion": "v0.14.0",
               "ocneDriverChecksum": "c10f757291664ae041569934951ae42d2d4021d4031f6ba009370cb92b7173fe",

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,13 +151,13 @@
               "rancherUI": "v2.7.2-7/release-2.7.2",
               "ocneDriverVersion": "v0.14.0",
               "ocneDriverChecksum": "c10f757291664ae041569934951ae42d2d4021d4031f6ba009370cb92b7173fe",
-              "tag": "v2.7.3-20230626201408-a56717991",
+              "tag": "v2.7.3-20230628173719-72ada53b0",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-20230626201408-a56717991"
+              "tag": "v2.7.3-20230628173719-72ada53b0"
             }
           ]
         },


### PR DESCRIPTION
Backport Rancher 2.7.3 image uptake to release-1.6 branch.