### PR TITLE
VZ-10226: Handle K8s API errors to reduce log noise 

### DIFF
--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -78,14 +78,14 @@ func IsK8sAPIServerError(err error) (bool, string) {
 	if err == nil {
 		return false, ""
 	}
-	var message string = ""
+	var message string
 	if errors.IsServiceUnavailable(err) {
 		message = "KubernetesAPIServerError: the server is currently unable to handle the request"
 		return true, message
 	}
 
 	if errors.IsTooManyRequests(err) {
-		message = "the server has received too many requests and has asked us to try again later"
+		message = "KubernetesAPIServerError: the server has received too many requests and has asked us to try again later"
 		return true, message
 	}
 

--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -5,6 +5,7 @@ package spi
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"strings"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -71,4 +72,26 @@ func ShouldLogKubernetesAPIError(err error) bool {
 		return false
 	}
 	return true
+}
+
+func IsK8sAPIServerError(err error) (bool, string) {
+	if err == nil {
+		return false, ""
+	}
+	var message string = ""
+	if errors.IsServiceUnavailable(err) {
+		message = "KubernetesAPIServerError: the server is currently unable to handle the request"
+		return true, message
+	}
+
+	if errors.IsTooManyRequests(err) {
+		message = "the server has received too many requests and has asked us to try again later"
+		return true, message
+	}
+
+	if !strings.Contains(err.Error(), "the server is currently unable to handle the request") {
+		message = "KubernetesAPIServerError: the server is currently unable to handle the request"
+		return true, message
+	}
+	return false, message
 }

--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -81,7 +81,7 @@ func IsK8sAPIServerError(err error) (bool, string) {
 		return false, ""
 	}
 	var message string
-	if errors.IsServiceUnavailable(err) {
+	if errors.IsServiceUnavailable(err) || strings.Contains(err.Error(), "the server is currently unable to handle the request") {
 		message = "KubernetesAPIServerError: the server is currently unable to handle the request"
 		return true, message
 	}
@@ -91,9 +91,5 @@ func IsK8sAPIServerError(err error) (bool, string) {
 		return true, message
 	}
 
-	if strings.Contains(err.Error(), "the server is currently unable to handle the request") {
-		message = "KubernetesAPIServerError: the server is currently unable to handle the request"
-		return true, message
-	}
 	return false, message
 }

--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -91,7 +91,7 @@ func IsK8sAPIServerError(err error) (bool, string) {
 		return true, message
 	}
 
-	if !strings.Contains(err.Error(), "the server is currently unable to handle the request") {
+	if strings.Contains(err.Error(), "the server is currently unable to handle the request") {
 		message = "KubernetesAPIServerError: the server is currently unable to handle the request"
 		return true, message
 	}

--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -74,6 +74,8 @@ func ShouldLogKubernetesAPIError(err error) bool {
 	return true
 }
 
+// IsK8sAPIServerError returns false if the error is not due to Kubernetes API server load or too many requests rate limit.
+// The goal is to reduce log noise in platform operator and provide meaningful information
 func IsK8sAPIServerError(err error) (bool, string) {
 	if err == nil {
 		return false, ""

--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -5,7 +5,6 @@ package spi
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"strings"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -81,12 +80,12 @@ func IsK8sAPIServerError(err error) (bool, string) {
 		return false, ""
 	}
 	var message string
-	if errors.IsServiceUnavailable(err) || strings.Contains(err.Error(), "the server is currently unable to handle the request") {
+	if strings.Contains(err.Error(), "the server is currently unable to handle the request") {
 		message = "KubernetesAPIServerError: the server is currently unable to handle the request"
 		return true, message
 	}
 
-	if errors.IsTooManyRequests(err) {
+	if strings.Contains(err.Error(), "too many requests and has asked us to try again") {
 		message = "KubernetesAPIServerError: the server has received too many requests and has asked us to try again later"
 		return true, message
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -171,7 +171,12 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 			// If component is not installed,install it
 			compLog.Oncef("Component %s install started ", compName)
 			if err := comp.Install(compContext); err != nil {
-				if !ctrlerrors.IsRetryableError(err) {
+				IsK8sAPIServerError, errorMessage := ctrlerrors.IsK8sAPIServerError(err)
+				if IsK8sAPIServerError {
+					compLog.Debugf("Error running Install for component %s: %v", compName, err)
+					compLog.ErrorfThrottled(errorMessage)
+				}
+				if !(ctrlerrors.IsRetryableError(err) && IsK8sAPIServerError) {
 					compLog.ErrorfThrottled("Error running Install for component %s: %v", compName, err)
 				}
 

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -158,7 +158,12 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 			}
 			compLog.Progressf("Component %s pre-install is running ", compName)
 			if err := comp.PreInstall(compContext); err != nil {
-				if !ctrlerrors.IsRetryableError(err) {
+				IsK8sAPIServerError, errorMessage := ctrlerrors.IsK8sAPIServerError(err)
+				if IsK8sAPIServerError {
+					compLog.Debugf("Error running pre-install for component %s: %v", compName, err)
+					compLog.ErrorfThrottled(errorMessage)
+				}
+				if !(ctrlerrors.IsRetryableError(err) || IsK8sAPIServerError) {
 					compLog.ErrorfThrottled("Error running PreInstall for component %s: %v", compName, err)
 				}
 
@@ -176,7 +181,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 					compLog.Debugf("Error running Install for component %s: %v", compName, err)
 					compLog.ErrorfThrottled(errorMessage)
 				}
-				if !(ctrlerrors.IsRetryableError(err) && IsK8sAPIServerError) {
+				if !(ctrlerrors.IsRetryableError(err) || IsK8sAPIServerError) {
 					compLog.ErrorfThrottled("Error running Install for component %s: %v", compName, err)
 				}
 
@@ -197,7 +202,12 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 		case compStatePostInstall:
 			compLog.Oncef("Component %s post-install running", compName)
 			if err := comp.PostInstall(compContext); err != nil {
-				if !ctrlerrors.IsRetryableError(err) {
+				IsK8sAPIServerError, errorMessage := ctrlerrors.IsK8sAPIServerError(err)
+				if IsK8sAPIServerError {
+					compLog.Debugf("Error running PostInstall for component %s: %v", compName, err)
+					compLog.ErrorfThrottled(errorMessage)
+				}
+				if !(ctrlerrors.IsRetryableError(err) || IsK8sAPIServerError) {
 					compLog.ErrorfThrottled("Error running PostInstall for component %s: %v", compName, err)
 				}
 

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade_component.go
@@ -101,7 +101,12 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 		case compStatePreUpgrade:
 			compLog.Oncef("Component %s pre-upgrade running", compName)
 			if err := comp.PreUpgrade(compContext); err != nil {
-				if !ctrlerrors.IsRetryableError(err) {
+				IsK8sAPIServerError, errorMessage := ctrlerrors.IsK8sAPIServerError(err)
+				if IsK8sAPIServerError {
+					compLog.Debugf("Error running pre-upgrade for component %s: %v", compName, err)
+					compLog.ErrorfThrottled(errorMessage)
+				}
+				if !(ctrlerrors.IsRetryableError(err) || IsK8sAPIServerError) {
 					compLog.ErrorfThrottled("Failed pre-upgrade for component %s: %v", compName, err)
 				}
 				return ctrl.Result{}, err
@@ -111,7 +116,12 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 		case compStateUpgrade:
 			compLog.Progressf("Component %s upgrade running", compName)
 			if err := comp.Upgrade(compContext); err != nil {
-				if !ctrlerrors.IsRetryableError(err) {
+				IsK8sAPIServerError, errorMessage := ctrlerrors.IsK8sAPIServerError(err)
+				if IsK8sAPIServerError {
+					compLog.Debugf("Error running upgrade for component %s: %v", compName, err)
+					compLog.ErrorfThrottled(errorMessage)
+				}
+				if !(ctrlerrors.IsRetryableError(err) || IsK8sAPIServerError) {
 					compLog.ErrorfThrottled("Failed upgrading component %s, will retry: %v", compName, err)
 				}
 				// check to see whether this is due to a pending upgrade
@@ -132,7 +142,12 @@ func (r *Reconciler) upgradeSingleComponent(spiCtx spi.ComponentContext, upgrade
 		case compStatePostUpgrade:
 			compLog.Oncef("Component %s post-upgrade running", compName)
 			if err := comp.PostUpgrade(compContext); err != nil {
-				if !ctrlerrors.IsRetryableError(err) {
+				IsK8sAPIServerError, errorMessage := ctrlerrors.IsK8sAPIServerError(err)
+				if IsK8sAPIServerError {
+					compLog.Debugf("Error running post-upgrade for component %s: %v", compName, err)
+					compLog.ErrorfThrottled(errorMessage)
+				}
+				if !(ctrlerrors.IsRetryableError(err) || IsK8sAPIServerError) {
 					compLog.ErrorfThrottled("Failed post-upgrade for component %s: %v", compName, err)
 				}
 				return ctrl.Result{}, err


### PR DESCRIPTION
This PR has code fixes to handle Kubernetes API server errors such as "server unavailability due to load" and "too many requests" during installation, pre-install, pre-upgrade, and upgrading of a Verrazzano component. 