### PR TITLE
VZ-10301: update cert-manager images

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -52,24 +52,24 @@
           "images": [
             {
               "image": "cert-manager-controller",
-              "tag": "v1.7.1-20230531063350-d7589309",
+              "tag": "v1.7.1-20230720072138-d7815774",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "cert-manager-acmesolver",
-              "tag": "v1.7.1-20230531063350-d7589309",
+              "tag": "v1.7.1-20230720072138-d7815774",
               "helmFullImageKey": "extraArgs[0]"
             },
             {
               "image": "cert-manager-cainjector",
-              "tag": "v1.7.1-20230531063350-d7589309",
+              "tag": "v1.7.1-20230720072138-d7815774",
               "helmFullImageKey": "cainjector.image.repository",
               "helmTagKey": "cainjector.image.tag"
             },
             {
               "image": "cert-manager-webhook",
-              "tag": "v1.7.1-20230531063350-d7589309",
+              "tag": "v1.7.1-20230720072138-d7815774",
               "helmFullImageKey": "webhook.image.repository",
               "helmTagKey": "webhook.image.tag"
             }


### PR DESCRIPTION
port from https://github.com/verrazzano/verrazzano/pull/6530 , images created from oracle/release/1.7.1
