### PR TITLE
VZ-10181 cleanup argocd during uninstall

### DIFF
--- a/platform-operator/controllers/verrazzano/component/argocd/argocd.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/argocd.go
@@ -93,7 +93,8 @@ func removeArgoResourceKind(ctx spi.ComponentContext, kind string) error {
 	if err := c.List(context.TODO(), &resources, client.InNamespace(constants.ArgoCDNamespace)); err != nil {
 		return err
 	}
-	for _, resource := range resources.Items {
+	for i := range resources.Items {
+		resource := resources.Items[i]
 		// for each resource delete the finalizer and then delete the resource
 		_, err := controllerruntime.CreateOrUpdate(context.TODO(), c, &resource, func() error {
 			resource.SetFinalizers([]string{})

--- a/platform-operator/controllers/verrazzano/component/argocd/argocd.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/argocd.go
@@ -4,6 +4,7 @@
 package argocd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
@@ -11,8 +12,13 @@ import (
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Constants for Kubernetes resource names
@@ -63,4 +69,45 @@ func isArgoCDReady(ctx spi.ComponentContext) bool {
 	}
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
 	return ready.DeploymentsAreReady(ctx.Log(), ctx.Client(), deployments, 1, prefix)
+}
+
+// remove stale argo app, app set, and project resources
+func removeArgoResources(ctx spi.ComponentContext) error {
+	if err := removeArgoResourceKind(ctx, common.ArgoCDKindApplication); err != nil {
+		return err
+	}
+	if err := removeArgoResourceKind(ctx, common.ArgoCDKindApplicationSet); err != nil {
+		return err
+	}
+	if err := removeArgoResourceKind(ctx, common.ArgoCDKindAppProject); err != nil {
+		return err
+	}
+	return nil
+}
+
+// removeArgoResourceKind iterates through the ArgoCD resources installed, removes the finalizer, and deletes them
+func removeArgoResourceKind(ctx spi.ComponentContext, kind string) error {
+	c := ctx.Client()
+	resources := unstructured.UnstructuredList{}
+	resources.SetGroupVersionKind(common.GetArgoProjAPIGVRForResource(kind))
+	if err := c.List(context.TODO(), &resources, client.InNamespace(constants.ArgoCDNamespace)); err != nil {
+		return err
+	}
+	for _, resource := range resources.Items {
+		// for each resource delete the finalizer and then delete the resource
+		_, err := controllerruntime.CreateOrUpdate(context.TODO(), c, &resource, func() error {
+			resource.SetFinalizers([]string{})
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("Error removing finalizer stale ArgoCD %s resource %s", kind, resource.GetName())
+		}
+
+		err = c.Delete(context.TODO(), &resource)
+		if err != nil {
+			return fmt.Errorf("Error removing finalizer stale ArgoCD %s resource %s", kind, resource.GetName())
+
+		}
+	}
+	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/argocd/argocd_component.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/argocd_component.go
@@ -5,7 +5,6 @@ package argocd
 
 import (
 	"fmt"
-	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
@@ -14,6 +13,7 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
@@ -158,6 +158,15 @@ func (c argoCDComponent) PostUpgrade(ctx spi.ComponentContext) error {
 		return err
 	}
 	return c.HelmComponent.PostUpgrade(ctx)
+}
+
+// PostUninstall runs the ArgoCD PostUninstall function
+// Remove the argo application resources
+func (c argoCDComponent) PostUninstall(ctx spi.ComponentContext) error {
+	if err := removeArgoResources(ctx); err != nil {
+		return err
+	}
+	return c.HelmComponent.PostUninstall(ctx)
 }
 
 // ConfigureKeycloakOIDC

--- a/platform-operator/controllers/verrazzano/component/common/argocd.go
+++ b/platform-operator/controllers/verrazzano/component/common/argocd.go
@@ -3,6 +3,10 @@
 
 package common
 
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
 // ArgoCD HTTPS Configuration
 const (
 	ArgoCDCompName      = "argoCD"
@@ -22,3 +26,21 @@ const (
 	ArgoCDRepoServer               = "argocd-repo-server"
 	ArgoCDServer                   = "argocd-server"
 )
+
+// ArgoCD GVK
+const (
+	ArgoCDAPIGroup           = "argoproj.io"
+	ArgoCDKindApplication    = "Application"
+	ArgoCDKindAppProject     = "AppProject"
+	ArgoCDKindApplicationSet = "ApplicationSet"
+	ArgoCDAPIVersion         = "v1alpha1"
+)
+
+// func GetArgoProjAPIGVRForResource returns a argoproj.io/v1alpha1 GroupVersionResource structure for specified kind
+func GetArgoProjAPIGVRForResource(kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   ArgoCDAPIGroup,
+		Version: ArgoCDAPIVersion,
+		Kind:    kind,
+	}
+}


### PR DESCRIPTION
Uninstall does not clean up the argocd resources that get created when an app gets deployed. If a user chooses to configure an app with a finalizer, that will stop the deletion of the argocd namespace and cause uninstall to fail. This change removes the finalizer and deletes the application, applicationset, and appproject argocd resources in the argo postuninstall step.