### PR TITLE
Enable input plugins in FluentOperator only if output is available

### DIFF
--- a/platform-operator/controllers/verrazzano/component/fluentoperator/fluentoperator.go
+++ b/platform-operator/controllers/verrazzano/component/fluentoperator/fluentoperator.go
@@ -22,7 +22,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentbitosoutput"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 )
@@ -105,7 +104,7 @@ func appendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		args["clusterName"] = string(registrationSecret.Data[constants.ClusterNameData])
 		args["secretName"] = constants.MCRegistrationSecret
 	}
-	if ctx.ActualCR().Status.Components[fluentbitosoutput.ComponentName] != nil && ctx.ActualCR().Status.Components[fluentbitosoutput.ComponentName].State == v1alpha1.CompStateReady {
+	if ctx.ActualCR().Status.Components["fluentbit-opensearch-output"] != nil && ctx.ActualCR().Status.Components["fluentbit-opensearch-output"].State == v1alpha1.CompStateReady {
 		args["enableInput"] = true
 	}
 	overridesFileName, err := generateOverrideFile(filepath.Join(config.GetHelmOverridesDir(), fluentOperatorOverrideFile), args)

--- a/platform-operator/controllers/verrazzano/component/fluentoperator/fluentoperator.go
+++ b/platform-operator/controllers/verrazzano/component/fluentoperator/fluentoperator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentbitosoutput"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 )
@@ -98,10 +99,14 @@ func appendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 	}
 	args := make(map[string]interface{})
 	args["clusterName"] = adminClusterName
+	args["enableInput"] = false
 	if registrationSecret != nil {
 		args["isManagedCluster"] = true
 		args["clusterName"] = string(registrationSecret.Data[constants.ClusterNameData])
 		args["secretName"] = constants.MCRegistrationSecret
+	}
+	if ctx.ActualCR().Status.Components[fluentbitosoutput.ComponentName] != nil && ctx.ActualCR().Status.Components[fluentbitosoutput.ComponentName].State == v1alpha1.CompStateReady {
+		args["enableInput"] = true
 	}
 	overridesFileName, err := generateOverrideFile(filepath.Join(config.GetHelmOverridesDir(), fluentOperatorOverrideFile), args)
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -82,7 +82,8 @@ func (r *Reconciler) installComponents(spiCtx spi.ComponentContext, tracker *ins
 		if comp.Name() == fluentbitosoutput.ComponentName {
 			isFluentOperatorExists, fluentOperatorComp := registry.FindComponent(fluentbitosoutput.ComponentName)
 			if isFluentOperatorExists {
-				if result := r.installSingleComponent(spiCtx, tracker.getComponentInstallContext(fluentOperatorComp.Name()), fluentOperatorComp, preUpgrade); result.Requeue {
+				compContext := spiCtx.Init(fluentOperatorComp.Name()).Operation(vzconst.InstallOperation)
+				if err := fluentOperatorComp.Upgrade(compContext); err != nil {
 					requeue = true
 				}
 			}

--- a/platform-operator/helm_config/overrides/fluent-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/fluent-operator-values.yaml
@@ -35,12 +35,12 @@ fluentbit:
       fluentbit.verrazzano.io/namespace-config: verrazzano
   input:
     tail:
-      enable: {{ enableInput }}
+      enable: {{ .enableInput }}
       readFromHead: true
       storageType: filesystem
       pauseOnChunksOverlimit: "on"
     systemd:
-      enable: {{ enableInput }}
+      enable: {{ .enableInput }}
       path: "/run/log/journal"
       stripUnderscores: "on"
       systemdFilter:

--- a/platform-operator/helm_config/overrides/fluent-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/fluent-operator-values.yaml
@@ -35,10 +35,12 @@ fluentbit:
       fluentbit.verrazzano.io/namespace-config: verrazzano
   input:
     tail:
+      enable: {{ enableInput }}
       readFromHead: true
       storageType: filesystem
       pauseOnChunksOverlimit: "on"
     systemd:
+      enable: {{ enableInput }}
       path: "/run/log/journal"
       stripUnderscores: "on"
       systemdFilter:


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
