### PR TITLE
WORKER_NODE_COUNT=2

### DIFF
--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
             trim: true)
         string (
             name: "WORKER_NODE_COUNT",
-            defaultValue: '5',
+            defaultValue: '2',
             description: 'Number of OCNE worker nodes',
             trim: true)
         choice (


### PR DESCRIPTION
Five worker nodes did not help too much on stability but increase the time of Create OCNE cluster.
- The time of Create OCNE cluster reduced to 20~25 mins (from 40mins).
- Decrease the probability of "Create OCNE cluster failed with the intermittent yum repo issue".
