### PR TITLE
VZ-10451 write error message to module condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
-	github.com/verrazzano/verrazzano-modules v0.0.0-20230725180422-12e34aafc597
+	github.com/verrazzano/verrazzano-modules v0.0.0-20230731185225-9ea69fc0babe
 	github.com/verrazzano/verrazzano-monitoring-operator v0.0.31-0.20230425042339-1243c1ab0595
 	go.uber.org/zap v1.24.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616

--- a/go.sum
+++ b/go.sum
@@ -661,8 +661,8 @@ github.com/verrazzano/fluent-operator/v2 v2.2.0 h1:rsKzccy5Di5SdbIJW31AdbWqET7cH
 github.com/verrazzano/fluent-operator/v2 v2.2.0/go.mod h1:v/q0zLEOWP6MKHP7xvrhtASZTwlrk4LcCne/kgPQ7J0=
 github.com/verrazzano/oam-kubernetes-runtime v0.3.3-3 h1:bxHzLJ7CtPOQ8RKVEGbxb3q1Zoq7wMH60AF6vSEXdEo=
 github.com/verrazzano/oam-kubernetes-runtime v0.3.3-3/go.mod h1:yw2g1lpW2qcQPPVI/0pcgmnRQL2KU9CucT06laPlG24=
-github.com/verrazzano/verrazzano-modules v0.0.0-20230725180422-12e34aafc597 h1:1lb6qg21StJv2/4kolpvLks6HdeUUNDR/GkTI9HCNuI=
-github.com/verrazzano/verrazzano-modules v0.0.0-20230725180422-12e34aafc597/go.mod h1:CVq6IMZE0jH+h6j+TiClWnN9oxV174HG19XdJNxxrBc=
+github.com/verrazzano/verrazzano-modules v0.0.0-20230731185225-9ea69fc0babe h1:WiLUYDYFQMgy0VXiAm59PB6obUZ1bRYltLHeKcXHeis=
+github.com/verrazzano/verrazzano-modules v0.0.0-20230731185225-9ea69fc0babe/go.mod h1:CVq6IMZE0jH+h6j+TiClWnN9oxV174HG19XdJNxxrBc=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.31-0.20230425042339-1243c1ab0595 h1:+4buE2SAKOJbTavB6zJhNd95wkfQ22NY95SvBJF0YlQ=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.31-0.20230425042339-1243c1ab0595/go.mod h1:xvQSMEAZ4XsURzSfWOiadnGRIFTRfBUaNXckZO0UeWw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=


### PR DESCRIPTION
When a module is reconciling and gets and error, update the module condition with the error message so that it is visible to the user.

This allows you to see errors that happen during lifecycle.  For example:

```
verrazzano-install   cert-manager               2.0.0-1+64b89a57   True    Successfully installed Module `cert-manager` as Helm release `cert-manager/cert-manager`
verrazzano-install   cert-manager-webhook-oci                      False   OCI DNS not configured
verrazzano-install   cluster-api                2.0.0-1+64b89a57   True    Successfully installed Module `cluster-api` as Helm release `verrazzano-capi/cluster-api`
```