### PR TITLE
VZ-10117: Fix component availability reporting for uninstalled components (release-1.5)

### DIFF
--- a/platform-operator/controllers/verrazzano/healthcheck/availability_test.go
+++ b/platform-operator/controllers/verrazzano/healthcheck/availability_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package healthcheck

--- a/platform-operator/controllers/verrazzano/healthcheck/availability_test.go
+++ b/platform-operator/controllers/verrazzano/healthcheck/availability_test.go
@@ -4,6 +4,9 @@
 package healthcheck
 
 import (
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -13,8 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
-	"time"
 )
 
 const reldir = "../../../manifests/profiles"
@@ -101,21 +102,25 @@ func TestSetAvailabilityFields(t *testing.T) {
 		name       string
 		components []spi.Component
 		available  string
+		states     []vzapi.CompStateType
 	}{
 		{
 			"no components, no availability",
 			[]spi.Component{},
 			zeroOfZero,
+			[]vzapi.CompStateType{},
 		},
 		{
 			"enabled but not available",
 			[]spi.Component{newFakeComponent(rancher, rancher, vzapi.ComponentUnavailable, true)},
 			"0/1",
+			[]vzapi.CompStateType{vzapi.CompStateInstalling},
 		},
 		{
 			"enabled and available",
 			[]spi.Component{newFakeComponent(rancher, rancher, vzapi.ComponentAvailable, true)},
 			"1/1",
+			[]vzapi.CompStateType{vzapi.CompStateReady},
 		},
 		{
 			"multiple components",
@@ -125,6 +130,15 @@ func TestSetAvailabilityFields(t *testing.T) {
 				newFakeComponent(grafana, grafana, vzapi.ComponentUnavailable, true),
 			},
 			"2/3",
+			[]vzapi.CompStateType{vzapi.CompStateReady, vzapi.CompStateReady, vzapi.CompStateInstalling},
+		},
+		{
+			"uninstalled component",
+			[]spi.Component{
+				newFakeComponent(grafana, grafana, vzapi.ComponentAvailable, false),
+			},
+			"0/0",
+			[]vzapi.CompStateType{vzapi.CompStateUninstalled},
 		},
 	}
 
@@ -137,16 +151,22 @@ func TestSetAvailabilityFields(t *testing.T) {
 					Components: map[string]*vzapi.ComponentStatusDetails{},
 				},
 			}
-			for _, component := range tt.components {
-				if component.IsEnabled(nil) {
-					vz.Status.Components[component.Name()] = &vzapi.ComponentStatusDetails{
-						State: vzapi.CompStateReady,
-					}
+			for i, component := range tt.components {
+				vz.Status.Components[component.Name()] = &vzapi.ComponentStatusDetails{
+					State: tt.states[i],
 				}
 			}
 			status, err := p.newStatus(log, vz, tt.components)
 			assert.NoError(t, err)
 			assert.NotNil(t, status)
+			assert.Equal(t, tt.available, status.Available)
+
+			// make sure any components with a state of "uninstalled" have their availability set to "unavailable"
+			for i, component := range tt.components {
+				if tt.states[i] == vzapi.CompStateUninstalled {
+					assert.Equal(t, vzapi.ComponentUnavailable, string(status.Components[component.Name()]))
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
Backport of fix to availability reporting in the Verrazzano CR status to the release-1.5 branch.

See https://github.com/verrazzano/verrazzano/pull/6305 for details.