### PR TITLE
VZ-10226: Upgrade Cluster API components only if the images are outdated

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -262,7 +262,6 @@ func (c *PodMatcherClusterAPI) matchAndPrepareUpgradeOptions(ctx spi.ComponentCo
 		return applyUpgradeOptions, err
 	}
 
-	ctx.Log().Info("LIST OF PODS", podList.String())
 	const formatString = "%s/%s:%s"
 	for _, pod := range podList.Items {
 		for _, co := range pod.Spec.Containers {
@@ -280,10 +279,17 @@ func (c *PodMatcherClusterAPI) matchAndPrepareUpgradeOptions(ctx spi.ComponentCo
 			}
 			ctx.Log().Info(clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider)
 			if isImageOutOfDate(ctx.Log(), clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider) == OutOfDate {
-				applyUpgradeOptions.InfrastructureProviders = append(applyUpgradeOptions.ControlPlaneProviders, fmt.Sprintf(formatString, ComponentNamespace, ociProviderName, overrides.GetOCIVersion()))
+				applyUpgradeOptions.InfrastructureProviders = append(applyUpgradeOptions.InfrastructureProviders, fmt.Sprintf(formatString, ComponentNamespace, ociProviderName, overrides.GetOCIVersion()))
 			}
 		}
 	}
 	ctx.Log().Info("upgrade options", applyUpgradeOptions.CoreProvider, "=>", applyUpgradeOptions.BootstrapProviders, "=>", applyUpgradeOptions.InfrastructureProviders, "==>", applyUpgradeOptions.ControlPlaneProviders)
 	return applyUpgradeOptions, nil
+}
+
+func isUpgradeOptionsEmpty(upgradeOptions clusterapi.ApplyUpgradeOptions) bool {
+	return len(upgradeOptions.CoreProvider) == 0 ||
+		len(upgradeOptions.BootstrapProviders) == 0 ||
+		len(upgradeOptions.ControlPlaneProviders) == 0 ||
+		len(upgradeOptions.InfrastructureProviders) == 0
 }

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -266,19 +266,24 @@ func (c *PodMatcherClusterAPI) matchAndPrepareUpgradeOptions(ctx spi.ComponentCo
 	const formatString = "%s/%s:%s"
 	for _, pod := range podList.Items {
 		for _, co := range pod.Spec.Containers {
+			ctx.Log().Info(clusterAPIControllerImage, co.Image, c.coreProvider)
 			if isImageOutOfDate(ctx.Log(), clusterAPIControllerImage, co.Image, c.coreProvider) == OutOfDate {
 				applyUpgradeOptions.CoreProvider = fmt.Sprintf(formatString, ComponentNamespace, clusterAPIProviderName, overrides.GetClusterAPIVersion())
 			}
+			ctx.Log().Info(clusterAPIOCNEBoostrapControllerImage, co.Image, c.bootstrapProvider)
 			if isImageOutOfDate(ctx.Log(), clusterAPIOCNEBoostrapControllerImage, co.Image, c.bootstrapProvider) == OutOfDate {
 				applyUpgradeOptions.BootstrapProviders = append(applyUpgradeOptions.BootstrapProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overrides.GetOCNEBootstrapVersion()))
 			}
+			ctx.Log().Info(clusterAPIOCNEControlPLaneControllerImage, co.Image, c.controlPlaneProvider)
 			if isImageOutOfDate(ctx.Log(), clusterAPIOCNEControlPLaneControllerImage, co.Image, c.controlPlaneProvider) == OutOfDate {
 				applyUpgradeOptions.ControlPlaneProviders = append(applyUpgradeOptions.ControlPlaneProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overrides.GetOCNEControlPlaneVersion()))
 			}
+			ctx.Log().Info(clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider)
 			if isImageOutOfDate(ctx.Log(), clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider) == OutOfDate {
 				applyUpgradeOptions.InfrastructureProviders = append(applyUpgradeOptions.ControlPlaneProviders, fmt.Sprintf(formatString, ComponentNamespace, ociProviderName, overrides.GetOCIVersion()))
 			}
 		}
 	}
+	ctx.Log().Info("upgrade options", applyUpgradeOptions.CoreProvider, "=>", applyUpgradeOptions.BootstrapProviders, "=>", applyUpgradeOptions.InfrastructureProviders, "==>", applyUpgradeOptions.ControlPlaneProviders)
 	return applyUpgradeOptions, nil
 }

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -243,6 +243,7 @@ func (c *PodMatcherClusterAPI) initializeImageVersionsFromBOM(log vzlog.Verrazza
 
 // isImageOutOfDate returns true if the container image is not as expected (out of date)
 func isImageOutOfDate(log vzlog.VerrazzanoLogger, imageName, actualImage, expectedImage string) ImageCheckResult {
+	log.Infof("Checking if the image %v is out of date,  actual image: %v, expected image: %v", imageName, actualImage, expectedImage)
 	if strings.Contains(actualImage, imageName) {
 		if 0 != strings.Compare(actualImage, expectedImage) {
 			return OutOfDate
@@ -264,28 +265,24 @@ func (c *PodMatcherClusterAPI) matchAndPrepareUpgradeOptions(ctx spi.ComponentCo
 	const formatString = "%s/%s:%s"
 	for _, pod := range podList.Items {
 		for _, co := range pod.Spec.Containers {
-			ctx.Log().Info(clusterAPIControllerImage, co.Image, c.coreProvider)
 			if isImageOutOfDate(ctx.Log(), clusterAPIControllerImage, co.Image, c.coreProvider) == OutOfDate {
 				applyUpgradeOptions.CoreProvider = fmt.Sprintf(formatString, ComponentNamespace, clusterAPIProviderName, overrides.GetClusterAPIVersion())
 			}
-			ctx.Log().Info(clusterAPIOCNEBoostrapControllerImage, co.Image, c.bootstrapProvider)
 			if isImageOutOfDate(ctx.Log(), clusterAPIOCNEBoostrapControllerImage, co.Image, c.bootstrapProvider) == OutOfDate {
 				applyUpgradeOptions.BootstrapProviders = append(applyUpgradeOptions.BootstrapProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overrides.GetOCNEBootstrapVersion()))
 			}
-			ctx.Log().Info(clusterAPIOCNEControlPLaneControllerImage, co.Image, c.controlPlaneProvider)
 			if isImageOutOfDate(ctx.Log(), clusterAPIOCNEControlPLaneControllerImage, co.Image, c.controlPlaneProvider) == OutOfDate {
 				applyUpgradeOptions.ControlPlaneProviders = append(applyUpgradeOptions.ControlPlaneProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overrides.GetOCNEControlPlaneVersion()))
 			}
-			ctx.Log().Info(clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider)
 			if isImageOutOfDate(ctx.Log(), clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider) == OutOfDate {
 				applyUpgradeOptions.InfrastructureProviders = append(applyUpgradeOptions.InfrastructureProviders, fmt.Sprintf(formatString, ComponentNamespace, ociProviderName, overrides.GetOCIVersion()))
 			}
 		}
 	}
-	ctx.Log().Info("upgrade options", applyUpgradeOptions.CoreProvider, "=>", applyUpgradeOptions.BootstrapProviders, "=>", applyUpgradeOptions.InfrastructureProviders, "==>", applyUpgradeOptions.ControlPlaneProviders)
 	return applyUpgradeOptions, nil
 }
 
+// isUpgradeOptionsEmpty returns true if any of the options is not empty
 func isUpgradeOptionsEmpty(upgradeOptions clusterapi.ApplyUpgradeOptions) bool {
 	return len(upgradeOptions.CoreProvider) == 0 ||
 		len(upgradeOptions.BootstrapProviders) == 0 ||

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -202,6 +202,9 @@ func applyTemplate(templateContent string, params interface{}) (bytes.Buffer, er
 
 func getImage(subComponent, imageName string) (string, error) {
 	bomFile, err := bom.NewBom(config.GetDefaultBOMFilePath())
+	if err != nil {
+		return "", err
+	}
 	images, err := bomFile.GetImageNameList(subComponent)
 	if err != nil {
 		return "", fmt.Errorf("Failed to get the images for subComponent")

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -254,7 +254,6 @@ func isImageOutOfDate(log vzlog.VerrazzanoLogger, imageName, actualImage, expect
 
 // MatchAndPrepareUpgradeOptions when a pod has an outdated cluster api controllers images and prepares upgrade options for outdated images.
 func (c *PodMatcherClusterAPI) matchAndPrepareUpgradeOptions(ctx spi.ComponentContext, overrides OverridesInterface) (clusterapi.ApplyUpgradeOptions, error) {
-
 	c.initializeImageVersionsFromBOM(ctx.Log())
 	applyUpgradeOptions := clusterapi.ApplyUpgradeOptions{}
 	podList := &v1.PodList{}

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -302,7 +302,10 @@ func (c clusterAPIComponent) Upgrade(ctx spi.ComponentContext) error {
 	if err != nil {
 		return err
 	}
-	return capiClient.ApplyUpgrade(applyUpgradeOptions)
+	if !isUpgradeOptionsEmpty(applyUpgradeOptions) {
+		return capiClient.ApplyUpgrade(applyUpgradeOptions)
+	}
+	return nil
 }
 
 func (c clusterAPIComponent) PostUpgrade(ctx spi.ComponentContext) error {

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -284,20 +284,14 @@ func (c clusterAPIComponent) Upgrade(ctx spi.ComponentContext) error {
 	if err != nil {
 		return err
 	}
-	overridesContext := newOverridesContext(overrides)
 
-	// Set up the upgrade options for the CAPI apply upgrade.
-	/*	const formatString = "%s/%s:%s"
-		applyUpgradeOptions := clusterapi.ApplyUpgradeOptions{
-			CoreProvider:            fmt.Sprintf(formatString, ComponentNamespace, clusterAPIProviderName, overridesContext.GetClusterAPIVersion()),
-			BootstrapProviders:      []string{fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overridesContext.GetOCNEBootstrapVersion())},
-			ControlPlaneProviders:   []string{fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overrides.GetOCNEControlPlaneVersion())},
-			InfrastructureProviders: []string{fmt.Sprintf(formatString, ComponentNamespace, ociProviderName, overridesContext.GetOCIVersion())},
-		}*/
+	overridesContext := newOverridesContext(overrides)
 	podMatcher := &PodMatcherClusterAPI{}
 	if err = podMatcher.initializeImageVersionsFromBOM(ctx.Log()); err != nil {
 		return err
 	}
+
+	// Set up the upgrade options for the CAPI apply upgrade.
 	applyUpgradeOptions, err := podMatcher.matchAndPrepareUpgradeOptions(ctx, overridesContext)
 	if err != nil {
 		return err

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -217,7 +217,6 @@ func (c clusterAPIComponent) Install(ctx spi.ComponentContext) error {
 	}
 
 	overridesContext := newOverridesContext(overrides)
-
 	// Set up the init options for the CAPI init.
 	initOptions := clusterapi.InitOptions{
 		CoreProvider:            fmt.Sprintf("%s:%s", clusterAPIProviderName, overridesContext.GetClusterAPIVersion()),


### PR DESCRIPTION
This PR fixes the issue where Cluster API components are upgraded only if the images do not match. 