### PR TITLE
VZ-10531: None profile bug-fix for error "Invalid OCI DNS configuration"

### DIFF
--- a/platform-operator/controllers/verrazzano/component/spi/testdata/basicNoneMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/basicNoneMerged.yaml
@@ -96,7 +96,8 @@ spec:
                       topologyKey: kubernetes.io/hostname
                     weight: 100
     dns:
-      enabled: false
+      wildcard:
+        domain: "nip.io"
     elasticsearch:
       enabled: false
       nodes:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneCertManagerOverrideMerged.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneCertManagerOverrideMerged.yaml
@@ -98,7 +98,8 @@ spec:
                       topologyKey: kubernetes.io/hostname
                     weight: 100
     dns:
-      enabled: false
+      wildcard:
+        domain: "nip.io"
     elasticsearch:
       enabled: false
       nodes:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneESArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneESArgsStorageOverride.yaml
@@ -106,7 +106,8 @@ spec:
                       topologyKey: kubernetes.io/hostname
                     weight: 100
     dns:
-      enabled: false
+      wildcard:
+        domain: "nip.io"
     elasticsearch:
       enabled: false
       nodes:

--- a/platform-operator/controllers/verrazzano/component/spi/testdata/noneKeycloakInstallArgsStorageOverride.yaml
+++ b/platform-operator/controllers/verrazzano/component/spi/testdata/noneKeycloakInstallArgsStorageOverride.yaml
@@ -103,7 +103,8 @@ spec:
                       topologyKey: kubernetes.io/hostname
                     weight: 100
     dns:
-      enabled: false
+      wildcard:
+        domain: "nip.io"
     elasticsearch:
       enabled: false
       nodes:

--- a/platform-operator/manifests/profiles/v1alpha1/none.yaml
+++ b/platform-operator/manifests/profiles/v1alpha1/none.yaml
@@ -28,8 +28,6 @@ spec:
       enabled: false
     console:
       enabled: false
-    dns:
-      enabled: false
     elasticsearch:
       enabled: false
       nodes:

--- a/platform-operator/manifests/profiles/v1beta1/none.yaml
+++ b/platform-operator/manifests/profiles/v1beta1/none.yaml
@@ -28,8 +28,6 @@ spec:
       enabled: false
     console:
       enabled: false
-    dns:
-      enabled: false
     fluentd:
       enabled: false
     fluentOperator:


### PR DESCRIPTION
This PR have the changes to remove the dns entries from the None profile because the dns component doesn't have the enabled field and it wipes out the config from base.yaml