### PR TITLE
Update OCNE capi provider with registry and status condition change

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -235,11 +235,11 @@
           "images": [
             {
               "image": "cluster-api-ocne-bootstrap-controller",
-              "tag": "v1.6.1-20230620181634-aebde3b"
+              "tag": "v1.6.1-20230713001831-abc04fb"
             },
             {
               "image": "cluster-api-ocne-control-plane-controller",
-              "tag": "v1.6.1-20230620181634-aebde3b"
+              "tag": "v1.6.1-20230713001831-abc04fb"
             }
           ]
         }


### PR DESCRIPTION
New OCNE capi image with following details:

Private registry fix (do not override crio) and status condition string typo.
Branch name : release/1.6
Version String : v1.6.1
Verrazzano Module commit: 15c5f4d37de4f486deb07234bcccac2d91053b36
Verrazzano Module branch: release/1.6
Verrazzano Module tag: v1.6.1-20230712221459-5a4801d6
OCNE Docker image tag : v1.6.1-20230713001831-abc04fb
