### PR TITLE
Fix race condition, metricsexporter.Init() needs to be called once

### DIFF
--- a/platform-operator/controllers/verrazzano/reconcile/controller_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller_test.go
@@ -7,10 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
-	vzcontroller "github.com/verrazzano/verrazzano/platform-operator/controllers"
 	"reflect"
-	"sigs.k8s.io/yaml"
 	"sync"
 	"testing"
 	"time"
@@ -26,7 +23,9 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	constants2 "github.com/verrazzano/verrazzano/pkg/mcconstants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
+	vzcontroller "github.com/verrazzano/verrazzano/platform-operator/controllers"
 	cmissuer "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/issuer"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	helm2 "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
@@ -63,6 +62,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/yaml"
 )
 
 // For unit testing
@@ -92,6 +92,10 @@ func (nm nsMatcher) Matches(i interface{}) bool {
 
 func (nsMatcher) String() string {
 	return "namespace matcher"
+}
+
+func init() {
+	metricsexporter.Init()
 }
 
 // TestGetClusterRoleBindingName tests generating a ClusterRoleBinding name
@@ -132,7 +136,6 @@ func TestGetUninstallJobName(t *testing.T) {
 //
 //	ensure a finalizer is added if it doesn't exist
 func TestInstall(t *testing.T) {
-	metricsexporter.Init()
 	tests := []struct {
 		namespace string
 		name      string
@@ -638,7 +641,6 @@ func TestUninstallComplete(t *testing.T) {
 // WHEN a Verrazzano resource has been deleted
 // THEN ensure an uninstall job is started
 func TestUninstallStarted(t *testing.T) {
-	metricsexporter.Init()
 	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"
@@ -760,8 +762,6 @@ func setFakeComponentsDisabled() {
 // WHEN a Verrazzano resource has been deleted
 // THEN ensure all the objects are deleted
 func TestUninstallSucceeded(t *testing.T) {
-	metricsexporter.Init()
-
 	unitTesting = true
 	namespace := "verrazzano"
 	name := "test"

--- a/platform-operator/controllers/verrazzano/reconcile/install_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_test.go
@@ -6,16 +6,16 @@ package reconcile
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/test/keycloakutil"
-	"github.com/verrazzano/verrazzano/platform-operator/metricsexporter"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/time"
-	"net/url"
-	"strings"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
@@ -69,7 +69,6 @@ var (
 // WHEN all components have the smaller LastReconciledGeneration than verrazzano CR in the request
 // THEN ensure a Reconciling State
 func TestStartUpdate(t *testing.T) {
-	metricsexporter.Init()
 	initUnitTesing()
 	status := vzapi.VerrazzanoStatus{
 		State:   vzapi.VzStateReady,

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade_test.go
@@ -7,9 +7,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/test/keycloakutil"
-	"github.com/verrazzano/verrazzano/platform-operator/metricsexporter"
-	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	"math/big"
 	"path/filepath"
 	"testing"
@@ -23,6 +20,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/test/keycloakutil"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
@@ -45,6 +43,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -78,8 +77,6 @@ var jaegerEnabled = true
 // WHEN a verrazzano version is empty
 // THEN ensure a condition with type UpgradeStarted is not added
 func TestUpgradeNoVersion(t *testing.T) {
-	metricsexporter.Init()
-
 	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
@@ -877,8 +874,6 @@ func TestUpgradeIsCompInstalledFailure(t *testing.T) {
 // WHEN the component upgrades normally
 // THEN no error is returned and the correct spi.Component upgrade methods have been returned
 func TestUpgradeComponent(t *testing.T) {
-	metricsexporter.Init()
-
 	initUnitTesing()
 	// Need to use real component name since upgrade loops through registry
 	componentName := oam.ComponentName
@@ -991,8 +986,6 @@ func TestUpgradeComponent(t *testing.T) {
 // WHEN the component fails to upgrade since a status other than "deployed" exists
 // THEN the offending secret is deleted so the upgrade can proceed
 func TestUpgradeComponentWithBlockingStatus(t *testing.T) {
-	metricsexporter.Init()
-
 	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"
@@ -1090,8 +1083,6 @@ func TestUpgradeComponentWithBlockingStatus(t *testing.T) {
 // WHEN where one component is enabled and another is disabled
 // THEN the upgrade completes normally and the correct spi.Component upgrade methods have not been invoked for the disabled component
 func TestUpgradeMultipleComponentsOneDisabled(t *testing.T) {
-	metricsexporter.Init()
-
 	initUnitTesing()
 	namespace := "verrazzano"
 	name := "test"


### PR DESCRIPTION
The metricsexporter_utils `Init` function calls other functions that result in a goroutine being spawned. There were multiple unit tests that called the `Init` function. Because Init spawns a goroutine and it was being called multiple times, there was a race condition that caused an intermittent panic.

I fixed the race condition by changing the unit tests to call `metricsexporter.Init` from an `init` function in the test package, and removed all of the other calls to `Init`, so that it will only be called once. I verified the race condition no longer exists with `go test -race`.