### PR TITLE
VZ-10218: Add snapshot of CAPI resources to vz bug-report back port to release-1.6

### DIFF
--- a/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
+++ b/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_types.go
@@ -8,6 +8,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const VerrazzanoManagedClusterKind = "VerrazzanoManagedCluster"
+
 // The VerrazzanoManagedCluster custom resource contains information about a
 // kubernetes cluster where Verrazzano managed applications are deployed.
 

--- a/tools/vz/Makefile
+++ b/tools/vz/Makefile
@@ -1,5 +1,6 @@
 # Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+include ../../make/quality.mk
 
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 VZ_DIR:=github.com$(shell echo ${MAKEFILE_DIR} | sed 's/.*github.com//')

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -7,6 +7,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
@@ -22,12 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"os"
-	"path/filepath"
+	dynfake "k8s.io/client-go/dynamic/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
-	"testing"
 )
 
 const (
@@ -737,10 +739,13 @@ func TestInstallCmdDifferentVersion(t *testing.T) {
 func createNewTestCommandAndBuffers(t *testing.T, c client.Client) (*cobra.Command, *bytes.Buffer, *bytes.Buffer, *testhelpers.FakeRootCmdContext) {
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
+
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	if c != nil {
 		rc.SetClient(c)
 	}
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
+
 	cmd := NewCmdInstall(rc)
 	assert.NotNil(t, cmd)
 	return cmd, buf, errBuf, rc
@@ -806,6 +811,8 @@ func TestAnalyzeCommandDefault(t *testing.T) {
 	}()
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: stdoutFile, ErrOut: stderrFile})
 	rc.SetClient(c)
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
+
 	cmd := analyze.NewCmdAnalyze(rc)
 	assert.NotNil(t, cmd)
 	err = cmd.Execute()

--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	dynfake "k8s.io/client-go/dynamic/fake"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -147,6 +148,7 @@ func TestUninstallCmdDefaultTimeout(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
 	cmd := NewCmdUninstall(rc)
 	assert.NotNil(t, cmd)
 	tempKubeConfigPath, _ := os.CreateTemp(os.TempDir(), testKubeConfig)
@@ -293,6 +295,7 @@ func TestUninstallCmdDefaultNoVPO(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
 	cmd := NewCmdUninstall(rc)
 	assert.NotNil(t, cmd)
 	tempKubeConfigPath, _ := os.CreateTemp(os.TempDir(), testKubeConfig)
@@ -328,6 +331,7 @@ func TestUninstallCmdDefaultNoUninstallJob(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
 	cmd := NewCmdUninstall(rc)
 	assert.NotNil(t, cmd)
 	cmd.PersistentFlags().Set(constants.LogFormatFlag, "simple")
@@ -365,6 +369,7 @@ func TestUninstallCmdDefaultNoVzResource(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
 	cmd := NewCmdUninstall(rc)
 	tempKubeConfigPath, _ := os.CreateTemp(os.TempDir(), testKubeConfig)
 	cmd.Flags().String(constants.GlobalFlagKubeConfig, tempKubeConfigPath.Name(), "")
@@ -440,6 +445,7 @@ func TestUninstallWithConfirmUninstallFlag(t *testing.T) {
 			errBuf := new(bytes.Buffer)
 			rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 			rc.SetClient(c)
+			rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
 			cmd := NewCmdUninstall(rc)
 
 			if tt.fields.doesUninstall {

--- a/tools/vz/cmd/upgrade/upgrade_test.go
+++ b/tools/vz/cmd/upgrade/upgrade_test.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	dynfake "k8s.io/client-go/dynamic/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -83,6 +84,7 @@ func TestUpgradeCmdDefaultTimeoutBugReport(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
 	cmd := NewCmdUpgrade(rc)
 	assert.NotNil(t, cmd)
 	cmd.PersistentFlags().Set(constants.TimeoutFlag, "2ms")
@@ -160,6 +162,7 @@ func TestUpgradeCmdDefaultNoVPO(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
 	cmd := NewCmdUpgrade(rc)
 	assert.NotNil(t, cmd)
 	cmd.PersistentFlags().Set(constants.VersionFlag, "v1.4.0")
@@ -192,6 +195,7 @@ func TestUpgradeCmdDefaultMultipleVPO(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
 	cmd := NewCmdUpgrade(rc)
 	assert.NotNil(t, cmd)
 	cmd.PersistentFlags().Set(constants.VersionFlag, "v1.4.0")
@@ -329,6 +333,7 @@ func TestUpgradeCmdNoVerrazzano(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
 	cmd := NewCmdUpgrade(rc)
 	assert.NotNil(t, cmd)
 
@@ -351,6 +356,7 @@ func TestUpgradeCmdLesserStatusVersion(t *testing.T) {
 	errBuf := new(bytes.Buffer)
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	rc.SetClient(c)
+	rc.SetDynamicClient(dynfake.NewSimpleDynamicClient(helpers.GetScheme()))
 	cmd := NewCmdUpgrade(rc)
 	assert.NotNil(t, cmd)
 	cmd.PersistentFlags().Set(constants.VersionFlag, "v1.3.3")

--- a/tools/vz/pkg/bugreport/reportgen.go
+++ b/tools/vz/pkg/bugreport/reportgen.go
@@ -85,7 +85,7 @@ func CaptureClusterSnapshot(kubeClient kubernetes.Interface, dynamicClient dynam
 		fmt.Fprintf(vzHelper.GetOutputStream(), "\n"+msgPrefix+"resources from the cluster ...\n")
 	}
 	// Capture list of resources from verrazzano-install and verrazzano-system namespaces
-	err = captureResources(client, kubeClient, clusterSnapshotCtx.BugReportDir, vz, vzHelper, nsList)
+	err = captureResources(client, kubeClient, dynamicClient, clusterSnapshotCtx.BugReportDir, vz, vzHelper, nsList)
 	if err != nil {
 		pkghelpers.LogError(fmt.Sprintf("There is an error with capturing the Verrazzano resources: %s", err.Error()))
 	}
@@ -96,13 +96,18 @@ func CaptureClusterSnapshot(kubeClient kubernetes.Interface, dynamicClient dynam
 	}
 
 	// Capture Verrazzano Projects and VerrazzanoManagedCluster
-	if err := captureMultiClusterResources(dynamicClient, clusterSnapshotCtx.BugReportDir, vzHelper); err != nil {
+	if err = captureMultiClusterResources(dynamicClient, clusterSnapshotCtx.BugReportDir, vzHelper); err != nil {
+		return err
+	}
+
+	// Capture global CAPI resources
+	if err = pkghelpers.CaptureGlobalCapiResources(dynamicClient, clusterSnapshotCtx.BugReportDir, vzHelper); err != nil {
 		return err
 	}
 	return nil
 }
 
-func captureResources(client clipkg.Client, kubeClient kubernetes.Interface, bugReportDir string, vz *v1beta1.Verrazzano, vzHelper pkghelpers.VZHelper, namespaces []string) error {
+func captureResources(client clipkg.Client, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface, bugReportDir string, vz *v1beta1.Verrazzano, vzHelper pkghelpers.VZHelper, namespaces []string) error {
 	// List of pods to collect the logs
 	vpoPod, _ := pkghelpers.GetPodList(client, constants.AppLabel, constants.VerrazzanoPlatformOperator, vzconstants.VerrazzanoInstallNamespace)
 	vaoPod, _ := pkghelpers.GetPodList(client, constants.AppLabel, constants.VerrazzanoApplicationOperator, vzconstants.VerrazzanoSystemNamespace)
@@ -123,7 +128,7 @@ func captureResources(client clipkg.Client, kubeClient kubernetes.Interface, bug
 	ecr := make(chan ErrorsChannel, 1)
 	ecl := make(chan ErrorsChannelLogs, 1)
 
-	go captureVZResource(wg, evr, vz, bugReportDir, vzHelper)
+	go captureVZResource(wg, evr, vz, bugReportDir)
 
 	go captureLogs(wg, ecl, kubeClient, Pods{PodList: vpoPod, Namespace: vzconstants.VerrazzanoInstallNamespace}, bugReportDir, vzHelper, 0)
 	go captureLogs(wg, ecl, kubeClient, Pods{PodList: vpoWebHookPod, Namespace: vzconstants.VerrazzanoInstallNamespace}, bugReportDir, vzHelper, 0)
@@ -135,7 +140,7 @@ func captureResources(client clipkg.Client, kubeClient kubernetes.Interface, bug
 		go captureLogs(wg, ecl, kubeClient, Pods{PodList: externalDNSPod, Namespace: vzconstants.CertManager}, bugReportDir, vzHelper, 0)
 	}
 	for _, ns := range namespaces {
-		go captureK8SResources(wg, ecr, kubeClient, ns, bugReportDir, vzHelper)
+		go captureK8SResources(wg, ecr, kubeClient, dynamicClient, ns, bugReportDir, vzHelper)
 	}
 
 	wg.Wait()
@@ -195,9 +200,9 @@ func captureAdditionalLogs(client clipkg.Client, kubeClient kubernetes.Interface
 }
 
 // captureVZResource collects the Verrazzano resource as a JSON, in parallel
-func captureVZResource(wg *sync.WaitGroup, ec chan ErrorsChannel, vz *v1beta1.Verrazzano, bugReportDir string, vzHelper pkghelpers.VZHelper) {
+func captureVZResource(wg *sync.WaitGroup, ec chan ErrorsChannel, vz *v1beta1.Verrazzano, bugReportDir string) {
 	defer wg.Done()
-	err := pkghelpers.CaptureVZResource(bugReportDir, vz, vzHelper)
+	err := pkghelpers.CaptureVZResource(bugReportDir, vz)
 	if err != nil {
 		ec <- ErrorsChannel{ErrorMessage: err.Error()}
 	}
@@ -219,9 +224,9 @@ func captureLogs(wg *sync.WaitGroup, ec chan ErrorsChannelLogs, kubeClient kuber
 }
 
 // captureK8SResources captures Kubernetes workloads, pods, events, ingresses and services from the list of namespaces in parallel
-func captureK8SResources(wg *sync.WaitGroup, ec chan ErrorsChannel, kubeClient kubernetes.Interface, namespace, bugReportDir string, vzHelper pkghelpers.VZHelper) {
+func captureK8SResources(wg *sync.WaitGroup, ec chan ErrorsChannel, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface, namespace, bugReportDir string, vzHelper pkghelpers.VZHelper) {
 	defer wg.Done()
-	if err := pkghelpers.CaptureK8SResources(kubeClient, namespace, bugReportDir, vzHelper); err != nil {
+	if err := pkghelpers.CaptureK8SResources(kubeClient, dynamicClient, namespace, bugReportDir, vzHelper); err != nil {
 		ec <- ErrorsChannel{ErrorMessage: err.Error()}
 	}
 }

--- a/tools/vz/pkg/helpers/scheme.go
+++ b/tools/vz/pkg/helpers/scheme.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helpers
+
+import (
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	vmcv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func GetScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+	_ = clustersv1alpha1.AddToScheme(scheme)
+	_ = vmcv1alpha1.AddToScheme(scheme)
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: clustersv1alpha1.SchemeGroupVersion.Group, Version: clustersv1alpha1.SchemeGroupVersion.Version, Kind: clustersv1alpha1.VerrazzanoProjectKind + "List"}, &clustersv1alpha1.VerrazzanoProjectList{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: vmcv1alpha1.SchemeGroupVersion.Group, Version: vmcv1alpha1.SchemeGroupVersion.Version, Kind: vmcv1alpha1.VerrazzanoManagedClusterKind + "List"}, &vmcv1alpha1.VerrazzanoManagedClusterList{})
+	AddCapiToScheme(scheme)
+	return scheme
+}
+
+func AddCapiToScheme(scheme *runtime.Scheme) {
+	for _, resource := range capiNamespacedResources {
+		scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: resource.GVR.Group, Version: resource.GVR.Version, Kind: resource.Kind + "List"}, &unstructured.Unstructured{})
+	}
+	for _, resource := range capiResources {
+		scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: resource.GVR.Group, Version: resource.GVR.Version, Kind: resource.Kind + "List"}, &unstructured.Unstructured{})
+	}
+}

--- a/tools/vz/pkg/helpers/vzcapture.go
+++ b/tools/vz/pkg/helpers/vzcapture.go
@@ -10,13 +10,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	oamcore "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	clustersv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	vzoamapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
-	"io"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,10 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"os"
-	"path/filepath"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 var errBugReport = "an error occurred while creating the bug report: %s"
@@ -91,7 +92,7 @@ func CreateReportArchive(captureDir string, bugRepFile *os.File) error {
 
 // CaptureK8SResources collects the Workloads (Deployment and ReplicaSet, StatefulSet, Daemonset), pods, events, ingress
 // and services from the specified namespace, as JSON files
-func CaptureK8SResources(kubeClient kubernetes.Interface, namespace, captureDir string, vzHelper VZHelper) error {
+func CaptureK8SResources(kubeClient kubernetes.Interface, dynamicClient dynamic.Interface, namespace, captureDir string, vzHelper VZHelper) error {
 	if err := captureWorkLoads(kubeClient, namespace, captureDir, vzHelper); err != nil {
 		return err
 	}
@@ -105,6 +106,9 @@ func CaptureK8SResources(kubeClient kubernetes.Interface, namespace, captureDir 
 		return err
 	}
 	if err := captureServices(kubeClient, namespace, captureDir, vzHelper); err != nil {
+		return err
+	}
+	if err := captureCapiNamespacedResources(dynamicClient, namespace, captureDir, vzHelper); err != nil {
 		return err
 	}
 	return nil
@@ -154,7 +158,7 @@ func GetPodListAll(client clipkg.Client, namespace string) ([]corev1.Pod, error)
 }
 
 // CaptureVZResource captures Verrazzano resources as a JSON file
-func CaptureVZResource(captureDir string, vz *v1beta1.Verrazzano, vzHelper VZHelper) error {
+func CaptureVZResource(captureDir string, vz *v1beta1.Verrazzano) error {
 	var vzRes = filepath.Join(captureDir, constants.VzResource)
 	f, err := os.OpenFile(vzRes, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
@@ -284,7 +288,7 @@ func captureWorkLoads(kubeClient kubernetes.Interface, namespace, captureDir str
 	return nil
 }
 
-// captureLog captures the log from the pod in the captureDir
+// CapturePodLog captures the log from the pod in the captureDir
 func CapturePodLog(kubeClient kubernetes.Interface, pod corev1.Pod, namespace, captureDir string, vzHelper VZHelper, duration int64) error {
 	podName := pod.Name
 	if len(podName) == 0 {
@@ -436,7 +440,7 @@ func GetVZManagedNamespaces(kubeClient kubernetes.Interface) []string {
 // RemoveDuplicate removes duplicates from origSlice
 func RemoveDuplicate(origSlice []string) []string {
 	allKeys := make(map[string]bool)
-	returnSlice := []string{}
+	var returnSlice []string
 	for _, item := range origSlice {
 		if _, value := allKeys[item]; !value {
 			allKeys[item] = true

--- a/tools/vz/pkg/helpers/vzcapture_capi.go
+++ b/tools/vz/pkg/helpers/vzcapture_capi.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	v1Alpha1            = "v1alpha1"
+	v1Alpha3            = "v1alpha3"
+	v1Beta1             = "v1beta1"
+	v1Beta2             = "v1beta2"
+	addonsGroup         = "addons.cluster.x-k8s.io"
+	bootstrapGroup      = "bootstrap.cluster.x-k8s.io"
+	clusterGroup        = "cluster.x-k8s.io"
+	clusterctlGroup     = "clusterctl.cluster.x-k8s.io"
+	controlPlaneGroup   = "controlplane.cluster.x-k8s.io"
+	infrastructureGroup = "infrastructure.cluster.x-k8s.io"
+	ipamGroup           = "ipam.cluster.x-k8s.io"
+	managementGroup     = "management.cattle.io"
+	runtimeGroup        = "runtime.cluster.x-k8s.io"
+)
+
+type capiResource struct {
+	GVR  schema.GroupVersionResource
+	Kind string
+}
+
+// capiResources - resources that are not namespaced
+var capiResources = []capiResource{
+	{GVR: schema.GroupVersionResource{Group: runtimeGroup, Version: v1Alpha1, Resource: "extensionconfigs"}, Kind: "ExtensionConfig"},
+	{GVR: schema.GroupVersionResource{Group: managementGroup, Version: "v3", Resource: "kontainerdrivers"}, Kind: "KontainerDriver"},
+}
+
+// capiNamespacedResources - resources that are namespaced
+var capiNamespacedResources = []capiResource{
+	{GVR: schema.GroupVersionResource{Group: addonsGroup, Version: v1Beta1, Resource: "clusterresourcesetbindings"}, Kind: "ClusterResourceSetBinding"},
+	{GVR: schema.GroupVersionResource{Group: addonsGroup, Version: v1Beta1, Resource: "clusterresourcesets"}, Kind: "ClusterResourceSet"},
+	{GVR: schema.GroupVersionResource{Group: bootstrapGroup, Version: v1Alpha1, Resource: "ocneconfigs"}, Kind: "OCNEConfig"},
+	{GVR: schema.GroupVersionResource{Group: bootstrapGroup, Version: v1Alpha1, Resource: "ocneconfigtemplates"}, Kind: "OCNEConfigTemplate"},
+	{GVR: schema.GroupVersionResource{Group: clusterGroup, Version: v1Beta1, Resource: "clusterclasses"}, Kind: "ClusterClass"},
+	{GVR: schema.GroupVersionResource{Group: clusterGroup, Version: v1Beta1, Resource: "clusters"}, Kind: "Cluster"},
+	{GVR: schema.GroupVersionResource{Group: clusterGroup, Version: v1Beta1, Resource: "machinedeployments"}, Kind: "MachineDeployment"},
+	{GVR: schema.GroupVersionResource{Group: clusterGroup, Version: v1Beta1, Resource: "machinehealthchecks"}, Kind: "MachineHealthCheck"},
+	{GVR: schema.GroupVersionResource{Group: clusterGroup, Version: v1Beta1, Resource: "machinepools"}, Kind: "MachinePool"},
+	{GVR: schema.GroupVersionResource{Group: clusterGroup, Version: v1Beta1, Resource: "machines"}, Kind: "Machine"},
+	{GVR: schema.GroupVersionResource{Group: clusterGroup, Version: v1Beta1, Resource: "machinesets"}, Kind: "MachineSet"},
+	{GVR: schema.GroupVersionResource{Group: clusterctlGroup, Version: v1Alpha3, Resource: "providers"}, Kind: "Provider"},
+	{GVR: schema.GroupVersionResource{Group: controlPlaneGroup, Version: v1Alpha1, Resource: "ocnecontrolplanes"}, Kind: "OCNEControlPlane"},
+	{GVR: schema.GroupVersionResource{Group: controlPlaneGroup, Version: v1Alpha1, Resource: "ocnecontrolplanetemplates"}, Kind: "OCNEControlPlaneTemplate"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ociclusteridentities"}, Kind: "OCIClusterIdentity"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ociclusters"}, Kind: "OCICluster"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ociclustertemplates"}, Kind: "OCIClusterTemplate"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ocimachinepools"}, Kind: "OCIMachinePool"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ocimachines"}, Kind: "OCIMachine"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ocimachinetemplates"}, Kind: "OCIMachineTemplate"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ocimanagedclusters"}, Kind: "OCIManagedCluster"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ocimanagedclustertemplates"}, Kind: "OCIManagedClusterTemplate"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ocimanagedcontrolplanes"}, Kind: "OCIManagedControlPlane"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ocimanagedcontrolplanetemplates"}, Kind: "OCIManagedControlPlaneTemplate"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ocimanagedmachinepools"}, Kind: "OCIManagedMachinePool"},
+	{GVR: schema.GroupVersionResource{Group: infrastructureGroup, Version: v1Beta2, Resource: "ocimanagedmachinepooltemplates"}, Kind: "OCIManagedMachinePoolTemplate"},
+	{GVR: schema.GroupVersionResource{Group: ipamGroup, Version: v1Alpha1, Resource: "ipaddressclaims"}, Kind: "IPAddressClaim"},
+	{GVR: schema.GroupVersionResource{Group: ipamGroup, Version: v1Alpha1, Resource: "ipaddresses"}, Kind: "IPAddress"},
+}
+
+// CaptureGlobalCapiResources captures global resources related to ClusterAPI
+func CaptureGlobalCapiResources(dynamicClient dynamic.Interface, captureDir string, vzHelper VZHelper) error {
+	for _, resource := range capiResources {
+		if err := captureGlobalResource(dynamicClient, resource.GVR, resource.Kind, captureDir, vzHelper); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// captureCapiNamespacedResources captures resources related to ClusterAPI
+func captureCapiNamespacedResources(dynamicClient dynamic.Interface, namespace, captureDir string, vzHelper VZHelper) error {
+	for _, resource := range capiNamespacedResources {
+		if err := captureNamespacedResource(dynamicClient, resource.GVR, resource.Kind, namespace, captureDir, vzHelper); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func captureGlobalResource(dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, kind string, captureDir string, vzHelper VZHelper) error {
+	namespace := "default"
+	list, err := dynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		LogError(fmt.Sprintf("An error occurred while listing %s in namespace %s: %s\n", kind, namespace, err.Error()))
+		return nil
+	}
+	if len(list.Items) > 0 {
+		LogMessage(fmt.Sprintf("%s in namespace: %s ...\n", kind, namespace))
+		if err = createFile(list, namespace, fmt.Sprintf("%s.json", strings.ToLower(kind)), captureDir, vzHelper); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func captureNamespacedResource(dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, kind string, namespace, captureDir string, vzHelper VZHelper) error {
+	list, err := dynamicClient.Resource(gvr).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		LogError(fmt.Sprintf("An error occurred while listing %s in namespace %s: %s\n", kind, namespace, err.Error()))
+		return nil
+	}
+	if len(list.Items) > 0 {
+		LogMessage(fmt.Sprintf("%s in namespace: %s ...\n", kind, namespace))
+		if err = createFile(list, namespace, fmt.Sprintf("%s.json", strings.ToLower(kind)), captureDir, vzHelper); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tools/vz/pkg/helpers/vzsanitize.go
+++ b/tools/vz/pkg/helpers/vzsanitize.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helpers
@@ -12,11 +12,17 @@ import (
 var regexToReplacementList = []string{}
 
 const ipv4Regex = "[[:digit:]]{1,3}\\.[[:digit:]]{1,3}\\.[[:digit:]]{1,3}\\.[[:digit:]]{1,3}"
+const userData = "\"user_data\":\\s+\"[A-Za-z0-9=+]+\""
+const sshAuthKeys = "\"ssh_authorized_keys\":\\s+\"[A-Za-z0-9=+ \\-\\/@]+\""
+const ocid = "ocid1\\.[[:lower:]]+\\.[[:alnum:]]+\\.[[:alnum:]]*\\.[[:alnum:]]+"
 
 // InitRegexToReplacementMap Initialize the regex string to replacement string map
 // Append to this map for any future additions
 func InitRegexToReplacementMap() {
 	regexToReplacementList = append(regexToReplacementList, ipv4Regex)
+	regexToReplacementList = append(regexToReplacementList, userData)
+	regexToReplacementList = append(regexToReplacementList, sshAuthKeys)
+	regexToReplacementList = append(regexToReplacementList, ocid)
 }
 
 // SanitizeString sanitizes each line in a given file,

--- a/tools/vz/test/helpers/fake_cmd_context.go
+++ b/tools/vz/test/helpers/fake_cmd_context.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
 	"k8s.io/client-go/discovery"
 	discoveryFake "k8s.io/client-go/discovery/fake"
 
@@ -115,6 +116,11 @@ func (rc *FakeRootCmdContext) GetHTTPClient() *http.Client {
 // GetDynamicClient - return a dynamic client for use with the fake go-client
 func (rc *FakeRootCmdContext) GetDynamicClient(cmd *cobra.Command) (dynamic.Interface, error) {
 	return rc.dynamicClient, nil
+}
+
+// SetDynamicClient - set a dynamic client for use with the fake go-client (used for testing)
+func (rc *FakeRootCmdContext) SetDynamicClient(dynClient dynamic.Interface) {
+	rc.dynamicClient = dynClient
 }
 
 func NewFakeRootCmdContext(streams genericclioptions.IOStreams) *FakeRootCmdContext {


### PR DESCRIPTION
VZ-10218: Add snapshot of CAPI resources to vz bug-report

Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
