### PR TITLE
VZ-10244 Change the default value of Rancher setting

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -133,9 +133,11 @@ const (
 	SettingAuthResyncCron             = "auth-user-info-resync-cron"
 	SettingAuthMaxAge                 = "auth-user-info-max-age-seconds"
 	SettingAuthTTL                    = "auth-user-session-ttl-minutes"
+	SettingKubeDefaultTokenTTL        = "kubeconfig-default-token-ttl-minutes" //nolint:gosec //#gosec G101
 	SettingAuthResyncCronValue        = "*/15 * * * *"
 	SettingAuthMaxAgeValue            = "600"
 	SettingAuthTTLValue               = "540"
+	SettingKubeDefaultTokenTTLValue   = "540"
 )
 
 // auth config

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -737,6 +737,13 @@ func configureAuthSettings(ctx spi.ComponentContext) error {
 		return log.ErrorfThrottledNewErr("failed configuring auth-user-session-ttl-minutes setting: %s",
 			err.Error())
 	}
+
+	// Set "kubeconfig-default-token-ttl-minutes" to "540", less than the Keycloak default SSO session max (600 minutes)
+	if err := createOrUpdateResource(ctx, types.NamespacedName{Name: SettingKubeDefaultTokenTTL}, common.GVKSetting,
+		map[string]interface{}{"value": SettingKubeDefaultTokenTTLValue}); err != nil {
+		return log.ErrorfThrottledNewErr("failed configuring kubeconfig-default-token-ttl-minutes setting: %s",
+			err.Error())
+	}
 	return nil
 }
 

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -157,13 +157,13 @@
               "rancherUI": "v2.7.2-11/release-2.7.2",
               "ocneDriverVersion": "v0.22.0",
               "ocneDriverChecksum": "f219cbae68b73d41c41b078a12a2de02bbe26b46dbf66f942028af72823fa216",
-              "tag": "v2.7.3-20230727145533-79ad189ae",
+              "tag": "v2.7.3-20230728050034-92ef766dd",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-20230727145533-79ad189ae"
+              "tag": "v2.7.3-20230728050034-92ef766dd"
             }
           ]
         },

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -121,6 +121,7 @@ var _ = t.Describe("rancher", Label("f:infra-lcm",
 						verifySettingValue(rancher.SettingAuthResyncCron, rancher.SettingAuthResyncCronValue, k8sClient)
 						verifySettingValue(rancher.SettingAuthMaxAge, rancher.SettingAuthMaxAgeValue, k8sClient)
 						verifySettingValue(rancher.SettingAuthTTL, rancher.SettingAuthTTLValue, k8sClient)
+						verifySettingValue(rancher.SettingKubeDefaultTokenTTL, rancher.SettingKubeDefaultTokenTTLValue, k8sClient)
 					}
 
 					start = time.Now()


### PR DESCRIPTION
Tune the Rancher setting kubeconfig-default-token-ttl-minutes in accordance with the Keycloak setting. Also, update Rancher image.
