### PR TITLE
VZ-10346: Do not require --version when --manifests is used with vz upgrade in air-gapped environment (#6539) (release-1.5)

### DIFF
--- a/tools/vz/cmd/helpers/command.go
+++ b/tools/vz/cmd/helpers/command.go
@@ -6,12 +6,16 @@ package helpers
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/semver"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // NewCommand - utility method to create cobra commands
@@ -69,11 +73,41 @@ func GetVersion(cmd *cobra.Command, vzHelper helpers.VZHelper) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	// If the user has provided an operator YAML, attempt to get the version from the VPO deployment
+	if ManifestsFlagChanged(cmd) {
+		manifestsVersion, err := getVersionFromOperatorYAML(cmd, vzHelper)
+		if err != nil {
+			return "", err
+		}
+
+		if manifestsVersion != "" {
+			// If the user has explicitly passed a version, make sure it matches the version in the manifests
+			if cmd.PersistentFlags().Changed(constants.VersionFlag) {
+				match, err := versionsMatch(manifestsVersion, version)
+				if err != nil {
+					return "", err
+				}
+				if match {
+					// Return version and not manifestsVersion because version may have prerelease and build values that are
+					// not present in the manifests version, and make sure it has a "v" prefix
+					if !strings.HasPrefix(version, "v") {
+						version = "v" + version
+					}
+					return version, nil
+				}
+				return "", fmt.Errorf("Requested version '%s' does not match manifests version '%s'", version, manifestsVersion)
+			}
+
+			return manifestsVersion, nil
+		}
+	}
+
 	if version == constants.VersionFlagDefault {
 		// Find the latest release version of Verrazzano
 		version, err = helpers.GetLatestReleaseVersion(vzHelper.GetHTTPClient())
 		if err != nil {
-			return version, err
+			return "", err
 		}
 	} else {
 		// Validate the version string
@@ -84,6 +118,66 @@ func GetVersion(cmd *cobra.Command, vzHelper helpers.VZHelper) (string, error) {
 		version = fmt.Sprintf("v%s", installVersion.ToString())
 	}
 	return version, nil
+}
+
+// getVersionFromOperatorYAML attempts to parse the user-provided operator YAML and returns the
+// Verrazzano version from a label on the verrazzano-platform-operator deployment.
+func getVersionFromOperatorYAML(cmd *cobra.Command, vzHelper helpers.VZHelper) (string, error) {
+	localOperatorFilename, userVisibleFilename, isTempFile, err := getOrDownloadOperatorYAML(cmd, "", vzHelper)
+	if err != nil {
+		return "", err
+	}
+	if isTempFile {
+		// the operator YAML is a temporary file that must be deleted after applying it
+		defer os.Remove(localOperatorFilename)
+	}
+
+	fileObj, err := os.Open(localOperatorFilename)
+	defer func() { fileObj.Close() }()
+	if err != nil {
+		return "", err
+	}
+	objectsInYAML, err := k8sutil.Unmarshall(bufio.NewReader(fileObj))
+	if err != nil {
+		return "", err
+	}
+	vpoDeployIdx, _ := findVPODeploymentIndices(objectsInYAML)
+	if vpoDeployIdx == -1 {
+		return "", fmt.Errorf("Unable to find verrazzano-platform-operator deployment in operator file: %s", userVisibleFilename)
+	}
+
+	vpoDeploy := &objectsInYAML[vpoDeployIdx]
+	version, found, err := unstructured.NestedString(vpoDeploy.Object, "metadata", "labels", "app.kubernetes.io/version")
+	if err != nil || !found {
+		return "", err
+	}
+
+	// versions we return are expected to start with "v"
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return version, err
+}
+
+// versionsMatch returns true if the versions are semantically equivalent. Only the major, minor, and patch fields are considered.
+func versionsMatch(left, right string) (bool, error) {
+	leftVersion, err := semver.NewSemVersion(left)
+	if err != nil {
+		return false, err
+	}
+	rightVersion, err := semver.NewSemVersion(right)
+	if err != nil {
+		return false, err
+	}
+
+	// When comparing the versions, ignore the prerelease and build versions. This is needed to support development scenarios
+	// where the version to upgrade to looks like x.y.z-nnnn+hash but the VPO version label is x.y.z.
+	leftVersion.Prerelease = ""
+	leftVersion.Build = ""
+	rightVersion.Prerelease = ""
+	rightVersion.Build = ""
+
+	return leftVersion.IsEqualTo(rightVersion), nil
 }
 
 // ConfirmWithUser asks the user a yes/no question and returns true if the user answered yes, false

--- a/tools/vz/cmd/upgrade/upgrade_test.go
+++ b/tools/vz/cmd/upgrade/upgrade_test.go
@@ -214,7 +214,6 @@ func TestUpgradeCmdOperatorFile(t *testing.T) {
 			assert.NotNil(t, cmd)
 			cmd.PersistentFlags().Set(tt.manifestsFlagName, "../../test/testdata/operator-file-fake.yaml")
 			cmd.PersistentFlags().Set(constants.WaitFlag, "false")
-			cmd.PersistentFlags().Set(constants.VersionFlag, "v1.4.0")
 			cmdHelpers.SetDeleteFunc(cmdHelpers.FakeDeleteFunc)
 			defer cmdHelpers.SetDefaultDeleteFunc()
 
@@ -252,7 +251,7 @@ func TestUpgradeCmdOperatorFile(t *testing.T) {
 			// Verify the version got updated
 			err = c.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "verrazzano"}, vz)
 			assert.NoError(t, err)
-			assert.Equal(t, "v1.4.0", vz.Spec.Version)
+			assert.Equal(t, "v1.5.2", vz.Spec.Version)
 		})
 	}
 }


### PR DESCRIPTION
Backport of the bug fix to release-1.5. See #6539 for details.
