### PR TITLE
VZ-10217 check if Rancher driver provisioned before deleting cattle-system and resources

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -741,6 +741,7 @@ func IsClusterProvisionedByRancher() (bool, error) {
 
 // IsClusterProvisionedByOCNEContainerDriver checks if the Kubernetes cluster was provisioned by the Rancher OCNE container driver.
 func IsClusterProvisionedByOCNEContainerDriver() (bool, error) {
+	vzlog.DefaultLogger().Infof("DEBUG:  IsClusterProvisionedByOCNEContainerDriver called")
 	client, err := k8sutil.GetCoreV1Func()
 	if err != nil {
 		return false, err
@@ -749,6 +750,7 @@ func IsClusterProvisionedByOCNEContainerDriver() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	vzlog.DefaultLogger().Infof("DEBUG:  IsClusterProvisionedByOCNEContainerDriver calling %v", checkContainerDriverProvisionedFunc)
 
 	return checkContainerDriverProvisionedFunc(client, dynClient)
 }
@@ -801,6 +803,7 @@ func checkContainerDriverProvisioned(client corev1.CoreV1Interface, dynClient dy
 		return false, nil
 	}
 	if err != nil {
+		vzlog.DefaultLogger().Infof("DEBUG:  checkContainerDriverProvisioned called.  Returning error %v", err)
 		return false, err
 	}
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -801,7 +801,6 @@ func checkContainerDriverProvisioned(client corev1.CoreV1Interface, dynClient dy
 		return false, nil
 	}
 	if err != nil {
-		vzlog.DefaultLogger().Infof("DEBUG:  checkContainerDriverProvisioned called.  Returning error %v", err)
 		return false, err
 	}
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -71,6 +71,9 @@ const cattleUIEnvName = "CATTLE_UI_OFFLINE_PREFERRED"
 // fluentbitFilterAndParserTemplate is the template name that consists Fluentbit Filter and Parser resource for Istio.
 const fluentbitFilterAndParserTemplate = "rancher-filter-parser.yaml"
 
+// clusterProvisioner is the configmap indicating the kontainer driver that provisioned the cluster
+const clusterProvisioner = "cluster-provisioner"
+
 // Environment variables for the Rancher images
 // format: imageName: baseEnvVar
 var imageEnvVars = map[string]string{
@@ -101,16 +104,25 @@ var certificates = []types.NamespacedName{
 }
 
 // For use to override during unit tests
-type checkClusterProvisionedFuncSig func(client corev1.CoreV1Interface, dynClient dynamic.Interface) (bool, error)
+type checkProvisionedFuncSig func(client corev1.CoreV1Interface, dynClient dynamic.Interface) (bool, error)
 
-var checkClusterProvisionedFunc checkClusterProvisionedFuncSig = checkClusterProvisioned
+var checkClusterProvisionedFunc checkProvisionedFuncSig = checkClusterProvisioned
 
-func SetCheckClusterProvisionedFunc(newFunc checkClusterProvisionedFuncSig) {
+func SetCheckClusterProvisionedFunc(newFunc checkProvisionedFuncSig) {
 	checkClusterProvisionedFunc = newFunc
 }
 func SetDefaultCheckClusterProvisionedFunc() {
 	checkClusterProvisionedFunc = checkClusterProvisioned
 }
+
+var checkContainerDriverProvisionedFunc checkProvisionedFuncSig = checkContainerDriverProvisioned
+
+//func SetCheckContainerDriverProvisionedFunc(newFunc checkProvisionedFuncSig) {
+//	checkClusterProvisionedFunc = newFunc
+//}
+//func SetDefaultCheckContainerDriverProvisionedFunc() {
+//	checkClusterProvisionedFunc = checkContainerDriverProvisioned
+//}
 
 func NewComponent() spi.Component {
 	return rancherComponent{
@@ -727,6 +739,20 @@ func IsClusterProvisionedByRancher() (bool, error) {
 	return checkClusterProvisionedFunc(client, dynClient)
 }
 
+// IsClusterProvisionedByContainerDriver checks if the Kubernetes cluster was provisioned by the Rancher OCNE container driver.
+func IsClusterProvisionedByOcneContainerDriver() (bool, error) {
+	client, err := k8sutil.GetCoreV1Func()
+	if err != nil {
+		return false, err
+	}
+	dynClient, err := k8sutil.GetDynamicClientFunc()
+	if err != nil {
+		return false, err
+	}
+
+	return checkContainerDriverProvisioned(client, dynClient)
+}
+
 // checkClusterProvisioned checks if the Kubernetes cluster was provisioned by Rancher.
 func checkClusterProvisioned(client corev1.CoreV1Interface, dynClient dynamic.Interface) (bool, error) {
 	// Check for the "local" namespace.
@@ -765,6 +791,22 @@ func checkClusterProvisioned(client corev1.CoreV1Interface, dynClient dynamic.In
 	}
 
 	return false, nil
+}
+
+// checkContainerDriverProvisioned checks if the Kubernetes cluster was provisioned by the OCNE KontainerDriver.
+func checkContainerDriverProvisioned(client corev1.CoreV1Interface, dynClient dynamic.Interface) (bool, error) {
+	// Find the provisioner configmap resource and check if ociocne is indicated as the driver.
+	_, err := client.ConfigMaps(ComponentNamespace).Get(context.TODO(), clusterProvisioner, metav1.GetOptions{})
+	if kerrs.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	// NOTE: not checking driver version since the existence of configmap alone indicates a container driver is responsible
+	// for the provisioning of the cluster
+	return true, nil
 }
 
 // createOrUpdateRancherUser create or update the new Rancher user mapped to Keycloak user verrazzano

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -796,7 +796,7 @@ func checkClusterProvisioned(client corev1.CoreV1Interface, dynClient dynamic.In
 // checkContainerDriverProvisioned checks if the Kubernetes cluster was provisioned by the OCNE KontainerDriver.
 func checkContainerDriverProvisioned(client corev1.CoreV1Interface, dynClient dynamic.Interface) (bool, error) {
 	// Find the provisioner configmap resource and check if ociocne is indicated as the driver.
-	_, err := client.ConfigMaps(ComponentNamespace).Get(context.TODO(), clusterProvisioner, metav1.GetOptions{})
+	_, err := client.ConfigMaps(constants.DefaultNamespace).Get(context.TODO(), clusterProvisioner, metav1.GetOptions{})
 	if kerrs.IsNotFound(err) {
 		return false, nil
 	}
@@ -804,7 +804,7 @@ func checkContainerDriverProvisioned(client corev1.CoreV1Interface, dynClient dy
 		return false, err
 	}
 
-	// NOTE: not checking driver version since the existence of configmap alone indicates a container driver is responsible
+	// NOTE: not checking driver type since the existence of configmap alone indicates a container driver is responsible
 	// for the provisioning of the cluster
 	return true, nil
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -740,8 +740,8 @@ func IsClusterProvisionedByRancher() (bool, error) {
 }
 
 // IsClusterProvisionedByOCNEContainerDriver checks if the Kubernetes cluster was provisioned by the Rancher OCNE container driver.
-func IsClusterProvisionedByOCNEContainerDriver() (bool, error) {
-	vzlog.DefaultLogger().Infof("DEBUG:  IsClusterProvisionedByOCNEContainerDriver called")
+func IsClusterProvisionedByOCNEContainerDriver(ctx spi.ComponentContext) (bool, error) {
+	ctx.Log().Infof("DEBUG:  IsClusterProvisionedByOCNEContainerDriver called")
 	client, err := k8sutil.GetCoreV1Func()
 	if err != nil {
 		return false, err
@@ -750,7 +750,7 @@ func IsClusterProvisionedByOCNEContainerDriver() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	vzlog.DefaultLogger().Infof("DEBUG:  IsClusterProvisionedByOCNEContainerDriver calling %v", checkContainerDriverProvisionedFunc)
+	ctx.Log().Infof("DEBUG:  IsClusterProvisionedByOCNEContainerDriver calling %v", checkContainerDriverProvisionedFunc)
 
 	return checkContainerDriverProvisionedFunc(client, dynClient)
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -750,7 +750,7 @@ func IsClusterProvisionedByOcneContainerDriver() (bool, error) {
 		return false, err
 	}
 
-	return checkContainerDriverProvisioned(client, dynClient)
+	return checkContainerDriverProvisionedFunc(client, dynClient)
 }
 
 // checkClusterProvisioned checks if the Kubernetes cluster was provisioned by Rancher.

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -739,8 +739,8 @@ func IsClusterProvisionedByRancher() (bool, error) {
 	return checkClusterProvisionedFunc(client, dynClient)
 }
 
-// IsClusterProvisionedByContainerDriver checks if the Kubernetes cluster was provisioned by the Rancher OCNE container driver.
-func IsClusterProvisionedByOcneContainerDriver() (bool, error) {
+// IsClusterProvisionedByOCNEContainerDriver checks if the Kubernetes cluster was provisioned by the Rancher OCNE container driver.
+func IsClusterProvisionedByOCNEContainerDriver() (bool, error) {
 	client, err := k8sutil.GetCoreV1Func()
 	if err != nil {
 		return false, err

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -740,8 +740,7 @@ func IsClusterProvisionedByRancher() (bool, error) {
 }
 
 // IsClusterProvisionedByOCNEContainerDriver checks if the Kubernetes cluster was provisioned by the Rancher OCNE container driver.
-func IsClusterProvisionedByOCNEContainerDriver(ctx spi.ComponentContext) (bool, error) {
-	ctx.Log().Infof("DEBUG:  IsClusterProvisionedByOCNEContainerDriver called")
+func IsClusterProvisionedByOCNEContainerDriver() (bool, error) {
 	client, err := k8sutil.GetCoreV1Func()
 	if err != nil {
 		return false, err
@@ -750,7 +749,6 @@ func IsClusterProvisionedByOCNEContainerDriver(ctx spi.ComponentContext) (bool, 
 	if err != nil {
 		return false, err
 	}
-	ctx.Log().Infof("DEBUG:  IsClusterProvisionedByOCNEContainerDriver calling %v", checkContainerDriverProvisionedFunc)
 
 	return checkContainerDriverProvisionedFunc(client, dynClient)
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -117,12 +117,12 @@ func SetDefaultCheckClusterProvisionedFunc() {
 
 var checkContainerDriverProvisionedFunc checkProvisionedFuncSig = checkContainerDriverProvisioned
 
-//func SetCheckContainerDriverProvisionedFunc(newFunc checkProvisionedFuncSig) {
-//	checkClusterProvisionedFunc = newFunc
-//}
-//func SetDefaultCheckContainerDriverProvisionedFunc() {
-//	checkClusterProvisionedFunc = checkContainerDriverProvisioned
-//}
+func SetCheckContainerDriverProvisionedFunc(newFunc checkProvisionedFuncSig) {
+	checkContainerDriverProvisionedFunc = newFunc
+}
+func SetDefaultCheckContainerDriverProvisionedFunc() {
+	checkContainerDriverProvisionedFunc = checkContainerDriverProvisioned
+}
 
 func NewComponent() spi.Component {
 	return rancherComponent{

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -200,7 +200,7 @@ func rancherArtifactsExist(ctx spi.ComponentContext) bool {
 // forkPostUninstall - fork uninstall install of Rancher
 func forkPostUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMonitor) error {
 	if !vzcr.IsRancherEnabled(ctx.EffectiveCR()) {
-		ctx.Log().Infof("Rancher not enabled - no post uninstall cleanup performed")
+		ctx.Log().Progressf("Rancher not enabled - no post uninstall cleanup performed")
 		return nil
 	}
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -200,7 +200,7 @@ func rancherArtifactsExist(ctx spi.ComponentContext) bool {
 // forkPostUninstall - fork uninstall install of Rancher
 func forkPostUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMonitor) error {
 	if !vzcr.IsRancherEnabled(ctx.EffectiveCR()) {
-		ctx.Log().Progressf("Rancher not enabled - no post uninstall cleanup performed")
+		ctx.Log().Oncef("Rancher not enabled - no post uninstall cleanup performed")
 		return nil
 	}
 

--- a/platform-operator/controllers/verrazzano/reconcile/controller_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller_test.go
@@ -540,6 +540,8 @@ func TestUninstallComplete(t *testing.T) {
 	testFunc := func(client typedcorev1.CoreV1Interface, dynClient dynamic.Interface) (bool, error) { return false, nil }
 	rancher.SetCheckClusterProvisionedFunc(testFunc)
 	defer rancher.SetDefaultCheckClusterProvisionedFunc()
+	rancher.SetCheckContainerDriverProvisionedFunc(testFunc)
+	defer rancher.SetDefaultCheckContainerDriverProvisionedFunc()
 
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
@@ -645,6 +647,8 @@ func TestUninstallStarted(t *testing.T) {
 	testFunc := func(client typedcorev1.CoreV1Interface, dynClient dynamic.Interface) (bool, error) { return false, nil }
 	rancher.SetCheckClusterProvisionedFunc(testFunc)
 	defer rancher.SetDefaultCheckClusterProvisionedFunc()
+	rancher.SetCheckContainerDriverProvisionedFunc(testFunc)
+	defer rancher.SetDefaultCheckContainerDriverProvisionedFunc()
 
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
@@ -765,6 +769,8 @@ func TestUninstallSucceeded(t *testing.T) {
 	testFunc := func(client typedcorev1.CoreV1Interface, dynClient dynamic.Interface) (bool, error) { return false, nil }
 	rancher.SetCheckClusterProvisionedFunc(testFunc)
 	defer rancher.SetDefaultCheckClusterProvisionedFunc()
+	rancher.SetCheckContainerDriverProvisionedFunc(testFunc)
+	defer rancher.SetDefaultCheckContainerDriverProvisionedFunc()
 
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -377,7 +377,7 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvisioned bool) (ctrl.Result, error) {
 	log := ctx.Log()
 	// check on whether cluster is OCNE container driver provisioned
-	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOCNEContainerDriver()
+	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOCNEContainerDriver(ctx)
 	ctx.Log().Infof("ocneContainerDriverProvisioned: %v", ocneContainerDriverProvisioned)
 	if err != nil {
 		ctx.Log().Errorf("Error returned from container provisioned test: %v", err)
@@ -420,6 +420,7 @@ func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvision
 			Log:    log,
 		}.RemoveFinalizersAndDelete()
 		if err != nil {
+			ctx.Log().Errorf("Error during namespace deletion: %v", err)
 			return ctrl.Result{}, err
 		}
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -377,7 +377,7 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvisioned bool) (ctrl.Result, error) {
 	log := ctx.Log()
 	// check on whether cluster is OCNE container driver provisioned
-	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOcneContainerDriver()
+	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOCNEContainerDriver()
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -378,7 +378,9 @@ func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvision
 	log := ctx.Log()
 	// check on whether cluster is OCNE container driver provisioned
 	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOCNEContainerDriver()
+	ctx.Log().Infof("ocneContainerDriverProvisioned: %v", ocneContainerDriverProvisioned)
 	if err != nil {
+		ctx.Log().Errorf("Error returned from container provisioned test: %v", err)
 		return ctrl.Result{}, err
 	}
 	// Load a set of all component namespaces plus shared namespaces

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -377,7 +377,7 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvisioned bool) (ctrl.Result, error) {
 	log := ctx.Log()
 	// check on whether cluster is OCNE container driver provisioned
-	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOCNEContainerDriver(ctx)
+	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOCNEContainerDriver()
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -377,12 +377,12 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvisioned bool) (ctrl.Result, error) {
 	log := ctx.Log()
 	// check on whether cluster is OCNE container driver provisioned
-	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOCNEContainerDriver(ctx)
-	ctx.Log().Infof("ocneContainerDriverProvisioned: %v", ocneContainerDriverProvisioned)
-	if err != nil {
-		ctx.Log().Errorf("Error returned from container provisioned test: %v", err)
-		return ctrl.Result{}, err
-	}
+	//ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOCNEContainerDriver(ctx)
+	//ctx.Log().Infof("ocneContainerDriverProvisioned: %v", ocneContainerDriverProvisioned)
+	//if err != nil {
+	//	ctx.Log().Errorf("Error returned from container provisioned test: %v", err)
+	//	return ctrl.Result{}, err
+	//}
 	// Load a set of all component namespaces plus shared namespaces
 	nsSet := make(map[string]bool)
 	for _, comp := range registry.GetComponents() {
@@ -390,9 +390,9 @@ func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvision
 		if rancherProvisioned && comp.Namespace() == rancher.ComponentNamespace {
 			continue
 		}
-		if ocneContainerDriverProvisioned && comp.Namespace() == rancher.ComponentNamespace {
-			continue
-		}
+		//if ocneContainerDriverProvisioned && comp.Namespace() == rancher.ComponentNamespace {
+		//	continue
+		//}
 		if comp.Namespace() == cmcontroller.ComponentNamespace && !vzcr.IsCertManagerEnabled(ctx.EffectiveCR()) {
 			log.Progressf("Cert-Manager not enabled, skip namespace cleanup")
 			continue

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -378,6 +378,9 @@ func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvision
 	log := ctx.Log()
 	// check on whether cluster is OCNE container driver provisioned
 	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOcneContainerDriver()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	// Load a set of all component namespaces plus shared namespaces
 	nsSet := make(map[string]bool)
 	for _, comp := range registry.GetComponents() {

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -376,11 +376,16 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 // - returns an error or a requeue with delay result
 func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvisioned bool) (ctrl.Result, error) {
 	log := ctx.Log()
+	// check on whether cluster is OCNE container driver provisioned
+	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOcneContainerDriver()
 	// Load a set of all component namespaces plus shared namespaces
 	nsSet := make(map[string]bool)
 	for _, comp := range registry.GetComponents() {
 		// Don't delete the rancher component namespace if cluster was provisioned by Rancher.
 		if rancherProvisioned && comp.Namespace() == rancher.ComponentNamespace {
+			continue
+		}
+		if ocneContainerDriverProvisioned && comp.Namespace() == rancher.ComponentNamespace {
 			continue
 		}
 		if comp.Namespace() == cmcontroller.ComponentNamespace && !vzcr.IsCertManagerEnabled(ctx.EffectiveCR()) {

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -377,22 +377,17 @@ func (r *Reconciler) deleteSecret(log vzlog.VerrazzanoLogger, namespace string, 
 func (r *Reconciler) deleteNamespaces(ctx spi.ComponentContext, rancherProvisioned bool) (ctrl.Result, error) {
 	log := ctx.Log()
 	// check on whether cluster is OCNE container driver provisioned
-	//ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOCNEContainerDriver(ctx)
-	//ctx.Log().Infof("ocneContainerDriverProvisioned: %v", ocneContainerDriverProvisioned)
-	//if err != nil {
-	//	ctx.Log().Errorf("Error returned from container provisioned test: %v", err)
-	//	return ctrl.Result{}, err
-	//}
+	ocneContainerDriverProvisioned, err := rancher.IsClusterProvisionedByOCNEContainerDriver(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	// Load a set of all component namespaces plus shared namespaces
 	nsSet := make(map[string]bool)
 	for _, comp := range registry.GetComponents() {
 		// Don't delete the rancher component namespace if cluster was provisioned by Rancher.
-		if rancherProvisioned && comp.Namespace() == rancher.ComponentNamespace {
+		if (rancherProvisioned || ocneContainerDriverProvisioned) && comp.Namespace() == rancher.ComponentNamespace {
 			continue
 		}
-		//if ocneContainerDriverProvisioned && comp.Namespace() == rancher.ComponentNamespace {
-		//	continue
-		//}
 		if comp.Namespace() == cmcontroller.ComponentNamespace && !vzcr.IsCertManagerEnabled(ctx.EffectiveCR()) {
 			log.Progressf("Cert-Manager not enabled, skip namespace cleanup")
 			continue

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_test.go
@@ -587,6 +587,12 @@ func runDeleteNamespacesTest(t *testing.T, cmEnabled bool) {
 		return apiextv1fake.NewSimpleClientset().ApiextensionsV1(), nil
 	}
 
+	k8sutil.GetCoreV1Func = common.MockGetCoreV1()
+	k8sutil.GetDynamicClientFunc = common.MockDynamicClient()
+	defer func() {
+		k8sutil.GetCoreV1Func = k8sutil.GetCoreV1Client
+		k8sutil.GetDynamicClientFunc = k8sutil.GetDynamicClient
+	}()
 	testFunc := func(client typedcorev1.CoreV1Interface, dynClient dynamic.Interface) (bool, error) { return false, nil }
 	rancher.SetCheckContainerDriverProvisionedFunc(testFunc)
 	defer rancher.SetDefaultCheckContainerDriverProvisionedFunc()

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	apiextv1fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	apiextv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	"k8s.io/client-go/dynamic"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"reflect"
 	"testing"
 	"time"
@@ -584,6 +586,10 @@ func runDeleteNamespacesTest(t *testing.T, cmEnabled bool) {
 	k8sutil.GetAPIExtV1ClientFunc = func() (apiextv1client.ApiextensionsV1Interface, error) {
 		return apiextv1fake.NewSimpleClientset().ApiextensionsV1(), nil
 	}
+
+	testFunc := func(client typedcorev1.CoreV1Interface, dynClient dynamic.Interface) (bool, error) { return false, nil }
+	rancher.SetCheckContainerDriverProvisionedFunc(testFunc)
+	defer rancher.SetDefaultCheckContainerDriverProvisionedFunc()
 
 	const fakeNS = "foo"
 	nameSpaces := []client.Object{}

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,13 +151,13 @@
               "rancherUI": "v2.7.2-8/release-2.7.2",
               "ocneDriverVersion": "v0.16.0",
               "ocneDriverChecksum": "67f9a55465bc28b120b085eb1591e16467e031740f4f374869554e7f50e06535",
-              "tag": "v2.7.3-20230706150326-72ada53b0",
+              "tag": "v2.7.3-20230707185355-8ae6b211f",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-20230706150326-72ada53b0"
+              "tag": "v2.7.3-20230707185355-8ae6b211f"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -149,8 +149,8 @@
               "image": "rancher",
               "dashboard": "v2.7.2-20230630202538-1f346be21",
               "rancherUI": "v2.7.2-8/release-2.7.2",
-              "ocneDriverVersion": "v0.15.0",
-              "ocneDriverChecksum": "1f9f716b2f14f51fdab19e1ee98042801bcc40098eae2aca6725d4f360f4f7c9",
+              "ocneDriverVersion": "v0.16.0",
+              "ocneDriverChecksum": "67f9a55465bc28b120b085eb1591e16467e031740f4f374869554e7f50e06535",
               "tag": "v2.7.3-20230706150326-72ada53b0",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"


### PR DESCRIPTION
- Ensure that cattle-system namespace and its resources aren't deleted during VZ uninstall if the cluster is Rancher container driver/OCNE provisioned
- Some simplification of Rancher post-uninstall cleanup logic

MC and uninstall resiliency pipelines were run in addition to standard pipelines and manual functional testing with provisioned cluster.