### PR TITLE
VZ-10127 - Adds pre-uninstall to VMO component to wait for cleanup of VMI pods/ingresses, and to external-dns component to wait for external-dns annotated ingresses and services to be cleaned up, so that DNS records can be deleted.

### DIFF
--- a/platform-operator/constants/constants.go
+++ b/platform-operator/constants/constants.go
@@ -44,8 +44,8 @@ const AdminClusterConfigMapName = "verrazzano-admin-cluster"
 // ServerDataKey is the key into ConfigMap data for cluster server address
 const ServerDataKey = "server"
 
-// VzConsoleIngress - the name of the ingress for Verrazzano console and api
-const VzConsoleIngress = "verrazzano-ingress"
+// VzIngress - the name of the ingress for Verrazzano console and api
+const VzIngress = "verrazzano-ingress"
 
 // RegistryOverrideEnvVar is the environment variable name used to override the registry housing images we install
 const RegistryOverrideEnvVar = "REGISTRY"

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
@@ -76,7 +76,7 @@ func NewComponent() spi.Component {
 			IngressNames: []types.NamespacedName{
 				{
 					Namespace: ComponentNamespace,
-					Name:      constants.VzConsoleIngress,
+					Name:      constants.VzIngress,
 				},
 			},
 		},

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component_test.go
@@ -4,6 +4,8 @@
 package authproxy
 
 import (
+	"testing"
+
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -16,7 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 
 	helmcli "github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -119,7 +120,7 @@ func TestIsEnabled(t *testing.T) {
 func TestGetIngressNames(t *testing.T) {
 	ingressNames := NewComponent().GetIngressNames(nil)
 	assert.True(t, len(ingressNames) == 1)
-	assert.Equal(t, constants.VzConsoleIngress, ingressNames[0].Name)
+	assert.Equal(t, constants.VzIngress, ingressNames[0].Name)
 	assert.Equal(t, ComponentNamespace, ingressNames[0].Namespace)
 }
 

--- a/platform-operator/controllers/verrazzano/component/common/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/common/vmi.go
@@ -42,7 +42,8 @@ const (
 	defaultStorageSize    = "50Gi"
 )
 
-var vmoLabelSelector = labels.SelectorFromSet(labels.Set{vmoconst.VMOLabel: VMIName})
+var vmoManagedLabels = labels.Set{vmoconst.VMOLabel: VMIName}
+var vmoLabelSelector = labels.SelectorFromSet(vmoManagedLabels)
 
 // ResourceRequestValues defines the storage information that will be passed to VMI instance
 type ResourceRequestValues struct {

--- a/platform-operator/controllers/verrazzano/component/common/vmi_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/vmi_test.go
@@ -622,9 +622,6 @@ func TestDeleteVMI(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "otherVMI", Namespace: "otherNS"},
 	}
 
-	type args struct {
-		ctx spi.ComponentContext
-	}
 	tests := []struct {
 		name          string
 		vmis          []client.Object

--- a/platform-operator/controllers/verrazzano/component/common/vmi_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/vmi_test.go
@@ -346,8 +346,8 @@ func TestReassociateResources(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme2.Scheme).WithObjects(&corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: vmoComponentNamespace,
-			Name:      vmoComponentName,
+			Namespace: VMOComponentNamespace,
+			Name:      VMOComponentName,
 		},
 	}).Build()
 	err := ExportVMOHelmChart(spi.NewFakeContext(fakeClient, nil, nil, false))
@@ -355,11 +355,11 @@ func TestReassociateResources(t *testing.T) {
 	err = ReassociateVMOResources(spi.NewFakeContext(fakeClient, nil, nil, false))
 	assert.NoError(t, err)
 	service := corev1.Service{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: vmoComponentNamespace, Name: vmoComponentName}, &service)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: VMOComponentNamespace, Name: VMOComponentName}, &service)
 	assert.NoError(t, err)
 	assert.Contains(t, service.Labels["app.kubernetes.io/managed-by"], "Helm")
-	assert.Contains(t, service.Annotations["meta.helm.sh/release-name"], vmoComponentName)
-	assert.Contains(t, service.Annotations["meta.helm.sh/release-namespace"], vmoComponentNamespace)
+	assert.Contains(t, service.Annotations["meta.helm.sh/release-name"], VMOComponentName)
+	assert.Contains(t, service.Annotations["meta.helm.sh/release-namespace"], VMOComponentNamespace)
 	assert.NotContains(t, service.Annotations["helm.sh/resource-policy"], "keep")
 }
 
@@ -376,18 +376,18 @@ func TestExportVmoHelmChart(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme2.Scheme).WithObjects(&corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: vmoComponentNamespace,
-			Name:      vmoComponentName,
+			Namespace: VMOComponentNamespace,
+			Name:      VMOComponentName,
 		},
 	}).Build()
 	err := ExportVMOHelmChart(spi.NewFakeContext(fakeClient, nil, nil, false))
 	assert.NoError(t, err)
 	service := corev1.Service{}
-	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: vmoComponentNamespace, Name: vmoComponentName}, &service)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: VMOComponentNamespace, Name: VMOComponentName}, &service)
 	assert.NoError(t, err)
 	assert.Contains(t, service.Labels["app.kubernetes.io/managed-by"], "Helm")
-	assert.Contains(t, service.Annotations["meta.helm.sh/release-name"], vmoComponentName)
-	assert.Contains(t, service.Annotations["meta.helm.sh/release-namespace"], vmoComponentNamespace)
+	assert.Contains(t, service.Annotations["meta.helm.sh/release-name"], VMOComponentName)
+	assert.Contains(t, service.Annotations["meta.helm.sh/release-namespace"], VMOComponentNamespace)
 	assert.Contains(t, service.Annotations["helm.sh/resource-policy"], "keep")
 }
 

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns.go
@@ -46,7 +46,6 @@ const (
 	clusterRoleName                 = ComponentName
 	clusterRoleBindingName          = ComponentName
 	externalDNSIngressAnnotationKey = "external-dns.alpha.kubernetes.io/target"
-	externalDNSSvcAnnotationKey     = "external-dns.alpha.kubernetes.io/hostname"
 )
 
 type isInstalledFuncType func(releaseName string, namespace string) (found bool, err error)

--- a/platform-operator/controllers/verrazzano/component/externaldns/external_dns_component.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/external_dns_component.go
@@ -99,6 +99,18 @@ func (c *externalDNSComponent) PostUninstall(ctx spi.ComponentContext) error {
 	return postUninstall(ctx.Log(), ctx.Client())
 }
 
+// PreUninstall makes sure that it is safe to uninstall external-dns
+func (c externalDNSComponent) PreUninstall(ctx spi.ComponentContext) error {
+	if ctx.IsDryRun() {
+		ctx.Log().Debug("%s PreUninstall dry run", ComponentName)
+		return nil
+	}
+	if err := preUninstall(ctx.Log(), ctx.Client()); err != nil {
+		return err
+	}
+	return c.HelmComponent.PreUninstall(ctx)
+}
+
 // ValidateUpdate checks if the specified new Verrazzano CR is valid for this component to be updated
 func (c *externalDNSComponent) ValidateUpdate(old *vzapi.Verrazzano, new *vzapi.Verrazzano) error {
 	// Do not allow any changes except to enable the component post-install

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali.go
@@ -170,6 +170,14 @@ func createOrUpdateAuthPolicy(ctx spi.ComponentContext) error {
 	return err
 }
 
+// deleteKialiIngress Deletes the Kiali ingress
+func deleteKialiIngress(ctx spi.ComponentContext, namespace string) error {
+	ingress := v1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: kialiSystemName, Namespace: namespace},
+	}
+	return clipkg.IgnoreNotFound(ctx.Client().Delete(context.TODO(), &ingress))
+}
+
 func getKialiHostName(context spi.ComponentContext) (string, error) {
 	dnsDomain, err := vzconfig.BuildDNSDomain(context.Client(), context.EffectiveCR())
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali_component.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali_component.go
@@ -144,6 +144,15 @@ func (c kialiComponent) PostUpgrade(ctx spi.ComponentContext) error {
 	return c.createOrUpdateKialiResources(ctx)
 }
 
+// PostUninstall Kiali-post-uninstall processing, delete the Kiali ingress
+func (c kialiComponent) PostUninstall(ctx spi.ComponentContext) error {
+	ctx.Log().Debugf("Kiali post-uninstall")
+	if err := c.HelmComponent.Uninstall(ctx); err != nil {
+		return err
+	}
+	return deleteKialiIngress(ctx, c.ChartNamespace)
+}
+
 // IsReady Kiali-specific ready-check
 func (c kialiComponent) IsReady(context spi.ComponentContext) bool {
 	if c.HelmComponent.IsReady(context) {

--- a/platform-operator/controllers/verrazzano/component/kiali/kiali_component.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/kiali_component.go
@@ -147,7 +147,7 @@ func (c kialiComponent) PostUpgrade(ctx spi.ComponentContext) error {
 // PostUninstall Kiali-post-uninstall processing, delete the Kiali ingress
 func (c kialiComponent) PostUninstall(ctx spi.ComponentContext) error {
 	ctx.Log().Debugf("Kiali post-uninstall")
-	if err := c.HelmComponent.Uninstall(ctx); err != nil {
+	if err := c.HelmComponent.PostUninstall(ctx); err != nil {
 		return err
 	}
 	return deleteKialiIngress(ctx, c.ChartNamespace)

--- a/platform-operator/controllers/verrazzano/component/registry/registry.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry.go
@@ -123,6 +123,20 @@ func GetComponents() []spi.Component {
 	return getComponentsFn()
 }
 
+func GetComponentsForUninstall() []spi.Component {
+	if len(componentsRegistry) == 0 {
+		InitRegistry()
+	}
+	comps := getComponentsFn()
+	uninstallComps := make([]spi.Component, len(comps))
+	uninstallIdx := len(comps) - 1
+	for _, comp := range comps {
+		uninstallComps[uninstallIdx] = comp
+		uninstallIdx--
+	}
+	return uninstallComps
+}
+
 // getComponents is the internal impl function for GetComponents, to allow overriding it for testing purposes
 func getComponents() []spi.Component {
 	return componentsRegistry

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -211,7 +211,7 @@ func TestGetComponentsForUninstall(t *testing.T) {
 	uninstallComps := GetComponentsForUninstall()
 	a.Equal(len(comps), len(uninstallComps))
 	j := len(comps) - 1
-	for i, _ := range uninstallComps {
+	for i := range uninstallComps {
 		a.Equal(comps[j].Name(), uninstallComps[i].Name())
 		a.Equal(comps[j].Namespace(), uninstallComps[i].Namespace())
 		a.Equal(reflect.TypeOf(comps[j]).Name(), reflect.TypeOf(uninstallComps[i]).Name())

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -4,6 +4,7 @@
 package registry
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -197,6 +198,25 @@ func TestGetComponents(t *testing.T) {
 	a.Equal(comps[i].Name(), thanos.ComponentName)
 	i++
 	a.Equal(comps[i].Name(), clusteragent.ComponentName)
+}
+
+// TestGetComponents tests getting the components
+// GIVEN a component
+//
+//	WHEN I call GetComponentsForUninstall
+//	THEN it returns all the components in reverse order of GetComponents
+func TestGetComponentsForUninstall(t *testing.T) {
+	a := assert.New(t)
+	comps := GetComponents()
+	uninstallComps := GetComponentsForUninstall()
+	a.Equal(len(comps), len(uninstallComps))
+	j := len(comps) - 1
+	for i, _ := range uninstallComps {
+		a.Equal(comps[j].Name(), uninstallComps[i].Name())
+		a.Equal(comps[j].Namespace(), uninstallComps[i].Namespace())
+		a.Equal(reflect.TypeOf(comps[j]).Name(), reflect.TypeOf(uninstallComps[i]).Name())
+		j--
+	}
 }
 
 // TestFindComponent tests FindComponent

--- a/platform-operator/controllers/verrazzano/component/vmo/vmo_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/vmo/vmo_component_test.go
@@ -272,6 +272,13 @@ func TestPreUninstall(t *testing.T) {
 			Labels:    vmoLabels,
 		},
 	}
+	vmoSvc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.VerrazzanoSystemNamespace,
+			Name:      "test-vmo-svc",
+			Labels:    vmoLabels,
+		},
+	}
 	nonVMODeploy := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: constants.VerrazzanoSystemNamespace,
@@ -321,9 +328,15 @@ func TestPreUninstall(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name:      "Test PreUninstall when VMI and a VMO service exist",
+			vmi:       &testVMI,
+			otherObjs: []client.Object{&vmoSvc},
+			expectErr: true,
+		},
+		{
 			name:      "Test PreUninstall when VMI and multiple VMO-labeled resources exist",
 			vmi:       &testVMI,
-			otherObjs: []client.Object{&vmoDeploy, &vmoIngress, &vmoStatefulSet},
+			otherObjs: []client.Object{&vmoDeploy, &vmoIngress, &vmoStatefulSet, &vmoSvc},
 			expectErr: true,
 		},
 		{

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_component.go
@@ -46,10 +46,10 @@ func (r *Reconciler) uninstallComponents(log vzlog.VerrazzanoLogger, cr *v1alpha
 
 	var requeue bool
 
-	// Loop through the Verrazzano components and Uninstall each one.
+	// Loop through the Verrazzano components in uninstall order, and Uninstall each one.
 	// Don't block uninstalling the next component if the current one has an error.
 	// It is normal for a component to return an error if it is waiting for some condition.
-	for _, comp := range registry.GetComponents() {
+	for _, comp := range registry.GetComponentsForUninstall() {
 		UninstallContext := tracker.getComponentUninstallContext(comp.Name())
 		result, err := r.uninstallSingleComponent(spiCtx, UninstallContext, comp)
 		if err != nil || result.Requeue {

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade_test.go
@@ -930,8 +930,8 @@ func TestUpgradeComponent(t *testing.T) {
 	mockComp.EXPECT().IsReady(gomock.Any()).Return(true).AnyTimes()
 
 	ingressList := networkingv1.IngressList{Items: []networkingv1.Ingress{}}
-	//sa := rbac.NewServiceAccount(namespace, name, []string{}, map[string]string{})
-	//crb := rbac.NewClusterRoleBinding(&vz, buildClusterRoleBindingName(namespace, name), getInstallNamespace(), buildServiceAccountName(name))
+	// sa := rbac.NewServiceAccount(namespace, name, []string{}, map[string]string{})
+	// crb := rbac.NewClusterRoleBinding(&vz, buildClusterRoleBindingName(namespace, name), getInstallNamespace(), buildServiceAccountName(name))
 	authConfig := createKeycloakAuthConfig()
 	localAuthConfig := createLocalAuthConfig()
 	kcSecret := createKeycloakSecret()
@@ -1616,7 +1616,7 @@ func TestInstanceRestoreWithEmptyStatus(t *testing.T) {
 			},
 		},
 		&networkingv1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VzConsoleIngress},
+			ObjectMeta: metav1.ObjectMeta{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VzIngress},
 			Spec: networkingv1.IngressSpec{
 				Rules: []networkingv1.IngressRule{
 					{Host: consoleURL},
@@ -1805,7 +1805,7 @@ func TestInstanceRestoreWithPopulatedStatus(t *testing.T) {
 			},
 		},
 		&networkingv1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VzConsoleIngress},
+			ObjectMeta: metav1.ObjectMeta{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VzIngress},
 			Spec: networkingv1.IngressSpec{
 				Rules: []networkingv1.IngressRule{
 					{Host: consoleURL},

--- a/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance.go
+++ b/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance.go
@@ -46,7 +46,7 @@ func GetInstanceInfo(ctx spi.ComponentContext) *v1alpha1.InstanceInfo {
 
 	var consoleURL *string
 	if vzcr.IsConsoleEnabled(ctx.EffectiveCR()) {
-		consoleURL = getComponentIngressURL(ingressList.Items, ctx, authproxy.ComponentName, constants.VzConsoleIngress)
+		consoleURL = getComponentIngressURL(ingressList.Items, ctx, authproxy.ComponentName, constants.VzIngress)
 	} else {
 		consoleURL = nil
 	}

--- a/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance_test.go
+++ b/platform-operator/controllers/verrazzano/vzinstance/verrazzano_instance_test.go
@@ -6,9 +6,10 @@ package vzinstance
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -95,7 +96,7 @@ func TestGetInstanceInfo(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VzConsoleIngress},
+					ObjectMeta: metav1.ObjectMeta{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VzIngress},
 					Spec: networkingv1.IngressSpec{
 						Rules: []networkingv1.IngressRule{
 							{Host: consoleURL},
@@ -177,7 +178,7 @@ func TestGetInstanceInfoManagedCluster(t *testing.T) {
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VzConsoleIngress},
+					ObjectMeta: metav1.ObjectMeta{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.VzIngress},
 					Spec: networkingv1.IngressSpec{
 						Rules: []networkingv1.IngressRule{
 							{Host: consoleURL},


### PR DESCRIPTION
**Note to Reviewers**
There are minor refactoring changes, and making some constants public etc, but the main changes are in the following files:

vmo_component.go
externaldns.go

Some smaller relevant changes are in registry.go and kiali_component.go.

**Description:**
Adds pre-uninstall to VMO component to wait for cleanup of VMI pods/ingresses.
Adds pre-uninstall to external-dns component to wait for external-dns annotated ingresses and services to be cleaned up, so that DNS records can be deleted before external-dns is uninstalled.
Modifies the Kiali component to delete the ingress in PostUninstall, which it created in PostInstall.

I’ve manually verified numerous times that these changes result in the clean up of DNS records. However, this change does not absolutely confirm that the records are deleted, so there is a small possibility that it may still leave a bit of cruft behind (e.g. if external-dns has network trouble when deleting the records and has to retry over a period of time, before which we might uninstall external-dns). 