### PR TITLE
Fix release-1.5 HA pipeline

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -32,7 +32,8 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value, use older version as default to ensure cluster will perform upgrade
-                choices: [ "v1.23.4", "v1.22.5", "v1.21.5", "v1.24.1" ])
+                // NOTE: 1.5 officially supports up to k8s 1.24, and 1.24 is currently the oldest OKE version available
+                choices: [ "v1.24.1" ])
         choice (name: 'OKE_NODE_POOL',
                 description: 'OKE node pool configuration',
                 // 1st choice is the default value

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1
@@ -6,11 +6,12 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/validators"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	v1 "k8s.io/api/core/v1"
-	"strings"
 
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,6 +59,10 @@ func (v *Verrazzano) ValidateCreate() error {
 		return nil
 	}
 
+	if err := validators.ValidateKubernetesVersionSupported(); err != nil {
+		return err
+	}
+
 	// Verify only one instance of the operator is running
 	if err := v.verifyPlatformOperatorSingleton(); err != nil {
 		return err
@@ -102,6 +107,10 @@ func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
 	if !config.Get().WebhookValidationEnabled {
 		log.Info("Validation disabled, skipping")
 		return nil
+	}
+
+	if err := validators.ValidateKubernetesVersionSupported(); err != nil {
+		return err
 	}
 
 	// Verify only one instance of the operator is running

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook_test.go
@@ -1,13 +1,15 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1
 
 import (
 	goerrors "errors"
+	"fmt"
+	"testing"
+
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/validators"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
@@ -19,14 +21,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// k8sVersionValidFunc returns no error when the K8S version of the "cluster" is validated during
+// unit tests
+var k8sVersionValidFunc = func() error { return nil }
+
 // TestCreateCallbackSuccessWithVersion Tests the create callback with valid spec version
 // GIVEN a ValidateCreate() request with a valid version
 // WHEN the version provided is a valid version
 // THEN no error is returned
 func TestCreateCallbackSuccessWithVersion(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
+	k8sVersionCheckOrig := validators.ValidateKubernetesVersionSupported
+	validators.ValidateKubernetesVersionSupported = k8sVersionValidFunc
 	defer func() {
 		config.SetDefaultBomFilePath("")
+		validators.ValidateKubernetesVersionSupported = k8sVersionCheckOrig
 	}()
 
 	getControllerRuntimeClient = func(scheme *runtime.Scheme) (client.Client, error) {
@@ -49,8 +58,11 @@ func TestCreateCallbackSuccessWithVersion(t *testing.T) {
 // THEN no error is returned
 func TestCreateCallbackSuccessWithoutVersion(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
+	k8sVersionCheckOrig := validators.ValidateKubernetesVersionSupported
+	validators.ValidateKubernetesVersionSupported = k8sVersionValidFunc
 	defer func() {
 		config.SetDefaultBomFilePath("")
+		validators.ValidateKubernetesVersionSupported = k8sVersionCheckOrig
 	}()
 
 	getControllerRuntimeClient = func(scheme *runtime.Scheme) (client.Client, error) {
@@ -112,8 +124,11 @@ func runCreateCallbackWithInvalidVersion(t *testing.T) error {
 // THEN no error is returned
 func TestUpdateCallbackSuccessWithNewVersion(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
+	k8sVersionCheckOrig := validators.ValidateKubernetesVersionSupported
+	validators.ValidateKubernetesVersionSupported = k8sVersionValidFunc
 	defer func() {
 		config.SetDefaultBomFilePath("")
+		validators.ValidateKubernetesVersionSupported = k8sVersionCheckOrig
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -144,8 +159,11 @@ func TestUpdateCallbackSuccessWithNewVersion(t *testing.T) {
 // THEN no error is returned
 func TestUpdateCallbackSuccessWithOldAndNewVersion(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
+	k8sVersionCheckOrig := validators.ValidateKubernetesVersionSupported
+	validators.ValidateKubernetesVersionSupported = k8sVersionValidFunc
 	defer func() {
 		config.SetDefaultBomFilePath("")
+		validators.ValidateKubernetesVersionSupported = k8sVersionCheckOrig
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -317,8 +335,11 @@ func runUpdateCallbackChangedProfileTest() error {
 // THEN no error is returned
 func TestDefaultProfileWithProd(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
+	k8sVersionCheckOrig := validators.ValidateKubernetesVersionSupported
+	validators.ValidateKubernetesVersionSupported = k8sVersionValidFunc
 	defer func() {
 		config.SetDefaultBomFilePath("")
+		validators.ValidateKubernetesVersionSupported = k8sVersionCheckOrig
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{},
@@ -341,8 +362,11 @@ func TestDefaultProfileWithProd(t *testing.T) {
 // THEN no error is returned
 func TestDefaultWithProd(t *testing.T) {
 	config.SetDefaultBomFilePath(testBomFilePath)
+	k8sVersionCheckOrig := validators.ValidateKubernetesVersionSupported
+	validators.ValidateKubernetesVersionSupported = k8sVersionValidFunc
 	defer func() {
 		config.SetDefaultBomFilePath("")
+		validators.ValidateKubernetesVersionSupported = k8sVersionCheckOrig
 	}()
 	oldSpec := &Verrazzano{
 		Spec: VerrazzanoSpec{
@@ -507,4 +531,34 @@ func TestUpdateMissingOciLoggingApiSecret(t *testing.T) {
 		getControllerRuntimeClient = validators.GetClient
 	}()
 	assert.Error(t, newSpec.ValidateUpdate(oldSpec))
+}
+
+// TestInvalidClusterK8SVersion Tests the create and update callbacks when the cluster's K8S version is unsupported
+// GIVEN a ValidateCreate() or ValidateUpdate() request
+// WHEN the cluster K8S version is unsupported
+// THEN an error is returned
+func TestInvalidClusterK8SVersion(t *testing.T) {
+	config.SetDefaultBomFilePath(testBomFilePath)
+	k8sVersionCheckOrig := validators.ValidateKubernetesVersionSupported
+	errMsg := "fake validator invalid kubernetes version"
+	validators.ValidateKubernetesVersionSupported = func() error {
+		return fmt.Errorf(errMsg)
+	}
+	defer func() {
+		config.SetDefaultBomFilePath("")
+		validators.ValidateKubernetesVersionSupported = k8sVersionCheckOrig
+	}()
+
+	getControllerRuntimeClient = func(scheme *runtime.Scheme) (client.Client, error) {
+		return fake.NewClientBuilder().WithScheme(newScheme()).Build(), nil
+	}
+	defer func() { getControllerRuntimeClient = validators.GetClient }()
+
+	currentSpec := &Verrazzano{
+		Spec: VerrazzanoSpec{
+			Profile: "dev",
+		},
+	}
+	assert.ErrorContains(t, currentSpec.ValidateCreate(), errMsg)
+	assert.ErrorContains(t, currentSpec.ValidateUpdate(currentSpec), errMsg)
 }

--- a/platform-operator/apis/verrazzano/v1beta1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1beta1/verrazzano_webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1beta1
@@ -6,8 +6,9 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/validators"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
@@ -58,6 +59,10 @@ func (v *Verrazzano) ValidateCreate() error {
 		return nil
 	}
 
+	if err := validators.ValidateKubernetesVersionSupported(); err != nil {
+		return err
+	}
+
 	client, err := getControllerRuntimeClient(newScheme())
 	if err != nil {
 		return err
@@ -102,6 +107,10 @@ func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
 	if !config.Get().WebhookValidationEnabled {
 		log.Info("Validation disabled, skipping")
 		return nil
+	}
+
+	if err := validators.ValidateKubernetesVersionSupported(); err != nil {
+		return err
 	}
 
 	// Verify only one instance of the operator is running

--- a/platform-operator/apis/verrazzano/validators/validate_test.go
+++ b/platform-operator/apis/verrazzano/validators/validate_test.go
@@ -210,7 +210,7 @@ func TestValidateNewVersionforInvalidVersions(t *testing.T) {
 // WHEN the respective version string are not in accordance with the rules
 // THEN an error is returned
 func TestValidateNewVersion(t *testing.T) {
-	//can add the case to test each of them separately, when they are invalid
+	// can add the case to test each of them separately, when they are invalid
 	config.SetDefaultBomFilePath(testBomFilePath)
 	defer func() {
 		config.SetDefaultBomFilePath("")
@@ -510,65 +510,65 @@ func Test_cleanTempFiles(t *testing.T) {
 	}
 }
 
-// TestIsKubernetesVersionSupported tests IsKubernetesVersionSupported()
+// TestValidateKubernetesVersionSupported tests ValidateKubernetesVersionSupported()
 // GIVEN a request for the validating that the Kubernetes version of cluster is supported by the operator
 // WHEN the Kubernetes version and Supported versions can be determined without error
 // AND the Kubernetes version is either equal to one of the supported versions or is a patch version of a supported version
-// THEN only true is returned
-func TestIsKubernetesVersionSupported(t *testing.T) {
+// THEN no error is returned, otherwise an error is returned
+func TestValidateKubernetesVersionSupported(t *testing.T) {
 	tests := []struct {
 		name                               string
 		getSupportedKubernetesVersionsFunc func() ([]string, error)
 		getKubernetesVersionFunc           func() (string, error)
-		result                             bool
+		expectSuccess                      bool
 	}{
 		{
 			name:                               "testFailGettingSupportedVersions",
 			getSupportedKubernetesVersionsFunc: func() ([]string, error) { return nil, fmt.Errorf("errored out") },
 			getKubernetesVersionFunc:           func() (string, error) { return "v0.1.5", nil },
-			result:                             false,
+			expectSuccess:                      false,
 		},
 		{
 			name:                               "testFailGettingKubernetesVersion",
 			getSupportedKubernetesVersionsFunc: func() ([]string, error) { return []string{"v0.1.0", "v0.2.0"}, nil },
 			getKubernetesVersionFunc:           func() (string, error) { return "", fmt.Errorf("errored out") },
-			result:                             false,
+			expectSuccess:                      false,
 		},
 		{
 			name:                               "testPassNoSupportedVersionsInBom",
 			getSupportedKubernetesVersionsFunc: func() ([]string, error) { return nil, nil },
 			getKubernetesVersionFunc:           func() (string, error) { return "", fmt.Errorf("errored out") },
-			result:                             true,
+			expectSuccess:                      true,
 		},
 		{
 			name:                               "testFailInvalidSupportedVersionsInBom",
 			getSupportedKubernetesVersionsFunc: func() ([]string, error) { return []string{"v1.2.0", "vx.y"}, nil },
 			getKubernetesVersionFunc:           func() (string, error) { return "v1.3.9", nil },
-			result:                             false,
+			expectSuccess:                      false,
 		},
 		{
 			name:                               "testFailInvalidKubernetesVersions",
 			getSupportedKubernetesVersionsFunc: func() ([]string, error) { return []string{"v1.2.0", "v1.3.0"}, nil },
 			getKubernetesVersionFunc:           func() (string, error) { return "vx.y", nil },
-			result:                             false,
+			expectSuccess:                      false,
 		},
 		{
 			name:                               "testPassExactSupportedKubernetesVersion",
 			getSupportedKubernetesVersionsFunc: func() ([]string, error) { return []string{"v1.2.5", "v1.3.0"}, nil },
 			getKubernetesVersionFunc:           func() (string, error) { return "v1.2.5", nil },
-			result:                             true,
+			expectSuccess:                      true,
 		},
 		{
 			name:                               "testPassPatchSupportedKubernetesVersion",
 			getSupportedKubernetesVersionsFunc: func() ([]string, error) { return []string{"v1.2.5", "v1.3.0"}, nil },
 			getKubernetesVersionFunc:           func() (string, error) { return "v1.3.8", nil },
-			result:                             true,
+			expectSuccess:                      true,
 		},
 		{
 			name:                               "testPassNotSupportedKubernetesVersion",
 			getSupportedKubernetesVersionsFunc: func() ([]string, error) { return []string{"v1.2.5", "v1.3.0"}, nil },
 			getKubernetesVersionFunc:           func() (string, error) { return "v1.4.8", nil },
-			result:                             false,
+			expectSuccess:                      false,
 		},
 	}
 	for _, tt := range tests {
@@ -582,7 +582,11 @@ func TestIsKubernetesVersionSupported(t *testing.T) {
 				getKubernetesClusterVersion = getKubernetesVersionOriginal
 
 			}()
-			assert.Equal(t, tt.result, IsKubernetesVersionSupported())
+			if tt.expectSuccess {
+				assert.NoError(t, ValidateKubernetesVersionSupported())
+			} else {
+				assert.Error(t, ValidateKubernetesVersionSupported())
+			}
 		})
 	}
 }

--- a/platform-operator/apis/verrazzano/validators/validate_test.go
+++ b/platform-operator/apis/verrazzano/validators/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package validators

--- a/platform-operator/main.go
+++ b/platform-operator/main.go
@@ -113,10 +113,6 @@ func main() {
 		internalconfig.SetDefaultBomFilePath(bomOverride)
 	}
 
-	if !validators.IsKubernetesVersionSupported() {
-		os.Exit(1)
-	}
-
 	// Log the Verrazzano version
 	version, err := validators.GetCurrentBomVersion()
 	if err == nil {


### PR DESCRIPTION
This PR fixes the HA pipeline in the release-1.5 periodic tests. There are two changes:
1. Adjust the OKE versions in the Jenkinsfile
2. Backport a change to the way the Kubernetes version is checked
