### PR TITLE
VZ-10390: metricsexporter spamming errors in the dev lre

### DIFF
--- a/platform-operator/metricsexporter/metricsexporter_utils.go
+++ b/platform-operator/metricsexporter/metricsexporter_utils.go
@@ -284,8 +284,10 @@ func AnalyzeVerrazzanoResourceMetrics(log vzlog.VerrazzanoLogger, cr vzapi.Verra
 				upgradeCompletionTime = status.LastTransitionTime
 			}
 		}
-		component, _ := registry.FindComponent(componentName)
-
+		found, component := registry.FindComponent(componentName)
+		if !found {
+			continue
+		}
 		componentJSONName := component.GetJSONName()
 		if installStartTime != "" && installCompletionTime != "" {
 			metricParserHelperFunction(log, componentJSONName, installStartTime, installCompletionTime, constants.InstallOperation)

--- a/platform-operator/metricsexporter/metricsexporter_utils.go
+++ b/platform-operator/metricsexporter/metricsexporter_utils.go
@@ -286,7 +286,7 @@ func AnalyzeVerrazzanoResourceMetrics(log vzlog.VerrazzanoLogger, cr vzapi.Verra
 		}
 		found, component := registry.FindComponent(componentName)
 		if !found {
-			log.Errorf("No component %s found", componentName)
+			log.Oncef("No component %s found", componentName)
 			return
 		}
 		componentJSONName := component.GetJSONName()

--- a/platform-operator/metricsexporter/metricsexporter_utils.go
+++ b/platform-operator/metricsexporter/metricsexporter_utils.go
@@ -284,6 +284,7 @@ func AnalyzeVerrazzanoResourceMetrics(log vzlog.VerrazzanoLogger, cr vzapi.Verra
 				upgradeCompletionTime = status.LastTransitionTime
 			}
 		}
+		component, _ := registry.FindComponent(componentName)
 
 		componentJSONName := component.GetJSONName()
 		if installStartTime != "" && installCompletionTime != "" {

--- a/platform-operator/metricsexporter/metricsexporter_utils.go
+++ b/platform-operator/metricsexporter/metricsexporter_utils.go
@@ -284,11 +284,7 @@ func AnalyzeVerrazzanoResourceMetrics(log vzlog.VerrazzanoLogger, cr vzapi.Verra
 				upgradeCompletionTime = status.LastTransitionTime
 			}
 		}
-		found, component := registry.FindComponent(componentName)
-		if !found {
-			log.Oncef("No component %s found", componentName)
-			return
-		}
+
 		componentJSONName := component.GetJSONName()
 		if installStartTime != "" && installCompletionTime != "" {
 			metricParserHelperFunction(log, componentJSONName, installStartTime, installCompletionTime, constants.InstallOperation)


### PR DESCRIPTION
Changed the log when component is not found from "Errorf" to "Oncef" to stop spamming
