### PR TITLE
OCNE Cluster Driver Tests - Single Cluster Creation

### DIFF
--- a/ci/ocne-cluster-driver/Jenkinsfile
+++ b/ci/ocne-cluster-driver/Jenkinsfile
@@ -70,6 +70,7 @@ pipeline {
                 defaultValue: '_excluded_test',
                 description: 'A regex matching any fully qualified test file that should not be executed (e.g. multicluster/|_excluded_test). Default: _excluded_test',
                 trim: true)
+        booleanParam (description: 'Whether to run all the OCNE Cluster Driver tests (true), or just the 1 bare minimum test case (false).', name: 'RUN_ALL_TESTS', defaultValue: false)
 
         // Optional parameters to the Ginkgo test suite
         string (name: 'DOCKER_ROOT_DIR',
@@ -551,7 +552,7 @@ def runGinkgo(testSuitePath) {
         sh """
             echo Starting the OCNE cluster driver tests
             cd ${WORKSPACE}/tests/e2e
-            ginkgo -p -v --timeout 2h --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/...
+            ginkgo -p -v --timeout 2h --keep-going --no-color ${GINKGO_REPORT_ARGS} -tags="${params.TAGGED_TESTS}" --focus-file="${params.INCLUDED_TESTS}" --skip-file="${params.EXCLUDED_TESTS}" ${testSuitePath}/... -- --runAllTests=${params.RUN_ALL_TESTS}
         """
     }
 }

--- a/tests/e2e/clusterapi/ocne-driver/ocne_cluster_driver_suite_test.go
+++ b/tests/e2e/clusterapi/ocne-driver/ocne_cluster_driver_suite_test.go
@@ -4,10 +4,18 @@
 package ocnedriver
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 )
+
+var runAllTests bool
+
+// init initializes variables from command line arguments
+func init() {
+	flag.BoolVar(&runAllTests, "runAllTests", false, "runAllTests toggles whether to run all cluster creation scenarios")
+}
 
 func TestOCNEClusterDriver(test *testing.T) {
 	t.RegisterFailHandler()


### PR DESCRIPTION
Backport https://github.com/verrazzano/verrazzano/pull/6754.

Introduces a boolean flag to only run 1 of the cluster creation tests in the OCNE cluster driver tests.