### PR TITLE
Add certificate to the Rancher requests

### DIFF
--- a/cluster-operator/controllers/vmc/sync_agent_secret.go
+++ b/cluster-operator/controllers/vmc/sync_agent_secret.go
@@ -195,8 +195,8 @@ func (r *VerrazzanoManagedClusterReconciler) getRancherCACert() (string, error) 
 	ingressSecret := corev1.Secret{}
 
 	err := r.Client.Get(context.TODO(), client.ObjectKey{
-		Namespace: vzconst.RancherSystemNamespace,
-		Name:      vzconst.RancherTLSCA,
+		Namespace: vzconst.VerrazzanoSystemNamespace,
+		Name:      vzconst.PrivateCABundle,
 	}, &ingressSecret)
 	if client.IgnoreNotFound(err) != nil {
 		return "", err

--- a/cluster-operator/controllers/vmc/sync_registration_secret.go
+++ b/cluster-operator/controllers/vmc/sync_registration_secret.go
@@ -225,8 +225,8 @@ func (r *VerrazzanoManagedClusterReconciler) getSecret(namespace string, secretN
 func (r *VerrazzanoManagedClusterReconciler) getAdminCaBundle() ([]byte, error) {
 	var caBundle []byte
 
-	// Append the CA bundle from tls-ca secret if it exists
-	optSecret, err := r.getSecret(constants.RancherSystemNamespace, constants.RancherTLSCA, false)
+	// Append the CA bundle from verrazzano-tls-ca secret if it exists
+	optSecret, err := r.getSecret(constants.VerrazzanoSystemNamespace, constants.PrivateCABundle, false)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	}

--- a/cluster-operator/controllers/vmc/sync_registration_secret_test.go
+++ b/cluster-operator/controllers/vmc/sync_registration_secret_test.go
@@ -45,8 +45,8 @@ func TestVerrazzanoManagedClusterReconcilerGetAdminCaBundle(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      constants.RancherTLSCA,
-						Namespace: constants.RancherSystemNamespace,
+						Name:      constants.PrivateCABundle,
+						Namespace: constants.VerrazzanoSystemNamespace,
 					},
 					Data: map[string][]byte{
 						constants.CABundleKey: tlsCABundleData,
@@ -70,8 +70,8 @@ func TestVerrazzanoManagedClusterReconcilerGetAdminCaBundle(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      constants.RancherTLSCA,
-						Namespace: constants.RancherSystemNamespace,
+						Name:      constants.PrivateCABundle,
+						Namespace: constants.VerrazzanoSystemNamespace,
 					},
 					Data: map[string][]byte{
 						constants.CABundleKey: vzTLSBundleData,
@@ -111,8 +111,8 @@ func TestVerrazzanoManagedClusterReconcilerGetAdminCaBundle(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      constants.RancherTLSCA,
-						Namespace: constants.RancherSystemNamespace,
+						Name:      constants.PrivateCABundle,
+						Namespace: constants.VerrazzanoSystemNamespace,
 					},
 					Data: map[string][]byte{
 						constants.CABundleKey: vzTLSBundleData,

--- a/cluster-operator/controllers/vmc/vmc_controller_test.go
+++ b/cluster-operator/controllers/vmc/vmc_controller_test.go
@@ -1855,8 +1855,8 @@ func expectSyncAgent(t *testing.T, mock *mocks.MockClient, name string, rancherE
 	if rancherEnabled {
 		// Expect a call to get the tls-ca secret, return the secret as not found
 		mock.EXPECT().
-			Get(gomock.Any(), types.NamespacedName{Namespace: constants.RancherSystemNamespace, Name: constants.RancherTLSCA}, gomock.Not(gomock.Nil()), gomock.Any()).
-			Return(errors.NewNotFound(schema.GroupResource{Group: constants.RancherSystemNamespace, Resource: "Secret"}, constants.RancherTLSCA))
+			Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.PrivateCABundle}, gomock.Not(gomock.Nil()), gomock.Any()).
+			Return(errors.NewNotFound(schema.GroupResource{Group: constants.VerrazzanoSystemNamespace, Resource: "Secret"}, constants.PrivateCABundle))
 
 		// Expect a call to get the Rancher ingress tls secret, return the secret with the fields set
 		mock.EXPECT().
@@ -1993,8 +1993,8 @@ func expectSyncRegistration(t *testing.T, mock *mocks.MockClient, name string, e
 
 	// Expect a call to get the tls-ca secret, return the secret as not found
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: constants.RancherSystemNamespace, Name: constants.RancherTLSCA}, gomock.Not(gomock.Nil()), gomock.Any()).
-		Return(errors.NewNotFound(schema.GroupResource{Group: constants.RancherSystemNamespace, Resource: "Secret"}, constants.RancherTLSCA))
+		Get(gomock.Any(), types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.PrivateCABundle}, gomock.Not(gomock.Nil()), gomock.Any()).
+		Return(errors.NewNotFound(schema.GroupResource{Group: constants.VerrazzanoSystemNamespace, Resource: "Secret"}, constants.PrivateCABundle))
 
 	// Expect a call to get the keycloak ingress and return the ingress.
 	mock.EXPECT().
@@ -2611,8 +2611,8 @@ func expectRancherConfigK8sCalls(t *testing.T, k8sMock *mocks.MockClient, admin 
 
 	// Expect a call to get the Rancher additional CA secret
 	k8sMock.EXPECT().
-		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: rancherNamespace, Name: constants.RancherTLSCA}), gomock.Not(gomock.Nil()), gomock.Any()).
-		Return(errors.NewNotFound(schema.GroupResource{Group: rancherNamespace, Resource: "Secret"}, constants.RancherTLSCA))
+		Get(gomock.Any(), gomock.Eq(types.NamespacedName{Namespace: constants.VerrazzanoSystemNamespace, Name: constants.PrivateCABundle}), gomock.Not(gomock.Nil()), gomock.Any()).
+		Return(errors.NewNotFound(schema.GroupResource{Group: constants.VerrazzanoSystemNamespace, Resource: "Secret"}, constants.PrivateCABundle))
 }
 
 // expectMockCallsForDelete mocks expectations for the VMC deletion scenario. These are the common mock expectations across

--- a/platform-operator/controllers/verrazzano/component/common/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/common/rancher.go
@@ -76,19 +76,19 @@ func GetRootCA(c client.Reader) ([]byte, error) {
 	return secret.Data[RancherCACert], nil
 }
 
-// GetAdditionalCA fetches the Rancher tls-cA secret
-// returns empty byte array of the secret tls-ca is not found
+// GetAdditionalCA fetches the verrazzano-tls-ca secret
+// returns empty byte array of the secret verrazzano-tls-ca is not found
 func GetAdditionalCA(c client.Reader) []byte {
 	secret := &corev1.Secret{}
 	nsName := types.NamespacedName{
-		Namespace: CattleSystem,
-		Name:      constants.RancherTLSCA}
+		Namespace: constants.VerrazzanoSystemNamespace,
+		Name:      constants.PrivateCABundle}
 
 	if err := c.Get(context.TODO(), nsName, secret); err != nil {
 		return []byte{}
 	}
 
-	return secret.Data[constants.RancherTLSCAKey]
+	return secret.Data[constants.CABundleKey]
 }
 
 func CertPool(certs ...[]byte) *x509.CertPool {


### PR DESCRIPTION
Updates the source of truth for additional CA certs for the multicluster Rancher proxy requests.