### PR TITLE
VZ-9661: Upgrade to Istio 1.17.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### v2.0.0
+### v1.6.4
 
 Component version updates:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### v2.0.0
+
+Component version updates:
+
+- Istio v1.17.2
+
 ### v1.6.1
 Features:
 

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -11,6 +11,7 @@ Copyright (C) 2021, 2023, Oracle and/or its affiliates.
 Copyright (C) 2021, Oracle and/or its affiliates.
 Copyright (C) 2022, 2023, Oracle and/or its affiliates.
 Copyright (C) 2022, Oracle and/or its affiliates.
+Copyright (C) 2023, Oracle and/or its affiliates.
 Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
 Copyright (c) 2015-2021 Bitnami
 Copyright (c) 2020, 2021, Oracle and/or its affiliates.
@@ -21,16 +22,12 @@ Copyright (c) 2020, Oracle and/or its affiliates.
 Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 Copyright (c) 2021, Oracle and/or its affiliates.
-Copyright (c) 2021, Oracle and/or its affiliates. -->")
-Copyright (c) 2021, Oracle and/or its affiliates.")
 Copyright (c) 2022, 2023, Oracle and/or its affiliates.
-Copyright (c) 2022, 2023, Oracle and/or its affiliates. -->
 Copyright (c) 2022, Oracle and/or its affiliates.
 Copyright (c) 2023, Oracle and/or its affiliates.
-Copyright (c) {{if ne $createdYear $updatedYear }}{{printf "%s" $createdYear}}, {{end}}{{printf "%s" $updatedYear}}, Oracle and/or its affiliates.
 Copyright 2018 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors. All Rights Reserved.
-Copyright 2020, Oracle Corporation and/or its affiliates.
+Copyright 2020, 2023, Oracle Corporation and/or its affiliates.
 Copyright 2023, Oracle Corporation and/or its affiliates.
 
 ----------------------------------- Notices ------------------------------------
@@ -153,17 +150,6 @@ SPDX:MIT
 Copyright (C) 2014-2015, Lann Martin
 Copyright (C) 2015, Matt Farina and Matt Butcher
 Copyright (C) 2015-2016, Google
-
---------------------------------- (separator) ----------------------------------
-
-== Dependency
-github.com/alessio/shellescape
-
-== License Type
-SPDX:MIT
-
-== Copyright
-Copyright (c) 2016 Alessio Treglia
 
 --------------------------------- (separator) ----------------------------------
 
@@ -652,6 +638,17 @@ Copyright (c) 2013 Fatih Arslan
 --------------------------------- (separator) ----------------------------------
 
 == Dependency
+github.com/fluent/fluent-operator/v2
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+(no copyright notices found)
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
 github.com/fsnotify/fsnotify
 
 == License Type
@@ -722,6 +719,17 @@ Copyright 2018 Solly Ross
 Copyright 2019 The logr Authors.
 Copyright 2020 The Kubernetes Authors.
 Copyright 2021 The logr Authors.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/go-openapi/errors
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2015 go-swagger maintainers
 
 --------------------------------- (separator) ----------------------------------
 
@@ -2184,268 +2192,6 @@ Copyright (c) 2016, 2018, 2020, Oracle and/or its affiliates.
 --------------------------------- (separator) ----------------------------------
 
 == Dependency
-github.com/pelletier/go-toml
-
-== License Type
-=== MIT-e49b63d8
-=== Apache-2.0
-The bulk of github.com/pelletier/go-toml is distributed under the MIT license
-(see below), with the exception of localtime.go and localtime.test.go.
-Those two files have been copied over from Google's civil library at revision
-ed46f5086358513cf8c25f8e3f022cb838a49d66, and are distributed under the Apache
-2.0 license (see below).
-
-
-github.com/pelletier/go-toml:
-
-
-The MIT License (MIT)
-
-Copyright (c) 2013 - 2021 Thomas Pelletier, Eric Anderton
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-localtime.go, localtime_test.go:
-
-Originals:
-    https://raw.githubusercontent.com/googleapis/google-cloud-go/ed46f5086358513cf8c25f8e3f022cb838a49d66/civil/civil.go
-    https://raw.githubusercontent.com/googleapis/google-cloud-go/ed46f5086358513cf8c25f8e3f022cb838a49d66/civil/civil_test.go
-Changes:
-    * Renamed files from civil* to localtime*.
-    * Package changed from civil to toml.
-    * 'Local' prefix added to all structs.
-License:
-    https://raw.githubusercontent.com/googleapis/google-cloud-go/ed46f5086358513cf8c25f8e3f022cb838a49d66/LICENSE
-
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
-
-== Copyright
-Copyright (c) 2013 - 2021 Thomas Pelletier, Eric Anderton
-Copyright 2016 Google LLC
-
---------------------------------- (separator) ----------------------------------
-
-== Dependency
 github.com/pelletier/go-toml/v2
 
 == License Type
@@ -2866,6 +2612,36 @@ Copyright (c) 2018 Aliaksandr Valialkin
 --------------------------------- (separator) ----------------------------------
 
 == Dependency
+github.com/verrazzano/verrazzano-modules
+
+== License Type
+SPDX:UPL-1.0
+
+== Copyright
+Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+Copyright (C) 2021, 2022, Oracle and/or its affiliates.
+Copyright (C) 2021, 2023, Oracle and/or its affiliates.
+Copyright (C) 2021, Oracle and/or its affiliates.
+Copyright (C) 2022, Oracle and/or its affiliates.
+Copyright (C) 2023, Oracle and/or its affiliates.
+Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+Copyright (c) 2020, Oracle and/or its affiliates.
+Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+Copyright (c) 2021, 2023, Oracle and/or its affiliates.
+Copyright (c) 2021, Oracle and/or its affiliates.
+Copyright (c) 2021, Oracle and/or its affiliates. -->")
+Copyright (c) 2021, Oracle and/or its affiliates.")
+Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+Copyright (c) 2022, Oracle and/or its affiliates.
+Copyright (c) 2023, Oracle America, Inc. and its affiliates.
+Copyright (c) 2023, Oracle and/or its affiliates.
+Copyright (c) {{if ne $createdYear $updatedYear }}{{printf "%s" $createdYear}}, {{end}}{{printf "%s" $updatedYear}}, Oracle and/or its affiliates.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
 github.com/verrazzano/verrazzano-monitoring-operator
 
 == License Type
@@ -2992,7 +2768,9 @@ SPDX:MIT
 
 == Copyright
 Copyright (c) 2017 Uber Technologies, Inc.
-Copyright (c) 2019 Uber Technologies, Inc.
+Copyright (c) 2017-2021 Uber Technologies, Inc.
+Copyright (c) 2020 Uber Technologies, Inc.
+Copyright (c) 2021 Uber Technologies, Inc.
 
 --------------------------------- (separator) ----------------------------------
 
@@ -3128,6 +2906,7 @@ Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2022 The Go Authors. All rights reserved.
+Copyright 2023 The Go Authors. All rights reserved.
 
 == Patents
 Additional IP Rights Grant (Patents)
@@ -3243,6 +3022,7 @@ Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2022 The Go Authors. All rights reserved.
+Copyright 2023 The Go Authors. All rights reserved.
 
 == Patents
 Additional IP Rights Grant (Patents)
@@ -3367,6 +3147,7 @@ SPDX:BSD-3-Clause--modified-by-Google
 == Copyright
 Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
 
 == Patents
 Additional IP Rights Grant (Patents)
@@ -3745,7 +3526,7 @@ Copyright (c) 2013, The GoGo Authors. All rights reserved.
 Copyright (c) 2016 json-iterator
 Copyright (c) 2018 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors.  All rights reserved.
-Copyright 2016-2020 Istio Authors
+Copyright 2016-2022 Istio Authors
 Copyright 2017 Istio Authors
 Copyright 2017-2018 Istio Authors
 Copyright 2018 Istio Authors
@@ -3753,6 +3534,7 @@ Copyright 2019 Istio Authors
 Copyright 2019 Istio Authors. All Rights Reserved.
 Copyright 2020 Istio Authors
 Copyright 2021 Istio Authors
+Copyright 2022 Istio Authors
 
 --------------------------------- (separator) ----------------------------------
 
@@ -3766,21 +3548,26 @@ SPDX:Apache-2.0
 Copyright (c) 2006-2010 Kirill Simonov
 Copyright (c) 2006-2011 Kirill Simonov
 Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright (c) 2011, Open Knowledge Foundation Ltd.
 Copyright (c) 2011-2019 Canonical Ltd
 Copyright (c) 2012 Alex Ogier. All rights reserved.
 Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
 Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2012,2013 Ernest Micklei
 Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2013, The GoGo Authors. All rights reserved.
 Copyright (c) 2014 Sam Ghods
 Copyright (c) 2014, Evan Phoenix
 Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+Copyright (c) 2016 Mail.Ru Group
 Copyright (c) 2016 json-iterator
 Copyright (c) 2017 The Go Authors. All rights reserved.
 Copyright (c) 2018 The Go Authors. All rights reserved.
+Copyright (c) 2019 Josh Bleecher Snyder
+Copyright (c) 2020 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors.  All rights reserved.
-Copyright 2016-2020 Istio Authors
+Copyright 2016-2022 Istio Authors
 Copyright 2019 Istio Authors
 
 --------------------------------- (separator) ----------------------------------
@@ -3948,6 +3735,7 @@ Copyright 2020 Intel Coporation.
 Copyright 2020 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 --------------------------------- (separator) ----------------------------------
 
@@ -4349,23 +4137,6 @@ Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2021 The Kubernetes Authors.
-
---------------------------------- (separator) ----------------------------------
-
-== Dependency
-sigs.k8s.io/kind
-
-== License Type
-SPDX:Apache-2.0
-
-== Copyright
-Copyright (c) 2015-2018 gimme contributors
-Copyright 2016 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2022 The Kubernetes Authors.
 
 --------------------------------- (separator) ----------------------------------
 
@@ -5088,5 +4859,5 @@ The above copyright notice and either this complete permission notice or at a mi
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 === ATTRIBUTION-HELPER-GENERATED:
-=== Attribution helper version: {Major:0 Minor:11 GitVersion:0.10.0-108-gc398c3cf GitCommit:c398c3cf1bca9bc72e2382e8918b1e9ccedd0816 GitTreeState:clean BuildDate:2023-03-31T00:10:24Z GoVersion:go1.19.2 Compiler:gc Platform:darwin/amd64}
-=== License file based on go.mod with md5 sum:  33e138ba7f1de3a0214874fe62e859c0
+=== Attribution helper version: {Major:0 Minor:11 GitVersion:0.10.0-110-gd8300771 GitCommit:d8300771fadb50f0559a6f0dcf4c61ee69c63412 GitTreeState:clean BuildDate:2023-06-01T14:41:46Z GoVersion:go1.19.11 Compiler:gc Platform:darwin/amd64}
+=== License file based on go.mod with md5 sum:  ab7e8796ea3cb1989904084ce57a318b

--- a/cluster-operator/controllers/vmc/sync_thanos.go
+++ b/cluster-operator/controllers/vmc/sync_thanos.go
@@ -312,7 +312,7 @@ func (r *VerrazzanoManagedClusterReconciler) createOrUpdateServiceEntry(name, ho
 
 func populateServiceEntry(se *istioclinet.ServiceEntry, host string, port uint32) {
 	se.Spec.Hosts = []string{host}
-	se.Spec.Ports = []*istionet.Port{
+	se.Spec.Ports = []*istionet.ServicePort{
 		{
 			Name:       "grpc",
 			Number:     port,

--- a/go.mod
+++ b/go.mod
@@ -37,8 +37,8 @@ require (
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.10.3
-	istio.io/api v0.0.0-20221208152505-d807bc07da6a
-	istio.io/client-go v1.15.4
+	istio.io/api v0.0.0-20230712174848-a2b2de508c88
+	istio.io/client-go v1.17.4
 	k8s.io/api v0.26.3
 	k8s.io/apiextensions-apiserver v0.26.1
 	k8s.io/apimachinery v0.27.2
@@ -175,8 +175,8 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220926220553-6981cbe3cfce // indirect
-	google.golang.org/grpc v1.49.0 // indirect
+	google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55 // indirect
+	google.golang.org/grpc v1.50.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1106,8 +1106,8 @@ google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP
 google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
-google.golang.org/genproto v0.0.0-20220926220553-6981cbe3cfce h1:+2ye9vAK4F9F/LCex8dT2cDk0VnTAwUL8uRgX/6nAMU=
-google.golang.org/genproto v0.0.0-20220926220553-6981cbe3cfce/go.mod h1:woMGP53BroOrRY3xTxlbr8Y3eB/nzAvvFM83q7kG2OI=
+google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55 h1:U1u4KB2kx6KR/aJDjQ97hZ15wQs8ZPvDcGcRynBhkvg=
+google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55/go.mod h1:45EK0dUbEZ2NHjCeAd2LXmyjAgGUGrpGROgjhC3ADck=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -1140,8 +1140,8 @@ google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.49.0 h1:WTLtQzmQori5FUH25Pq4WT22oCsv8USpQ+F6rqtsmxw=
-google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
+google.golang.org/grpc v1.50.1 h1:DS/BukOZWp8s6p4Dt/tOaJaTQyPyOoCcrjroHuCeLzY=
+google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -1196,10 +1196,10 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20221208152505-d807bc07da6a h1:iDZ1DnoyKfuMBRyNs7VFmk3H2WO1t0VkLo6guqrl4bk=
-istio.io/api v0.0.0-20221208152505-d807bc07da6a/go.mod h1:hQkF0Q19MCmfOTre/Sg4KvrwwETq45oaFplnBm2p4j8=
-istio.io/client-go v1.15.4 h1:egG65oKORRfkMJvLEcC83AhpJCD3Y6c0MYFozPr/jkk=
-istio.io/client-go v1.15.4/go.mod h1:3zv8ew5I7DS8cZwTzNSuUF5Shv80wDYRzFRtQ/c/M4c=
+istio.io/api v0.0.0-20230712174848-a2b2de508c88 h1:w7lSk+XcYNzGC5xtHBFvaV7QTBMQC5nM4l8xxFslGgk=
+istio.io/api v0.0.0-20230712174848-a2b2de508c88/go.mod h1:owGDRg9uqMob8CN1gxaOzk6nJxnbT8wrP7PmggpJHHY=
+istio.io/client-go v1.17.4 h1:BFVO3q4/qT3vwd30T+a8LdvW+vM7psqebluXiXsSWCI=
+istio.io/client-go v1.17.4/go.mod h1:994/wFLmyN7Th6Cat2pACSwvp6VaGYlonm3mpuRAOq8=
 k8s.io/api v0.25.4 h1:3YO8J4RtmG7elEgaWMb4HgmpS2CfY1QlaOz9nwB+ZSs=
 k8s.io/api v0.25.4/go.mod h1:IG2+RzyPQLllQxnhzD8KQNEu4c4YvyDTpSMztf4A0OQ=
 k8s.io/apiextensions-apiserver v0.25.4 h1:7hu9pF+xikxQuQZ7/30z/qxIPZc2J1lFElPtr7f+B6U=

--- a/pkg/k8s/webhook/webhook.go
+++ b/pkg/k8s/webhook/webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package webhook
@@ -13,16 +13,18 @@ import (
 	ctrlcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func DeleteMutatingWebhookConfiguration(log vzlog.VerrazzanoLogger, client ctrlcli.Client, name string) error {
-	wh := adminv1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-	}
-	log.Progressf("Deleting MutatingWebhookConfiguration %s", name)
-	if err := client.Delete(context.TODO(), &wh); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
+func DeleteMutatingWebhookConfiguration(log vzlog.VerrazzanoLogger, client ctrlcli.Client, names []string) error {
+	for _, name := range names {
+		wh := adminv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
 		}
-		return log.ErrorfThrottledNewErr("Failed to delete MutatingWebhookConfiguration %:, %v", name, err)
+		log.Progressf("Deleting MutatingWebhookConfiguration %s", name)
+		if err := client.Delete(context.TODO(), &wh); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return log.ErrorfThrottledNewErr("Failed to delete MutatingWebhookConfiguration %:, %v", name, err)
+		}
 	}
 	return nil
 }

--- a/pkg/k8s/webhook/webhook_test.go
+++ b/pkg/k8s/webhook/webhook_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package webhook
@@ -96,7 +96,7 @@ func TestDeleteMutating(t *testing.T) {
 	asserts.NoError(err)
 
 	// Delete the webhook
-	err = DeleteMutatingWebhookConfiguration(vzlog.DefaultLogger(), c, name)
+	err = DeleteMutatingWebhookConfiguration(vzlog.DefaultLogger(), c, []string{name})
 
 	// Validate that webhook is deleted
 	asserts.NoError(err)
@@ -124,6 +124,6 @@ func TestDeleteMutatingNotExists(t *testing.T) {
 	asserts.True(errors.IsNotFound(err))
 
 	// Delete the webhook
-	err = DeleteMutatingWebhookConfiguration(vzlog.DefaultLogger(), c, name)
+	err = DeleteMutatingWebhookConfiguration(vzlog.DefaultLogger(), c, []string{name})
 	asserts.NoError(err)
 }

--- a/platform-operator/Dockerfile
+++ b/platform-operator/Dockerfile
@@ -21,7 +21,7 @@ ARG VERRAZZANO_PLATFORM_OPERATOR_IMAGE
 # copy olcne repos needed to install kubectl, istioctl
 COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano/platform-operator/repos/*.repo /etc/yum.repos.d/
 
-RUN microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs openssl jq kubectl-1.23.11-1.el8 istio-istioctl-1.17.2-3.el8 \
+RUN microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs openssl jq kubectl-1.26.6-1.el8 istio-istioctl-1.17.2-3.el8 \
     && microdnf clean all \
     && rm -rf /var/cache/yum /var/lib/rpm/* \
     && groupadd -r verrazzano \

--- a/platform-operator/Dockerfile
+++ b/platform-operator/Dockerfile
@@ -21,7 +21,7 @@ ARG VERRAZZANO_PLATFORM_OPERATOR_IMAGE
 # copy olcne repos needed to install kubectl, istioctl
 COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano/platform-operator/repos/*.repo /etc/yum.repos.d/
 
-RUN microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs openssl jq kubectl-1.23.11-1.el8 istio-istioctl-1.15.3-2.el8 \
+RUN microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs openssl jq kubectl-1.23.11-1.el8 istio-istioctl-1.17.2-3.el8 \
     && microdnf clean all \
     && rm -rf /var/cache/yum /var/lib/rpm/* \
     && groupadd -r verrazzano \

--- a/platform-operator/controllers/verrazzano/component/coherence/coherence_component.go
+++ b/platform-operator/controllers/verrazzano/component/coherence/coherence_component.go
@@ -114,7 +114,8 @@ func (c coherenceComponent) PostUninstall(context spi.ComponentContext) error {
 	if err := webhook.DeleteValidatingWebhookConfiguration(context.Log(), context.Client(), "coherence-operator-validating-webhook-configuration"); err != nil {
 		return err
 	}
-	if err := webhook.DeleteMutatingWebhookConfiguration(context.Log(), context.Client(), "coherence-operator-mutating-webhook-configuration"); err != nil {
+	webhooks := []string{"coherence-operator-mutating-webhook-configuration"}
+	if err := webhook.DeleteMutatingWebhookConfiguration(context.Log(), context.Client(), webhooks); err != nil {
 		return err
 	}
 	return nil

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -79,6 +79,8 @@ const istiodIstioSystem = "istiod-istio-system"
 
 const istioSidecarMutatingWebhook = "istio-sidecar-injector"
 
+const istioRevisionMutatingWebhook = "istio-revision-tag-default"
+
 var istioLabelSelector = clipkg.ListOptions{LabelSelector: labels.Set(map[string]string{"release": "istio"}).AsSelector()}
 
 const (
@@ -450,7 +452,8 @@ func (i istioComponent) PreUpgrade(context spi.ComponentContext) error {
 		}
 	}
 	// Upgrading Istio may result in a duplicate mutating webhook configuration. Istioctl will recreate the webhook during upgrade.
-	return webhook.DeleteMutatingWebhookConfiguration(context.Log(), context.Client(), istioSidecarMutatingWebhook)
+	webhooks := []string{istioSidecarMutatingWebhook, istioRevisionMutatingWebhook}
+	return webhook.DeleteMutatingWebhookConfiguration(context.Log(), context.Client(), webhooks)
 }
 
 func (i istioComponent) PostUpgrade(context spi.ComponentContext) error {

--- a/platform-operator/controllers/verrazzano/component/rancherbackup/testdata/test-bom.json
+++ b/platform-operator/controllers/verrazzano/component/rancherbackup/testdata/test-bom.json
@@ -102,12 +102,12 @@
           "images": [
             {
               "image": "pilot",
-              "tag": "1.15.3",
+              "tag": "1.17.2",
               "helmFullImageKey": "values.pilot.image"
             },
             {
               "image": "proxyv2",
-              "tag": "1.15.3",
+              "tag": "1.17.2",
               "helmImageKey": "values.global.proxy.image",
               "helmTagKey": "values.global.tag",
               "helmRegistryAndRepoKey": "values.global.hub"
@@ -181,7 +181,7 @@
           "images": [
             {
               "image": "proxyv2",
-              "tag": "1.15.3",
+              "tag": "1.17.2",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {
@@ -226,7 +226,7 @@
             },
             {
               "image": "proxyv2",
-              "tag": "1.15.3",
+              "tag": "1.17.2",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {

--- a/platform-operator/helm_config/overrides/istio-cr.yaml
+++ b/platform-operator/helm_config/overrides/istio-cr.yaml
@@ -72,7 +72,7 @@ spec:
   values:
     global:
       hub: ghcr.io/verrazzano
-      tag: 1.15.3
+      tag: 1.17.2
       multiCluster:
         enabled: false
       istioNamespace: istio-system

--- a/platform-operator/repos/ol8-olcne15.repo
+++ b/platform-operator/repos/ol8-olcne15.repo
@@ -1,8 +1,0 @@
-# Copyright (c) 2023, Oracle and/or its affiliates.
-# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-
-[ol8-olcne]
-name=Oracle Linux 8 OLCNE 1.5
-baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/olcne15/x86_64
-gpgcheck=0
-enabled=1

--- a/platform-operator/repos/ol8-olcne17.repo
+++ b/platform-operator/repos/ol8-olcne17.repo
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+[ol8-olcne-1.7]
+name=Oracle Linux 8 OLCNE 1.7
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/olcne17/x86_64
+gpgcheck=0
+enabled=1

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -121,7 +121,7 @@
     },
     {
       "name": "istio",
-      "version": "1.15.3",
+      "version": "1.17.2",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -129,12 +129,12 @@
           "images": [
             {
               "image": "pilot",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.17.2-20230627214838-887ef0a0",
               "helmFullImageKey": "values.pilot.image"
             },
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.17.2-20230627214838-887ef0a0",
               "helmImageKey": "values.global.proxy.image",
               "helmTagKey": "values.global.tag",
               "helmRegistryAndRepoKey": "values.global.hub"
@@ -261,7 +261,7 @@
           "images": [
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.17.2-20230627214838-887ef0a0",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {
@@ -307,7 +307,7 @@
             },
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.17.2-20230627214838-887ef0a0",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {


### PR DESCRIPTION
Upgrade to Istio 1.17.2.

Additional updates:
- Updated istio client apis (go.mod) and third party licenses text file
- Upgraded to kubectl 1.26.6 in verrazzano-platform-operator dockerfile.
- Deleting mutating webhook istio-revision-tag-default on preupgrade due to conflicting errors (error code IST0139) with MutatingWebhookConfiguration istio-sidecar-injector on Verrazzano upgrade (upgrading Istio from v1.15.3 to v1.17.2)

```
[2023-07-24T19:11:03.707Z] 2023-07-24T19:11:02.694Z info Failed running istioctl command /usr/local/bin/istioctl install -y -f /verrazzano/platform-operator/helm_config/overrides/istio-cr.yaml -f /tmp/istio-782601928.yaml -f /tmp/istio-1150836344.yaml --set values.pilot.image=ghcr.io/verrazzano/pilot:1.17.2-20230627214838-887ef0a0 --set values.global.hub=ghcr.io/verrazzano --set values.global.proxy.image=proxyv2 --set values.global.tag=1.17.2-20230627214838-887ef0a0 --set values.global.imagePullSecrets[0]=verrazzano-container-registry: WARNING: Istio control planes installed: 1.15.3.\nWARNING: A newer installed version of Istio has been detected. Running this command will overwrite it.\nError: failed to install manifests: errors occurred during operation: creating default tag would conflict:\nError [IST0139] (MutatingWebhookConfiguration istio-sidecar-injector ) Webhook overlaps with others: [istio-revision-tag-default/namespace.sidecar-injector.istio.io]. This may cause injection to occur twice.\nError [IST0139] (MutatingWebhookConfiguration istio-sidecar-injector ) Webhook overlaps with others: [istio-revision-tag-default/object.sidecar-injector.istio.io]. This may cause injection to occur twice.\nError [IST0139] (MutatingWebhookConfiguration istio-sidecar-injector ) Webhook overlaps with others: [istio-revision-tag-default/rev.namespace.sidecar-injector.istio.io]. This may cause injection to occur twice.\nError [IST0139] (MutatingWebhookConfiguration istio-sidecar-injector ) Webhook overlaps with others: [istio-revision-tag-default/rev.object.sidecar-injector.istio.io]. This may cause injection to occur twice.\n
[2023-07-24T19:11:03.707Z] 2023-07-24T19:11:02.694Z error Failed upgrading component istio, will retry: Failed to run '/usr/local/bin/istioctl install -y -f /verrazzano/platform-operator/helm_config/overrides/istio-cr.yaml -f /tmp/istio-782601928.yaml -f /tmp/istio-1150836344.yaml --set values.pilot.image=ghcr.io/verrazzano/pilot:1.17.2-20230627214838-887ef0a0 --set values.global.hub=ghcr.io/verrazzano --set values.global.proxy.image=proxyv2 --set values.global.tag=1.17.2-20230627214838-887ef0a0 --set values.global.imagePullSecrets[0]=verrazzano-container-registry :  Error exit status 1
[2023-07-24T19:11:03.707Z] 2023-07-24T19:11:03.066Z info Running istioctl command: /usr/local/bin/istioctl install -y -f /verrazzano/platform-operator/helm_config/overrides/istio-cr.yaml -f /tmp/istio-747458770.yaml -f /tmp/istio-2864676108.yaml --set values.pilot.image=ghcr.io/verrazzano/pilot:1.17.2-20230627214838-887ef0a0 --set values.global.hub=ghcr.io/verrazzano --set values.global.proxy.image=proxyv2 --set values.global.tag=1.17.2-20230627214838-887ef0a0 --set values.global.imagePullSecrets[0]=verrazzano-container-registry
```