### PR TITLE
Use mysql-server:8.0.32 in test file to fix BOM validation failure

### DIFF
--- a/tests/testdata/grafana/grafana-mysql.yaml
+++ b/tests/testdata/grafana/grafana-mysql.yaml
@@ -82,7 +82,7 @@ spec:
               name: data
       containers:
         - name: mysql
-          image: "ghcr.io/verrazzano/community-server:8.0.33"
+          image: "ghcr.io/verrazzano/mysql-server:8.0.32"
           imagePullPolicy: "IfNotPresent"
           resources:
             requests:


### PR DESCRIPTION
This PR fixes the BOM validation failure in release-1.4, by using the image from the BOM in the test script.
