### PR TITLE
VZ-10215: fix upgrade of clusterAPI component

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -93,7 +93,7 @@ func (c clusterAPIComponent) Namespace() string {
 
 // ShouldInstallBeforeUpgrade returns true if component can be installed before upgrade is done.
 func (c clusterAPIComponent) ShouldInstallBeforeUpgrade() bool {
-	return true
+	return false
 }
 
 // GetDependencies returns the dependencies of this component.

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component_test.go
@@ -79,7 +79,7 @@ func TestNamespace(t *testing.T) {
 func TestShouldInstallBeforeUpgrade(t *testing.T) {
 	var comp clusterAPIComponent
 	flag := comp.ShouldInstallBeforeUpgrade()
-	assert.Equal(t, true, flag)
+	assert.Equal(t, false, flag)
 }
 
 // TestGetDependencies tests the GetDependencies function

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -32,7 +32,6 @@ import (
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/clusterapi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
@@ -127,7 +126,7 @@ func NewComponent() spi.Component {
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "rancher-values.yaml"),
 			AppendOverridesFunc:       AppendOverrides,
 			Certificates:              certificates,
-			Dependencies:              []string{networkpolicies.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName, clusterapi.ComponentName, fluentoperator.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName, fluentoperator.ComponentName},
 			AvailabilityObjects: &ready.AvailabilityObjects{
 				DeploymentNames: []types.NamespacedName{
 					{


### PR DESCRIPTION
This pull request fixes the upgrade of the clusterAPI component when going from a version without clusterAPI (1.5.3) to a version with clusterAPI (1.6.0).  The upgrade was first installing clusterAPI deployments and then later upgrading clusterAPI components which resulted in the clusterAPI components getting redeployed.

With this fix the clusterAPI deployments are not redeployed.