### PR TITLE
VZ-10310.  Fix managed cluster scrape with production certs

### DIFF
--- a/cluster-operator/controllers/vmc/sync_prometheus.go
+++ b/cluster-operator/controllers/vmc/sync_prometheus.go
@@ -89,7 +89,7 @@ func (r *VerrazzanoManagedClusterReconciler) newScrapeConfig(cacrtSecret *corev1
 		return nil, err
 	}
 	if len(cacrtSecret.Data["cacrt"]) > 0 {
-		newScrapeConfig.Set(prometheusConfigBasePath+getCAKey(vmc), "tls_config", "ca_file")
+		newScrapeConfig.Set(managedCertsBasePath+getCAKey(vmc), "tls_config", "ca_file")
 		newScrapeConfig.Set(false, "tls_config", "insecure_skip_verify")
 	}
 	return newScrapeConfig, nil
@@ -137,8 +137,6 @@ func (r *VerrazzanoManagedClusterReconciler) mutateAdditionalScrapeConfigs(ctx c
 	if err != nil {
 		return err
 	}
-	// TODO: Set this in the newScrapeConfig function when we remove the "old" Prometheus code
-	newScrapeConfig.Set(managedCertsBasePath+getCAKey(vmc), "tls_config", "ca_file")
 
 	editScrapeJobName := vmc.Name
 

--- a/cluster-operator/controllers/vmc/vmc_controller_test.go
+++ b/cluster-operator/controllers/vmc/vmc_controller_test.go
@@ -415,7 +415,7 @@ func TestCreateVMCNoCACert(t *testing.T) {
 
 // TestCreateVMCFetchCACertFromManagedCluster tests the Reconcile method for the following use case
 // GIVEN a request to reconcile an VerrazzanoManagedCluster resource
-// WHEN a VerrazzanoManagedCluster resource has been applied and the caSecret field is empty
+// WHEN a VerrazzanoManagedCluster resource has been applied and the caSecret field is NOT empty
 // THEN ensure that we fetch the CA cert secret from the managed cluster and populate the caSecret field
 func TestCreateVMCFetchCACertFromManagedCluster(t *testing.T) {
 	// clear any cached user auth tokens when the test completes
@@ -460,7 +460,7 @@ func TestCreateVMCFetchCACertFromManagedCluster(t *testing.T) {
 		if err != nil {
 			asserts.Fail("failed due to error %v", err)
 		}
-		validateScrapeConfig(t, scrapeConfig, prometheusConfigBasePath, false)
+		validateScrapeConfig(t, scrapeConfig, prometheusConfigBasePath, true)
 		return nil
 	}, func(secret *corev1.Secret) error {
 		scrapeConfigYaml := secret.Data[constants.PromAdditionalScrapeConfigsSecretKey]
@@ -469,7 +469,7 @@ func TestCreateVMCFetchCACertFromManagedCluster(t *testing.T) {
 			asserts.Fail("failed due to error %v", err)
 		}
 		scrapeConfig := getJob(scrapeConfigs.Children(), testManagedCluster)
-		validateScrapeConfig(t, scrapeConfig, managedCertsBasePath, false)
+		validateScrapeConfig(t, scrapeConfig, managedCertsBasePath, true)
 		return nil
 	}, func(secret *corev1.Secret) error {
 		asserts.NotEmpty(secret.Data["ca-test"], "Expected to find a managed cluster TLS cert")
@@ -2559,9 +2559,15 @@ func validateScrapeConfig(t *testing.T, scrapeConfig *gabs.Container, caBasePath
 	asserts.Equal(testManagedCluster, scrapeConfig.Search("metric_relabel_configs", "0",
 		"replacement").Data(),
 		"metric_relabel_configs entry to post-process verrazzano_cluster label does not have right replacement value")
+	schemePath := scrapeConfig.Path("scheme")
+	tlsScrapeConfig := scrapeConfig.Search("tls_config", "ca_file")
 	if expectTLSConfig {
-		asserts.Equal("https", scrapeConfig.Path("scheme").Data(), "wrong scheme")
-		asserts.Equal(caBasePath+"ca-test", scrapeConfig.Search("tls_config", "ca_file").Data(), "Wrong cert path")
+		asserts.Equal("https", schemePath.Data(), "wrong scheme")
+		assert.NotNil(t, tlsScrapeConfig)
+		asserts.Equal(caBasePath+"ca-test", tlsScrapeConfig.Data(), "Wrong cert path")
+	} else {
+		assert.Nil(t, tlsScrapeConfig)
+		asserts.Equal("https", schemePath.Data(), "wrong scheme")
 	}
 }
 


### PR DESCRIPTION
Fixes an issue setting up remote scrape targets on an admin cluster where the managed cluster CA bundle is empty (as is the case with certs issued by trusted CAs).  

At present we're unconditionally setting the CA bundle which for the empty bundle case causes a scrape error for Prometheus, similar to what's shown below:

```
Get "[https://prometheus.vmi.system.xxx.xxx.xxx:443/federate?match%5B%5D=%7B__name__%3D~%22..%2A%22%7D](https://prometheus.vmi.system.xxx.xxx.xxx.io/federate?match%5B%5D=%7B__name__%3D~%22..%2A%22%7D)": unable to load specified CA cert /etc/prometheus/managed-cluster-ca-certs/ca-mgd1-oke2: open /etc/prometheus/managed-cluster-ca-certs/ca-mgd1-oke2: no such file or directory
```

This change
- uses the managed cluster path inside `newScrapeConfig` when setting it conditionally.
- remove the code that unconditionally sets the managed-cluster scrape path in the scrape config after calling `newScrapeConfig`
- Updates the unit tests to capture the scenario

`newScrapeConfig` seems to only be used from this code.

