### PR TITLE
VZ-10107 - Change the Rancher cattle-system namespace's verrazzano.io/namespace label to equal the namespace name, to match network policy

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_postinstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_postinstall.go
@@ -166,7 +166,9 @@ func labelNamespace(c client.Client) error {
 		}
 		if _, found := nsList.Items[i].Labels[constants.VerrazzanoManagedKey]; isRancherNamespace(&(nsList.Items[i])) && !found {
 			nsList.Items[i].Labels[constants.VerrazzanoManagedKey] = nsList.Items[i].Name
-			return c.Update(context.TODO(), &(nsList.Items[i]), &client.UpdateOptions{})
+			if err := c.Update(context.TODO(), &(nsList.Items[i]), &client.UpdateOptions{}); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_postinstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_postinstall.go
@@ -166,7 +166,7 @@ func labelNamespace(c client.Client) error {
 		}
 		if _, found := nsList.Items[i].Labels[constants.VerrazzanoManagedKey]; isRancherNamespace(&(nsList.Items[i])) && !found {
 			nsList.Items[i].Labels[constants.VerrazzanoManagedKey] = nsList.Items[i].Name
-			c.Update(context.TODO(), &(nsList.Items[i]), &client.UpdateOptions{})
+			return c.Update(context.TODO(), &(nsList.Items[i]), &client.UpdateOptions{})
 		}
 	}
 	return nil

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall.go
@@ -5,6 +5,7 @@ package rancher
 
 import (
 	"context"
+
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -30,7 +31,7 @@ func createCattleSystemNamespace(log vzlog.VerrazzanoLogger, c client.Client) er
 		if namespace.Labels == nil {
 			namespace.Labels = map[string]string{}
 		}
-		namespace.Labels[constants.VerrazzanoManagedKey] = common.RancherName
+		namespace.Labels[constants.VerrazzanoManagedKey] = common.CattleSystem
 		return nil
 	}); err != nil {
 		return err

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall_test.go
@@ -4,12 +4,16 @@
 package rancher
 
 import (
+	"context"
 	"errors"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -49,6 +53,9 @@ func TestCreateCattleNamespace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			assert.Nil(t, createCattleSystemNamespace(log, tt.c))
+			ns := v1.Namespace{}
+			tt.c.Get(context.TODO(), types.NamespacedName{Name: common.CattleSystem}, &ns)
+			assert.Equal(t, common.CattleSystem, ns.Labels[constants.VerrazzanoManagedKey])
 		})
 	}
 }


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
