### PR TITLE
Tweak the Ruler integration to fix communication issues

### DIFF
--- a/platform-operator/controllers/verrazzano/component/thanos/thanos.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos.go
@@ -119,6 +119,7 @@ func appendReloaderSidecarOverrides(ctx spi.ComponentContext, kvs []bom.KeyValue
 	kvs = append(kvs, []bom.KeyValue{
 		{Key: fmt.Sprintf("%s.image", sidecarPrefix), Value: imageString},
 		{Key: fmt.Sprintf("%s.name", sidecarPrefix), Value: configReloaderSubcomponentName},
+		{Key: fmt.Sprintf("%s.command[0]", sidecarPrefix), Value: "/bin/prometheus-config-reloader"},
 		{Key: fmt.Sprintf("%s.args[0]", sidecarPrefix), Value: "--listen-address=:8080"},
 		{Key: fmt.Sprintf("%s.args[1]", sidecarPrefix), Value: "--reload-url=http://127.0.0.1:10902/-/reload"},
 		{Key: fmt.Sprintf("%s.args[2]", sidecarPrefix), Value: "--watched-dir=/conf/rules/"},

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_test.go
@@ -206,6 +206,7 @@ func TestAppendOverrides(t *testing.T) {
 	reloaderSidecarKVS := map[string]string{
 		"ruler.sidecars[0].image":                                    `ghcr.io/verrazzano/prometheus-config-reloader:v\d+\.\d+\.\d+-.+-.+`,
 		"ruler.sidecars[0].name":                                     configReloaderSubcomponentName,
+		"ruler.sidecars[0].command[0]":                               "/bin/prometheus-config-reloader",
 		"ruler.sidecars[0].args[0]":                                  "--listen-address=:8080",
 		"ruler.sidecars[0].args[1]":                                  "--reload-url=http://127.0.0.1:10902/-/reload",
 		"ruler.sidecars[0].args[2]":                                  "--watched-dir=/conf/rules/",

--- a/platform-operator/helm_config/overrides/thanos-values.yaml
+++ b/platform-operator/helm_config/overrides/thanos-values.yaml
@@ -108,7 +108,7 @@ ruler:
     # Turn off hostname to disable auto-generated backend
     hostname: ""
   alertmanagers:
-    - https://prometheus-operator-kube-p-alertmanager:9093
+    - http://prometheus-operator-kube-p-alertmanager:9093
 
 receive:
   podSecurityContext:

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
@@ -120,6 +120,17 @@ spec:
         - operation:
             ports:
               - "10902"
+    # allow query to talk to the Store API on Thanos Ruler
+    - from:
+        - source:
+            namespaces:
+              - verrazzano-system
+            principals:
+              - cluster.local/ns/verrazzano-monitoring/sa/thanos-query
+      to:
+        - operation:
+            ports:
+              - "10901"
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
@@ -131,6 +131,17 @@ spec:
         - operation:
             ports:
               - "10901"
+    # allow Prometheus to scrape from Thanos Ruler
+    - from:
+        - source:
+            namespaces:
+              - verrazzano-monitoring
+            principals:
+              - cluster.local/ns/verrazzano-monitoring/sa/prometheus-operator-kube-p-prometheus
+      to:
+        - operation:
+            ports:
+              - "10902"
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
@@ -129,6 +129,19 @@ spec:
       ports:
         - port: 10902
           protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-monitoring
+          podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - query
+      ports:
+        - port: 10901
+          protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/name: {{ include "common.names.fullname" . }}

--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/networkpolicy.yaml
@@ -129,18 +129,27 @@ spec:
       ports:
         - port: 10902
           protocol: TCP
+    # allow query to talk to the Store API on Thanos Ruler
     - from:
         - namespaceSelector:
             matchLabels:
               verrazzano.io/namespace: verrazzano-monitoring
           podSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                  - query
+            matchLabels:
+              app.kubernetes.io/component: query
       ports:
         - port: 10901
+          protocol: TCP
+    # allow Prometheus to scrape from Thanos Ruler
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 10902
           protocol: TCP
   podSelector:
     matchLabels:


### PR DESCRIPTION
**Changes**
- add the reload command to the prometheus config reloader so that it picks up rule changes
- alertmanager is outside of the mesh, so send http requests to the service endpoint
- Allow query to access the storeAPI of Thanos Ruler
- Allow Prometheus to scrape metrics from Thanos Ruler

**Testing**
- Install Verrazzano from this branch
- Change a rule and make sure it gets updated in Ruler
- Check the Ruler and Query pod logs to make sure no communication errors are happening
- Check the Ruler and Query consoles to make sure all rules/targets are available