### PR TITLE
VZ-10350: Backport to 1.6 fixes for derive versions and upgrade jobs

### DIFF
--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -437,33 +437,31 @@ def getStageOfUpgradeJob(job) {
 def getTipOfBranchToMasterJob(String release, String commitSHA) {
     return {
         stage("Upgrade Verrazzano from tip of ${release} to master") {
-            if( CLEAN_BRANCH_NAME != 'master') {
-                    script{
-                        try{
-                            echo "Running upgrade job from version ${release}-${commitSHA} to master"
-                            retry(count: JOB_PROMOTION_RETRIES) {
-                                def jobStatus =  build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
-                                parameters: [
-                                    string(name: 'GIT_COMMIT_TO_USE', value: "${commitSHA}"),
-                                    string(name: 'VERSION_FOR_INSTALL', value: "${release}" ),
-                                    string(name: 'VERSION_FOR_UPGRADE', value: "master"),
-                                    string(name: 'VZ_INSTALL_CONFIG', value: params.VZ_INSTALL_CONFIG),
-                                    string(name: 'IS_TRIGGERED_MANUALLY', value: "NO"),
-                                    string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                    string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                    string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                    string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                    string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                    string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
-                                ],  wait: true, propagate: true
-                            }
-                        } catch(err) {
-                            catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                                echo "Caught: ${err}"
-                                sh "exit 1"
-                            }
-                        }
-                    } 
+            script{
+                try{
+                    echo "Running upgrade job from version ${release}-${commitSHA} to master"
+                    retry(count: JOB_PROMOTION_RETRIES) {
+                        def jobStatus =  build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
+                        parameters: [
+                            string(name: 'GIT_COMMIT_TO_USE', value: "${commitSHA}"),
+                            string(name: 'VERSION_FOR_INSTALL', value: "${release}" ),
+                            string(name: 'VERSION_FOR_UPGRADE', value: "master"),
+                            string(name: 'VZ_INSTALL_CONFIG', value: params.VZ_INSTALL_CONFIG),
+                            string(name: 'IS_TRIGGERED_MANUALLY', value: "NO"),
+                            string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                            string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                            string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                            string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                            string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                            string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
+                        ],  wait: true, propagate: true
+                    }
+                } catch(err) {
+                    catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                        echo "Caught: ${err}"
+                        sh "exit 1"
+                    }
+                }
             }
         }
     }

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -129,7 +129,7 @@ pipeline {
                         cd ${workspace}
                         git tag | awk '/v1[.]/' >  tags.txt
                         cat tags.txt
-                        git ls-remote --heads https://github.com/verrazzano/verrazzano.git 'refs/heads/release-1*' | cut -d '/' -f 3 | cut -d '-' -f 2 > releaseBranches.txt
+                        git ls-remote --heads https://github.com/verrazzano/verrazzano.git 'refs/heads/release-*' | cut -d '/' -f 3 | cut -d '-' -f 2 | grep -v '0' > releaseBranches.txt
                         cat releaseBranches.txt
                     """
                     def props = readProperties file: '.verrazzano-development-version'

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -129,6 +129,8 @@ pipeline {
                         cd ${workspace}
                         git tag | awk '/v1[.]/' >  tags.txt
                         cat tags.txt
+                        git ls-remote --heads https://github.com/verrazzano/verrazzano.git 'refs/heads/release-1*' | cut -d '/' -f 3 | cut -d '-' -f 2 > releaseBranches.txt
+                        cat releaseBranches.txt
                     """
                     def props = readProperties file: '.verrazzano-development-version'
                     VERRAZZANO_DEV_VERSION = props['verrazzano-development-version']
@@ -152,37 +154,27 @@ pipeline {
                 stage('Compute required N Upgrade Jobs') {
                 steps {
                     script {
+                        // Extract list of releases from git tags
                         final String fileContent = readFile(file: "${workspace}/tags.txt")
                         List gitTags = extractReleaseTags(fileContent)
                         echo "gitTags = ${gitTags}"
-                        def excludeReleases = params.EXCLUDE_RELEASES
-                        def excludeReleasesList = excludeReleases.trim().split('\\s*,\\s*')
-                        println(excludeReleasesList)
-                        def finalReleaseList  = []
-                        //Remove the excluded releases from jobs
-                        for(releaseTag in gitTags){
-                            def excluded = false
-                            for(excludedRelease in excludeReleasesList){
-                                String[] splitReleaseTag  = releaseTag.replace('v', '').split("\\.")
-                                def releaseTagMinorVersion = "v"+ splitReleaseTag[0] + "." + splitReleaseTag[1]
-                                String[] splitDevVersion = VERRAZZANO_DEV_VERSION.split("\\.")
-                                if (splitReleaseTag[0] > splitDevVersion[0] || splitReleaseTag[1] > splitDevVersion[1] || releaseTagMinorVersion == excludedRelease) {
-                                    excluded = true
-                                }
-                            }
-                            if(excluded == false){
-                                finalReleaseList.add(releaseTag)
-                            }
-                        }
+                        List finalReleaseList = removeExcludedReleases(gitTags)
                         echo "List of Releases after excluding the user requested releases: ${finalReleaseList}"
                         listOfUpgradeJobs = addTargetUpgradeVersion(finalReleaseList)
-                        minorReleaseList = getCleanReleaseVersion(finalReleaseList)
-                        echo "List of minor release: ${minorReleaseList}"
+
+                        //Extract list of releases from git branches
+                        fileContent = readFile(file: "${workspace}/releaseBranches.txt")
+                        List releaseBranches = extractReleaseTags(fileContent)
+                        echo "Release Branches: ${releaseBranches}"
+                        List finalReleaseBranchesList = removeExcludedReleases(releaseBranches)
+
+                        //minorReleaseList = getCleanReleaseVersion(finalReleaseBranchesList)
+                        echo "List of minor release: ${finalReleaseBranchesList}"
                         def listOfTipOfReleaseUpgradeJobs = []
                         def releaseCommitMap = [:]
-                        for(minorRelease in minorReleaseList){  
-                            releaseCommit = getTipOfReleaseBranches(minorRelease)
-                            String key = "v"+minorRelease
+                        for(releaseBranch in finalReleaseBranchesList){
+                            releaseCommit = getTipOfReleaseBranches(releaseBranch)
+                            String key = "v"+releaseBranch
                             releaseCommitMap.put(releaseCommit, getTipOfBranchToMasterJob(key, releaseCommit))
                         }
                         listOfTipOfReleaseUpgradeJobs.add(releaseCommitMap)
@@ -399,6 +391,32 @@ def getTipOfReleaseBranches(releaseNumber){
         userRemoteConfigs: [[url: env.SCM_VERRAZZANO_GIT_URL]]])
         def releaseBranchCommitSHA = scmReleaseBranchInfo.GIT_COMMIT
     return releaseBranchCommitSHA
+}
+
+// Remove the excluded releases from jobs
+def removeExcludedReleases(List releases){
+    echo "List of release branches inside function: ${releases}"
+    def excludeReleases = params.EXCLUDE_RELEASES
+    def excludeReleasesList = excludeReleases.trim().split('\\s*,\\s*')
+    println(excludeReleasesList)
+    def finalReleaseList  = []
+
+    for(releaseTag in releases){
+        def excluded = false
+        for(excludedRelease in excludeReleasesList){
+            String[] splitReleaseTag  = releaseTag.replace('v', '').split("\\.")
+            def releaseTagMinorVersion = splitReleaseTag[0] + "." + splitReleaseTag[1]
+            String[] splitDevVersion = VERRAZZANO_DEV_VERSION.split("\\.")
+            if (splitReleaseTag[0] > splitDevVersion[0] || splitReleaseTag[1] > splitDevVersion[1] || releaseTagMinorVersion == excludedRelease || "v"+releaseTagMinorVersion == excludedRelease) {
+                excluded = true
+            }
+        }
+        if(excluded == false){
+            finalReleaseList.add(releaseTag)
+        }
+    }
+     echo "Final releases: ${finalReleaseList}"
+    return finalReleaseList
 }
 
 def getStageOfUpgradeJob(job) {

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -158,7 +158,7 @@ pipeline {
                         final String fileContent = readFile(file: "${workspace}/tags.txt")
                         List gitTags = extractReleaseTags(fileContent)
                         echo "gitTags = ${gitTags}"
-                        List finalReleaseList = removeExcludedReleases(gitTags)
+                        def finalReleaseList = removeExcludedReleases(gitTags)
                         echo "List of Releases after excluding the user requested releases: ${finalReleaseList}"
                         listOfUpgradeJobs = addTargetUpgradeVersion(finalReleaseList)
 
@@ -166,9 +166,8 @@ pipeline {
                         fileContent = readFile(file: "${workspace}/releaseBranches.txt")
                         List releaseBranches = extractReleaseTags(fileContent)
                         echo "Release Branches: ${releaseBranches}"
-                        List finalReleaseBranchesList = removeExcludedReleases(releaseBranches)
+                        List finalReleaseBranchesList = removeExcludedReleaseBranches(releaseBranches)
 
-                        //minorReleaseList = getCleanReleaseVersion(finalReleaseBranchesList)
                         echo "List of minor release: ${finalReleaseBranchesList}"
                         def listOfTipOfReleaseUpgradeJobs = []
                         def releaseCommitMap = [:]
@@ -352,12 +351,12 @@ def getSuspectList(commitList, userMappings) {
     return retValue
 }
 
-def List<List> addTargetUpgradeVersion(List releases){
-
+def List<List> addTargetUpgradeVersion(releases){
     upgradeJobsList = []
-    releases.each {
-        upgradeJobsList.add(["$it", TARGET_UPGRADE_VERSION])
+    for (release in releases){
+        upgradeJobsList.add([release, TARGET_UPGRADE_VERSION])
     }
+    println("UPGRADE JOB LIST DEBUG" + upgradeJobsList)
     return upgradeJobsList
 }
 
@@ -368,16 +367,6 @@ List extractReleaseTags(final String fileContent) {
         releases << tag
     }
     return releases
-}
-
-def getCleanReleaseVersion(List releaseList){
-    List minorReleases = []
-    for(tag in releaseList){
-        if (tag[-1] == "0"){
-            minorReleases.add(tag[1..3])
-        }
-    }
-    return minorReleases
 }
 
 def getTipOfReleaseBranches(releaseNumber){ 
@@ -399,6 +388,18 @@ def removeExcludedReleases(List releases){
     def excludeReleases = params.EXCLUDE_RELEASES
     def excludeReleasesList = excludeReleases.trim().split('\\s*,\\s*')
     println(excludeReleasesList)
+    def finalReleaseString = sh(returnStdout: true, script: "go run  ${WORKSPACE}/ci/tools/derive_upgrade_version.go ${workspace} versions-lt ${VERRAZZANO_DEV_VERSION} ${excludeReleasesList}").trim()
+    def finalReleaseList = finalReleaseString.split()
+    echo "Final releases: ${finalReleaseList}"
+    return finalReleaseList
+}
+
+// Remove the excluded releases from jobs
+def removeExcludedReleaseBranches(List releases){
+    echo "List of release branches inside function: ${releases}"
+    def excludeReleases = params.EXCLUDE_RELEASES
+    def excludeReleasesList = excludeReleases.trim().split('\\s*,\\s*')
+    println(excludeReleasesList)
     def finalReleaseList  = []
 
     for(releaseTag in releases){
@@ -406,8 +407,7 @@ def removeExcludedReleases(List releases){
         for(excludedRelease in excludeReleasesList){
             String[] splitReleaseTag  = releaseTag.replace('v', '').split("\\.")
             def releaseTagMinorVersion = splitReleaseTag[0] + "." + splitReleaseTag[1]
-            String[] splitDevVersion = VERRAZZANO_DEV_VERSION.split("\\.")
-            if (splitReleaseTag[0] > splitDevVersion[0] || splitReleaseTag[1] > splitDevVersion[1] || releaseTagMinorVersion == excludedRelease || "v"+releaseTagMinorVersion == excludedRelease) {
+            if (releaseTagMinorVersion == excludedRelease || "v"+releaseTagMinorVersion == excludedRelease) {
                 excluded = true
             }
         }
@@ -455,29 +455,31 @@ def getStageOfUpgradeJob(job) {
 def getTipOfBranchToMasterJob(String release, String commitSHA) {
     return {
         stage("Upgrade Verrazzano from tip of ${release} to master") {
-            script{
-                try{
-                    echo "Running upgrade job from version ${release}-${commitSHA} to master"
-                    retry(count: JOB_PROMOTION_RETRIES) {
+            if( CLEAN_BRANCH_NAME == 'master') {
+                script{
+                    try{
+                        echo "Running upgrade job from version ${release}-${commitSHA} to master"
+                        retry(count: JOB_PROMOTION_RETRIES) {
                         def jobStatus =  build job: "/verrazzano-upgrade-path-tests/${CLEAN_BRANCH_NAME}",
-                        parameters: [
-                            string(name: 'GIT_COMMIT_TO_USE', value: "${commitSHA}"),
-                            string(name: 'VERSION_FOR_INSTALL', value: "${release}" ),
-                            string(name: 'VERSION_FOR_UPGRADE', value: "master"),
-                            string(name: 'VZ_INSTALL_CONFIG', value: params.VZ_INSTALL_CONFIG),
-                            string(name: 'IS_TRIGGERED_MANUALLY', value: "NO"),
-                            string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                            string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                            string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                            string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                            string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                            string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
-                        ],  wait: true, propagate: true
-                    }
-                } catch(err) {
-                    catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                        echo "Caught: ${err}"
-                        sh "exit 1"
+                            parameters: [
+                                string(name: 'GIT_COMMIT_TO_USE', value: "${commitSHA}"),
+                                string(name: 'VERSION_FOR_INSTALL', value: "${release}" ),
+                                string(name: 'VERSION_FOR_UPGRADE', value: "master"),
+                                string(name: 'VZ_INSTALL_CONFIG', value: params.VZ_INSTALL_CONFIG),
+                                string(name: 'IS_TRIGGERED_MANUALLY', value: "NO"),
+                                string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
+                                string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
+                                string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
+                                string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
+                                string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
+                            ],  wait: true, propagate: true
+                        }
+                    } catch(err) {
+                        catchError(message: "${STAGE_NAME} Failed with ${err}", buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            echo "Caught: ${err}"
+                            sh "exit 1"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR backports the below fixes to release-1.6:
- Fixes derive versions go tool to accurately derive interim and install version for upgrade resiliency pipeline.
- Fixes release branches to skip upgrade job from tip of release to master since this is done in master branch. 
- Removed the exclude release versions logic  from Jenkinsfile and implemented in go tool to handle edge cases such as Major releases and easier maintenance. 
- Refactored the upgrade minor release pipeline to use derive versions go tool to compute release tags after excluding the out of support releases. 