### PR TITLE
VZ-10183 Ignore VMC list if the CRD does not exist

### DIFF
--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package appoper

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
@@ -6,7 +6,6 @@ package appoper
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"path/filepath"
 	"strings"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
@@ -113,7 +113,7 @@ func (c applicationOperatorComponent) PostUpgrade(ctx spi.ComponentContext) erro
 	err := ctx.Client().List(clientCtx, &vmcList)
 	// Ignore if CRD doesn't exist
 	if _, ok := err.(*meta.NoKindMatchError); ok {
-		ctx.Log().Debugf("VerrazzanoManagedCluster kind does not exist, skipping ClusterRoleBinding update")
+		ctx.Log().Debugf("VerrazzanoManagedCluster kind does not exist, skipping ClusterRoleBinding delete")
 		return nil
 	}
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_component.go
@@ -6,6 +6,7 @@ package appoper
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"path/filepath"
 	"strings"
 
@@ -110,6 +111,11 @@ func (c applicationOperatorComponent) PostUpgrade(ctx spi.ComponentContext) erro
 	// the system for multicluster.
 	vmcList := vmcv1alpha1.VerrazzanoManagedClusterList{}
 	err := ctx.Client().List(clientCtx, &vmcList)
+	// Ignore if CRD doesn't exist
+	if _, ok := err.(*meta.NoKindMatchError); ok {
+		ctx.Log().Debugf("VerrazzanoManagedCluster kind does not exist, skipping ClusterRoleBinding update")
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/component/appoper/app_operator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/appoper/app_operator_component_test.go
@@ -6,6 +6,8 @@ package appoper
 import (
 	"context"
 	"fmt"
+	"github.com/golang/mock/gomock"
+	"github.com/verrazzano/verrazzano/application-operator/mocks"
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"helm.sh/helm/v3/pkg/action"
@@ -13,6 +15,7 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/time"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	"testing"
 
@@ -121,6 +124,21 @@ func TestAppOperatorPostUpgradeNoDeleteClusterRoleBinding(t *testing.T) {
 			},
 		}).Build()
 	err := NewComponent().PostUpgrade(spi.NewFakeContext(fakeClient, vz, nil, false))
+	assert.NoError(t, err)
+}
+
+// TestAppOperatorPostUpgradeNoDeleteClusterRoleBinding tests the PostUpgrade function
+// GIVEN a call to PostUpgrade
+// WHEN the VMC CRD does not exist
+// THEN no error is returned
+func TestAppOperatorVMCMissing(t *testing.T) {
+	vz := &v1alpha1.Verrazzano{}
+	mocker := gomock.NewController(t)
+	mockClient := mocks.NewMockClient(mocker)
+
+	mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(&meta.NoKindMatchError{})
+
+	err := NewComponent().PostUpgrade(spi.NewFakeContext(mockClient, vz, nil, false))
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
**Changes**
- Ignore the VMC list if no kind error is returned from the list request

**Testing**
- Install 1.5.3 with the cluster operator disabled
- Upgrade to this branch and verify that upgrade completes