### PR TITLE
Increase timeout from 60 to 90 minutes for Kind pipeline

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -7,7 +7,7 @@ def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {
     options {
-        timeout(time: 1, unit: 'HOURS')
+        timeout(time: 90, unit: 'MINUTES')
         skipDefaultCheckout true
         timestamps ()
     }


### PR DESCRIPTION
The timeout is 90 minutes on master and release-1.6, and the release-1.5 periodics have some timeouts for Kind tests because they usually take right around 1 hour to complete, so bumping this timeout so it aligns with other branches.