### PR TITLE
VZ-10243 Uptake new Rancher image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,13 +151,13 @@
               "rancherUI": "v2.7.2-9/release-2.7.2",
               "ocneDriverVersion": "v0.17.0",
               "ocneDriverChecksum": "a8f12c6c19fbe9b4d3834068e0bf7286611552267a1da58c5091df62e404705b",
-              "tag": "v2.7.3-20230711191216-8ae6b211f",
+              "tag": "v2.7.3-20230712031816-51373799e",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-20230711191216-8ae6b211f"
+              "tag": "v2.7.3-20230712031816-51373799e"
             }
           ]
         },


### PR DESCRIPTION
Uptake new Rancher image for resolving system-library syncing errors seen in the Rancher logs. See https://github.com/verrazzano/rancher/pull/122 for details.
