### PR TITLE
VZ-10226: Upgrade cluster API controller images if they are outdated. 

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -59,6 +59,7 @@ type ImageConfig struct {
 
 const (
 	defaultClusterAPIDir = "/verrazzano/.cluster-api"
+	clusterAPIDirEnv     = "VERRAZZANO_CLUSTER_API_DIR"
 )
 
 var clusterAPIDir = defaultClusterAPIDir
@@ -69,6 +70,13 @@ func setClusterAPIDir(dir string) {
 }
 func resetClusterAPIDir() {
 	clusterAPIDir = defaultClusterAPIDir
+}
+
+func getClusterAPIDir() string {
+	if capiDir := os.Getenv(clusterAPIDirEnv); len(capiDir) > 0 {
+		return capiDir
+	}
+	return clusterAPIDir
 }
 
 // preInstall implementation for the ClusterAPI Component
@@ -131,7 +139,7 @@ func createClusterctlYaml(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	err = os.Mkdir(clusterAPIDir, 0755)
+	err = os.Mkdir(getClusterAPIDir(), 0755)
 	if err != nil {
 		if !os.IsExist(err) {
 			return err
@@ -139,7 +147,7 @@ func createClusterctlYaml(ctx spi.ComponentContext) error {
 	}
 
 	// Create the clusterctl.yaml used when initializing CAPI.
-	return os.WriteFile(clusterAPIDir+"/clusterctl.yaml", result.Bytes(), 0600)
+	return os.WriteFile(getClusterAPIDir()+"/clusterctl.yaml", result.Bytes(), 0600)
 }
 
 // applyTemplate applies the CAPI provider image overrides and versions to the clusterctl.yaml template

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -5,10 +5,16 @@ package clusterapi
 
 import (
 	"bytes"
-	"os"
-	"text/template"
-
+	"context"
+	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	v1 "k8s.io/api/core/v1"
+	"os"
+	clusterapi "sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"text/template"
 )
 
 const clusterctlYamlTemplate = `
@@ -45,10 +51,14 @@ providers:
 `
 
 const (
-	clusterTopology         = "CLUSTER_TOPOLOGY"
-	expClusterResourceSet   = "EXP_CLUSTER_RESOURCE_SET"
-	expMachinePool          = "EXP_MACHINE_POOL"
-	initOCIClientsOnStartup = "INIT_OCI_CLIENTS_ON_STARTUP"
+	clusterTopology                           = "CLUSTER_TOPOLOGY"
+	expClusterResourceSet                     = "EXP_CLUSTER_RESOURCE_SET"
+	expMachinePool                            = "EXP_MACHINE_POOL"
+	initOCIClientsOnStartup                   = "INIT_OCI_CLIENTS_ON_STARTUP"
+	clusterAPIControllerImage                 = "cluster-api-controller"
+	clusterAPIOCIControllerImage              = "cluster-api-oci-controller"
+	clusterAPIOCNEBoostrapControllerImage     = "cluster-api-ocne-bootstrap-controller"
+	clusterAPIOCNEControlPLaneControllerImage = "cluster-api-ocne-control-plane-controller"
 )
 
 type ImageConfig struct {
@@ -56,6 +66,22 @@ type ImageConfig struct {
 	Repository string
 	Tag        string
 }
+
+// PodMatcherClusterAPI matches pods with an out of date CoreProvider, BootstrapProvider, ControlPlaneProvider, or InfrastructureProvider.
+type PodMatcherClusterAPI struct {
+	coreProvider           string
+	bootstrapProvider      string
+	controlPlaneProvider   string
+	infrastructureProvider string
+}
+
+type ImageCheckResult int
+
+const (
+	OutOfDate ImageCheckResult = iota
+	UpToDate
+	NotFound
+)
 
 const (
 	defaultClusterAPIDir = "/verrazzano/.cluster-api"
@@ -167,4 +193,61 @@ func applyTemplate(templateContent string, params interface{}) (bytes.Buffer, er
 
 	// Return the result containing the processed template
 	return buf, nil
+}
+
+// Initializes Cluster API controller image versions considering overrides from VZ CR
+func (c *PodMatcherClusterAPI) initializeImageVersionsOverrides(log vzlog.VerrazzanoLogger, overrides OverridesInterface) error {
+	c.coreProvider = overrides.GetClusterAPIControllerFullImagePath()
+	c.infrastructureProvider = overrides.GetOCIControllerFullImagePath()
+	c.bootstrapProvider = overrides.GetOCNEBootstrapControllerFullImagePath()
+	c.controlPlaneProvider = overrides.GetOCNEControlPlaneControllerFullImagePath()
+	return nil
+}
+
+// isImageOutOfDate returns true if the container image is not as expected (out of date)
+func isImageOutOfDate(log vzlog.VerrazzanoLogger, imageName, actualImage, expectedImage string) ImageCheckResult {
+	log.Infof("Checking if the image %v is out of date,  actual image: %v, expected image: %v", imageName, actualImage, expectedImage)
+	if strings.Contains(actualImage, imageName) {
+		if 0 != strings.Compare(actualImage, expectedImage) {
+			return OutOfDate
+		}
+		return UpToDate
+	}
+	return NotFound
+}
+
+// MatchAndPrepareUpgradeOptions when a pod has an outdated cluster api controllers images and prepares upgrade options for outdated images.
+func (c *PodMatcherClusterAPI) matchAndPrepareUpgradeOptions(ctx spi.ComponentContext, overrides OverridesInterface) (clusterapi.ApplyUpgradeOptions, error) {
+	c.initializeImageVersionsOverrides(ctx.Log(), overrides)
+	applyUpgradeOptions := clusterapi.ApplyUpgradeOptions{}
+	podList := &v1.PodList{}
+	if err := ctx.Client().List(context.TODO(), podList, &client.ListOptions{Namespace: ComponentNamespace}); err != nil {
+		return applyUpgradeOptions, err
+	}
+	const formatString = "%s/%s:%s"
+	for _, pod := range podList.Items {
+		for _, co := range pod.Spec.Containers {
+			if isImageOutOfDate(ctx.Log(), clusterAPIControllerImage, co.Image, c.coreProvider) == OutOfDate {
+				applyUpgradeOptions.CoreProvider = fmt.Sprintf(formatString, ComponentNamespace, clusterAPIProviderName, overrides.GetClusterAPIVersion())
+			}
+			if isImageOutOfDate(ctx.Log(), clusterAPIOCNEBoostrapControllerImage, co.Image, c.bootstrapProvider) == OutOfDate {
+				applyUpgradeOptions.BootstrapProviders = append(applyUpgradeOptions.BootstrapProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overrides.GetOCNEBootstrapVersion()))
+			}
+			if isImageOutOfDate(ctx.Log(), clusterAPIOCNEControlPLaneControllerImage, co.Image, c.controlPlaneProvider) == OutOfDate {
+				applyUpgradeOptions.ControlPlaneProviders = append(applyUpgradeOptions.ControlPlaneProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overrides.GetOCNEControlPlaneVersion()))
+			}
+			if isImageOutOfDate(ctx.Log(), clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider) == OutOfDate {
+				applyUpgradeOptions.InfrastructureProviders = append(applyUpgradeOptions.InfrastructureProviders, fmt.Sprintf(formatString, ComponentNamespace, ociProviderName, overrides.GetOCIVersion()))
+			}
+		}
+	}
+	return applyUpgradeOptions, nil
+}
+
+// isUpgradeOptionsNotEmpty returns true if any of the options is not empty
+func isUpgradeOptionsNotEmpty(upgradeOptions clusterapi.ApplyUpgradeOptions) bool {
+	return len(upgradeOptions.CoreProvider) != 0 ||
+		len(upgradeOptions.BootstrapProviders) != 0 ||
+		len(upgradeOptions.ControlPlaneProviders) != 0 ||
+		len(upgradeOptions.InfrastructureProviders) != 0
 }

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -217,7 +217,6 @@ func (c clusterAPIComponent) Install(ctx spi.ComponentContext) error {
 	}
 
 	overridesContext := newOverridesContext(overrides)
-
 	// Set up the init options for the CAPI init.
 	initOptions := clusterapi.InitOptions{
 		CoreProvider:            fmt.Sprintf("%s:%s", clusterAPIProviderName, overridesContext.GetClusterAPIVersion()),
@@ -285,18 +284,19 @@ func (c clusterAPIComponent) Upgrade(ctx spi.ComponentContext) error {
 	if err != nil {
 		return err
 	}
+
 	overridesContext := newOverridesContext(overrides)
+	podMatcher := &PodMatcherClusterAPI{}
 
 	// Set up the upgrade options for the CAPI apply upgrade.
-	const formatString = "%s/%s:%s"
-	applyUpgradeOptions := clusterapi.ApplyUpgradeOptions{
-		CoreProvider:            fmt.Sprintf(formatString, ComponentNamespace, clusterAPIProviderName, overridesContext.GetClusterAPIVersion()),
-		BootstrapProviders:      []string{fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overridesContext.GetOCNEBootstrapVersion())},
-		ControlPlaneProviders:   []string{fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overrides.GetOCNEControlPlaneVersion())},
-		InfrastructureProviders: []string{fmt.Sprintf(formatString, ComponentNamespace, ociProviderName, overridesContext.GetOCIVersion())},
+	applyUpgradeOptions, err := podMatcher.matchAndPrepareUpgradeOptions(ctx, overridesContext)
+	if err != nil {
+		return err
 	}
-
-	return capiClient.ApplyUpgrade(applyUpgradeOptions)
+	if !isUpgradeOptionsNotEmpty(applyUpgradeOptions) {
+		return capiClient.ApplyUpgrade(applyUpgradeOptions)
+	}
+	return nil
 }
 
 func (c clusterAPIComponent) PostUpgrade(ctx spi.ComponentContext) error {

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -293,7 +293,7 @@ func (c clusterAPIComponent) Upgrade(ctx spi.ComponentContext) error {
 	if err != nil {
 		return err
 	}
-	if !isUpgradeOptionsNotEmpty(applyUpgradeOptions) {
+	if isUpgradeOptionsNotEmpty(applyUpgradeOptions) {
 		return capiClient.ApplyUpgrade(applyUpgradeOptions)
 	}
 	return nil

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component_test.go
@@ -452,6 +452,7 @@ func TestUpgrade(t *testing.T) {
 	SetCAPIInitFunc(fakeClusterAPINew)
 	defer ResetCAPIInitFunc()
 	config.SetDefaultBomFilePath(testBomFilePath)
+	config.TestHelmConfigDir = TestHelmConfigDir
 
 	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects().Build()
 	var comp clusterAPIComponent

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
@@ -6,6 +6,7 @@ package clusterapi
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -188,7 +189,12 @@ func formatProviderURL(remote bool, owner string, repo string, version string, m
 	if remote {
 		return fmt.Sprintf("https://github.com/%s/%s/releases/%s/%s", owner, repo, version, metadataFile)
 	}
-	return fmt.Sprintf("/verrazzano/capi/%s/%s/%s", repo, version, metadataFile)
+
+	var capiRoot = "/verrazzano/capi"
+	if _, err := os.Stat(capiRoot); err != nil {
+		capiRoot = path.Join(config.GetPlatformDir(), "capi")
+	}
+	return fmt.Sprintf("%s/%s/%s/%s", capiRoot, repo, version, metadataFile)
 }
 
 // createOverrides - create the overrides input for install/upgrade of the

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
@@ -55,18 +55,22 @@ type capiImage struct {
 type OverridesInterface interface {
 	GetGlobalRegistry() string
 	GetClusterAPIRepository() string
+	GetClusterAPIControllerFullImagePath() string
 	GetClusterAPITag() string
 	GetClusterAPIURL() string
 	GetClusterAPIVersion() string
 	GetOCIRepository() string
+	GetOCIControllerFullImagePath() string
 	GetOCITag() string
 	GetOCIURL() string
 	GetOCIVersion() string
 	GetOCNEBootstrapRepository() string
+	GetOCNEBootstrapControllerFullImagePath() string
 	GetOCNEBootstrapTag() string
 	GetOCNEBootstrapURL() string
 	GetOCNEBootstrapVersion() string
 	GetOCNEControlPlaneRepository() string
+	GetOCNEControlPlaneControllerFullImagePath() string
 	GetOCNEControlPlaneTag() string
 	GetOCNEControlPlaneURL() string
 	GetOCNEControlPlaneVersion() string
@@ -142,6 +146,22 @@ func (c capiOverrides) GetOCNEControlPlaneURL() string {
 
 func (c capiOverrides) GetOCNEControlPlaneVersion() string {
 	return getProviderVersion(c.DefaultProviders.OCNEControlPlane)
+}
+
+func (c capiOverrides) GetClusterAPIControllerFullImagePath() string {
+	return fmt.Sprintf("%s/%s:%s", c.GetClusterAPIRepository(), clusterAPIControllerImage, c.GetClusterAPITag())
+}
+
+func (c capiOverrides) GetOCIControllerFullImagePath() string {
+	return fmt.Sprintf("%s/%s:%s", c.GetOCIRepository(), clusterAPIOCIControllerImage, c.GetOCITag())
+}
+
+func (c capiOverrides) GetOCNEBootstrapControllerFullImagePath() string {
+	return fmt.Sprintf("%s/%s:%s", c.GetOCNEBootstrapRepository(), clusterAPIOCNEBoostrapControllerImage, c.GetOCNEBootstrapTag())
+}
+
+func (c capiOverrides) GetOCNEControlPlaneControllerFullImagePath() string {
+	return fmt.Sprintf("%s/%s:%s", c.GetOCNEControlPlaneRepository(), clusterAPIOCNEControlPLaneControllerImage, c.GetOCNEControlPlaneTag())
 }
 
 // getRepositoryForProvider - return the repository in the format that clusterctl

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides_test.go
@@ -310,17 +310,18 @@ func TestOverridesInterface(t *testing.T) {
 
 	assert.Equal(t, "ghcr.io", tc.GetGlobalRegistry())
 
+	capiRoot := "/verrazzano/platform-operator/capi"
 	assert.Equal(t, "myreg.io/verrazzano", tc.GetOCNEBootstrapRepository())
 	assert.Equal(t, "v1.0", tc.GetOCNEBootstrapTag())
 	assert.Equal(t, "/test/bootstrap.yaml", tc.GetOCNEBootstrapURL())
 
 	assert.Equal(t, "ghcr.io/verrazzano", tc.GetOCNEControlPlaneRepository())
 	assert.Equal(t, "v1.1", tc.GetOCNEControlPlaneTag())
-	assert.Equal(t, "/verrazzano/capi/control-plane-ocne/v0.1.0/control-plane-components.yaml", tc.GetOCNEControlPlaneURL())
+	assert.Equal(t, capiRoot+"/control-plane-ocne/v0.1.0/control-plane-components.yaml", tc.GetOCNEControlPlaneURL())
 
 	assert.Equal(t, "ghcr.io/verrazzano", tc.GetClusterAPIRepository())
 	assert.Equal(t, CoreImageTag, tc.GetClusterAPITag())
-	assert.Equal(t, "/verrazzano/capi/cluster-api/v1.3.3/core-components.yaml", tc.GetClusterAPIURL())
+	assert.Equal(t, capiRoot+"/cluster-api/v1.3.3/core-components.yaml", tc.GetClusterAPIURL())
 
 	assert.Equal(t, "myreg2.io/oci-repo", tc.GetOCIRepository())
 	assert.Equal(t, "v0.8.2", tc.GetOCITag())

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides_test.go
@@ -314,18 +314,22 @@ func TestOverridesInterface(t *testing.T) {
 	assert.Equal(t, "myreg.io/verrazzano", tc.GetOCNEBootstrapRepository())
 	assert.Equal(t, "v1.0", tc.GetOCNEBootstrapTag())
 	assert.Equal(t, "/test/bootstrap.yaml", tc.GetOCNEBootstrapURL())
+	assert.Equal(t, "myreg.io/verrazzano/"+clusterAPIOCNEBoostrapControllerImage+":v1.0", tc.GetOCNEBootstrapControllerFullImagePath())
 
 	assert.Equal(t, "ghcr.io/verrazzano", tc.GetOCNEControlPlaneRepository())
 	assert.Equal(t, "v1.1", tc.GetOCNEControlPlaneTag())
 	assert.Equal(t, capiRoot+"/control-plane-ocne/v0.1.0/control-plane-components.yaml", tc.GetOCNEControlPlaneURL())
+	assert.Equal(t, "ghcr.io/verrazzano/"+clusterAPIOCNEControlPLaneControllerImage+":v1.1", tc.GetOCNEControlPlaneControllerFullImagePath())
 
 	assert.Equal(t, "ghcr.io/verrazzano", tc.GetClusterAPIRepository())
 	assert.Equal(t, CoreImageTag, tc.GetClusterAPITag())
 	assert.Equal(t, capiRoot+"/cluster-api/v1.3.3/core-components.yaml", tc.GetClusterAPIURL())
+	assert.Equal(t, "ghcr.io/verrazzano/"+clusterAPIControllerImage+":v1.3.3-20230427222746-876fe3dc9", tc.GetClusterAPIControllerFullImagePath())
 
 	assert.Equal(t, "myreg2.io/oci-repo", tc.GetOCIRepository())
 	assert.Equal(t, "v0.8.2", tc.GetOCITag())
 	assert.Equal(t, "https://github.com/oci-repo/cluster-api-provider-oci/releases/v0.8.2/infrastructure-components.yaml", tc.GetOCIURL())
+	assert.Equal(t, "myreg2.io/oci-repo/"+clusterAPIOCIControllerImage+":v0.8.2", tc.GetOCIControllerFullImagePath())
 
 }
 

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_test.go
@@ -4,6 +4,10 @@
 package clusterapi
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"os"
 	"testing"
 	"time"
@@ -67,5 +71,195 @@ func TestCreateClusterctlYaml(t *testing.T) {
 	err := createClusterctlYaml(compContext)
 	assert.NoError(t, err)
 	_, err = os.Stat(dir + "/clusterctl.yaml")
+	assert.NoError(t, err)
+}
+
+// TestToSkipSettingUpgradeOptions tests the matchAndPrepareUpgradeOptions function
+// GIVEN a call to matchAndPrepareUpgradeOptions
+//
+//	WHEN images are initialized from BOM with overrides and same images as in the Running Pods.
+//	THEN upgrade options are not set since there is no change in the image
+func TestToSkipSettingUpgradeOptions(t *testing.T) {
+	const capiOverrides = `
+{
+  "global": {
+    "registry": "ghcr.io"
+  },
+  "defaultProviders": {
+    "ocneBootstrap": {
+      "url": "/test/bootstrap.yaml",
+      "image": {
+        "registry": "myreg.io",
+        "tag": "v1.0"
+      }
+    },
+    "ocneControlPlane": {
+      "image": {
+        "repository": "verrazzano",
+        "registry": "ghcr.io",
+        "tag": "1.0.0-1-20211215184123-0a1b633"
+      }
+    },
+    "oci": {
+      "version": "v0.8.2",
+      "image": {
+        "repository": "oci-repo",
+        "registry": "myreg2.io",
+        "tag": "v0.8.2"
+      }
+    },
+    "core": {
+    }
+  }
+}`
+
+	vz := &v1alpha1.Verrazzano{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vz",
+		},
+		Spec: v1alpha1.VerrazzanoSpec{
+			Components: v1alpha1.ComponentSpec{
+				ClusterAPI: &v1alpha1.ClusterAPIComponent{
+					InstallOverrides: v1alpha1.InstallOverrides{
+						ValueOverrides: []v1alpha1.Overrides{
+							{
+								Values: &apiextensionsv1.JSON{
+									Raw: []byte(capiOverrides),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ComponentNamespace,
+			Name:      controlPlaneOcneProvider + "-95d8c5d97-m6mbr",
+			Labels: map[string]string{
+				providerLabel: clusterAPIProvider,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  clusterAPIOCNEControlPLaneControllerImage,
+					Image: "ghcr.io/verrazzano/cluster-api-ocne-control-plane-controller:1.0.0-1-20211215184123-0a1b633",
+				},
+			},
+		},
+	}).Build()
+	compContext := spi.NewFakeContext(fakeClient, vz, nil, false)
+	config.SetDefaultBomFilePath(testBomFilePath)
+	config.TestHelmConfigDir = TestHelmConfigDir
+	overrides, err := createOverrides(compContext)
+	assert.NoError(t, err)
+	assert.NotNil(t, overrides)
+	overridesContext := newOverridesContext(overrides)
+	podMatcher := &PodMatcherClusterAPI{}
+	applyUpgradeOptions, err := podMatcher.matchAndPrepareUpgradeOptions(compContext, overridesContext)
+	assert.NoError(t, err)
+	assert.False(t, isUpgradeOptionsNotEmpty(applyUpgradeOptions))
+	assert.NoError(t, err)
+}
+
+// TestToSetUpgradeOptions tests the matchAndPrepareUpgradeOptions function
+// GIVEN a call to matchAndPrepareUpgradeOptions
+//
+//	WHEN images are initialized from BOM with overrides
+//	THEN upgrade options are set only for the outdated cluster API images.
+//
+// Ex: In this test cluster-api-ocne-control-plane-controller image is outdated
+// Therefore, upgrade options is set with the updated cluster-api-ocne-control-plane-controller image.
+func TestToSetUpgradeOptions(t *testing.T) {
+	const capiOverrides = `
+{
+  "global": {
+    "registry": "ghcr.io"
+  },
+  "defaultProviders": {
+    "ocneBootstrap": {
+      "url": "/test/bootstrap.yaml",
+      "image": {
+        "registry": "myreg.io",
+        "tag": "v1.0"
+      }
+    },
+    "ocneControlPlane": {
+      "image": {
+        "repository": "verrazzano",
+        "registry": "ghcr.io",
+        "tag": "0.0.1-1-20211215184123-0a1b633"
+      }
+    },
+    "oci": {
+      "version": "v0.8.2",
+      "image": {
+        "repository": "oci-repo",
+        "registry": "myreg2.io",
+        "tag": "v0.8.2"
+      }
+    },
+    "core": {
+    }
+  }
+}`
+
+	vz := &v1alpha1.Verrazzano{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vz",
+		},
+		Spec: v1alpha1.VerrazzanoSpec{
+			Components: v1alpha1.ComponentSpec{
+				ClusterAPI: &v1alpha1.ClusterAPIComponent{
+					InstallOverrides: v1alpha1.InstallOverrides{
+						ValueOverrides: []v1alpha1.Overrides{
+							{
+								Values: &apiextensionsv1.JSON{
+									Raw: []byte(capiOverrides),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ComponentNamespace,
+				Name:      controlPlaneOcneProvider + "-95d8c5d97-m6mbr",
+				Labels: map[string]string{
+					providerLabel: clusterAPIProvider,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  clusterAPIOCNEControlPLaneControllerImage,
+						Image: "ghcr.io/verrazzano/cluster-api-ocne-control-plane-controller:0.0.1-20211215184123-older",
+					},
+				},
+			},
+		}).Build()
+
+	compContext := spi.NewFakeContext(fakeClient, vz, nil, false)
+	config.SetDefaultBomFilePath(testBomFilePath)
+	config.TestHelmConfigDir = TestHelmConfigDir
+	overrides, err := createOverrides(compContext)
+	assert.NoError(t, err)
+	assert.NotNil(t, overrides)
+	overridesContext := newOverridesContext(overrides)
+	podMatcher := &PodMatcherClusterAPI{}
+	applyUpgradeOptions, err := podMatcher.matchAndPrepareUpgradeOptions(compContext, overridesContext)
+	assert.NoError(t, err)
+	assert.True(t, isUpgradeOptionsNotEmpty(applyUpgradeOptions))
+	// Checking for specific upgrade option that contains component namespace, OCNE provider, and it's version.
+	// Upgrade option is not empty only if there is a change in the image.
+	expectedUpgradeOption := []string{"verrazzano-capi/ocne:v0.1.0"}
+	assert.Equal(t, expectedUpgradeOption, applyUpgradeOptions.ControlPlaneProviders)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This PR backports a fix to upgrade the cluster API controller images if they are older. 