### PR TITLE
VZ-10418 - disassociate cattle-cluster-agent network policy from the VZ Helm chart during upgrade, since that's now in Rancher.

### DIFF
--- a/platform-operator/controllers/verrazzano/component/common/helm.go
+++ b/platform-operator/controllers/verrazzano/component/common/helm.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package common

--- a/platform-operator/controllers/verrazzano/component/common/helm.go
+++ b/platform-operator/controllers/verrazzano/component/common/helm.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,6 +16,13 @@ type HelmManagedResource struct {
 	Obj            clipkg.Object
 	NamespacedName types.NamespacedName
 }
+
+const (
+	helmReleaseNameKey      = "meta.helm.sh/release-name"
+	helmReleaseNamespaceKey = "meta.helm.sh/release-namespace"
+	helmResourcePolicyKey   = "helm.sh/resource-policy"
+	managedByLabelKey       = "app.kubernetes.io/managed-by"
+)
 
 // AssociateHelmObject annotates an object as being managed by the specified release Helm chart
 // If the object was already associated with a different Helm release (e.g verrazzano), then that relationship will be broken
@@ -30,18 +38,54 @@ func AssociateHelmObject(cli clipkg.Client, obj clipkg.Object, releaseName types
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations["meta.helm.sh/release-name"] = releaseName.Name
-	annotations["meta.helm.sh/release-namespace"] = releaseName.Namespace
+	annotations[helmReleaseNameKey] = releaseName.Name
+	annotations[helmReleaseNamespaceKey] = releaseName.Namespace
 	if keepResource {
 		// Specify "keep" so that resource doesn't get deleted when we change the release name
-		annotations["helm.sh/resource-policy"] = "keep"
+		annotations[helmResourcePolicyKey] = "keep"
 	}
 	obj.SetAnnotations(annotations)
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = map[string]string{}
 	}
-	labels["app.kubernetes.io/managed-by"] = "Helm"
+	labels[managedByLabelKey] = "Helm"
+	obj.SetLabels(labels)
+	err := cli.Update(context.TODO(), obj)
+	return obj, err
+}
+
+// DisassociateHelmObject removes Helm release annotations from an object so that it is no longer
+// managed by that Helm chart
+func DisassociateHelmObject(cli clipkg.Client, obj clipkg.Object, namespacedName types.NamespacedName, keepResource bool, managedByHelm bool) (clipkg.Object, error) {
+	if err := cli.Get(context.TODO(), namespacedName, obj); err != nil {
+		if errors.IsNotFound(err) {
+			return obj, nil
+		}
+		return obj, err
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	delete(annotations, helmReleaseNameKey)
+	delete(annotations, helmReleaseNamespaceKey)
+
+	if keepResource {
+		// Specify "keep" so that resource doesn't get deleted when we change the release name
+		annotations[helmResourcePolicyKey] = "keep"
+	}
+	obj.SetAnnotations(annotations)
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	if managedByHelm {
+		labels[managedByLabelKey] = "Helm"
+	} else {
+		delete(labels, managedByLabelKey)
+	}
 	obj.SetLabels(labels)
 	err := cli.Update(context.TODO(), obj)
 	return obj, err
@@ -59,7 +103,7 @@ func RemoveResourcePolicyAnnotation(cli clipkg.Client, obj clipkg.Object, namesp
 	if annotations == nil {
 		return obj, nil
 	}
-	delete(annotations, "helm.sh/resource-policy")
+	delete(annotations, helmResourcePolicyKey)
 	obj.SetAnnotations(annotations)
 	err := cli.Update(context.TODO(), obj)
 	return obj, err

--- a/platform-operator/controllers/verrazzano/component/common/helm_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/helm_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package common
 
 import (

--- a/platform-operator/controllers/verrazzano/component/common/helm_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/helm_test.go
@@ -1,0 +1,189 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var objWithExistingHelmOwner = v1.Deployment{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "some-ns",
+		Name:      "some-name",
+		Annotations: map[string]string{
+			helmReleaseNameKey:      "some-release",
+			helmReleaseNamespaceKey: "some-ns",
+		},
+		Labels: map[string]string{
+			managedByLabelKey: "Helm",
+		},
+	},
+}
+
+var objNoHelmOwner = v1.Deployment{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "some-ns",
+		Name:      "some-name",
+		Annotations: map[string]string{
+			"some/annot": "someval",
+		},
+		Labels: map[string]string{
+			"somelabel": "somelabelval",
+		},
+	},
+}
+
+func TestAssociateHelmObject(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *v1.Deployment
+		keep bool
+	}{
+		{"Existing Helm owner, keep=true", &objWithExistingHelmOwner, true},
+		{"Existing Helm owner, keep=false", &objWithExistingHelmOwner, false},
+		{"No Helm owner, keep=true", &objNoHelmOwner, true},
+		{"No Helm owner, keep=false", &objNoHelmOwner, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// deep copy the object since AssociateHelmObject makes inline changes
+			myDeployment := v1.Deployment{}
+			tt.obj.DeepCopyInto(&myDeployment)
+			origLabels := myDeployment.Labels
+			origAnnotations := myDeployment.Annotations
+
+			fakeClient := fake.NewClientBuilder().WithObjects(&myDeployment).Build()
+			newHelmReleaseName := types.NamespacedName{Namespace: "new-rel-namespace", Name: "new-rel-name"}
+			objName := types.NamespacedName{Namespace: myDeployment.GetNamespace(), Name: myDeployment.GetName()}
+			_, err := AssociateHelmObject(fakeClient, &myDeployment, newHelmReleaseName, objName, tt.keep)
+			assert.NoError(t, err)
+
+			newDeployment := v1.Deployment{}
+			err = fakeClient.Get(context.TODO(), objName, &newDeployment)
+			assert.NoError(t, err)
+			assert.Equal(t, newHelmReleaseName.Name, newDeployment.Annotations[helmReleaseNameKey])
+			assert.Equal(t, newHelmReleaseName.Namespace, newDeployment.Annotations[helmReleaseNamespaceKey])
+			if tt.keep {
+				assert.Equal(t, "keep", newDeployment.Annotations[helmResourcePolicyKey])
+			} else {
+				assert.Equal(t, "", newDeployment.Annotations[helmResourcePolicyKey])
+			}
+			assertOtherLabelsAnnotationsUnchanged(t, newDeployment, origAnnotations, origLabels)
+		})
+	}
+}
+
+func TestDisassociateHelmObject(t *testing.T) {
+	tests := []struct {
+		name          string
+		obj           *v1.Deployment
+		keep          bool
+		managedByHelm bool
+	}{
+		{"Existing Helm owner, keep=true, managedByHelm", &objWithExistingHelmOwner, true, true},
+		{"Existing Helm owner, keep=false, managedByHelm", &objWithExistingHelmOwner, false, true},
+		{"No Helm owner, keep=true, NOT managed by Helm", &objNoHelmOwner, true, false},
+		{"No Helm owner, keep=false, NOT managed by Helm", &objNoHelmOwner, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// deep copy the object since DisassociateHelmObject makes inline changes
+			myDeployment := v1.Deployment{}
+			tt.obj.DeepCopyInto(&myDeployment)
+			origLabels := myDeployment.Labels
+			origAnnotations := myDeployment.Annotations
+
+			fakeClient := fake.NewClientBuilder().WithObjects(&myDeployment).Build()
+			objName := types.NamespacedName{Namespace: myDeployment.GetNamespace(), Name: myDeployment.GetName()}
+			_, err := DisassociateHelmObject(fakeClient, &myDeployment, objName, tt.keep, tt.managedByHelm)
+			assert.NoError(t, err)
+
+			newDeployment := v1.Deployment{}
+			err = fakeClient.Get(context.TODO(), objName, &newDeployment)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "", newDeployment.Annotations[helmReleaseNameKey])
+			assert.Equal(t, "", newDeployment.Annotations[helmReleaseNamespaceKey])
+			if tt.keep {
+				assert.Equal(t, "keep", newDeployment.Annotations[helmResourcePolicyKey])
+			} else {
+				assert.Equal(t, "", newDeployment.Annotations[helmResourcePolicyKey])
+			}
+			if tt.managedByHelm {
+				assert.Equal(t, "Helm", newDeployment.Labels[managedByLabelKey])
+			} else {
+				assert.Equal(t, "", newDeployment.Labels[managedByLabelKey])
+			}
+			assertOtherLabelsAnnotationsUnchanged(t, newDeployment, origAnnotations, origLabels)
+		})
+	}
+}
+
+func TestRemoveResourcePolicyAnnotation(t *testing.T) {
+	withResourcePolicyAnnotation := v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "some-ns",
+			Name:      "some-name",
+			Annotations: map[string]string{
+				helmResourcePolicyKey: "Keep",
+			},
+		},
+	}
+	noResourcePolicyAnnotation := v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "some-ns",
+			Name:      "some-name",
+			Annotations: map[string]string{
+				helmResourcePolicyKey: "Keep",
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		obj  *v1.Deployment
+	}{
+		{"with existing resource policy", &withResourcePolicyAnnotation},
+		{"with existing resource policy", &noResourcePolicyAnnotation},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// deep copy the object since DisassociateHelmObject makes inline changes
+			myDeployment := v1.Deployment{}
+			tt.obj.DeepCopyInto(&myDeployment)
+
+			fakeClient := fake.NewClientBuilder().WithObjects(&myDeployment).Build()
+			objName := types.NamespacedName{Namespace: myDeployment.GetNamespace(), Name: myDeployment.GetName()}
+			_, err := RemoveResourcePolicyAnnotation(fakeClient, &myDeployment, objName)
+			assert.NoError(t, err)
+
+			newDeployment := v1.Deployment{}
+			err = fakeClient.Get(context.TODO(), objName, &newDeployment)
+			assert.NoError(t, err)
+			assert.Equal(t, "", newDeployment.Annotations[helmResourcePolicyKey])
+		})
+	}
+}
+
+// assertOtherLabelsAnnotationsUnchanged asserts that labels and annotations except the ones used by Helm
+// are retained unchanged
+func assertOtherLabelsAnnotationsUnchanged(t *testing.T, newDeployment v1.Deployment, origAnnotations map[string]string, origLabels map[string]string) {
+	// other annotations and labels are retained unchanged
+	for key, val := range origAnnotations {
+		if key == helmReleaseNamespaceKey || key == helmReleaseNameKey {
+			continue
+		}
+		assert.Equal(t, val, newDeployment.Annotations[key])
+	}
+	for key, val := range origLabels {
+		if key == managedByLabelKey {
+			continue
+		}
+		assert.Equal(t, val, newDeployment.Labels[key])
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_component.go
+++ b/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_component.go
@@ -80,8 +80,8 @@ func (c networkPoliciesComponent) PreInstall(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	// Associate the network policies to the verrazzano-network-policies release
-	if err := associateNetworkPoliciesWithHelm(ctx); err != nil {
+	// Update the network policies to associate or disassociate the verrazzano-network-policies release as needed
+	if err := updateNetworkPoliciesHelmRelease(ctx); err != nil {
 		return err
 	}
 
@@ -101,8 +101,8 @@ func (c networkPoliciesComponent) PreUpgrade(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	// Associate the network policies to the verrazzano-network-policies release
-	err := associateNetworkPoliciesWithHelm(ctx)
+	// Update the network policies to associate or disassociate the verrazzano-network-policies release as needed
+	err := updateNetworkPoliciesHelmRelease(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
