### PR TITLE
VZ-9920: Add prometheus metrics for fluentbit

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -666,8 +666,8 @@ func TestApplySystemMonitors(t *testing.T) {
 	monitors.SetGroupVersionKind(schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor"})
 	err = client.List(context.TODO(), monitors)
 	assert.NoError(t, err)
-	// expect that 9 ServiceMonitors are created
-	assert.Len(t, monitors.Items, 10)
+	// expect that 11 ServiceMonitors are created
+	assert.Len(t, monitors.Items, 11)
 }
 
 // TestValidatePrometheusOperator tests the validation of the Prometheus Operator installation and the Verrazzano CR

--- a/platform-operator/helm_config/overrides/fluent-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/fluent-operator-values.yaml
@@ -45,6 +45,18 @@ fluentbit:
         enable: false
       storageType: filesystem
       pauseOnChunksOverlimit: "on"
+    fluentBitMetrics:
+      scrapeInterval: "2"
+      scrapeOnStart: true
+      tag: "fb.metrics"
+  output:
+    prometheusMetricsExporter:
+      match: "fb.metrics"
+      metricsExporter:
+        host: "0.0.0.0"
+        port: 2020
+        addLabels:
+          app: "fluentbit"
   filter:
     systemd:
       enable: false

--- a/platform-operator/thirdparty/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/platform-operator/thirdparty/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1757,6 +1757,31 @@ spec:
                       server, e.g: /something'
                     type: string
                 type: object
+              prometheusExporter:
+                description: PrometheusExporter_types defines Prometheus exporter
+                  configuration to expose metrics from Fluent Bit.
+                properties:
+                  addLabels:
+                    additionalProperties:
+                      type: string
+                    description: This allows you to add custom labels to all metrics
+                      exposed through the prometheus exporter. You may have multiple
+                      of these fields
+                    type: object
+                  host:
+                    description: 'IP address or hostname of the target HTTP Server,
+                      default: 0.0.0.0'
+                    type: string
+                  port:
+                    description: This is the port Fluent Bit will bind to when hosting
+                      prometheus metrics.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                required:
+                - host
+                type: object
               prometheusRemoteWrite:
                 description: PrometheusRemoteWrite_types defines Prometheus Remote
                   Write configuration.

--- a/platform-operator/thirdparty/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/platform-operator/thirdparty/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -1757,6 +1757,31 @@ spec:
                       server, e.g: /something'
                     type: string
                 type: object
+              prometheusExporter:
+                description: PrometheusExporter_types defines Prometheus exporter
+                  configuration to expose metrics from Fluent Bit.
+                properties:
+                  addLabels:
+                    additionalProperties:
+                      type: string
+                    description: This allows you to add custom labels to all metrics
+                      exposed through the prometheus exporter. You may have multiple
+                      of these fields
+                    type: object
+                  host:
+                    description: 'IP address or hostname of the target HTTP Server,
+                      default: 0.0.0.0'
+                    type: string
+                  port:
+                    description: This is the port Fluent Bit will bind to when hosting
+                      prometheus metrics.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                required:
+                - host
+                type: object
               prometheusRemoteWrite:
                 description: PrometheusRemoteWrite_types defines Prometheus Remote
                   Write configuration.

--- a/platform-operator/thirdparty/charts/fluent-operator/templates/fluentbit-clusterinput-metrics.yaml
+++ b/platform-operator/thirdparty/charts/fluent-operator/templates/fluentbit-clusterinput-metrics.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.fluentbit.enable -}}
+{{- if .Values.fluentbit.input.fluentBitMetrics -}}
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterInput
+metadata:
+  name: fluentbit-metrics
+  labels:
+    fluentbit.fluent.io/enabled: "true"
+    fluentbit.fluent.io/component: logging
+spec:
+  fluentBitMetrics:
+{{ toYaml .Values.fluentbit.input.fluentBitMetrics | indent 4}}
+{{- end }}
+{{- end }}

--- a/platform-operator/thirdparty/charts/fluent-operator/templates/fluentbit-output-prometheus-exporter.yaml
+++ b/platform-operator/thirdparty/charts/fluent-operator/templates/fluentbit-output-prometheus-exporter.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.fluentbit.enable -}}
+{{- if .Values.fluentbit.output.prometheusMetricsExporter -}}
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterOutput
+metadata:
+  name: prometheus-exporter
+  labels:
+    fluentbit.fluent.io/enabled: "true"
+    fluentbit.fluent.io/component: logging
+spec:
+  match: {{ .Values.fluentbit.output.prometheusMetricsExporter.match }}
+  prometheusExporter:
+{{ toYaml .Values.fluentbit.output.prometheusMetricsExporter.metricsExporter | indent 4}}
+{{- end }}
+{{- end }}

--- a/platform-operator/thirdparty/charts/fluent-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/fluent-operator/values.yaml
@@ -161,6 +161,12 @@ fluentbit:
   #     path:
   #       procfs: /host/proc
   #       sysfs: /host/sys
+    fluentBitMetrics: {}
+    # uncomment below fluentBitMetrics section if you want to collect fluentBit metrics
+#    fluentBitMetrics:
+#      scrapeInterval: "2"
+#      scrapeOnStart: true
+#      tag: "fb.metrics"
 
   # Configure the output plugin parameter in FluentBit.
   # You can set enable to true to output logs to the specified location.
@@ -198,6 +204,15 @@ fluentbit:
     # You can configure the opensearch-related configuration here
     stdout:
       enable: false
+    # Uncomment the following section to enable Prometheus metrics exporter.
+    prometheusMetricsExporter: {}
+#    prometheusMetricsExporter:
+#      match: "fb.metrics"
+#      metricsExporter:
+#        host: "0.0.0.0"
+#        port: 2020
+#        addLabels:
+#          app: "fluentbit"
   service:
     storage: {}
 # Remove the above storage section and uncomment below section if you want to configure file-system as storage for buffer

--- a/platform-operator/thirdparty/manifests/prometheus-operator/fluentbit_monitor.yaml
+++ b/platform-operator/thirdparty/manifests/prometheus-operator/fluentbit_monitor.yaml
@@ -1,23 +1,23 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: fluentd
+  name: fluentbit
   namespace: {{ .monitoringNamespace }}
   labels:
     release: prometheus-operator
 spec:
   namespaceSelector:
     matchNames:
-      - {{ .systemNamespace }}
+    - {{ .systemNamespace }}
   selector:
     matchLabels:
-      app: fluentd
+      app.kubernetes.io/name: "fluent-bit"
   endpoints:
     - path: /metrics
-      targetPort: http-metrics
+      targetPort: metrics
       enableHttp2: false
       {{ if .isIstioEnabled }}
       scheme: https
@@ -26,6 +26,6 @@ spec:
         certFile: /etc/istio-certs/cert-chain.pem
         keyFile: /etc/istio-certs/key.pem
         insecureSkipVerify: true
-      {{ else }}
+        {{ else }}
       scheme: http
       {{ end }}

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -472,8 +472,8 @@
           "name": "fluent-operator",
           "images": [
             {
-              "image": "fluent-operator",
-              "tag": "v2.2.0-20230711070818-2fe76f7",
+              "image": "fluent-operator-jenkins",
+              "tag": "20230724084428-2e35ceb",
               "helmFullImageKey": "operator.container.repository",
               "helmTagKey": "operator.container.tag"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -472,8 +472,8 @@
           "name": "fluent-operator",
           "images": [
             {
-              "image": "fluent-operator-jenkins",
-              "tag": "20230724084428-2e35ceb",
+              "image": "fluent-operator",
+              "tag": "v2.2.0-20230725071427-8e93dbe",
               "helmFullImageKey": "operator.container.repository",
               "helmTagKey": "operator.container.tag"
             },


### PR DESCRIPTION
- Service Monitor added for fluentbit
- FluentOperator chart update to support prometheus exporter input/output plugin.
- Enabled  prometheus exporter input/output plugin in Fluent-operator Override.
