### PR TITLE
VZ-10129 Add verrazzano_component metrics label for new components

### DIFF
--- a/platform-operator/helm_config/overrides/kube-state-metrics-values.yaml
+++ b/platform-operator/helm_config/overrides/kube-state-metrics-values.yaml
@@ -51,6 +51,14 @@ prometheus:
         - pod
         targetLabel: verrazzano_component
       - action: replace
+        regex: (verrazzano-capi);(clusterAPI);(capi-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;clusterAPI;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
         regex: (verrazzano-system);(clusterOperator);(verrazzano-cluster-operator-[a-z0-9-]+)(.*)
         replacement: $2
         separator: ;clusterOperator;
@@ -86,6 +94,22 @@ prometheus:
         regex: (verrazzano-system);(fluentd);(fluentd-[a-z0-9-]+)(.*)
         replacement: $2
         separator: ;fluentd;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(fluentOperator);(fluent-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;fluentOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(fluentbitOpensearchOutput);(fluent-bit-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;fluentbitOpensearchOutput;
         sourceLabels:
         - namespace
         - pod
@@ -278,6 +302,14 @@ prometheus:
         regex: (verrazzano-backup);(velero);(restic-[a-z0-9-]+|velero-[a-z0-9-]+)(.*)
         replacement: $2
         separator: ;velero;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(thanos);(thanos-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;thanos;
         sourceLabels:
         - namespace
         - pod

--- a/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -182,6 +182,14 @@ kubelet:
         - pod
         targetLabel: verrazzano_component
       - action: replace
+        regex: (verrazzano-capi);(clusterAPI);(capi-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;clusterAPI;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
         regex: (verrazzano-system);(coherenceOperator);(coherence-operator-[a-z0-9-]+)(.*)
         replacement: $2
         separator: ;coherenceOperator;
@@ -209,6 +217,22 @@ kubelet:
         regex: (verrazzano-system);(fluentd);(fluentd-[a-z0-9-]+)(.*)
         replacement: $2
         separator: ;fluentd;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(fluentOperator);(fluent-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;fluentOperator;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(fluentbitOpensearchOutput);(fluent-bit-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;fluentbitOpensearchOutput;
         sourceLabels:
         - namespace
         - pod
@@ -401,6 +425,14 @@ kubelet:
         regex: (verrazzano-backup);(velero);(restic-[a-z0-9-]+|velero-[a-z0-9-]+)(.*)
         replacement: $2
         separator: ;velero;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(thanos);(thanos-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;thanos;
         sourceLabels:
         - namespace
         - pod
@@ -456,6 +488,14 @@ kubelet:
         - pod
         targetLabel: verrazzano_component
       - action: replace
+        regex: (verrazzano-capi);(clusterAPI);(capi-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;clusterAPI;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
         regex: (verrazzano-system);(clusterOperator);(verrazzano-cluster-operator-[a-z0-9-]+)(.*)
         replacement: $2
         separator: ;clusterOperator;
@@ -491,6 +531,22 @@ kubelet:
         regex: (verrazzano-system);(fluentd);(fluentd-[a-z0-9-]+)(.*)
         replacement: $2
         separator: ;fluentd;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(fluentbitOpensearchOutput);(fluent-bit-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;fluentbitOpensearchOutput;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-system);(fluentOperator);(fluent-operator-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;fluentOperator;
         sourceLabels:
         - namespace
         - pod
@@ -683,6 +739,14 @@ kubelet:
         regex: (verrazzano-backup);(velero);(restic-[a-z0-9-]+|velero-[a-z0-9-]+)(.*)
         replacement: $2
         separator: ;velero;
+        sourceLabels:
+        - namespace
+        - pod
+        targetLabel: verrazzano_component
+      - action: replace
+        regex: (verrazzano-monitoring);(thanos);(thanos-[a-z0-9-]+)(.*)
+        replacement: $2
+        separator: ;thanos;
         sourceLabels:
         - namespace
         - pod


### PR DESCRIPTION
**Changes**
- Add the verrazzano_cluster label for CAPI, Thanos, Fluentbit, and Fluent Operator

**Testing**
- Install on a local cluster and make sure the metrics get propagated to the Grafana Verrazzano Resource Usage dashboard

