### PR TITLE
Fix Thanos Ruler auth policy

### DIFF
--- a/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
+++ b/platform-operator/thirdparty/charts/thanos/templates/verrazzano/authorizationpolicy.yaml
@@ -124,7 +124,7 @@ spec:
     - from:
         - source:
             namespaces:
-              - verrazzano-system
+              - verrazzano-monitoring
             principals:
               - cluster.local/ns/verrazzano-monitoring/sa/thanos-query
       to:


### PR DESCRIPTION
The Thanos Ruler auth policy had a bad namespace for one of the rules, which prevented Thanos Query from accessing the Ruler store API.