### PR TITLE
VZ-10372 Add the Thanos Ruler ingress to the Console and Rancher Dashboard

### DIFF
--- a/platform-operator/controllers/verrazzano/component/thanos/thanos.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos.go
@@ -146,7 +146,7 @@ func appendIngressOverrides(ctx spi.ComponentContext, kvs []bom.KeyValue) ([]bom
 		PathType:         netv1.PathTypeImplementationSpecific,
 		ServicePort:      constants.VerrazzanoAuthProxyServicePort,
 	}
-	kvs = append(kvs, bom.KeyValue{Key: "ruler.extraFlags[0]", Value: fmt.Sprintf("--alert.query-url=%s", frontendHostName)})
+	kvs = append(kvs, bom.KeyValue{Key: "ruler.extraFlags[0]", Value: fmt.Sprintf("--alert.query-url=https://%s", frontendHostName)})
 	return formatIngressOverrides(ctx, rulerProps, kvs), nil
 
 }

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
@@ -161,7 +161,7 @@ func TestAppendOverrides(t *testing.T) {
 		"ruler.ingress.extraTls[0].secretName":                                  rulerCertificateName,
 		`ruler.ingress.annotations.cert-manager\.io/cluster-issuer`:             constants2.VerrazzanoClusterIssuerName,
 		`ruler.ingress.annotations.cert-manager\.io/common-name`:                "thanos-ruler.default.11.22.33.44.nip.io",
-		`ruler.extraFlags[0]`:                                                   "--alert.query-url=thanos-query.default.11.22.33.44.nip.io",
+		`ruler.extraFlags[0]`:                                                   "--alert.query-url=https://thanos-query.default.11.22.33.44.nip.io",
 	}
 	sslipioKVs := map[string]string{
 		"queryFrontend.ingress.extraRules[0].host":                       "thanos-query.default.11.22.33.44.sslip.io",
@@ -173,7 +173,7 @@ func TestAppendOverrides(t *testing.T) {
 		"ruler.ingress.extraRules[0].host":                               "thanos-ruler.default.11.22.33.44.sslip.io",
 		"ruler.ingress.extraTls[0].hosts[0]":                             "thanos-ruler.default.11.22.33.44.sslip.io",
 		`ruler.ingress.annotations.cert-manager\.io/common-name`:         "thanos-ruler.default.11.22.33.44.sslip.io",
-		`ruler.extraFlags[0]`:                                            "--alert.query-url=thanos-query.default.11.22.33.44.sslip.io",
+		`ruler.extraFlags[0]`:                                            "--alert.query-url=https://thanos-query.default.11.22.33.44.sslip.io",
 	}
 	istioEnabledKV := map[string]string{
 		"verrazzano.isIstioEnabled": "true",
@@ -199,7 +199,7 @@ func TestAppendOverrides(t *testing.T) {
 		`ruler.ingress.annotations.external-dns\.alpha\.kubernetes\.io/target`:         "verrazzano-ingress.default.mydomain.com",
 		`ruler.ingress.annotations.external-dns\.alpha\.kubernetes\.io/ttl`:            "60",
 		`ruler.ingress.annotations.cert-manager\.io/common-name`:                       "thanos-ruler.default.mydomain.com",
-		`ruler.extraFlags[0]`: "--alert.query-url=thanos-query.default.mydomain.com",
+		`ruler.extraFlags[0]`: "--alert.query-url=https://thanos-query.default.mydomain.com",
 	}
 	externalDNSZone := "mydomain.com"
 

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -157,13 +157,13 @@
               "rancherUI": "v2.7.2-10/release-2.7.2",
               "ocneDriverVersion": "v0.21.0",
               "ocneDriverChecksum": "ef300103b9b593a49006636dfc873147dcbb46d646f84ebe66af7037b3efa4d4",
-              "tag": "20230724191647-51373799e",
+              "tag": "v2.7.3-20230725135145-51373799e",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "20230724191647-51373799e"
+              "tag": "v2.7.3-20230725135145-51373799e"
             }
           ]
         },
@@ -271,7 +271,7 @@
             },
             {
               "image": "console",
-              "tag": "v2.0.0-20230711035747-67edc78",
+              "tag": "v2.0.0-20230724214803-d6adc4e",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -157,13 +157,13 @@
               "rancherUI": "v2.7.2-10/release-2.7.2",
               "ocneDriverVersion": "v0.21.0",
               "ocneDriverChecksum": "ef300103b9b593a49006636dfc873147dcbb46d646f84ebe66af7037b3efa4d4",
-              "tag": "v2.7.3-20230719153044-51373799e",
+              "tag": "20230724191647-51373799e",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-20230719153044-51373799e"
+              "tag": "20230724191647-51373799e"
             }
           ]
         },


### PR DESCRIPTION
**Changes**
- Added the Thanos Ruler ingress to the console and the Dashboard
- Small fix to the Thanos Ruler ingress overrides to fix the redirect for Thanos query

**Testing**
- Installed Verrazzano with ingress enabled and viewed that the ingress appeared in the console and Rancher dashboard
- Disabled ingress and verified that the links dissappeared