### PR TITLE
VZ-10410 Validate the Helm Charts For First Party Components

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,6 +273,8 @@ pipeline {
                     cd ${GO_REPO_PATH}/verrazzano
                     make precommit
                     make unit-test-coverage-ratcheting
+                    echo "Checking versions..."
+                    release/scripts/check_versions.sh ${VERRAZZANO_DEV_VERSION}
                 """
                     }
                     post {

--- a/platform-operator/helm_config/charts/fluentbit-opensearch-output/Chart.yaml
+++ b/platform-operator/helm_config/charts/fluentbit-opensearch-output/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/platform-operator/helm_config/charts/fluentbit-opensearch-output/Chart.yaml
+++ b/platform-operator/helm_config/charts/fluentbit-opensearch-output/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 1.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
This edit makes it so the release_versions.sh script is run under the compliance and quality control tests as part of the default Verrazzano job. I ran a test with an incorrect chart version and correct chart versions and it displayed the intended behavior. I 