### PR TITLE
VZ-7644: Rotation of VPO webhook certs when expired

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -269,3 +269,6 @@ const ThanosInternalUserName = "verrazzano-thanos-internal"
 
 // VerrazzanoPlatformOperatorHelmName is the Helm release name of the Verrazzano Platform Operator
 const VerrazzanoPlatformOperatorHelmName = "verrazzano-platform-operator"
+
+// VerrazzanoPlatformOperatorWebhook indicate the name of VPO webhook deployment name
+const VerrazzanoPlatformOperatorWebhook = "verrazzano-platform-operator-webhook"

--- a/platform-operator/controllers/certrotation/certrotation_actions.go
+++ b/platform-operator/controllers/certrotation/certrotation_actions.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package certrotation
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+// ValidateCertDate validates the certs.
+func (r *CertificateRotationManagerReconciler) ValidateCertDate(certContent []byte) (bool, error) {
+	block, _ := pem.Decode(certContent)
+	if block == nil {
+		return false, r.log.ErrorfNewErr("unable to parse the certificate")
+	}
+	certs, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false, r.log.ErrorfNewErr(err.Error())
+	}
+	deadline := time.Now().Add(r.CompareWindow)
+	if deadline.After(certs.NotAfter) {
+		r.log.Progressf("certificate for %s expires in less than %s hours",
+			certs.Subject.CommonName,
+			certs.NotAfter.Format(time.RFC3339))
+		return true, nil
+
+	}
+	r.log.Progressf("certificate for %s has validity %s",
+		certs.Subject.CommonName,
+		certs.NotAfter.Sub(deadline).Round(time.Hour))
+	return false, nil
+}
+
+// GetSecretData checks if secret exists in namespace or not
+// if exists then return secret data else return nil
+func (r *CertificateRotationManagerReconciler) GetSecretData(ctx context.Context, secretName string) (corev1.Secret, []byte) {
+	sec := corev1.Secret{}
+	err := r.Get(ctx, clipkg.ObjectKey{
+		Namespace: r.WatchNamespace,
+		Name:      secretName,
+	}, &sec)
+	if err != nil && apierrors.IsNotFound(err) {
+		r.log.Errorf("an error while listing the certificate secret %v", secretName)
+		return sec, nil
+	}
+	r.log.Debugf("successfully found the certificate secret %v", secretName)
+	if val, ok := sec.Data["tls.crt"]; ok {
+		return sec, val
+	}
+	return sec, nil
+}
+
+// DeleteSecret deletes the tls secret.
+func (r *CertificateRotationManagerReconciler) DeleteSecret(ctx context.Context, secretName corev1.Secret) error {
+	if err := r.Delete(ctx, &secretName, &clipkg.DeleteOptions{}); err != nil {
+		return r.log.ErrorfNewErr("an error while deleting the certificate secret %v in namespace %v with error %v", secretName.Name, r.WatchNamespace, err)
+	}
+	r.log.Infof("successfully deleted the secret %v in namespace %v ", secretName.Name, r.WatchNamespace)
+	return nil
+}
+
+func (r *CertificateRotationManagerReconciler) RolloutRestartDeployment(ctx context.Context) error {
+	deployment := appsv1.Deployment{}
+	var err error
+	err = r.Get(ctx, clipkg.ObjectKey{Namespace: r.TargetNamespace, Name: r.TargetDeployment}, &deployment)
+	r.log.Debugf("deployment listed with name %v", deployment.Name)
+	if err != nil && apierrors.IsNotFound(err) {
+		r.log.Errorf("an error while listing the deployment in namespace %v", r.TargetNamespace)
+		return err
+	}
+	time := time.Now()
+	_, err = controllerruntime.CreateOrUpdate(context.TODO(), r.Client, &deployment, func() error {
+		if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+			deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		deployment.Spec.Template.ObjectMeta.Annotations[vzconst.RestartVersionAnnotation] = buildRestartAnnotationString(time)
+		return nil
+	})
+	if err != nil {
+		r.log.Errorf("an error while patching the deployment %v in namespace %v", r.TargetDeployment, r.TargetNamespace)
+		return err
+	}
+	r.log.Infof("successfully restart the deployment %v in namespace %v ", r.TargetDeployment, r.WatchNamespace)
+	return nil
+}
+
+// buildRestartAnnotationString returns the current time for annotating deployment to restart the pod
+func buildRestartAnnotationString(time time.Time) string {
+	return time.String()
+}

--- a/platform-operator/controllers/certrotation/certrotation_actions.go
+++ b/platform-operator/controllers/certrotation/certrotation_actions.go
@@ -34,7 +34,7 @@ func (r *CertificateRotationManagerReconciler) ValidateCertDate(certContent []by
 		return true, nil
 
 	}
-	r.log.Progressf("certificate for %s has validity %s",
+	r.log.Progressf("Certificate %s is valid for %s hours",
 		certs.Subject.CommonName,
 		certs.NotAfter.Sub(deadline).Round(time.Hour))
 	return false, nil

--- a/platform-operator/controllers/certrotation/certrotation_controller.go
+++ b/platform-operator/controllers/certrotation/certrotation_controller.go
@@ -79,7 +79,7 @@ func (r *CertificateRotationManagerReconciler) Reconcile(ctx context.Context, re
 	err = r.CheckCertificateExpiration(ctx, certList)
 	if err != nil {
 		result := newRequeueWithDelay(5, 10, time.Second)
-		r.log.Debugf("Error while certification validation: %v", result.RequeueAfter)
+		r.log.Debugf("Error while checking certificate status: %v", result.RequeueAfter)
 		return result, err
 	}
 
@@ -87,7 +87,7 @@ func (r *CertificateRotationManagerReconciler) Reconcile(ctx context.Context, re
 		Requeue:      true,
 		RequeueAfter: r.CheckPeriod, // Check period is in duration already
 	}
-	r.log.Infof("Successfully validated the certificate: %v", result.RequeueAfter)
+	r.log.Infof("Successfully validated webhook certificates: %v", result.RequeueAfter)
 	return result, nil
 
 }

--- a/platform-operator/controllers/certrotation/certrotation_controller.go
+++ b/platform-operator/controllers/certrotation/certrotation_controller.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package certrotation
+
+import (
+	"context"
+	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	vzstatus "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/healthcheck"
+	vzcert "github.com/verrazzano/verrazzano/platform-operator/internal/k8s/certificate"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"time"
+)
+
+const (
+	controllerName     = "CertificateRotationManager"
+	componentNamespace = constants.VerrazzanoInstallNamespace
+	componentName      = "certrotation"
+)
+
+// CertificateRotationManagerReconciler reconciles certificate secrets.
+type CertificateRotationManagerReconciler struct {
+	clipkg.Client
+	Scheme           *runtime.Scheme
+	StatusUpdater    vzstatus.Updater
+	log              vzlog.VerrazzanoLogger
+	WatchNamespace   string
+	CertificatesList []string
+	TargetNamespace  string
+	TargetDeployment string
+	CompareWindow    time.Duration // should be in no of Seconds
+	CheckPeriod      time.Duration
+	lastReconcile    *time.Time
+}
+
+// SetupWithManager creates a new controller and adds it to the manager
+func (r *CertificateRotationManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).WithEventFilter(r.createComponentCertificatePredicate()).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+		}).
+		Complete(r)
+}
+
+// Reconcile the Certificate Secret
+func (r *CertificateRotationManagerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	lastReconcile := time.Now()
+	if r.lastReconcile != nil {
+		r.log.Debugf("Reconciling %v, time between reconciles: %v", req.NamespacedName, lastReconcile.Sub(*r.lastReconcile))
+	}
+	r.lastReconcile = &lastReconcile
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+	if result, err := r.initLogger(componentNamespace); err != nil {
+		return result, err
+	}
+	certList, err := r.getCertSecretList(ctx)
+	if err != nil {
+		// An error occurred requeue and try again
+		return newRequeueWithDelay(30, 60, time.Second), err
+	}
+	if len(certList) < len(r.CertificatesList) {
+		// If there are no matching certificates, we don't need to re-queue
+		r.log.Debugf("No matching certificate secrets found")
+		return newRequeueWithDelay(30, 60, time.Second), nil
+	}
+
+	err = r.CheckCertificateExpiration(ctx, certList)
+	if err != nil {
+		result := newRequeueWithDelay(5, 10, time.Second)
+		r.log.Debugf("Error while certification validation: %v", result.RequeueAfter)
+		return result, err
+	}
+
+	result := ctrl.Result{
+		Requeue:      true,
+		RequeueAfter: r.CheckPeriod, // Check period is in duration already
+	}
+	r.log.Infof("Successfully validated the certificate: %v", result.RequeueAfter)
+	return result, nil
+
+}
+
+// initialize secret logger
+func (r *CertificateRotationManagerReconciler) initLogger(secretNamespace string) (ctrl.Result, error) {
+	// Get the resource logger needed to log message using 'progress' and 'once' methods
+	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
+		Name:           componentName,
+		Namespace:      componentNamespace,
+		ID:             secretNamespace,
+		Generation:     0,
+		ControllerName: controllerName,
+	})
+	if err != nil {
+		zap.S().Errorf("Failed to create resource logger for CertificateRotationManager controller: %v", err)
+		return newRequeueWithDelay(3, 5, 5*time.Second), err
+	}
+	r.log = log
+	return ctrl.Result{}, nil
+}
+
+// Create a new Result that will cause a reconcile requeue after a short delay
+func newRequeueWithDelay(min, max int, unit time.Duration) ctrl.Result {
+	return vzctrl.NewRequeueWithDelay(min, max, unit)
+}
+
+func (r *CertificateRotationManagerReconciler) CheckCertificateExpiration(ctx context.Context, certsList []string) error {
+	mustRotate := false
+	var err error
+	status := make(map[string]bool)
+
+	for i := range certsList {
+		secret := certsList[i]
+		r.log.Debugf("secret/certificate found %v", secret)
+		sec, secdata := r.GetSecretData(ctx, secret)
+		if secdata == nil {
+			return r.log.ErrorfNewErr("an error occurred obtaining certificate data for %s", secret)
+		}
+		mustRotate, err = r.ValidateCertDate(secdata)
+		if err != nil {
+			return r.log.ErrorfNewErr("an error while validating the certificate secret data")
+		}
+		r.log.Debugf("cert data expiry status for secret %v is %v", secret, mustRotate)
+		status[secret] = mustRotate
+		if mustRotate {
+			err = r.DeleteSecret(ctx, sec)
+			if err != nil {
+				return r.log.ErrorfNewErr("an error deleting the certificate")
+			}
+		}
+	}
+	for s := range status {
+		if status[s] {
+			err = r.RolloutRestartDeployment(ctx)
+			if err != nil {
+				return err
+			}
+			break
+		}
+	}
+	return nil
+}
+
+func (r *CertificateRotationManagerReconciler) getCertSecretList(ctx context.Context) ([]string, error) {
+	certificates := make([]string, 0)
+	secretList := corev1.SecretList{}
+	listOptions := &clipkg.ListOptions{Namespace: r.WatchNamespace}
+	err := r.List(ctx, &secretList, listOptions)
+	if err != nil {
+		return nil, r.log.ErrorfNewErr("an error while listing the certificate sceret")
+	}
+	for _, secret := range secretList.Items {
+		if secret.Type == corev1.SecretTypeTLS {
+			certificates = append(certificates, secret.Name)
+		}
+	}
+	if len(certificates) > 0 {
+		return certificates, nil
+	}
+	r.log.Debugf("No certificates found in namespace %v", r.WatchNamespace)
+	return certificates, nil
+}
+
+func (r *CertificateRotationManagerReconciler) createComponentCertificatePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return r.isCertificateSecret(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return r.isCertificateSecret(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return r.isCertificateSecret(e.ObjectNew)
+		},
+	}
+}
+
+func (r *CertificateRotationManagerReconciler) isCertificateSecret(o clipkg.Object) bool {
+	certificate := o.(*corev1.Secret)
+	return certificate.Labels[vzcert.OperatorCertLabelKey] == vzcert.OperatorCertLabel &&
+		certificate.Labels[vzcert.OperatorCertLabelKey] != ""
+}

--- a/platform-operator/controllers/certrotation/certrotation_controller_test.go
+++ b/platform-operator/controllers/certrotation/certrotation_controller_test.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package certrotation
+
+import (
+	"bytes"
+	"context"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	vzstatus "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/healthcheck"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	VZNamespace         = "verrazzano-install"
+	VZWebhookDeployment = "verrazzano-platform-operator-webhook"
+	VZCertificate       = "verrazzano-platform-operator-tls"
+	CheckPeriodDuration = 1
+)
+
+var (
+	testScheme = runtime.NewScheme()
+	//checkPeriodDuration = time.Duration(1) * time.Second
+)
+
+func init() {
+	_ = k8scheme.AddToScheme(testScheme)
+}
+
+// TestExpiredValidateCertificate validate certificate
+// if certificate is expired
+// THEN restart the target deployment
+// (restart of operator will re-generate the certificate)
+func TestExpiredValidateCertificate(t *testing.T) {
+	asserts := assert.New(t)
+	deployment := getDeployment()
+	secret := getSecret(2)
+	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(&deployment, &secret).Build()
+	request0 := newRequest(deployment.Name, secret.Name)
+	reconciler := newCertificateManagerReconciler(cli, VZNamespace, VZNamespace, VZWebhookDeployment, 10)
+	res0, err0 := reconciler.Reconcile(context.TODO(), request0)
+	asserts.NoError(err0)
+	asserts.Equal(true, res0.Requeue)
+}
+
+// TestValidateCertificate checks certificate
+// if certificate is expired
+// THEN restart the target deployment
+func TestValidateCertificate(t *testing.T) {
+	asserts := assert.New(t)
+	deployment := getDeployment()
+	secret := getSecret(1)
+	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(&deployment, &secret).Build()
+	request0 := newRequest(deployment.Name, secret.Name)
+	reconciler := newCertificateManagerReconciler(cli, VZNamespace, VZNamespace, VZWebhookDeployment, 25)
+	res0, err0 := reconciler.Reconcile(context.TODO(), request0)
+	asserts.NoError(err0)
+	asserts.Equal(true, res0.Requeue)
+}
+
+// TestCertificate1 checks certificate
+// if target deployment doesn't exist
+// THEN Requeue should happen.
+func TestCertificate1(t *testing.T) {
+	asserts := assert.New(t)
+	deployment := getDeployment()
+	secret := getSecret(1)
+	// Set up the initial context
+	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(&deployment, &secret).Build()
+	request0 := newRequest(deployment.Name, secret.Name)
+	reconciler := newCertificateManagerReconciler(cli, VZNamespace, VZNamespace, "verrazzano", 25)
+	res0, err := reconciler.Reconcile(context.TODO(), request0)
+	asserts.Equal(true, res0.Requeue)
+	asserts.Equal(err, nil)
+}
+
+// TestCertificate2 checks certificate
+// if target Namespace doesn't exist
+// THEN Requeue should happen.
+func TestCertificate2(t *testing.T) {
+	asserts := assert.New(t)
+	deployment := getDeployment()
+	secret := getSecret(1)
+	// Set up the initial context
+	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(&deployment, &secret).Build()
+	request0 := newRequest(deployment.Name, secret.Name)
+	reconciler := newCertificateManagerReconciler(cli, VZNamespace, "verrazzano", VZWebhookDeployment, 25)
+	res0, err := reconciler.Reconcile(context.TODO(), request0)
+	asserts.Equal(true, res0.Requeue)
+	asserts.Equal(err, nil)
+}
+
+// TestCertificate3 checks certificate
+// if secret Namespace doesn't exist
+// THEN Requeue should happen.
+func TestCertificate3(t *testing.T) {
+	asserts := assert.New(t)
+	deployment := getDeployment()
+	secret := getSecret(1)
+	// Set up the initial context
+	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(&deployment, &secret).Build()
+	request0 := newRequest(deployment.Name, secret.Name)
+	reconciler := newCertificateManagerReconciler(cli, "verrazzano", VZNamespace, VZWebhookDeployment, 25)
+	res0, err := reconciler.Reconcile(context.TODO(), request0)
+	asserts.Equal(true, res0.Requeue)
+	asserts.Equal(err, nil)
+}
+
+// TestCertificate4 checks certificate
+// if secret/certificate doesn't exist
+// THEN Requeue should happen.
+func TestCertificate4(t *testing.T) {
+	asserts := assert.New(t)
+	deployment := getDeployment()
+	// Set up the initial context
+	cli := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(&deployment).Build()
+	request0 := newRequest(deployment.Name, deployment.Name)
+	reconciler := newCertificateManagerReconciler(cli, VZNamespace, VZNamespace, VZWebhookDeployment, 10)
+	res0, err := reconciler.Reconcile(context.TODO(), request0)
+	asserts.Equal(true, res0.Requeue)
+	asserts.Equal(err, nil)
+}
+
+// newScheme creates a new scheme that includes this package's object to use for testing
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	return scheme
+}
+
+// newRequest creates a new reconciler request for testing
+// namespace - The namespace to use in the request
+// name - The name to use in the request
+func newRequest(namespace string, name string) ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      name}}
+}
+
+func getInt32Ptr(i int32) *int32 {
+	return &i
+}
+
+func getSecret(days int) v1.Secret {
+	crt, key := getSecretValidData(days)
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      VZCertificate,
+			Namespace: VZNamespace,
+		},
+		Immutable: nil,
+		Data: map[string][]byte{
+			"tls.crt": crt,
+			"tls.key": key,
+		},
+		StringData: nil,
+		Type:       "kubernetes.io/tls",
+	}
+	return *secret
+}
+
+func getDeployment() appsv1.Deployment {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      VZWebhookDeployment,
+			Namespace: VZNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: getInt32Ptr(1),
+		},
+	}
+	return *deployment
+}
+
+func getSecretValidData(days int) ([]byte, []byte) {
+	value, _ := newSerialNumber()
+	caValue, caPrivateKey := getCaCert()
+	cert := &x509.Certificate{
+		DNSNames:     []string{VZCertificate},
+		SerialNumber: value,
+		Subject: pkix.Name{
+			CommonName: VZCertificate,
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(0, 0, days),
+		IsCA:         false,
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	// server private key
+	serverPrivKey, _ := rsa.GenerateKey(cryptorand.Reader, 4096)
+	serverCertBytes, _ := x509.CreateCertificate(cryptorand.Reader, cert, caValue, &serverPrivKey.PublicKey, caPrivateKey)
+	certPEM := new(bytes.Buffer)
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: serverCertBytes,
+	})
+
+	certPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(serverPrivKey),
+	})
+	return certPEM.Bytes(), certPrivKeyPEM.Bytes()
+}
+
+// newSerialNumber returns a new random serial number suitable for use in a certificate.
+func newSerialNumber() (*big.Int, error) {
+	// A serial number can be up to 20 octets in size.
+	return cryptorand.Int(cryptorand.Reader, new(big.Int).Lsh(big.NewInt(1), 8*20))
+}
+
+func getCaCert() (*x509.Certificate, *rsa.PrivateKey) {
+	value, _ := newSerialNumber()
+	// CA config
+	ca := &x509.Certificate{
+		DNSNames:     []string{VZCertificate},
+		SerialNumber: value,
+		Subject: pkix.Name{
+			CommonName: VZCertificate,
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(2, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// CA private key
+	caPrivKey, _ := rsa.GenerateKey(cryptorand.Reader, 4096)
+	// Self signed CA certificate
+	caBytes, _ := x509.CreateCertificate(cryptorand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	caPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(caPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+	})
+	return ca, caPrivKey
+}
+
+// newConfigMapReconciler creates a new reconciler for testing
+func newCertificateManagerReconciler(c client.Client, watchNamespace, targetNamespace, targetDeployment string, compareWindow int64) CertificateRotationManagerReconciler {
+	vzLog := vzlog.DefaultLogger()
+	scheme := newScheme()
+	reconciler := CertificateRotationManagerReconciler{
+		Client:           c,
+		Scheme:           scheme,
+		StatusUpdater:    &vzstatus.FakeVerrazzanoStatusUpdater{Client: c},
+		log:              vzLog,
+		WatchNamespace:   watchNamespace,
+		TargetNamespace:  targetNamespace,
+		TargetDeployment: targetDeployment,
+		CompareWindow:    time.Duration(compareWindow),
+	}
+	return reconciler
+}

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
@@ -146,6 +146,7 @@ spec:
             - --zap-log-level=info
             - --run-webhooks=true
             - --resource-validation={{ .Values.webhooks.resourceValidation }}
+            - --enable-leader-election={{ .Values.webhooks.enableWebhookLeaderElection }}
             {{ if .Values.experimentalFeatures.moduleAPI.enabled }}
             - --experimental-modules=true
             {{ end }}

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/values.yaml
@@ -43,6 +43,7 @@ webhookAffinity:
         weight: 100
 webhooks:
   resourceValidation: false
+  enableWebhookLeaderElection: true
 
 # Configuration for experimental features that are under active development
 experimentalFeatures:

--- a/platform-operator/internal/config/config.go
+++ b/platform-operator/internal/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"path/filepath"
+	"time"
 
 	"github.com/verrazzano/verrazzano/pkg/nginxutil"
 
@@ -33,6 +34,9 @@ const (
 )
 
 const defaultBomFilename = "verrazzano-bom.json"
+
+var DefaultExpiryWindow = 24 * 7 * time.Minute // 1 week
+var DefaultCheckPeriod = 10 * time.Minute      // 24 hours
 
 // Global override for the default BOM file path
 var bomFilePathOverride string
@@ -92,23 +96,31 @@ type OperatorConfig struct {
 
 	// ExperimentalModules toggles the VPO to use the experimental modules feature
 	ExperimentalModules bool
+
+	// CertificateExpiryCheckPeriodHours period for CertificateRotator Interval expiration check period in seconds.
+	CertificateExpiryCheckPeriodDuration *time.Duration
+
+	// CertificateExpiryCheckWindowDuration period for CertificateRotator window of time to rotate the webhook certificates before expiration in seconds
+	CertificateExpiryCheckWindowDuration *time.Duration
 }
 
 // The singleton instance of the operator config
 var instance = OperatorConfig{
-	CertDir:                        "/etc/webhook/certs",
-	MetricsAddr:                    ":8080",
-	LeaderElectionEnabled:          false,
-	VersionCheckEnabled:            true,
-	RunWebhookInit:                 false,
-	RunWebhooks:                    false,
-	ResourceRequirementsValidation: false,
-	WebhookValidationEnabled:       true,
-	VerrazzanoRootDir:              rootDir,
-	HealthCheckPeriodSeconds:       60,
-	MySQLCheckPeriodSeconds:        60,
-	MySQLRepairTimeoutSeconds:      120,
-	ExperimentalModules:            false,
+	CertDir:                              "/etc/webhook/certs",
+	MetricsAddr:                          ":8080",
+	LeaderElectionEnabled:                false,
+	VersionCheckEnabled:                  true,
+	RunWebhookInit:                       false,
+	RunWebhooks:                          false,
+	ResourceRequirementsValidation:       false,
+	WebhookValidationEnabled:             true,
+	VerrazzanoRootDir:                    rootDir,
+	HealthCheckPeriodSeconds:             60,
+	MySQLCheckPeriodSeconds:              60,
+	MySQLRepairTimeoutSeconds:            120,
+	ExperimentalModules:                  false,
+	CertificateExpiryCheckPeriodDuration: &DefaultCheckPeriod,  //run every week only to validate the certificates.
+	CertificateExpiryCheckWindowDuration: &DefaultExpiryWindow, //expiry window of two weeks.
 }
 
 // Set saves the operator config.  This should only be called at operator startup and during unit tests

--- a/platform-operator/internal/config/config.go
+++ b/platform-operator/internal/config/config.go
@@ -35,8 +35,8 @@ const (
 
 const defaultBomFilename = "verrazzano-bom.json"
 
-var DefaultExpiryWindow = 24 * 7 * time.Minute // 1 week
-var DefaultCheckPeriod = 10 * time.Minute      // 24 hours
+var DefaultExpiryWindow = 24 * 14 * time.Hour // 2 week or 336 hours
+var DefaultCheckPeriod = 24 * time.Hour       // 24 hours
 
 // Global override for the default BOM file path
 var bomFilePathOverride string

--- a/platform-operator/internal/k8s/certificate/certificate.go
+++ b/platform-operator/internal/k8s/certificate/certificate.go
@@ -30,8 +30,8 @@ const (
 	OldOperatorName      = "verrazzano-platform-operator"
 	OperatorCA           = "verrazzano-platform-operator-ca"
 	OperatorTLS          = "verrazzano-platform-operator-tls"
-	OperatorCertLabelKey = "install.verrazzano.io/vpo-webhook"
-	OperatorCertLabel    = "verrazzano"
+	OperatorCertLabelKey = "install.verrazzano.io/certificate"
+	OperatorCertLabel    = "verrazzano-platform-operator-webhook"
 	// OperatorNamespace is the resource namespace for the Verrazzano platform operator
 	OperatorNamespace = "verrazzano-install"
 	CRDName           = "verrazzanos.install.verrazzano.io"

--- a/platform-operator/internal/operatorinit/run_webhook.go
+++ b/platform-operator/internal/operatorinit/run_webhook.go
@@ -234,6 +234,6 @@ func checkleader() {
 	fmt.Println("This calls dervies from leader")
 }
 
-func checkelector() {
-	fmt.Println("This calls dervice from elector")
-}
+//func checkelector() {
+//	fmt.Println("This calls dervice from elector")
+//}

--- a/platform-operator/internal/operatorinit/run_webhook.go
+++ b/platform-operator/internal/operatorinit/run_webhook.go
@@ -81,7 +81,7 @@ func StartWebhookServers(config internalconfig.OperatorConfig, log *zap.SugaredL
 	// +kubebuilder:scaffold:builder
 	log.Info("Starting webhook controller-runtime manager")
 	var runnable manager.RunnableFunc = func(ctx context.Context) error {
-
+		checkleader()
 		return nil
 	}
 	if err := mgr.Add(runnable); err != nil {
@@ -228,4 +228,12 @@ func createOrUpdateNetworkPolicies(conf *rest.Config, log *zap.SugaredLogger, ku
 		return fmt.Errorf("Failed to create or update network policies: %v", netPolErrors)
 	}
 	return nil
+}
+
+func checkleader() {
+	fmt.Println("This calls dervies from leader")
+}
+
+func checkelector() {
+	fmt.Println("This calls dervice from elector")
 }

--- a/platform-operator/internal/operatorinit/run_webhook.go
+++ b/platform-operator/internal/operatorinit/run_webhook.go
@@ -4,6 +4,7 @@
 package operatorinit
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -79,6 +80,13 @@ func StartWebhookServers(config internalconfig.OperatorConfig, log *zap.SugaredL
 
 	// +kubebuilder:scaffold:builder
 	log.Info("Starting webhook controller-runtime manager")
+	var runnable manager.RunnableFunc = func(ctx context.Context) error {
+
+		return nil
+	}
+	if err := mgr.Add(runnable); err != nil {
+		return err
+	}
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		return fmt.Errorf("Failed starting webhook controller-runtime manager: %v", err)
 	}

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -98,7 +98,11 @@ func main() {
 	flag.Int64Var(&config.MySQLRepairTimeoutSeconds, "mysql-repair-timeout", config.MySQLRepairTimeoutSeconds,
 		"MySQL repair timeout seconds")
 	flag.BoolVar(&config.ExperimentalModules, "experimental-modules", config.ExperimentalModules, "enable experimental modules")
-
+	// Certificate expiry check
+	config.CertificateExpiryCheckPeriodDuration = flag.Duration("cert-expiry-check-period", internalconfig.DefaultCheckPeriod,
+		"Webhook certificate expiration check period in seconds, default 168h (1 week)")
+	config.CertificateExpiryCheckWindowDuration = flag.Duration("cert-rotation-window", internalconfig.DefaultExpiryWindow,
+		"The window of time to rotate the webhook certificates before expiration in seconds, default 336h (2 weeks)")
 	// Add the zap logger flag set to the CLI.
 	opts := kzap.Options{}
 	opts.BindFlags(flag.CommandLine)

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -100,9 +100,9 @@ func main() {
 	flag.BoolVar(&config.ExperimentalModules, "experimental-modules", config.ExperimentalModules, "enable experimental modules")
 	// Certificate expiry check
 	config.CertificateExpiryCheckPeriodDuration = flag.Duration("cert-expiry-check-period", internalconfig.DefaultCheckPeriod,
-		"Webhook certificate expiration check period in seconds, default 24 hours")
+		"Webhook certificate expiration check period in hours, default 24 hours")
 	config.CertificateExpiryCheckWindowDuration = flag.Duration("cert-rotation-window", internalconfig.DefaultExpiryWindow,
-		"The window of time to rotate the webhook certificates before expiration in seconds, default 336h (2 weeks)")
+		"The window of time to rotate the webhook certificates before expiration in hours, default 336h (2 weeks)")
 	// Add the zap logger flag set to the CLI.
 	opts := kzap.Options{}
 	opts.BindFlags(flag.CommandLine)

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -100,7 +100,7 @@ func main() {
 	flag.BoolVar(&config.ExperimentalModules, "experimental-modules", config.ExperimentalModules, "enable experimental modules")
 	// Certificate expiry check
 	config.CertificateExpiryCheckPeriodDuration = flag.Duration("cert-expiry-check-period", internalconfig.DefaultCheckPeriod,
-		"Webhook certificate expiration check period in seconds, default 168h (1 week)")
+		"Webhook certificate expiration check period in seconds, default 24 hours")
 	config.CertificateExpiryCheckWindowDuration = flag.Duration("cert-rotation-window", internalconfig.DefaultExpiryWindow,
 		"The window of time to rotate the webhook certificates before expiration in seconds, default 336h (2 weeks)")
 	// Add the zap logger flag set to the CLI.


### PR DESCRIPTION
* Added annotations in the webhook secrets so that it can filter the events only for labeled only,
* Created a cert controller which will watch the events and in every 24 hours will check the certificate's validation if it has an expiry of fewer than 15 days, then delete those secrets and restart the webhook deployment.