### PR TITLE
VZ-10358: remove system-library catalog during rancher post upgrade

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -255,6 +255,12 @@ var nodeDriverGVR = schema.GroupVersionResource{
 	Resource: "nodedrivers",
 }
 
+var catalogGVR = schema.GroupVersionResource{
+	Group:    "management.cattle.io",
+	Version:  "v3",
+	Resource: "catalogs",
+}
+
 var dynamicSchemaGVR = schema.GroupVersionResource{
 	Group:    "management.cattle.io",
 	Version:  "v3",

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -1130,6 +1130,24 @@ func TestPostUpgrade(t *testing.T) {
 	assert.Error(t, component.PostUpgrade(ctxWithoutIngress))
 }
 
+// TestPostUpgradeWithIngress tests a happy path post upgrade run with the rancher ingress
+// GIVEN a Rancher install state where all components are ready
+//
+//	WHEN PostUpgrade is called
+//	THEN PostUpgrade should return nil
+func TestPostUpgradeWithIngress(t *testing.T) {
+	s := getScheme()
+	s.AddKnownTypeWithName(GVKNodeDriverList, &unstructured.UnstructuredList{})
+	fakeDynamicClient := dynfake.NewSimpleDynamicClient(s)
+	setDynamicClientFunc(func() (dynamic.Interface, error) { return fakeDynamicClient, nil })
+	defer func() {
+		resetDynamicClientFunc()
+	}()
+	component := NewComponent()
+	_, ctxWithIngress := prepareContexts()
+	assert.NoError(t, component.PostUpgrade(ctxWithIngress))
+}
+
 func TestValidateUpdate(t *testing.T) {
 	disabled := false
 	tests := []struct {
@@ -1298,11 +1316,16 @@ func prepareContexts() (spi.ComponentContext, spi.ComponentContext) {
 		Build()
 	ctxWithIngress := spi.NewFakeContext(clientWithIngress, &vzDefaultCA, nil, false, profilesRelativePath)
 
-	// Setup OCI KontainerDriver with fake client and context
-	driverName := common.KontainerDriverOCIName
-	driverObj := createKontainerDriver(driverName)
+	// Setup unstructured resources with fake client and context
+	driverObj := createKontainerDriver(common.KontainerDriverOCIName)
 	driverObj.UnstructuredContent()["spec"].(map[string]interface{})["active"] = false
-	fakeDynamicClient := dynfake.NewSimpleDynamicClient(getScheme(), driverObj)
+	driverObj.UnstructuredContent()["spec"].(map[string]interface{})["url"] = " https://rancher.default.nip.io/kontainerdriver/ociocne/v0.22.0/kontainer-engine-driver-ociocne-linux"
+	okeDriverObj := createKontainerDriver(common.KontainerDriverOKEName)
+	okeDriverObj.UnstructuredContent()["spec"].(map[string]interface{})["active"] = false
+	okeDriverObj.UnstructuredContent()["spec"].(map[string]interface{})["url"] = " https://rancher.default.nip.io/kontainerdriver/oke/v1.8.3/kontainer-engine-driver-oke-linux"
+	nodeDriverObj := createNodeDriver("testnodedriver")
+	catalogObj := createCatalog("system-library")
+	fakeDynamicClient := dynfake.NewSimpleDynamicClient(getScheme(), driverObj, okeDriverObj, nodeDriverObj, catalogObj)
 	setDynamicClientFunc(func() (dynamic.Interface, error) { return fakeDynamicClient, nil })
 
 	// mock the pod executor when resetting the Rancher admin password

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_install.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_install.go
@@ -16,7 +16,6 @@ import (
 	networking "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -133,12 +132,7 @@ func cleanupRancherResources(ctx context.Context, c client.Client) error {
 	}
 
 	// Delete the system-library catalog which is no longer installed/supported.
-	catalog := schema.GroupVersionResource{
-		Group:    common.APIGroupRancherManagement,
-		Version:  common.APIGroupVersionRancherManagement,
-		Resource: "catalogs",
-	}
-	err = di.Resource(catalog).Delete(ctx, "system-library", metav1.DeleteOptions{})
+	err = di.Resource(catalogGVR).Delete(ctx, "system-library", metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_install.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_install.go
@@ -16,6 +16,7 @@ import (
 	networking "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -130,5 +131,17 @@ func cleanupRancherResources(ctx context.Context, c client.Client) error {
 			return err
 		}
 	}
+
+	// Delete the system-library catalog which is no longer installed/supported.
+	catalog := schema.GroupVersionResource{
+		Group:    common.APIGroupRancherManagement,
+		Version:  common.APIGroupVersionRancherManagement,
+		Resource: "catalogs",
+	}
+	err = di.Resource(catalog).Delete(ctx, "system-library", metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_install_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_install_test.go
@@ -28,6 +28,7 @@ const (
 	name      = "NAME"
 )
 
+var GVKCatalog = common.GetRancherMgmtAPIGVKForKind("Catalog")
 var GVKNodeDriver = common.GetRancherMgmtAPIGVKForKind("NodeDriver")
 var GVKDynamicSchema = common.GetRancherMgmtAPIGVKForKind("DynamicSchema")
 var GVKNodeDriverList = common.GetRancherMgmtAPIGVKForKind(GVKNodeDriver.Kind + "List")
@@ -40,6 +41,26 @@ func createKontainerDriver(name string) *unstructured.Unstructured {
 	kontainerDriver.SetName(name)
 	kontainerDriver.UnstructuredContent()["spec"] = map[string]interface{}{}
 	return kontainerDriver
+}
+
+func createNodeDriver(name string) *unstructured.Unstructured {
+	nodeDriver := &unstructured.Unstructured{
+		Object: map[string]interface{}{},
+	}
+	nodeDriver.SetGroupVersionKind(GVKNodeDriver)
+	nodeDriver.SetName(name)
+	nodeDriver.UnstructuredContent()["spec"] = map[string]interface{}{}
+	return nodeDriver
+}
+
+func createCatalog(name string) *unstructured.Unstructured {
+	catalog := &unstructured.Unstructured{
+		Object: map[string]interface{}{},
+	}
+	catalog.SetGroupVersionKind(GVKCatalog)
+	catalog.SetName(name)
+	catalog.UnstructuredContent()["spec"] = map[string]interface{}{}
+	return catalog
 }
 
 // TestAddAcmeIngressAnnotations verifies if LetsEncrypt Annotations are added to the Ingress


### PR DESCRIPTION
Pull request to remove system-library catalog during rancher post upgrade. This fixes the error "Local catalog directory is empty" seen the Rancher console.