### PR TITLE
OCNE Cluster Driver Tests: fix the check for obtaining OCNE & Verrazzano versions

### DIFF
--- a/tests/e2e/clusterapi/ocne-driver/environment.go
+++ b/tests/e2e/clusterapi/ocne-driver/environment.go
@@ -229,7 +229,7 @@ func fillOCNEVersion(log *zap.SugaredLogger) error {
 		return err
 	}
 	versionList := response.Children()
-	if len(versionList) != 1 {
+	if len(versionList) < 1 {
 		err = fmt.Errorf("response to OCNE versions request does not have expected length")
 		log.Error(err)
 		return err
@@ -284,7 +284,7 @@ func fillVerrazzanoVersions(log *zap.SugaredLogger) error {
 		return err
 	}
 	responseMap := response.ChildrenMap()
-	if len(responseMap) != 1 {
+	if len(responseMap) < 1 {
 		err = fmt.Errorf("response to Verrazzano versions request does not have expected length")
 		log.Error(err)
 		return err


### PR DESCRIPTION
Similar fix to https://github.com/verrazzano/verrazzano/pull/6673 in the OCNE cluster driver tests.

Fixes an error in test code logic when obtaining versions for OCNE and Verrazzano.
