### PR TITLE
VZ-10277: add latest console image with Alertmanager url

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -265,7 +265,7 @@
             },
             {
               "image": "console",
-              "tag": "v2.0.0-20230628190831-09d3d66",
+              "tag": "v2.0.0-20230711035747-67edc78",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },


### PR DESCRIPTION
Includes Alertmanager url changes from https://github.com/verrazzano/console/pull/263