### PR TITLE
VZ-10451 add component GetWatchDescriptors method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
-	github.com/verrazzano/verrazzano-modules v0.0.0-20230801202640-478e96f2ad3a
+	github.com/verrazzano/verrazzano-modules v0.0.0-20230802213211-affca69c3395
 	github.com/verrazzano/verrazzano-monitoring-operator v0.0.31-0.20230425042339-1243c1ab0595
 	go.uber.org/zap v1.24.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616

--- a/go.sum
+++ b/go.sum
@@ -661,8 +661,8 @@ github.com/verrazzano/fluent-operator/v2 v2.2.0 h1:rsKzccy5Di5SdbIJW31AdbWqET7cH
 github.com/verrazzano/fluent-operator/v2 v2.2.0/go.mod h1:v/q0zLEOWP6MKHP7xvrhtASZTwlrk4LcCne/kgPQ7J0=
 github.com/verrazzano/oam-kubernetes-runtime v0.3.3-3 h1:bxHzLJ7CtPOQ8RKVEGbxb3q1Zoq7wMH60AF6vSEXdEo=
 github.com/verrazzano/oam-kubernetes-runtime v0.3.3-3/go.mod h1:yw2g1lpW2qcQPPVI/0pcgmnRQL2KU9CucT06laPlG24=
-github.com/verrazzano/verrazzano-modules v0.0.0-20230801202640-478e96f2ad3a h1:EzCVMP/rEtmXX3qt+VyYjBFiuU5pcu7SNv6Pfo8O3sY=
-github.com/verrazzano/verrazzano-modules v0.0.0-20230801202640-478e96f2ad3a/go.mod h1:CVq6IMZE0jH+h6j+TiClWnN9oxV174HG19XdJNxxrBc=
+github.com/verrazzano/verrazzano-modules v0.0.0-20230802213211-affca69c3395 h1:x3kx37C9fwCHAZKu5V7x2xeX3WDgrE7nz1UQ708sv8g=
+github.com/verrazzano/verrazzano-modules v0.0.0-20230802213211-affca69c3395/go.mod h1:CVq6IMZE0jH+h6j+TiClWnN9oxV174HG19XdJNxxrBc=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.31-0.20230425042339-1243c1ab0595 h1:+4buE2SAKOJbTavB6zJhNd95wkfQ22NY95SvBJF0YlQ=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.31-0.20230425042339-1243c1ab0595/go.mod h1:xvQSMEAZ4XsURzSfWOiadnGRIFTRfBUaNXckZO0UeWw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
@@ -57,7 +57,6 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
-			UseModule:                 config.Get().ModuleIntegration,
 			AppendOverridesFunc:       AppendOverrides,
 			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_3_0,
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0]",

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager_component.go
@@ -63,7 +63,6 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
-			UseModule:                 config.Get().ModuleIntegration,
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0].name",
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "cert-manager-values.yaml"),
 			AppendOverridesFunc:       AppendOverrides,

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component.go
@@ -4,6 +4,7 @@
 package issuer
 
 import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -191,6 +192,12 @@ func (c clusterIssuerComponent) ShouldInstallBeforeUpgrade() bool {
 func (c clusterIssuerComponent) ShouldUseModule() bool {
 	return config.Get().ModuleIntegration
 }
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (c clusterIssuerComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
+}
+
 func (c clusterIssuerComponent) GetDependencies() []string {
 	return []string{networkpolicies.ComponentName, cmconstants.CertManagerComponentName}
 }

--- a/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/webhook_oci_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/webhook_oci_component.go
@@ -56,7 +56,6 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
-			UseModule:                 config.Get().ModuleIntegration,
 			InstallBeforeUpgrade:      true,
 			GetInstallOverridesFunc:   GetOverrides,
 			AppendOverridesFunc:       appendOCIDNSOverrides,

--- a/platform-operator/controllers/verrazzano/component/clusteragent/cluster_agent_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusteragent/cluster_agent_component.go
@@ -43,7 +43,6 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
-			UseModule:                 config.Get().ModuleIntegration,
 			AppendOverridesFunc:       AppendClusterAgentOverrides,
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0]",
 			Dependencies:              []string{networkpolicies.ComponentName, oam.ComponentName, istio.ComponentName},

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -6,6 +6,7 @@ package clusterapi
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 
 	"github.com/verrazzano/verrazzano/pkg/constants"
@@ -100,6 +101,11 @@ func (c clusterAPIComponent) ShouldInstallBeforeUpgrade() bool {
 // ShouldUseModule returns true if component is implemented using a Module
 func (c clusterAPIComponent) ShouldUseModule() bool {
 	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (c clusterAPIComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
 }
 
 // GetDependencies returns the dependencies of this component.

--- a/platform-operator/controllers/verrazzano/component/coherence/coherence_component.go
+++ b/platform-operator/controllers/verrazzano/component/coherence/coherence_component.go
@@ -51,7 +51,7 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
-			UseModule:                 useModule,
+			ModuleIntegrationConfig:   helm.ModuleIntegrationConfig{UseModule: useModule},
 			ImagePullSecretKeyname:    secret.DefaultImagePullSecretKeyName,
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "coherence-values.yaml"),
 			Dependencies:              []string{networkpolicies.ComponentName, fluentoperator.ComponentName},

--- a/platform-operator/controllers/verrazzano/component/console/console_component.go
+++ b/platform-operator/controllers/verrazzano/component/console/console_component.go
@@ -47,7 +47,6 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
-			UseModule:                 config.Get().ModuleIntegration,
 			Dependencies:              []string{networkpolicies.ComponentName, authproxy.ComponentName},
 			AppendOverridesFunc:       AppendOverrides,
 			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_4_0,

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
@@ -5,6 +5,7 @@ package grafana
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -66,6 +67,11 @@ func (g grafanaComponent) ShouldInstallBeforeUpgrade() bool {
 // ShouldUseModule returns true if component is implemented using a Module
 func (g grafanaComponent) ShouldUseModule() bool {
 	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (g grafanaComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
 }
 
 // GetDependencies returns the dependencies of the Grafana component

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -6,6 +6,7 @@ package helm
 import (
 	ctx "context"
 	"fmt"
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"github.com/verrazzano/verrazzano/pkg/namespace"
 	"os"
 	"sort"
@@ -33,8 +34,19 @@ import (
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ModuleIntegrationConfig specifies Module integration configuration
+type ModuleIntegrationConfig struct {
+	// UseModule if component should be implmemented by a Module, default false
+	UseModule bool
+	// WatchDescriptors contains the WatchDescriptor this the component
+	WatchDescriptors []controllerspi.WatchDescriptor
+}
+
 // HelmComponent struct needed to implement a component
 type HelmComponent struct {
+	// ModuleIntegrationConfig contains the configuration needed for Module integraiton
+	ModuleIntegrationConfig
+
 	// ReleaseName is the helm chart release name
 	ReleaseName string
 
@@ -61,9 +73,6 @@ type HelmComponent struct {
 
 	// InstallBeforeUpgrade if component can be installed before upgade is done, default false
 	InstallBeforeUpgrade bool
-
-	// UseModule if component should be implmemented by a Module, default false
-	UseModule bool
 
 	// PreInstallFunc is an optional function to run before installing
 	PreInstallFunc preInstallFuncSig
@@ -169,8 +178,12 @@ func (h HelmComponent) ShouldInstallBeforeUpgrade() bool {
 
 // ShouldUseModule returns true if component is implemented using a Module, default false
 func (h HelmComponent) ShouldUseModule() bool {
-	// return h.UseModule
 	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (h HelmComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return h.WatchDescriptors
 }
 
 // GetJsonName returns the josn name of the verrazzano component in CRD

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
@@ -887,7 +887,7 @@ func TestHelmComponent(t *testing.T) {
 		JSONName:                  compJSONName,
 		Dependencies:              compDependencies,
 		SupportsOperatorUninstall: enabled,
-		UseModule:                 enabled,
+		ModuleIntegrationConfig:   ModuleIntegrationConfig{UseModule: enabled},
 		Certificates:              compCertificates,
 		MinVerrazzanoVersion:      comVersion,
 		SkipUpgrade:               true,

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -6,6 +6,7 @@ package istio
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"path/filepath"
 	"strings"
 
@@ -488,6 +489,11 @@ func (i istioComponent) ShouldInstallBeforeUpgrade() bool {
 // ShouldUseModule returns true if component is implemented using a Module
 func (i istioComponent) ShouldUseModule() bool {
 	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (i istioComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
 }
 
 func deleteIstioCoreDNS(context spi.ComponentContext) error {

--- a/platform-operator/controllers/verrazzano/component/nginx/nginx_component.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/nginx_component.go
@@ -61,7 +61,6 @@ func NewComponent() spi.Component {
 			IgnoreNamespaceOverride:   true,
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
-			UseModule:                 config.Get().ModuleIntegration,
 			ImagePullSecretKeyname:    secret.DefaultImagePullSecretKeyName,
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), ValuesFileOverride),
 			PreInstallFunc:            PreInstall,

--- a/platform-operator/controllers/verrazzano/component/opensearch/opensearch_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/opensearch_component.go
@@ -5,6 +5,7 @@ package opensearch
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,6 +56,11 @@ func (o opensearchComponent) ShouldInstallBeforeUpgrade() bool {
 // ShouldUseModule returns true if component is implemented using a Module
 func (o opensearchComponent) ShouldUseModule() bool {
 	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (o opensearchComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
 }
 
 // GetDependencies returns the dependencies of the OpenSearch component

--- a/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards_component.go
@@ -5,6 +5,7 @@ package opensearchdashboards
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,6 +56,11 @@ func (d opensearchDashboardsComponent) ShouldInstallBeforeUpgrade() bool {
 // ShouldUseModule returns true if component is implemented using a Module
 func (d opensearchDashboardsComponent) ShouldUseModule() bool {
 	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (d opensearchDashboardsComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
 }
 
 // GetDependencies returns the dependencies of the OpenSearch-Dashbaords component

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -4,6 +4,7 @@
 package registry
 
 import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"reflect"
 	"testing"
 
@@ -885,6 +886,11 @@ func (f fakeComponent) ShouldInstallBeforeUpgrade() bool {
 // ShouldUseModule returns true if a module should be used for lifecycle management
 func (f fakeComponent) ShouldUseModule() bool {
 	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (f fakeComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
 }
 
 func (f fakeComponent) GetJSONName() string {

--- a/platform-operator/controllers/verrazzano/component/spi/component.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component.go
@@ -4,6 +4,7 @@
 package spi
 
 import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -12,7 +13,7 @@ import (
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ComponentContext Defines the context objects required for Component operations
+// ComponentContext interface defines the context objects required for Component operations
 type ComponentContext interface {
 	// Log returns the logger for the context
 	Log() vzlog.VerrazzanoLogger
@@ -48,8 +49,6 @@ type ComponentInfo interface {
 	Namespace() string
 	// ShouldInstallBeforeUpgrade returns true if component can be installed before upgrade is done, default false
 	ShouldInstallBeforeUpgrade() bool
-	// ShouldUseModule returns true if component is implemented using a Module, default false
-	ShouldUseModule() bool
 	// GetDependencies returns the dependencies of this component
 	GetDependencies() []string
 	// IsReady Indicates whether a component is Ready for dependency components
@@ -122,6 +121,14 @@ type ComponentValidator interface {
 	ValidateUpdateV1Beta1(old *v1beta1.Verrazzano, new *v1beta1.Verrazzano) error
 }
 
+// ModuleIntegration interface defines methods needed to integreate VPO with modules
+type ModuleIntegration interface {
+	// ShouldUseModule returns true if component is implemented using a Module, default false
+	ShouldUseModule() bool
+	// GetWatchDescriptors returns the list of WatchDescriptor for objects being watched by the component
+	GetWatchDescriptors() []controllerspi.WatchDescriptor
+}
+
 // Generate mocs for the spi.Component interface for use in tests.
 //go:generate mockgen -destination=../../../../mocks/component_mock.go -package=mocks -copyright_file=../../../../hack/boilerplate.go.txt github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi Component
 
@@ -132,6 +139,7 @@ type Component interface {
 	ComponentUninstaller
 	ComponentUpgrader
 	ComponentValidator
+	ModuleIntegration
 
 	Reconcile(ctx ComponentContext) error
 }

--- a/platform-operator/experimental/module-integration/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/module-integration/controllers/verrazzano/reconciler.go
@@ -96,7 +96,7 @@ func (r Reconciler) createOrUpdateModules(log vzlog.VerrazzanoLogger, effectiveC
 		})
 		if err != nil {
 			if !errors.IsConflict(err) {
-				log.Errorf("Failed createOrUpdate module %s: %v", module.Name, err)
+				log.ErrorfThrottled("Failed createOrUpdate module %s: %v", module.Name, err)
 			}
 			return result.NewResultShortRequeueDelayWithError(err)
 		}
@@ -126,10 +126,10 @@ func (r Reconciler) mutateModule(log vzlog.VerrazzanoLogger, effectiveCR *vzapi.
 
 // shouldCreateOrUpdateModule returns true if the Module should be created or updated
 func (r Reconciler) shouldCreateOrUpdateModule(effectiveCR *vzapi.Verrazzano, comp spi.Component) (bool, error) {
-	if !comp.ShouldUseModule() {
+	if !comp.IsEnabled(effectiveCR) {
 		return false, nil
 	}
-	if !comp.IsEnabled(effectiveCR) {
+	if !comp.ShouldUseModule() {
 		return false, nil
 	}
 

--- a/platform-operator/mocks/component_mock.go
+++ b/platform-operator/mocks/component_mock.go
@@ -9,6 +9,7 @@
 package mocks
 
 import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/base/controllerspi"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -433,6 +434,7 @@ func (mr *MockComponentInfoMockRecorder) ShouldUseModule() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldUseModule", reflect.TypeOf((*MockComponentInfo)(nil).ShouldUseModule))
 }
 
+
 // MockComponentInstaller is a mock of ComponentInstaller interface.
 type MockComponentInstaller struct {
 	ctrl     *gomock.Controller
@@ -697,6 +699,20 @@ func (m *MockComponent) GetOverrides(arg0 runtime.Object) interface{} {
 func (mr *MockComponentMockRecorder) GetOverrides(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOverrides", reflect.TypeOf((*MockComponent)(nil).GetOverrides), arg0)
+}
+
+// GetWatchDescriptors mocks base method.
+func (m *MockComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWatchDescriptors")
+	ret0, _ := ret[0].([]controllerspi.WatchDescriptor)
+	return ret0
+}
+
+// GetWatchDescriptors indicates an expected call of GetOverrides.
+func (mr *MockComponentMockRecorder) GetWatchDescriptors() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWatchDescriptors", reflect.TypeOf((*MockComponent)(nil).GetWatchDescriptors))
 }
 
 // Install mocks base method.


### PR DESCRIPTION
Add component GetWatchDescriptors method.  This is needed to allow components to specify the resources that they want to watch, along with the predicate.

Pass the component WatchDescriptors to the controller manager when creating Module controllers
Minor cleanup of Verrazzano reconcile
