### PR TITLE
replace link to archive page

### DIFF
--- a/release/docs/README_FULL.html
+++ b/release/docs/README_FULL.html
@@ -21,7 +21,7 @@
 <p>Select <a href="https://verrazzano.io/latest/docs/setup/quickstart/">Quick Start</a> to get started.</p>
 <p>Verrazzano <a href="https://github.com/verrazzano/verrazzano/releases/">release versions</a> and source code are available at <a href="https://github.com/verrazzano/verrazzano">https://github.com/verrazzano/verrazzano</a>.
 This repository contains a Kubernetes operator for installing Verrazzano and example applications for use with Verrazzano.</p>
-<p>For documentation from all releases, see the <a href="https://verrazzano.io/archive/docs/">Documentation Archive</a>.</p>
+<p>For documentation from all releases, use the version menu on the <a href="https://verrazzano.io/latest/docs/">Documentation home page</a>.</p>
 <h2 id="distribution-layout">Distribution layout</h2>
 <p>The Verrazzano distribution includes the following artifacts:</p>
 <ul>

--- a/release/docs/README_FULL.md
+++ b/release/docs/README_FULL.md
@@ -17,7 +17,7 @@ Select [Quick Start](https://verrazzano.io/latest/docs/setup/quickstart/) to get
 Verrazzano [release versions](https://github.com/verrazzano/verrazzano/releases/) and source code are available at [https://github.com/verrazzano/verrazzano](https://github.com/verrazzano/verrazzano).
 This repository contains a Kubernetes operator for installing Verrazzano and example applications for use with Verrazzano.
 
-For documentation from all releases, see the [Documentation Archive](https://verrazzano.io/archive/docs/).
+For documentation from all releases, use the version menu on the [Documentation](https://verrazzano.io/latest/docs/) home page.
 
 ## Distribution layout
 
@@ -44,7 +44,7 @@ The Verrazzano distribution includes the following artifacts:
       * `none.yaml`: The standard `none` profile to install Verrazzano
   * `images/`:  Verrazzano Enterprise Container Platform archives for private registry install.
 
-## Install Verrazzano 
+## Install Verrazzano
 
 Install Verrazzano using the instructions in the [Verrazzano Installation Guide](https://verrazzano.io/latest/docs/setup/install/installation/).
 

--- a/release/docs/README_LITE.md
+++ b/release/docs/README_LITE.md
@@ -17,7 +17,7 @@ Select [Quick Start](https://verrazzano.io/latest/docs/setup/quickstart/) to get
 Verrazzano [release versions](https://github.com/verrazzano/verrazzano/releases/) and source code are available at [https://github.com/verrazzano/verrazzano](https://github.com/verrazzano/verrazzano).
 This repository contains a Kubernetes operator for installing Verrazzano and example applications for use with Verrazzano.
 
-For documentation from all releases, see the [Documentation Archive](https://verrazzano.io/archive/docs/).
+For documentation from all releases, use the version menu on the [Documentation](https://verrazzano.io/latest/docs/) home page.
 
 ## Distribution layout
 


### PR DESCRIPTION
As per [VZ-9735](https://jira.oraclecorp.com/jira/browse/VZ-9735) Documentation Archive page is no longer needed, this PR removes and replaces links to the Documentation Archive page.
