### PR TITLE
VZ-10265 Check enabled istio deployments by label for readiness and availability check

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -9,11 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/reconcile/restart"
-
-	"github.com/verrazzano/verrazzano/pkg/vzcr"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
-
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/helm"
@@ -23,10 +18,13 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/k8s/webhook"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	installv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/reconcile/restart"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/monitor"
@@ -35,6 +33,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
@@ -78,6 +77,8 @@ const istiodIstioSystem = "istiod-istio-system"
 
 const istioSidecarMutatingWebhook = "istio-sidecar-injector"
 
+var istioLabelSelector = clipkg.ListOptions{LabelSelector: labels.Set(map[string]string{"release": "istio"}).AsSelector()}
+
 const (
 	// ExternalIPArg is used in a special case where Istio helm chart no longer supports ExternalIPs.
 	// Put external IPs into the IstioOperator YAML, which does support it
@@ -88,21 +89,6 @@ const (
 	externalIPJsonPath       = specServiceJSONPath + "." + externalIPJsonPathSuffix
 	meshConfigTracingPath    = "spec.meshConfig.defaultConfig.tracing"
 )
-
-var istioDeployments = []types.NamespacedName{
-	{
-		Name:      IstiodDeployment,
-		Namespace: IstioNamespace,
-	},
-	{
-		Name:      IstioIngressgatewayDeployment,
-		Namespace: IstioNamespace,
-	},
-	{
-		Name:      IstioEgressgatewayDeployment,
-		Namespace: IstioNamespace,
-	},
-}
 
 // istioComponent represents an Istio component
 type istioComponent struct {
@@ -402,7 +388,7 @@ func (i istioComponent) Upgrade(context spi.ComponentContext) error {
 }
 
 func (i istioComponent) IsAvailable(ctx spi.ComponentContext) (reason string, available vzapi.ComponentAvailability) {
-	return (&ready.AvailabilityObjects{DeploymentNames: istioDeployments}).IsAvailable(ctx.Log(), ctx.Client())
+	return (&ready.AvailabilityObjects{DeploymentSelectors: []clipkg.ListOption{&istioLabelSelector}}).IsAvailable(ctx.Log(), ctx.Client())
 }
 
 func (i istioComponent) IsReady(context spi.ComponentContext) bool {
@@ -434,8 +420,9 @@ func (i istioComponent) IsReady(context spi.ComponentContext) bool {
 	return true
 }
 
-func areIstioDeploymentsReady(context spi.ComponentContext, prefix string) bool {
-	return ready.DeploymentsAreReady(context.Log(), context.Client(), istioDeployments, 1, prefix)
+// areIstioDeploymentsReady verifies that the enabled deployments in the Istio Operator CR are ready
+func areIstioDeploymentsReady(ctx spi.ComponentContext, prefix string) bool {
+	return ready.DeploymentsReadyBySelectors(ctx.Log(), ctx.Client(), 1, prefix, &istioLabelSelector)
 }
 
 func isIstioManifestNotInstalledError(err error) bool {

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -397,7 +397,7 @@ func TestIsReady(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: IstioNamespace,
 				Name:      IstiodDeployment,
-				Labels:    map[string]string{"app": IstiodDeployment},
+				Labels:    map[string]string{"app": IstiodDeployment, "release": "istio"},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
@@ -431,7 +431,7 @@ func TestIsReady(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: IstioNamespace,
 				Name:      IstioIngressgatewayDeployment,
-				Labels:    map[string]string{"app": IstioIngressgatewayDeployment},
+				Labels:    map[string]string{"app": IstioIngressgatewayDeployment, "release": "istio"},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
@@ -459,23 +459,6 @@ func TestIsReady(t *testing.T) {
 				Namespace:   IstioNamespace,
 				Name:        IstioIngressgatewayDeployment + "-95d8c5d96",
 				Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
-			},
-		},
-		&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: IstioNamespace,
-				Name:      IstioEgressgatewayDeployment,
-				Labels:    map[string]string{"app": IstioEgressgatewayDeployment},
-			},
-			Spec: appsv1.DeploymentSpec{
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app": IstioEgressgatewayDeployment},
-				},
-			},
-			Status: appsv1.DeploymentStatus{
-				AvailableReplicas: 1,
-				Replicas:          1,
-				UpdatedReplicas:   1,
 			},
 		},
 		&v1.Pod{
@@ -1333,6 +1316,56 @@ func TestValidateInstallWithExistingIstio(t *testing.T) {
 		},
 	}
 	common.RunValidateInstallTest(t, NewComponent, tests...)
+}
+
+// TestIsAvailable test the IsAvailable function for Istio
+//
+//	 GIVEN a call to IsAvailable
+//		WHEN the deployments given in the istio operator are available
+//		THEN the status available is returned
+func TestIsAvailable(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: IstioNamespace,
+				Name:      IstiodDeployment,
+				Labels:    map[string]string{"app": IstiodDeployment, "release": "istio"},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": IstiodDeployment},
+				},
+			},
+			Status: appsv1.DeploymentStatus{
+				AvailableReplicas: 1,
+				ReadyReplicas:     1,
+				Replicas:          1,
+				UpdatedReplicas:   1,
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: IstioNamespace,
+				Name:      IstioIngressgatewayDeployment,
+				Labels:    map[string]string{"app": IstioIngressgatewayDeployment, "release": "istio"},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": IstioIngressgatewayDeployment},
+				},
+			},
+			Status: appsv1.DeploymentStatus{
+				AvailableReplicas: 1,
+				ReadyReplicas:     1,
+				Replicas:          1,
+				UpdatedReplicas:   1,
+			},
+		},
+	).Build()
+	compContext := spi.NewFakeContext(fakeClient, &v1alpha1.Verrazzano{}, nil, false)
+	var iComp istioComponent
+	_, available := iComp.IsAvailable(compContext)
+	assert.Equal(t, v1alpha1.ComponentAvailability(v1alpha1.ComponentAvailable), available)
 }
 
 func newScheme() *runtime.Scheme {


### PR DESCRIPTION
**Changes**
- The is ready check uses label selectors to make sure the deployments for Istio are ready

**Testing**
- Deploy a cluster with egress gateway disabled and verify the readiness check works
- Deploy a cluster with all enabled and verify the readiness check works


