### PR TITLE
VZ-10277: Enable Alertmanager UI tests

### DIFF
--- a/tests/e2e/config/scripts/v1alpha1/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/v1alpha1/install-verrazzano-kind.yaml
@@ -25,6 +25,8 @@ spec:
                 integration: sidecar
               prometheusSpec:
                 replicas: 2
+            alertmanager:
+              enabled: true
     prometheusAdapter:
       enabled: true
     kubeStateMetrics:

--- a/tests/e2e/config/scripts/v1beta1/install-verrazzano-kind.yaml
+++ b/tests/e2e/config/scripts/v1beta1/install-verrazzano-kind.yaml
@@ -25,6 +25,8 @@ spec:
                 integration: sidecar
               prometheusSpec:
                 replicas: 2
+            alertmanager:
+              enabled: true
     prometheusAdapter:
       enabled: true
     kubeStateMetrics:

--- a/tests/e2e/scripts/install/install_test.go
+++ b/tests/e2e/scripts/install/install_test.go
@@ -107,6 +107,9 @@ func getConsoleURLsFromResource(kubeconfig string) ([]string, error) {
 	if vz.Status.VerrazzanoInstance.ThanosQueryURL != nil {
 		consoleUrls = append(consoleUrls, *vz.Status.VerrazzanoInstance.ThanosQueryURL)
 	}
+	if vz.Status.VerrazzanoInstance.AlertmanagerURL != nil {
+		consoleUrls = append(consoleUrls, *vz.Status.VerrazzanoInstance.AlertmanagerURL)
+	}
 
 	return consoleUrls, nil
 }

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -260,7 +260,7 @@ func ensureContainerSecurityContext(sc *corev1.SecurityContext, podName, contain
 	if sc.RunAsNonRoot != nil && !*sc.RunAsNonRoot {
 		errors = append(errors, fmt.Errorf("SecurityContext not configured correctly for pod %s, container %s, RunAsNonRoot != true", podName, containerName))
 	}
-	if sc.Privileged == nil || *sc.Privileged {
+	if sc.Privileged != nil && *sc.Privileged {
 		errors = append(errors, fmt.Errorf("SecurityContext not configured correctly for pod %s, container %s, Privileged != false", podName, containerName))
 	}
 	if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {


### PR DESCRIPTION
- Enables Alertmanager in kind test for UI verification
- [SecurityContext.Privileged](https://pkg.go.dev/k8s.io/api@v0.27.4/core/v1#SecurityContext) is false by default if not specified, made corresponding change in tests/e2e/verify-install/security/pod_security_test.go
