### PR TITLE
VZ-10206 fix uninstall none profile 

### DIFF
--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -485,7 +485,7 @@ pipeline {
             }
         }
 
-        stage('Reinstall None') {
+        stage('Uninstall Prometheus Stack') {
             environment {
                 KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
                 OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
@@ -505,7 +505,7 @@ pipeline {
             }
         }
 
-        stage('Verify None') {
+        stage('Verify Prometheus Stack Gone') {
             parallel {
                 stage('verify-install/promstack') {
                     environment {
@@ -538,6 +538,74 @@ pipeline {
                             dumpK8sCluster('edge-stack-installation-cluster-snapshot')
                         }
                     }
+                }
+            }
+        }
+
+        stage('Uninstall') {
+            environment {
+                KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
+                OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
+            }
+            steps {
+                sh """
+                    ${GO_REPO_PATH}/vz uninstall -y --timeout 10m
+                    ${GO_REPO_PATH}/verrazzano/ci/scripts/wait-for-namespace-not-exist.sh verrazzano-install
+                """
+            }
+
+            post {
+                failure {
+                    archiveArtifacts artifacts: "**/kind-logs/**", allowEmptyArchive: true
+                    dumpK8sCluster('none-uninstall-failure-dump')
+                }
+                always {
+                    archiveArtifacts artifacts: "acceptance-test-operator.yaml,downloaded-operator.yaml,$INSTALL_CONFIG_FILE_KIND", allowEmptyArchive: true
+                }
+            }
+        }
+
+        stage('Reinstall None') {
+            environment {
+                KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
+                OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
+            }
+            steps {
+                sh """
+                    cp ${env.INSTALL_CONFIG_FILE_KIND_TESTS} ${env.INSTALL_CONFIG_FILE_KIND}
+                   ${GO_REPO_PATH}/vz install --filename ${env.INSTALL_CONFIG_FILE_KIND} --manifests ${WORKSPACE}/acceptance-test-operator.yaml --timeout 5m
+                """
+            }
+
+            post {
+                failure {
+                    archiveArtifacts artifacts: "**/kind-logs/**", allowEmptyArchive: true
+                    dumpK8sCluster('none-installation-failure-dump')
+                }
+                always {
+                    archiveArtifacts artifacts: "acceptance-test-operator.yaml,downloaded-operator.yaml,$INSTALL_CONFIG_FILE_KIND", allowEmptyArchive: true
+                }
+            }
+        }
+
+        stage('Uninstall Again') {
+            environment {
+                KIND_KUBERNETES_CLUSTER_VERSION = "${params.KUBERNETES_CLUSTER_VERSION}"
+                OCI_OS_LOCATION = "ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
+            }
+            steps {
+                sh """
+                    ${GO_REPO_PATH}/vz uninstall -y --timeout 10m
+                """
+            }
+
+            post {
+                failure {
+                    archiveArtifacts artifacts: "**/kind-logs/**", allowEmptyArchive: true
+                    dumpK8sCluster('none-uninstall-failure-dump')
+                }
+                always {
+                    archiveArtifacts artifacts: "acceptance-test-operator.yaml,downloaded-operator.yaml,$INSTALL_CONFIG_FILE_KIND", allowEmptyArchive: true
                 }
             }
         }

--- a/ci/scripts/wait-for-namespace-not-exist.sh
+++ b/ci/scripts/wait-for-namespace-not-exist.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# Waits until a namespace does not exist
+#
+NAMESPACE=$1
+i=0
+for (( i=1; i<=20; i++ ))
+do
+  kubectl get ns $NAMESPACE >&- 2>&-
+  if [ "$?" -eq 1 ]; then
+    exit 0
+  fi
+  echo "Waiting for namespace $NAMESPACE to be deleted ..."
+  sleep 5
+done
+exit 1

--- a/pkg/k8s/ready/deployment_ready.go
+++ b/pkg/k8s/ready/deployment_ready.go
@@ -75,7 +75,6 @@ func DoDeploymentsExist(log vzlog.VerrazzanoLogger, client clipkg.Client, namesp
 			return false
 		}
 		if !exists {
-			logProgressf(log, "%s is waiting for deployment %v to exist", prefix, namespacedName)
 			return false
 		}
 	}

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -5,11 +5,11 @@ package resource
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"reflect"
-
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -31,11 +31,17 @@ func (r Resource) Delete() error {
 		kind = r.Object.GetObjectKind().GroupVersionKind().Kind
 	}
 	err := r.Client.Delete(context.TODO(), r.Object)
-	if client.IgnoreNotFound(err) != nil {
+	if err != nil {
+		// Ignore if CRD doesn't exist
+		if _, ok := err.(*meta.NoKindMatchError); ok {
+			return nil
+		}
+		if client.IgnoreNotFound(err) == nil {
+			return nil
+		}
 		return r.Log.ErrorfNewErr("Failed to delete the resource of type %s, named %s/%s: %v", kind, r.Object.GetNamespace(), r.Object.GetName(), err)
-	} else if err == nil {
-		r.Log.Oncef("Successfully deleted %s %s/%s", kind, r.Object.GetNamespace(), r.Object.GetName())
 	}
+	r.Log.Oncef("Successfully deleted %s %s/%s", kind, r.Object.GetNamespace(), r.Object.GetName())
 	return nil
 }
 
@@ -75,6 +81,10 @@ func (r Resource) Exists() (bool, error) {
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: r.Namespace, Name: r.Name}, r.Object)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		// Ignore if CRD doesn't exist
+		if _, ok := err.(*meta.NoKindMatchError); ok {
 			return false, nil
 		}
 		return false, err

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"text/template"
 
 	cmutil "github.com/cert-manager/cert-manager/pkg/api/util"
@@ -184,8 +185,14 @@ func createCertManagerGVK(kind string) schema.GroupVersionKind {
 func deleteResources(log vzlog.VerrazzanoLogger, cli crtclient.Client, namespace string, obj crtclient.Object, gvk schema.GroupVersionKind) error {
 	// Use an unstructured object to get the list of resources
 	objectList := &unstructured.UnstructuredList{}
+
 	objectList.SetGroupVersionKind(gvk)
 	if err := cli.List(context.TODO(), objectList, crtclient.InNamespace(namespace)); err != nil {
+		// Ignore if CRD doesn't exist
+		_, ok := err.(*meta.NoKindMatchError)
+		if ok {
+			return nil
+		}
 		return err
 	}
 	for _, item := range objectList.Items {

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -5,7 +5,6 @@ package reconcile
 
 import (
 	"context"
-
 	vzappclusters "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	clustersapi "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/pkg/constants"
@@ -404,7 +403,6 @@ func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvision
 		if err := cmCleanupFunc(ctx.Log(), ctx.Client(), ns); err != nil {
 			return newRequeueWithDelay(), err
 		}
-		log.Progressf("Deleting namespace %s", ns)
 		err := resource.Resource{
 			Name:   ns,
 			Client: r.Client,
@@ -446,7 +444,6 @@ func (r *Reconciler) deleteIstioCARootCert(ctx spi.ComponentContext) error {
 	}
 
 	for _, ns := range namespaces.Items {
-		ctx.Log().Progressf("Deleting Istio root cert in namespace %s", ns.GetName())
 		err := resource.Resource{
 			Name:      istioRootCertName,
 			Namespace: ns.GetName(),

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_component.go
@@ -95,7 +95,7 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 				return ctrl.Result{}, err
 			}
 			if !installed {
-				compLog.Oncef("Component %s is not installed, nothing to do for uninstall", compName)
+				compLog.Debugf("Component %s is not installed, nothing to do for uninstall", compName)
 				UninstallContext.uninstallState = compStateUninstallEnd
 				continue
 			}


### PR DESCRIPTION
Fix uninstall of none profile. Part of the problem was that uninstall was failing since certain CRDs were not installed. Handle that case in the resource.go file.

Also added tests to a la cart to uninstall, re-install none, then uninstall again.