### PR TITLE
VZ-10035.  Roll rancher pods on update if cacerts is out of sync

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -203,6 +203,10 @@ func GetCoreV1Client(log ...vzlog.VerrazzanoLogger) (corev1.CoreV1Interface, err
 	return goClient.CoreV1(), nil
 }
 
+func ResetCoreV1Client() {
+	GetCoreV1Func = GetCoreV1Client
+}
+
 // GetAPIExtV1ClientFunc is the function to return the ApiextensionsV1Interface
 var GetAPIExtV1ClientFunc = GetAPIExtV1Client
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -521,7 +521,7 @@ func createOrUpdateResource(ctx spi.ComponentContext, nsn types.NamespacedName, 
 	return nil
 }
 
-// getSettingValue Returns a Rancher Settings objecgt value
+// getSettingValue Returns a Rancher Settings object value with the leading and trailing whitespace trimmed
 func getSettingValue(c client.Client, settingName string) string {
 	resource := unstructured.Unstructured{}
 	resource.SetGroupVersionKind(common.GVKSetting)

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -522,19 +522,22 @@ func createOrUpdateResource(ctx spi.ComponentContext, nsn types.NamespacedName, 
 }
 
 // getSettingValue Returns a Rancher Settings object value with the leading and trailing whitespace trimmed
-func getSettingValue(c client.Client, settingName string) string {
+func getSettingValue(c client.Client, settingName string) (string, error) {
 	resource := unstructured.Unstructured{}
 	resource.SetGroupVersionKind(common.GVKSetting)
 	resource.SetName(settingName)
-	err := c.Get(context.Background(), types.NamespacedName{Name: resource.GetName()}, &resource)
-	if err != nil {
-		return ""
+
+	if err := c.Get(context.Background(), types.NamespacedName{Name: resource.GetName()}, &resource); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return "", err
+		}
+		return "", nil
 	}
 	settingsContent := resource.UnstructuredContent()
 	if value, found := settingsContent["value"]; found {
-		return strings.TrimSpace(value.(string))
+		return strings.TrimSpace(value.(string)), nil
 	}
-	return ""
+	return "", nil
 }
 
 // createOrUpdateRancherVerrazzanoUser creates or updates the verrazzano user in Rancher

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -129,6 +129,7 @@ const (
 	SettingUILinkColorValue           = "rgb(49, 118, 217)"
 	SettingUIBrand                    = "ui-brand"
 	SettingUIBrandValue               = "verrazzano"
+	SettingCACerts                    = "cacerts"
 )
 
 // auth config
@@ -518,6 +519,22 @@ func createOrUpdateResource(ctx spi.ComponentContext, nsn types.NamespacedName, 
 	}
 
 	return nil
+}
+
+// getSettingValue Returns a Rancher Settings objecgt value
+func getSettingValue(c client.Client, settingName string) string {
+	resource := unstructured.Unstructured{}
+	resource.SetGroupVersionKind(common.GVKSetting)
+	resource.SetName(settingName)
+	err := c.Get(context.Background(), types.NamespacedName{Name: resource.GetName()}, &resource)
+	if err != nil {
+		return ""
+	}
+	settingsContent := resource.UnstructuredContent()
+	if value, found := settingsContent["value"]; found {
+		return strings.TrimSpace(value.(string))
+	}
+	return ""
 }
 
 // createOrUpdateRancherVerrazzanoUser creates or updates the verrazzano user in Rancher

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -10,22 +10,15 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gertd/go-pluralize"
-	kerrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	k8sversionutil "k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-
 	"github.com/verrazzano/verrazzano/application-operator/controllers"
 	"github.com/verrazzano/verrazzano/pkg/bom"
+	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	logcmn "github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -43,6 +36,18 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/monitor"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/vzconfig"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	kerrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	k8sversionutil "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ComponentName is the name of the component
@@ -73,6 +78,8 @@ const fluentbitFilterAndParserTemplate = "rancher-filter-parser.yaml"
 
 // clusterProvisioner is the configmap indicating the kontainer driver that provisioned the cluster
 const clusterProvisioner = "cluster-provisioner"
+
+const rancherDeploymentName = "rancher"
 
 // Environment variables for the Rancher images
 // format: imageName: baseEnvVar
@@ -461,7 +468,15 @@ func (r rancherComponent) Install(ctx spi.ComponentContext) error {
 	}
 	log.Debugf("Patched Rancher ingress")
 
-	return nil
+	return r.checkRestartRequired(ctx)
+}
+
+func (r rancherComponent) Upgrade(ctx spi.ComponentContext) error {
+	log := ctx.Log()
+	if err := r.HelmComponent.Upgrade(ctx); err != nil {
+		return log.ErrorfThrottledNewErr("Failed retrieving Rancher install component: %s", err.Error())
+	}
+	return r.checkRestartRequired(ctx)
 }
 
 // IsReady component check
@@ -826,5 +841,44 @@ func createOrUpdateRancherUser(ctx spi.ComponentContext) error {
 	if err = createOrUpdateRancherVerrazzanoUserGlobalRoleBinding(ctx, rancherUsername); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (r rancherComponent) checkRestartRequired(ctx spi.ComponentContext) error {
+	if r.isRancherReady(ctx) {
+		// If the pods are not restarted by the install operation, do a rolling restart to pick up any changes
+		ctx.Log().Progressf("Restarting Rancher deployment")
+		if err := restartRancherDeployment(ctx.Log(), ctx.Client()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func restartRancherDeployment(log vzlog.VerrazzanoLogger, c client.Client) error {
+	deployment := appsv1.Deployment{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Namespace: vzconst.RancherSystemNamespace,
+		Name: rancherDeploymentName}, &deployment); err != nil {
+		if kerrs.IsNotFound(err) {
+			log.Debugf("Rancher deployment %s/%s not found, nothing to do",
+				vzconst.RancherSystemNamespace, rancherDeploymentName)
+			return nil
+		}
+		log.ErrorfThrottled("Failed getting Rancher deployment %s/%s to restart pod: %v",
+			vzconst.RancherSystemNamespace, rancherDeploymentName, err)
+		return err
+	}
+
+	// annotate the deployment to do a restart of the pod
+	if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+		deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	deployment.Spec.Template.ObjectMeta.Annotations[vzconst.VerrazzanoRestartAnnotation] = time.Now().String()
+
+	if err := c.Update(context.TODO(), &deployment); err != nil {
+		return logcmn.ConflictWithLog(fmt.Sprintf("Failed updating deployment %s/%s", deployment.Namespace, deployment.Name), err, zap.S())
+	}
+	log.Infof("Updated Rancher deployment %s/%s with restart annotation to force a pod restart",
+		deployment.Namespace, deployment.Name)
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -930,7 +930,7 @@ func restartRancherDeployment(log vzlog.VerrazzanoLogger, c clipkg.Client) error
 }
 
 func getSecret(namespace string, name string) (*v1.Secret, error) {
-	v1Client, err := k8sutil.GetCoreV1Client()
+	v1Client, err := k8sutil.GetCoreV1Func()
 	if err != nil {
 		return nil, err
 	}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -875,7 +875,10 @@ func (r rancherComponent) isPrivateCABundleInSync(ctx spi.ComponentContext) (boo
 	if !found {
 		return true, nil
 	}
-	cacertsSettingsValue := getSettingValue(ctx.Client(), SettingCACerts)
+	cacertsSettingsValue, err := getSettingValue(ctx.Client(), SettingCACerts)
+	if err != nil {
+		return false, err
+	}
 	return cacertsSettingsValue == currentCABundleInSecret, nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -1281,7 +1281,7 @@ func prepareContexts() (spi.ComponentContext, spi.ComponentContext) {
 	}
 	serverURLSetting := createServerURLSetting()
 	okeDriver := createOkeDriver()
-	rancherPod := newPod("cattle-system", "rancher")
+	rancherPod := newPod(ComponentNamespace, "rancher")
 	rancherPod.Status = corev1.PodStatus{
 		Phase: corev1.PodRunning,
 	}
@@ -1434,11 +1434,11 @@ func TestValidateInstall(t *testing.T) {
 
 }
 
-// Test_getSecret tests the getSecret func
+// TestGetSecret tests the getSecret func
 // GIVEN a all to getSecret
 //
 //	THEN the secret is returned, or an error is returned if the secret does not exist
-func Test_getSecret(t *testing.T) {
+func TestGetSecret(t *testing.T) {
 	type args struct {
 		namespace string
 		name      string
@@ -1451,15 +1451,15 @@ func Test_getSecret(t *testing.T) {
 	}{
 		{
 			name: "GetSecretFound",
-			args: args{name: "mysecret", namespace: "cattle-system"},
+			args: args{name: "mysecret", namespace: ComponentNamespace},
 			want: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: "mysecret", Namespace: "cattle-system"},
+				ObjectMeta: metav1.ObjectMeta{Name: "mysecret", Namespace: ComponentNamespace},
 			},
 			wantErr: assert.NoError,
 		},
 		{
 			name:    "GetSecretNotFound",
-			args:    args{name: "mysecret", namespace: "cattle-system"},
+			args:    args{name: "mysecret", namespace: ComponentNamespace},
 			want:    nil,
 			wantErr: assert.Error,
 		},
@@ -1486,11 +1486,11 @@ func Test_getSecret(t *testing.T) {
 	}
 }
 
-// Test_restartRancherDeployment tests the getSecret func
+// TestRestartRancherDeployment tests the getSecret func
 // GIVEN a call to restartRancherDeployment
 //
 //	THEN the Rancher deployment is annotated for a rolling restart if present, or an error is returned for unexpected errors
-func Test_restartRancherDeployment(t *testing.T) {
+func TestRestartRancherDeployment(t *testing.T) {
 	log := vzlog.DefaultLogger()
 	deploymentName := types.NamespacedName{Namespace: constants2.RancherSystemNamespace, Name: ComponentName}
 
@@ -1581,11 +1581,11 @@ func Test_restartRancherDeployment(t *testing.T) {
 	}
 }
 
-// Test_rancherComponent_getCurrentCABundleSecretsValue tests the getCurrentCABundleSecretsValue  func of the rancherComonent
+// TestGetCurrentCABundleSecretsValue tests the getCurrentCABundleSecretsValue  func of the rancherComonent
 // GIVEN a call to rancherComponent.getCurrentCABundleSecretsValue
 //
 //	THEN the bundle data is returned if the secret exists and the bundle is present, or an error is returned and the found bool is false otherwise
-func Test_rancherComponent_getCurrentCABundleSecretsValue(t *testing.T) {
+func TestGetCurrentCABundleSecretsValue(t *testing.T) {
 	bundleData1 := "cabundledata"
 	emptyBundle := ""
 	bundleDataWithWhitespace := "  \t " + bundleData1 + "\n\t"
@@ -1655,11 +1655,11 @@ func Test_rancherComponent_getCurrentCABundleSecretsValue(t *testing.T) {
 	}
 }
 
-// Test_rancherComponent_isPrivateCABundleInSync tests the isPrivateCABundleInSync  func of the rancherComonent
+// TestIsPrivateCABundleInSync tests the isPrivateCABundleInSync  func of the rancherComonent
 // GIVEN a call to rancherComponent.isPrivateCABundleInSync
 //
 //	THEN true is returned if the bundle data in tls-ca is out of sync with the cacerts settings value, or an error
-func Test_rancherComponent_isPrivateCABundleInSync(t *testing.T) {
+func TestIsPrivateCABundleInSync(t *testing.T) {
 	bundleData1 := "cabundledata"
 	bundleDataWithWhitespace := "  \t " + bundleData1 + "\n\t"
 	tests := []struct {
@@ -1755,12 +1755,12 @@ func Test_rancherComponent_isPrivateCABundleInSync(t *testing.T) {
 	}
 }
 
-// Test_rancherComponent_checkRestartRequired tests the checkRestartRequired  func of the rancherComonent
+// TestCheckRestartRequired tests the checkRestartRequired  func of the rancherComonent
 // GIVEN a call to rancherComponent.checkRestartRequired
 //
 //	THEN the Rancher deployment is restarted if the CA bundle is out of sync with the secret AND a Rancher deployment
 //	  	rolling update is NOT already in progress
-func Test_rancherComponent_checkRestartRequired(t *testing.T) {
+func TestCheckRestartRequired(t *testing.T) {
 	deploymentName := types.NamespacedName{Namespace: constants2.RancherSystemNamespace, Name: ComponentName}
 	bundleData1 := "cabundledata"
 	bundleDataWithWhitespace := "  \t " + bundleData1 + "\n\t"

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -1089,8 +1089,8 @@ func TestIsReady(t *testing.T) {
 func TestPostInstall(t *testing.T) {
 	component := NewComponent()
 	ctxWithoutIngress, _ := prepareContexts()
-	assert.IsType(t, fmt.Errorf(""), component.PostInstall(ctxWithoutIngress))
-	//	assert.Nil(t, component.PostInstall(ctxWithIngress))
+	err := component.PostInstall(ctxWithoutIngress)
+	assert.Error(t, err)
 }
 
 // TestPostUpgrade tests a happy path post upgrade run

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall.go
@@ -78,7 +78,7 @@ func copyDefaultCACertificate(log vzlog.VerrazzanoLogger, c client.Client, vz *v
 				Name:      rancherTLSSecretName,
 			},
 		}
-		log.Infof("Updating Rancher private CA bundle")
+		log.Debugf("Copying default Verrazzano secret to Rancher namespace")
 		if _, err := controllerruntime.CreateOrUpdate(context.TODO(), c, rancherCaSecret, func() error {
 			rancherCaSecret.Data = map[string][]byte{
 				caCertsPem: caSecret.Data[certKey],

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall.go
@@ -6,10 +6,9 @@ package rancher
 import (
 	"context"
 
-	"github.com/verrazzano/verrazzano/platform-operator/constants"
-
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,6 +53,16 @@ func copyDefaultCACertificate(log vzlog.VerrazzanoLogger, c client.Client, vz *v
 		return err
 	}
 	if isCAIssuer {
+		// Only create the tls-ca secret on the first pass; after the initial creation the secret controller will handle any upates
+		// to it based on updates to verrazzano-system/verrazzano-tls
+		//if err := c.Get(context.TODO(), types.NamespacedName{Name: rancherTLSSecretName, Namespace: common.CattleSystem}, &v1.Secret{}); err != nil {
+		//	if !errors.IsNotFound(err) {
+		//		return err
+		//	}
+		//	log.Progressf("Rancher private CA secret")
+		//	return nil
+		//}
+		//log.Progressf("Creating Rancher private CA secret")
 		caSecretNamespace := clusterIssuer.ClusterResourceNamespace
 		caSecretName := clusterIssuer.CA.SecretName
 		namespacedName := types.NamespacedName{
@@ -79,7 +88,7 @@ func copyDefaultCACertificate(log vzlog.VerrazzanoLogger, c client.Client, vz *v
 				Name:      rancherTLSSecretName,
 			},
 		}
-		log.Debugf("Copying default Verrazzano secret to Rancher namespace")
+		log.Infof("Copying updating Rancher private CA bundle")
 		if _, err := controllerruntime.CreateOrUpdate(context.TODO(), c, rancherCaSecret, func() error {
 			rancherCaSecret.Data = map[string][]byte{
 				caCertsPem: caSecret.Data[certKey],

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_preinstall.go
@@ -53,16 +53,6 @@ func copyDefaultCACertificate(log vzlog.VerrazzanoLogger, c client.Client, vz *v
 		return err
 	}
 	if isCAIssuer {
-		// Only create the tls-ca secret on the first pass; after the initial creation the secret controller will handle any upates
-		// to it based on updates to verrazzano-system/verrazzano-tls
-		//if err := c.Get(context.TODO(), types.NamespacedName{Name: rancherTLSSecretName, Namespace: common.CattleSystem}, &v1.Secret{}); err != nil {
-		//	if !errors.IsNotFound(err) {
-		//		return err
-		//	}
-		//	log.Progressf("Rancher private CA secret")
-		//	return nil
-		//}
-		//log.Progressf("Creating Rancher private CA secret")
 		caSecretNamespace := clusterIssuer.ClusterResourceNamespace
 		caSecretName := clusterIssuer.CA.SecretName
 		namespacedName := types.NamespacedName{
@@ -88,7 +78,7 @@ func copyDefaultCACertificate(log vzlog.VerrazzanoLogger, c client.Client, vz *v
 				Name:      rancherTLSSecretName,
 			},
 		}
-		log.Infof("Copying updating Rancher private CA bundle")
+		log.Infof("Updating Rancher private CA bundle")
 		if _, err := controllerruntime.CreateOrUpdate(context.TODO(), c, rancherCaSecret, func() error {
 			rancherCaSecret.Data = map[string][]byte{
 				caCertsPem: caSecret.Data[certKey],

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -373,7 +373,7 @@ func TestGetUserNameForPrincipal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getUserNameForPrincipal(tt.principal); got != tt.want {
-				t.Errorf("getUserNameForPrincipal() = %v, want %v", got, tt.want)
+				t.Errorf("getUserNameForPrincipal() = %v, exepectedResult %v", got, tt.want)
 			}
 		})
 	}
@@ -441,7 +441,7 @@ func TestGetRancherUsername(t *testing.T) {
 				return
 			}
 			if got != tt.want {
-				t.Errorf("getRancherUsername() got = %v, want %v", got, tt.want)
+				t.Errorf("getRancherUsername() got = %v, exepectedResult %v", got, tt.want)
 			}
 		})
 	}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -373,7 +373,7 @@ func TestGetUserNameForPrincipal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getUserNameForPrincipal(tt.principal); got != tt.want {
-				t.Errorf("getUserNameForPrincipal() = %v, exepectedResult %v", got, tt.want)
+				t.Errorf("getUserNameForPrincipal() = %v, restartExpected %v", got, tt.want)
 			}
 		})
 	}
@@ -441,7 +441,7 @@ func TestGetRancherUsername(t *testing.T) {
 				return
 			}
 			if got != tt.want {
-				t.Errorf("getRancherUsername() got = %v, exepectedResult %v", got, tt.want)
+				t.Errorf("getRancherUsername() got = %v, restartExpected %v", got, tt.want)
 			}
 		})
 	}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -87,6 +87,7 @@ func getScheme() *runtime.Scheme {
 	_ = rbacv1.AddToScheme(scheme)
 	_ = v12.AddToScheme(scheme)
 	_ = batchv1.AddToScheme(scheme)
+	scheme.AddKnownTypeWithName(common.GetRancherMgmtAPIGVKForKind(common.KontainerDriverKind), &unstructured.Unstructured{})
 	return scheme
 }
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -373,7 +373,7 @@ func TestGetUserNameForPrincipal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getUserNameForPrincipal(tt.principal); got != tt.want {
-				t.Errorf("getUserNameForPrincipal() = %v, restartExpected %v", got, tt.want)
+				t.Errorf("getUserNameForPrincipal() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -441,7 +441,7 @@ func TestGetRancherUsername(t *testing.T) {
 				return
 			}
 			if got != tt.want {
-				t.Errorf("getRancherUsername() got = %v, restartExpected %v", got, tt.want)
+				t.Errorf("getRancherUsername() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_test.go
@@ -687,7 +687,10 @@ func getFakeRancherUser(userName string, principal string) *unstructured.Unstruc
 	return resource
 }
 
-func Test_getSettingValue(t *testing.T) {
+// TestGetSettingValue tests the getSettingValue func
+// GIVEN func call to getSettingValue(
+// THEN the value is returned if the setting is present, or an error if the field is not found but the setting exists
+func TestGetSettingValue(t *testing.T) {
 	tests := []struct {
 		name            string
 		settingName     string

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -125,7 +125,7 @@ func postUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMo
 		// If it's not finished running, requeue
 		if succeeded {
 			// Mark the monitor as completed.  Reconcile loop may call this function again
-			// and do not restartExpected to call forkPostUninstallFunc more than once.  Generate retryable error to
+			// and do not want to call forkPostUninstallFunc more than once.  Generate retryable error to
 			// run post job clenaup and reset monitor.
 			monitor.SetCompleted()
 			return ctrlerrors.RetryableError{Source: ComponentName}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -125,7 +125,7 @@ func postUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMo
 		// If it's not finished running, requeue
 		if succeeded {
 			// Mark the monitor as completed.  Reconcile loop may call this function again
-			// and do not exepectedResult to call forkPostUninstallFunc more than once.  Generate retryable error to
+			// and do not restartExpected to call forkPostUninstallFunc more than once.  Generate retryable error to
 			// run post job clenaup and reset monitor.
 			monitor.SetCompleted()
 			return ctrlerrors.RetryableError{Source: ComponentName}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_uninstall.go
@@ -125,7 +125,7 @@ func postUninstall(ctx spi.ComponentContext, monitor monitor.BackgroundProcessMo
 		// If it's not finished running, requeue
 		if succeeded {
 			// Mark the monitor as completed.  Reconcile loop may call this function again
-			// and do not want to call forkPostUninstallFunc more than once.  Generate retryable error to
+			// and do not exepectedResult to call forkPostUninstallFunc more than once.  Generate retryable error to
 			// run post job clenaup and reset monitor.
 			monitor.SetCompleted()
 			return ctrlerrors.RetryableError{Source: ComponentName}


### PR DESCRIPTION
When Verrazzano is updated to change between private CA configurations, the secret ` cattle-system/tls-ca` will be updated with the new private CA, but the Rancher pods will not be rotated to pick it up as the deployment remains unchanged.  This will cause SSO errors logging into Rancher via Keycloak until the pods are rotated to pick up the bundle change.

With this change, immediately after running Helm in the `Install()` and `Upgrade()` methods we
- compare the contents of the `cacerts` `Settings` object used by Rancher with the data in `cattle-system/tls-ca`
- if they are different, and a rolling update of the `cattle-system/rancher` deployment is not already in progress, start a rolling restart of the Rancher deployment to pick up the new value

Other changes:
- Adds an override of the `Upgrade()` func so we can have a chance to restart the Rancher deployment if necessary right after calling Helm
- return the error from invoking `HelmComponent.PostInstall()` directly without logging it to avoid logging retryable errors and clean up the logs
- Cleans up and fixes a few other unit tests

**NOTE** that this does not yet handle the Let's Encrypt staging case, that is being investigated as part of VZ-10166.
