### PR TITLE
VZ-10120: Append cluster names to the annotation

### DIFF
--- a/platform-operator/controllers/verrazzano/namespacewatch/namespace_watcher_test.go
+++ b/platform-operator/controllers/verrazzano/namespacewatch/namespace_watcher_test.go
@@ -230,21 +230,21 @@ func TestMoveSystemNamespaces(t *testing.T) {
 	config.TestProfilesDir = reldir
 	defer func() { config.TestProfilesDir = "" }()
 	client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(vzCR,
-		newReplicaSet("cattle-system", "rancher"),
-		newReplicaSet("cattle-system", "rancher-webhook"),
-		newReplicaSet("cattle-fleet-system", "gitjob"),
-		newReplicaSet("cattle-fleet-system", "fleet-controller"),
-		newReplicaSet("cattle-fleet-local-system", "fleet-agent"),
-		newPod("cattle-system", "rancher"),
-		newPod("cattle-system", "rancher-webhook"),
-		newPod("cattle-fleet-system", "gitjob"),
-		newPod("cattle-fleet-system", "fleet-controller"),
-		newPod("cattle-fleet-local-system", "fleet-agent"),
-		newReadyDeployment("cattle-system", "rancher"),
-		newReadyDeployment("cattle-system", "rancher-webhook"),
-		newReadyDeployment("cattle-fleet-system", "gitjob"),
-		newReadyDeployment("cattle-fleet-system", "fleet-controller"),
-		newReadyDeployment("cattle-fleet-local-system", "fleet-agent"), namespace1).Build()
+		newReplicaSet(rancher.ComponentNamespace, "rancher"),
+		newReplicaSet(rancher.ComponentNamespace, "rancher-webhook"),
+		newReplicaSet(rancher.FleetSystemNamespace, "gitjob"),
+		newReplicaSet(rancher.FleetSystemNamespace, "fleet-controller"),
+		newReplicaSet(rancher.FleetLocalSystemNamespace, "fleet-agent"),
+		newPod(rancher.ComponentNamespace, "rancher"),
+		newPod(rancher.ComponentNamespace, "rancher-webhook"),
+		newPod(rancher.FleetSystemNamespace, "gitjob"),
+		newPod(rancher.FleetSystemNamespace, "fleet-controller"),
+		newPod(rancher.FleetLocalSystemNamespace, "fleet-agent"),
+		newReadyDeployment(rancher.ComponentNamespace, "rancher"),
+		newReadyDeployment(rancher.ComponentNamespace, "rancher-webhook"),
+		newReadyDeployment(rancher.FleetSystemNamespace, "gitjob"),
+		newReadyDeployment(rancher.FleetSystemNamespace, "fleet-controller"),
+		newReadyDeployment(rancher.FleetLocalSystemNamespace, "fleet-agent"), namespace1).Build()
 	ctx := spi.NewFakeContext(client, vzCR, nil, false)
 	namespaceWatcher = NewNamespaceWatcher(ctx.Client(), period)
 	projectID := "p-47cnm"

--- a/platform-operator/controllers/verrazzano/namespacewatch/rancher_utils.go
+++ b/platform-operator/controllers/verrazzano/namespacewatch/rancher_utils.go
@@ -32,33 +32,34 @@ func getRancherProjectList(dynClient dynamic.Interface) (*unstructured.Unstructu
 }
 
 // getRancherSystemProjectID returns the ID of Rancher system project
-func (nw *NamespacesWatcher) getRancherSystemProjectID() (string, error) {
+func (nw *NamespacesWatcher) getRancherSystemProjectID() (string, string, error) {
 
 	isRancherReady, err := nw.IsRancherReady()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if !isRancherReady {
 		nw.log.Debugf("rancher is not enabled or ready")
-		return "", nil
+		return "", "", nil
 	}
 	dynClient, err := getDynamicClient()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	rancherProjectList, err := getRancherProjectList(dynClient)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	var projectID string
 	for _, rancherProject := range rancherProjectList.Items {
 		projectName := rancherProject.UnstructuredContent()["spec"].(map[string]interface{})["displayName"].(string)
+		clusterName := rancherProject.UnstructuredContent()["spec"].(map[string]interface{})["clusterName"].(string)
 		if projectName == "System" {
 			projectID = rancherProject.UnstructuredContent()["metadata"].(map[string]interface{})["name"].(string)
-			return projectID, nil
+			return clusterName, projectID, nil
 		}
 	}
-	return "", nil
+	return "", "", nil
 }
 
 // GetRancherMgmtAPIGVRForResource returns a management.cattle.io/v3 GroupVersionResource structure for specified kind


### PR DESCRIPTION
This PR fixes the issue where namespaces are annotated appropriately to the cluster in a multi-cluster scenario. Also refactored the unit tests to reduce code smells.  