### PR TITLE
VZ-10143 Add the Prometheus rules to the Thanos Ruler

### DIFF
--- a/platform-operator/controllers/verrazzano/component/thanos/thanos.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos.go
@@ -124,7 +124,7 @@ func appendReloaderSidecarOverrides(ctx spi.ComponentContext, kvs []bom.KeyValue
 		{Key: fmt.Sprintf("%s.args[2]", sidecarPrefix), Value: "--watched-dir=/conf/rules/"},
 		{Key: fmt.Sprintf("%s.volumeMounts[0].mountPath", sidecarPrefix), Value: "/conf/rules/"},
 		{Key: fmt.Sprintf("%s.volumeMounts[0].name", sidecarPrefix), Value: "ruler-config"},
-		{Key: "ruler.configmapName", Value: "prometheus-prometheus-operator-kube-p-prometheus-rulefiles-0"},
+		{Key: "ruler.existingConfigmap", Value: "prometheus-prometheus-operator-kube-p-prometheus-rulefiles-0"},
 
 		// Security setup for the sidecar
 		{Key: fmt.Sprintf("%s.securityContext.privileged", sidecarPrefix), Value: "false"},

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos.go
@@ -128,6 +128,7 @@ func appendReloaderSidecarOverrides(ctx spi.ComponentContext, kvs []bom.KeyValue
 
 		// Security setup for the sidecar
 		{Key: fmt.Sprintf("%s.securityContext.privileged", sidecarPrefix), Value: "false"},
+		{Key: fmt.Sprintf("%s.securityContext.allowPrivilegeEscalation", sidecarPrefix), Value: "false"},
 		{Key: fmt.Sprintf("%s.securityContext.capabilities.drop[0]", sidecarPrefix), Value: "ALL"},
 	}...)
 

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos.go
@@ -136,23 +136,8 @@ func appendReloaderSidecarOverrides(ctx spi.ComponentContext, kvs []bom.KeyValue
 }
 
 func constructFullImageString(bomFile bom.Bom, subcomponent bom.BomSubComponent, image bom.BomImage) string {
-	registry := func() string {
-		if image.Registry != "" {
-			return image.Registry
-		}
-		if subcomponent.Registry != "" {
-			return subcomponent.Registry
-		}
-		return bomFile.GetRegistry()
-	}()
-
-	repository := func() string {
-		if image.Repository != "" {
-			return image.Repository
-		}
-		return subcomponent.Repository
-	}()
-
+	registry := bomFile.ResolveRegistry(&subcomponent, image)
+	repository := bomFile.ResolveRepo(&subcomponent, image)
 	return fmt.Sprintf("%s/%s/%s:%s", registry, repository, image.ImageName, image.ImageTag)
 }
 

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos.go
@@ -115,7 +115,7 @@ func appendReloaderSidecarOverrides(ctx spi.ComponentContext, kvs []bom.KeyValue
 
 	image := subcomponent.Images[0]
 	imageString := constructFullImageString(bomFile, *subcomponent, image)
-	sidecarPrefix := "ruler.sidecar[0]"
+	sidecarPrefix := "ruler.sidecars[0]"
 	kvs = append(kvs, []bom.KeyValue{
 		{Key: fmt.Sprintf("%s.image", sidecarPrefix), Value: imageString},
 		{Key: fmt.Sprintf("%s.name", sidecarPrefix), Value: configReloaderSubcomponentName},

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
@@ -204,16 +204,16 @@ func TestAppendOverrides(t *testing.T) {
 	externalDNSZone := "mydomain.com"
 
 	reloaderSidecarKVS := map[string]string{
-		"ruler.sidecar[0].image":                                `ghcr.io/verrazzano/prometheus-config-reloader:v\d+\.\d+\.\d+-.+-.+`,
-		"ruler.sidecar[0].name":                                 configReloaderSubcomponentName,
-		"ruler.sidecar[0].args[0]":                              "--listen-address=:8080",
-		"ruler.sidecar[0].args[1]":                              "--reload-url=http://127.0.0.1:10902/-/reload",
-		"ruler.sidecar[0].args[2]":                              "--watched-dir=/conf/rules/",
-		"ruler.sidecar[0].volumeMounts[0].mountPath":            "/conf/rules/",
-		"ruler.sidecar[0].volumeMounts[0].name":                 "ruler-config",
-		"ruler.configmapName":                                   "prometheus-prometheus-operator-kube-p-prometheus-rulefiles-0",
-		"ruler.sidecar[0].securityContext.privileged":           "false",
-		"ruler.sidecar[0].securityContext.capabilities.drop[0]": "ALL",
+		"ruler.sidecars[0].image":                                `ghcr.io/verrazzano/prometheus-config-reloader:v\d+\.\d+\.\d+-.+-.+`,
+		"ruler.sidecars[0].name":                                 configReloaderSubcomponentName,
+		"ruler.sidecars[0].args[0]":                              "--listen-address=:8080",
+		"ruler.sidecars[0].args[1]":                              "--reload-url=http://127.0.0.1:10902/-/reload",
+		"ruler.sidecars[0].args[2]":                              "--watched-dir=/conf/rules/",
+		"ruler.sidecars[0].volumeMounts[0].mountPath":            "/conf/rules/",
+		"ruler.sidecars[0].volumeMounts[0].name":                 "ruler-config",
+		"ruler.configmapName":                                    "prometheus-prometheus-operator-kube-p-prometheus-rulefiles-0",
+		"ruler.sidecars[0].securityContext.privileged":           "false",
+		"ruler.sidecars[0].securityContext.capabilities.drop[0]": "ALL",
 	}
 
 	tests := []struct {

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
@@ -203,6 +203,19 @@ func TestAppendOverrides(t *testing.T) {
 	}
 	externalDNSZone := "mydomain.com"
 
+	reloaderSidecarKVS := map[string]string{
+		"ruler.sidecar[0].image":                                `ghcr.io/verrazzano/prometheus-config-reloader:v\d+\.\d+\.\d+-.+-.+`,
+		"ruler.sidecar[0].name":                                 configReloaderSubcomponentName,
+		"ruler.sidecar[0].args[0]":                              "--listen-address=:8080",
+		"ruler.sidecar[0].args[1]":                              "--reload-url=http://127.0.0.1:10902/-/reload",
+		"ruler.sidecar[0].args[2]":                              "--watched-dir=/conf/rules/",
+		"ruler.sidecar[0].volumeMounts[0].mountPath":            "/conf/rules/",
+		"ruler.sidecar[0].volumeMounts[0].name":                 "ruler-config",
+		"ruler.configmapName":                                   "prometheus-prometheus-operator-kube-p-prometheus-rulefiles-0",
+		"ruler.sidecar[0].securityContext.privileged":           "false",
+		"ruler.sidecar[0].securityContext.capabilities.drop[0]": "ALL",
+	}
+
 	tests := []struct {
 		name     string
 		vz       *v1alpha1.Verrazzano
@@ -306,6 +319,9 @@ func TestAppendOverrides(t *testing.T) {
 
 			expectedKVS := map[string]string{}
 			for k, v := range imageKVS {
+				expectedKVS[k] = v
+			}
+			for k, v := range reloaderSidecarKVS {
 				expectedKVS[k] = v
 			}
 			for k, v := range tt.extraKVS {

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
@@ -204,16 +204,17 @@ func TestAppendOverrides(t *testing.T) {
 	externalDNSZone := "mydomain.com"
 
 	reloaderSidecarKVS := map[string]string{
-		"ruler.sidecars[0].image":                                `ghcr.io/verrazzano/prometheus-config-reloader:v\d+\.\d+\.\d+-.+-.+`,
-		"ruler.sidecars[0].name":                                 configReloaderSubcomponentName,
-		"ruler.sidecars[0].args[0]":                              "--listen-address=:8080",
-		"ruler.sidecars[0].args[1]":                              "--reload-url=http://127.0.0.1:10902/-/reload",
-		"ruler.sidecars[0].args[2]":                              "--watched-dir=/conf/rules/",
-		"ruler.sidecars[0].volumeMounts[0].mountPath":            "/conf/rules/",
-		"ruler.sidecars[0].volumeMounts[0].name":                 "ruler-config",
-		"ruler.existingConfigmap":                                "prometheus-prometheus-operator-kube-p-prometheus-rulefiles-0",
-		"ruler.sidecars[0].securityContext.privileged":           "false",
-		"ruler.sidecars[0].securityContext.capabilities.drop[0]": "ALL",
+		"ruler.sidecars[0].image":                                    `ghcr.io/verrazzano/prometheus-config-reloader:v\d+\.\d+\.\d+-.+-.+`,
+		"ruler.sidecars[0].name":                                     configReloaderSubcomponentName,
+		"ruler.sidecars[0].args[0]":                                  "--listen-address=:8080",
+		"ruler.sidecars[0].args[1]":                                  "--reload-url=http://127.0.0.1:10902/-/reload",
+		"ruler.sidecars[0].args[2]":                                  "--watched-dir=/conf/rules/",
+		"ruler.sidecars[0].volumeMounts[0].mountPath":                "/conf/rules/",
+		"ruler.sidecars[0].volumeMounts[0].name":                     "ruler-config",
+		"ruler.existingConfigmap":                                    "prometheus-prometheus-operator-kube-p-prometheus-rulefiles-0",
+		"ruler.sidecars[0].securityContext.privileged":               "false",
+		"ruler.sidecars[0].securityContext.allowPrivilegeEscalation": "false",
+		"ruler.sidecars[0].securityContext.capabilities.drop[0]":     "ALL",
 	}
 
 	tests := []struct {

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
@@ -211,7 +211,7 @@ func TestAppendOverrides(t *testing.T) {
 		"ruler.sidecars[0].args[2]":                              "--watched-dir=/conf/rules/",
 		"ruler.sidecars[0].volumeMounts[0].mountPath":            "/conf/rules/",
 		"ruler.sidecars[0].volumeMounts[0].name":                 "ruler-config",
-		"ruler.configmapName":                                    "prometheus-prometheus-operator-kube-p-prometheus-rulefiles-0",
+		"ruler.existingConfigmap":                                "prometheus-prometheus-operator-kube-p-prometheus-rulefiles-0",
 		"ruler.sidecars[0].securityContext.privileged":           "false",
 		"ruler.sidecars[0].securityContext.capabilities.drop[0]": "ALL",
 	}

--- a/platform-operator/thirdparty/charts/thanos/templates/ruler/statefulset.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/ruler/statefulset.yaml
@@ -136,7 +136,7 @@ spec:
             - --label=ruler_cluster="{{ .Values.ruler.clusterName }}"
             - --alert.label-drop={{ .Values.ruler.replicaLabel }}
             - --objstore.config-file=/conf/objstore/objstore.yml
-            - --rule-file=/conf/rules/*.yml
+            - --rule-file=/conf/rules/*.yaml
             {{- range .Values.ruler.queries }}
             - --query={{ . }}
             {{- end }}

--- a/tests/e2e/config/scripts/configure_thanos_install_storage.sh
+++ b/tests/e2e/config/scripts/configure_thanos_install_storage.sh
@@ -50,8 +50,6 @@ if [ "${ENABLE_THANOS_RULER}" == "true" ]; then
 
   # Add the Thanos Ruler overrides
   yq -i eval ".spec.components.thanos.overrides.[0].values.ruler.enabled = true" ${INSTALL_CONFIG_TO_EDIT}
-  yq -i eval '.spec.components.thanos.overrides.[0].values.ruler.alertmanagers[0] = "https://prometheus-operator-kube-p-alertmanager:9093"' ${INSTALL_CONFIG_TO_EDIT}
-  yq -i eval '.spec.components.thanos.overrides.[0].values.ruler.config.groups[0].name = "test_group"' ${INSTALL_CONFIG_TO_EDIT}
 fi
 
 # Modify the VZ CR to enable storage on the Prometheus Thanos Sidecar

--- a/tests/e2e/pkg/thanos.go
+++ b/tests/e2e/pkg/thanos.go
@@ -26,7 +26,7 @@ func GetRulesFromThanosRuler(kubeconfigPath string) (interface{}, error) {
 	}
 
 	url := GetSystemThanosRulerURL(kubeconfigPath)
-	resp, err := doReq(url, "GET", "", "", "verrazzanno", password, nil, retryableClient)
+	resp, err := doReq(url, "GET", "", "", "verrazzano", password, nil, retryableClient)
 	if err != nil {
 		Log(Error, fmt.Sprintf("Failed to make a request to the Thanos Ruler ingress %v", err))
 		return nil, err

--- a/tests/e2e/pkg/thanos.go
+++ b/tests/e2e/pkg/thanos.go
@@ -46,8 +46,9 @@ func GetRulesFromThanosRuler(kubeconfigPath string) (interface{}, error) {
 		Log(Error, fmt.Sprintf("Failed to unmarshal the response data %s: %v", data, err))
 		return nil, err
 	}
+	Log(Debug, fmt.Sprintf("response body: %v", data.Data))
 
-	return data, err
+	return data.Data, err
 }
 
 // GetSystemThanosRulerURL gets the system Thanos Ingress host in the given cluster

--- a/tests/e2e/pkg/thanos.go
+++ b/tests/e2e/pkg/thanos.go
@@ -43,7 +43,7 @@ func GetRulesFromThanosRuler(kubeconfigPath string) (interface{}, error) {
 	var data ruleData
 	err = json.Unmarshal(resp.Body, &data)
 	if err != nil {
-		Log(Error, fmt.Sprintf("Failed to unmarshal the response data from %s: %v", url, err))
+		Log(Error, fmt.Sprintf("Failed to unmarshal the response data %s: %v", data, err))
 		return nil, err
 	}
 

--- a/tests/e2e/pkg/thanos.go
+++ b/tests/e2e/pkg/thanos.go
@@ -25,7 +25,7 @@ func GetRulesFromThanosRuler(kubeconfigPath string) (interface{}, error) {
 		return nil, err
 	}
 
-	url := GetSystemThanosRulerURL(kubeconfigPath)
+	url := fmt.Sprintf("%s/api/v1/rules", GetSystemThanosRulerURL(kubeconfigPath))
 	resp, err := doReq(url, "GET", "", "", "verrazzano", password, nil, retryableClient)
 	if err != nil {
 		Log(Error, fmt.Sprintf("Failed to make a request to the Thanos Ruler ingress %v", err))

--- a/tests/e2e/pkg/thanos.go
+++ b/tests/e2e/pkg/thanos.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package pkg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+)
+
+// GetRulesFromThanosRuler returns the rule data from the Thanos Ruler API is not empty given basic auth
+func GetRulesFromThanosRuler(username string, password string, kubeconfigPath string) (interface{}, error) {
+	retryableClient, err := GetVerrazzanoHTTPClient(kubeconfigPath)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed get an HTTP client: %v", err))
+		return nil, err
+	}
+
+	url := GetThanosQueryIngressHost(kubeconfigPath)
+	resp, err := doReq(url, "GET", "", "", username, password, nil, retryableClient)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		Log(Error, fmt.Sprintf("Failed to get an OK response from %s, response: %d", url, resp.StatusCode))
+		return nil, err
+	}
+
+	type ruleData struct {
+		Data interface{} `json:"data"`
+	}
+	var data ruleData
+	err = json.Unmarshal(resp.Body, &data)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed to unmarshal the response data from %s: %v", url, err))
+		return nil, err
+	}
+
+	return data, err
+}
+
+// GetSystemThanosRulerURL gets the system Thanos Ingress host in the given cluster
+func GetSystemThanosRulerURL(kubeconfigPath string) string {
+	clientset, err := GetKubernetesClientsetForCluster(kubeconfigPath)
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed to get clientset for cluster %v", err))
+		return ""
+	}
+	ingress, err := clientset.NetworkingV1().Ingresses(VerrazzanoNamespace).Get(context.TODO(), "thanos-ruler", metav1.GetOptions{})
+	if err != nil {
+		Log(Error, fmt.Sprintf("Failed to find Thanos Ruler Ingress %v", err))
+		return ""
+	}
+
+	Log(Info, fmt.Sprintf("Found Thanos Ruler Ingress %v, host %s", ingress.Name, ingress.Spec.Rules[0].Host))
+	return fmt.Sprintf("https://%s", ingress.Spec.Rules[0].Host)
+}

--- a/tests/e2e/verify-install/thanos/thanos_test.go
+++ b/tests/e2e/verify-install/thanos/thanos_test.go
@@ -26,7 +26,6 @@ const (
 var t = framework.NewTestFramework("thanos")
 
 var (
-	kubeconfigPath        string
 	isThanosSupported     bool
 	isThanosInstalled     bool
 	isStoreGatewayEnabled bool
@@ -179,6 +178,7 @@ var _ = t.Describe("Thanos", Label("f:platform-lcm.install"), func() {
 				Skip("Skipping Rule verification because Ruler is not enabled")
 			}
 
+			kubeconfigPath := getKubeConfigOrAbort()
 			Eventually(func() (interface{}, error) {
 				return pkg.GetRulesFromThanosRuler(kubeconfigPath)
 			}).WithPolling(pollingInterval).WithTimeout(waitTimeout).ShouldNot(BeNil())

--- a/tests/e2e/verify-install/thanos/thanos_test.go
+++ b/tests/e2e/verify-install/thanos/thanos_test.go
@@ -179,16 +179,8 @@ var _ = t.Describe("Thanos", Label("f:platform-lcm.install"), func() {
 				Skip("Skipping Rule verification because Ruler is not enabled")
 			}
 
-			var host string
-			var err error
-			Eventually(func() (string, error) {
-				host, err = k8sutil.GetHostnameFromGateway(constants.VerrazzanoSystemNamespace, "")
-				return host, err
-			}).WithPolling(pollingInterval).WithTimeout(waitTimeout).ShouldNot(BeEmpty())
-
-			url := fmt.Sprintf("https://%s/api/v1/rules", host)
 			Eventually(func() (interface{}, error) {
-				return pkg.GetRulesFromThanosRuler(url, host, kubeconfigPath)
+				return pkg.GetRulesFromThanosRuler(kubeconfigPath)
 			}).WithPolling(pollingInterval).WithTimeout(waitTimeout).ShouldNot(BeNil())
 		})
 	})


### PR DESCRIPTION
**Changes**
- Add the prometheus config reloader to the Thanos Ruler
- Mount the Prometheus Rule configmap
- Add e2e test to verify that the rules are properly loaded into Thanos Ruler

**Testing**
- Install by minimally enabling the Thanos ruler
- Verify the rules are populated in the Ruler UI.
