### PR TITLE
VZ-8902: Update NGINX ingress images in release-1.6

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -28,13 +28,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20230606201525-2d393218f",
+              "tag": "v1.7.1-20230712031907-3ae8a8da4",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "v1.7.1-20230606201525-2d393218f",
+              "tag": "v1.7.1-20230712031907-3ae8a8da4",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -271,7 +271,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20230606201525-2d393218f",
+              "tag": "v1.7.1-20230712031907-3ae8a8da4",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
@@ -326,7 +326,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20230606201525-2d393218f",
+              "tag": "v1.7.1-20230712031907-3ae8a8da4",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]
@@ -604,7 +604,7 @@
             },
             {
               "image": "kube-webhook-certgen",
-              "tag": "v1.7.1-20230606201525-2d393218f",
+              "tag": "v1.7.1-20230712031907-3ae8a8da4",
               "helmRegKey": "prometheusOperator.admissionWebhooks.patch.image.registry",
               "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
               "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"


### PR DESCRIPTION
Updates nginx-ingress images built with the change https://github.com/verrazzano/ingress-nginx/pull/7