### PR TITLE
VZ-10278: always capture CAPI resources

### DIFF
--- a/tools/vz/pkg/bugreport/reportgen.go
+++ b/tools/vz/pkg/bugreport/reportgen.go
@@ -257,9 +257,7 @@ func collectNamespaces(kubeClient kubernetes.Interface, dynamicClient dynamic.In
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, capiNS := range capiNSList {
-		nsList = append(nsList, capiNS)
-	}
+	nsList = append(nsList, capiNSList...)
 
 	// Include the namespaces specified by flag --include-namespaces
 	var additionalNS []string

--- a/tools/vz/pkg/helpers/vzhelper.go
+++ b/tools/vz/pkg/helpers/vzhelper.go
@@ -14,7 +14,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	vpoconstants "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
-	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	vzconstants "github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/github"
 	"io"
@@ -348,8 +347,8 @@ func GetVersionOut() string {
 }
 
 // VerifyVzInstallNamespaceExists returns existence of verrazzano-install namespace
-func VerifyVzInstallNamespaceExists() bool {
-	pods, err := pkg.ListPods(vzconstants.VerrazzanoInstall, metav1.ListOptions{})
+func VerifyVzInstallNamespaceExists(kubeClient kubernetes.Interface) bool {
+	pods, err := kubeClient.CoreV1().Pods(vzconstants.VerrazzanoInstall).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
This pull request includes changes to always capture the CAPI resources during vz analysis/bug-report.

Also, fixed a bug where the verrazzano-install namespace was not being included in the analysis.