### PR TITLE
VZ-10243 Uptake new Rancher image (#6446)

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,13 +151,13 @@
               "rancherUI": "v2.7.2-7/release-2.7.2",
               "ocneDriverVersion": "v0.14.0",
               "ocneDriverChecksum": "c10f757291664ae041569934951ae42d2d4021d4031f6ba009370cb92b7173fe",
-              "tag": "v2.7.3-20230628173719-72ada53b0",
+              "tag": "v2.7.3-20230712031816-51373799e",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-20230628173719-72ada53b0"
+              "tag": "v2.7.3-20230712031816-51373799e"
             }
           ]
         },


### PR DESCRIPTION
Backport of PR #6446 to release-1.6 to uptake new Rancher image for resolving system-library syncing errors seen in the Rancher logs. See https://github.com/verrazzano/rancher/pull/122 for details.
