### PR TITLE
VZ-10307: Follow up PR to update allowedNamespaces and update tests

### DIFF
--- a/tests/e2e/verify-none-profile/none_profile_test.go
+++ b/tests/e2e/verify-none-profile/none_profile_test.go
@@ -25,7 +25,7 @@ const (
 // Any other namespace not mentioned here is considered unnecessary
 var allowedNamespaces = []string{
 	"default", "kube-system", "kube-node-lease", "kube-public",
-	"monitoring", "local-path-storage", "metallb-system",
+	"cattle-system", "monitoring", "local-path-storage", "metallb-system",
 	"verrazzano-install", "verrazzano-system",
 }
 

--- a/tests/e2e/verify-none-profile/none_profile_test.go
+++ b/tests/e2e/verify-none-profile/none_profile_test.go
@@ -58,6 +58,6 @@ var _ = t.Describe("Verify Namespaces", func() {
 				failures = append(failures, item.Name)
 			}
 		}
-		Expect(failures).To(BeEmpty(), "Namespaces not allowed: %v, Allowed namespaces are %v", failures, allowedNamespaces)
+		Expect(failures).To(BeEmpty(), "Namespaces not allowed: %v, Allowed namespaces are only %v", failures, allowedNamespaces)
 	})
 })

--- a/tests/e2e/verify-none-profile/none_profile_test.go
+++ b/tests/e2e/verify-none-profile/none_profile_test.go
@@ -26,8 +26,7 @@ const (
 var allowedNamespaces = []string{
 	"default", "kube-system", "kube-node-lease", "kube-public",
 	"monitoring", "local-path-storage", "metallb-system",
-	"cattle-system", "verrazzano-install", "verrazzano-mc", "verrazzano-system",
-	"verrazzano-monitoring", "verrazzano-ingress-nginx",
+	"verrazzano-install", "verrazzano-system",
 }
 
 var beforesuite = t.BeforeSuiteFunc(func() {
@@ -52,9 +51,14 @@ var _ = t.Describe("Verify Namespaces", func() {
 
 		ns, err := pkg.ListNamespaces(metav1.ListOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
+
+		failures := []string{}
 		for _, item := range ns.Items {
 			_, isAllowed := allowedNamespacesMap[item.Name]
-			Expect(isAllowed).To(BeTrue(), fmt.Sprintf("Namespace %s is not allowed with none profile installation, Allowed namespaces are %v\n", item.Name, allowedNamespacesMap))
+			if !isAllowed {
+				failures = append(failures, fmt.Sprintf("Namespace %s is not allowed with none profile installation\n", item.Name))
+			}
 		}
+		Expect(failures).To(BeEmpty(), "Namespaces not allowed: %v, Allowed namespaces are %v", failures, allowedNamespaces)
 	})
 })

--- a/tests/e2e/verify-none-profile/none_profile_test.go
+++ b/tests/e2e/verify-none-profile/none_profile_test.go
@@ -4,7 +4,6 @@
 package verifynoneprofile
 
 import (
-	"fmt"
 	. "github.com/onsi/gomega"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
@@ -56,7 +55,7 @@ var _ = t.Describe("Verify Namespaces", func() {
 		for _, item := range ns.Items {
 			_, isAllowed := allowedNamespacesMap[item.Name]
 			if !isAllowed {
-				failures = append(failures, fmt.Sprintf("Namespace %s is not allowed with none profile installation\n", item.Name))
+				failures = append(failures, item.Name)
 			}
 		}
 		Expect(failures).To(BeEmpty(), "Namespaces not allowed: %v, Allowed namespaces are %v", failures, allowedNamespaces)


### PR DESCRIPTION
This PR have the changes to update the allowedNameSpaces list and update the verify-none-profile tests to report the list of all not allowed namespaces