### PR TITLE
VZ-10496 Only deploy Prometheus Rules for enabled components

### DIFF
--- a/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -54,6 +54,10 @@ prometheus:
       - action: replace
         targetLabel: verrazzano_cluster
         replacement: local
+  thanosService:
+    enabled: true
+  thanosServiceMonitor:
+    enabled: true
 
 alertmanager:
   enabled: false

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus-operator.yaml
@@ -120,7 +120,7 @@ spec:
         description: Prometheus operator in {{`{{`}} $labels.namespace {{`}}`}} namespace isn't ready to reconcile {{`{{`}} $labels.controller {{`}}`}} resources.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}/prometheus-operator/prometheusoperatornotready
         summary: Prometheus operator not ready
-      expr: min by (controller,namespace,cluster) (max_over_time(prometheus_operator_ready{job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[5m]) == 0)
+      expr: min by (controller,namespace,cluster) (max_over_time(prometheus_operator_ready{job="{{ $operatorJob }}",namespace="{{ $namespace }}",controller!="prometheus-agent"}[5m]) == 0)
       for: 5m
       labels:
         severity: warning

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/serviceThanosSidecar.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheus.enabled .Values.prometheus.thanosService.enabled }}
+{{- if and .Values.prometheus.enabled .Values.prometheus.thanosService.enabled (eq .Values.prometheus.thanos.integration "sidecar") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheus.thanosService.enabled .Values.prometheus.thanosServiceMonitor.enabled }}
+{{- if and .Values.prometheus.thanosService.enabled .Values.prometheus.thanosServiceMonitor.enabled (eq .Values.prometheus.thanos.integration "sidecar") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/absent_rules.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/absent_rules.yml
@@ -21,7 +21,7 @@ spec:
   groups:
   - name: thanos-component-absent
     rules:
-    {{- if not (.Values.metrics.prometheusRule.default.disabled.ThanosCompactIsDown | default false) }}
+    {{- if and (not (.Values.metrics.prometheusRule.default.disabled.ThanosCompactIsDown | default false)) .Values.compactor.enabled }}
     - alert: ThanosCompactIsDown
       annotations:
         {{- if .Values.commonAnnotations }}
@@ -39,7 +39,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $) | nindent 8 }}
         {{- end }}
     {{- end }}
-    {{- if not (.Values.metrics.prometheusRule.default.disabled.ThanosQueryIsDown | default false) }}
+    {{- if and (not (.Values.metrics.prometheusRule.default.disabled.ThanosQueryIsDown | default false)) .Values.query.enabled }}
     - alert: ThanosQueryIsDown
       annotations:
         {{- if .Values.commonAnnotations }}
@@ -57,7 +57,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $) | nindent 8 }}
         {{- end }}
     {{- end }}
-    {{- if not (.Values.metrics.prometheusRule.default.disabled.ThanosReceiveIsDown | default false) }}
+    {{- if and (not (.Values.metrics.prometheusRule.default.disabled.ThanosReceiveIsDown | default false)) .Values.receive.enabled }}
     - alert: ThanosReceiveIsDown
       annotations:
         {{- if .Values.commonAnnotations }}
@@ -75,7 +75,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $) | nindent 8 }}
         {{- end }}
     {{- end }}
-    {{- if not (.Values.metrics.prometheusRule.default.disabled.ThanosRuleIsDown | default false) }}
+    {{- if and (not (.Values.metrics.prometheusRule.default.disabled.ThanosRuleIsDown | default false)) .Values.ruler.enabled }}
     - alert: ThanosRuleIsDown
       annotations:
         {{- if .Values.commonAnnotations }}
@@ -103,7 +103,7 @@ spec:
         runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarisdown
         summary: Thanos component has disappeared.
       expr: |
-        absent(up{job=~".*thanos-sidecar.*"} == 1)
+        absent(up{job=~".*thanos-discovery.*"} == 1)
       for: 5m
       labels:
         severity: critical
@@ -111,7 +111,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $) | nindent 8 }}
         {{- end }}
     {{- end }}
-    {{- if not (.Values.metrics.prometheusRule.default.disabled.ThanosStoreIsDown | default false) }}
+    {{- if and (not (.Values.metrics.prometheusRule.default.disabled.ThanosStoreIsDown | default false)) .Values.storegateway.enabled }}
     - alert: ThanosStoreIsDown
       annotations:
         {{- if .Values.commonAnnotations }}

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/compaction.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/compaction.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.compaction ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.compaction ) .Values.compactor.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/query.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/query.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.query ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.query ) .Values.query.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/receive.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/receive.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.receive ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.receive ) .Values.receive.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/ruler.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/ruler.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.ruler ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.ruler ) .Values.ruler.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/sidecar.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/sidecar.yml
@@ -31,7 +31,7 @@ spec:
         runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarbucketoperationsfailed
         summary: Thanos Sidecar bucket operations are failing
       expr: |
-        sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~".*thanos-sidecar.*"}[5m])) > 0
+        sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~".*thanos-discovery.*"}[5m])) > 0
       for: 5m
       labels:
         severity: critical
@@ -49,7 +49,7 @@ spec:
         runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanossidecarnoconnectiontostartedprometheus
         summary: Thanos Sidecar cannot access Prometheus, even though Prometheus seems healthy and has reloaded WAL.
       expr: |
-        thanos_sidecar_prometheus_up{job=~".*thanos-sidecar.*"} == 0
+        thanos_sidecar_prometheus_up{job=~".*thanos-discovery.*"} == 0
         AND on (namespace, pod)
         prometheus_tsdb_data_replay_duration_seconds != 0
       for: 5m

--- a/platform-operator/thirdparty/charts/thanos/templates/alert-rule/store_gateway.yml
+++ b/platform-operator/thirdparty/charts/thanos/templates/alert-rule/store_gateway.yml
@@ -1,7 +1,7 @@
 {{- /*
 Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.md
 */ -}}
-{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.store_gateway ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
+{{- if and .Values.metrics.enabled (or .Values.metrics.prometheusRule.default.create .Values.metrics.prometheusRule.default.store_gateway ) .Values.storegateway.enabled ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:


### PR DESCRIPTION
**Changes**
- Added conditions to if statements for component level alerts to make sure that component has been enabled
- tweaked a few alerts to make sure they were properly firing (or properly inactive)

**Testing**
- Installed on cluster and enabled/disabled components to make sure their alerts were properly turned on and off