### PR TITLE
VZ-10386: Fix Opensearch IsInstalled() logs

### DIFF
--- a/platform-operator/controllers/verrazzano/component/opensearch/opensearch.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/opensearch.go
@@ -25,12 +25,13 @@ const (
 
 // doesOSExist is the IsInstalled check
 func doesOSExist(ctx spi.ComponentContext) bool {
-	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
 	sts := []types.NamespacedName{{
 		Name:      esMasterStatefulset,
 		Namespace: ComponentNamespace,
 	}}
-	return ready.DoStatefulSetsExist(ctx.Log(), ctx.Client(), sts, 1, prefix)
+	// FIXME: works, but is this as desired?
+	exists, _ := ready.DoesStatefulsetExist(ctx.Client(), sts[0])
+	return exists
 }
 
 // IsSingleDataNodeCluster returns true if there is exactly 1 or 0 data nodes

--- a/platform-operator/controllers/verrazzano/component/opensearch/opensearch.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/opensearch.go
@@ -31,7 +31,7 @@ func doesOSExist(ctx spi.ComponentContext) bool {
 	}
 	exists, err := ready.DoesStatefulsetExist(ctx.Client(), sts)
 	if err != nil {
-		ctx.Log().Errorf("component %s failed getting statefulset %v: %v", ctx.GetComponent(), sts, err)
+		ctx.Log().Errorf("Component %s failed getting statefulset %v: %v", ctx.GetComponent(), sts, err)
 	}
 	return exists
 }

--- a/platform-operator/controllers/verrazzano/component/opensearch/opensearch.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/opensearch.go
@@ -25,12 +25,14 @@ const (
 
 // doesOSExist is the IsInstalled check
 func doesOSExist(ctx spi.ComponentContext) bool {
-	sts := []types.NamespacedName{{
+	sts := types.NamespacedName{
 		Name:      esMasterStatefulset,
 		Namespace: ComponentNamespace,
-	}}
-	// FIXME: works, but is this as desired?
-	exists, _ := ready.DoesStatefulsetExist(ctx.Client(), sts[0])
+	}
+	exists, err := ready.DoesStatefulsetExist(ctx.Client(), sts)
+	if err != nil {
+		ctx.Log().Errorf("component %s failed getting statefulset %v: %v", ctx.GetComponent(), sts, err)
+	}
 	return exists
 }
 


### PR DESCRIPTION
During VZ install, the OpenSearch component logs `Component opensearch is waiting for statefulset verrazzano-system/vmi-system-es-master to exist` even when OpenSearch is disabled. This log message comes from the call to `DoStatefulSetsExist`, inside OpenSearch's `doesOSExist` function.

This PR changes the OpenSearch's `doesOSExist` function to log only when erroring, modeled similar to several other components' `IsInstalled` checks.