### PR TITLE
Do not apply upgrade options when it is false

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -293,7 +293,7 @@ func (c clusterAPIComponent) Upgrade(ctx spi.ComponentContext) error {
 	if err != nil {
 		return err
 	}
-	if !isUpgradeOptionsNotEmpty(applyUpgradeOptions) {
+	if isUpgradeOptionsNotEmpty(applyUpgradeOptions) {
 		return capiClient.ApplyUpgrade(applyUpgradeOptions)
 	}
 	return nil


### PR DESCRIPTION
This PR fixes the issue with CAPI Upgrade to skip applying upgrade options when upgrade options are empty. 