### PR TITLE
VZ-9693 Update Kiali version to 1.66.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### v2.0.0
+Component version updates:
+
+- Kiali v1.66.1
+
 ### v1.6.4
 
 Component version updates:

--- a/platform-operator/helm_config/overrides/kiali-server-values.yaml
+++ b/platform-operator/helm_config/overrides/kiali-server-values.yaml
@@ -12,7 +12,7 @@ auth:
 istio_namespace: istio-system
 
 deployment:
-  version_label: v1.57.1
+  version_label: v1.66.1
   # The platform operator will manage the Kiali ingress
   ingress:
     enabled: false
@@ -49,6 +49,10 @@ external_services:
     enabled: false
   tracing:
     enabled: false
+
+kiali_feature_flags:
+  validations:
+    ignore: ["KIA1201", "KIA0501"]
 
 server:
   web_root: ""

--- a/platform-operator/thirdparty/charts/README.md
+++ b/platform-operator/thirdparty/charts/README.md
@@ -197,7 +197,7 @@ The `kiali-server` folder was created by running the following commands:
 
 ```shell
 export KIALI_SERVER_CHART_REPO=https://kiali.org/helm-charts
-export KIALI_SERVER_CHART_VERSION=1.57.1
+export KIALI_SERVER_CHART_VERSION=1.66.1
 helm repo add kiali ${KIALI_SERVER_CHART_REPO}
 helm repo update
 rm -rf kiali-server

--- a/platform-operator/thirdparty/charts/kiali-server/Chart.yaml
+++ b/platform-operator/thirdparty/charts/kiali-server/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
-appVersion: v1.57.1
-description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
+appVersion: v1.66.1
+description: Kiali is an open source project for service mesh observability, refer
+  to https://www.kiali.io for details.
 home: https://github.com/kiali/kiali
 icon: https://raw.githubusercontent.com/kiali/kiali.io/master/themes/kiali/static/img/kiali_logo_masthead.png
 keywords:
@@ -15,4 +16,4 @@ sources:
 - https://github.com/kiali/kiali
 - https://github.com/kiali/kiali-operator
 - https://github.com/kiali/helm-charts
-version: 1.57.1
+version: 1.66.1

--- a/platform-operator/thirdparty/charts/kiali-server/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/kiali-server/templates/deployment.yaml
@@ -131,6 +131,14 @@ spec:
         - name: {{ .name }}
           mountPath: "{{ .mount }}"
         {{- end }}
+        {{- range $key, $val := (include "kiali-server.remote-cluster-secrets" .) | fromJson }}
+        - name: {{ $key }}
+          mountPath: "/kiali-remote-cluster-secrets/{{ $val }}"
+        {{- end }}
+        {{- range .Values.kiali_feature_flags.clustering.clusters }}
+        - name: {{ .name }}
+          mountPath: "/kiali-remote-cluster-secrets/{{ .secret_name }}"
+        {{- end }}
         {{- if .Values.deployment.resources }}
         resources:
         {{- toYaml .Values.deployment.resources | nindent 10 }}
@@ -164,6 +172,16 @@ spec:
         secret:
           secretName: {{ .name }}
           optional: {{ .optional | default false }}
+      {{- end }}
+      {{- range $key, $val := (include "kiali-server.remote-cluster-secrets" .) | fromJson }}
+      - name: {{ $key }}
+        secret:
+          secretName: {{ $val }}
+      {{- end }}
+      {{- range .Values.kiali_feature_flags.clustering.clusters }}
+      - name: {{ .name }}
+        secret:
+          secretName: {{ .secret_name }}
       {{- end }}
       {{- if or (.Values.deployment.affinity.node) (or (.Values.deployment.affinity.pod) (.Values.deployment.affinity.pod_anti)) }}
       affinity:

--- a/platform-operator/thirdparty/charts/kiali-server/templates/oauth.yaml
+++ b/platform-operator/thirdparty/charts/kiali-server/templates/oauth.yaml
@@ -11,7 +11,12 @@ metadata:
 redirectURIs:
 - {{ .Values.kiali_route_url }}
 grantMethod: auto
-allowAnyScope: true
+{{- if .Values.auth.openshift.token_inactivity_timeout }}
+accessTokenInactivityTimeoutSeconds: {{ .Values.auth.openshift.token_inactivity_timeout }}
+{{- end }}
+{{- if .Values.auth.openshift.token_max_age }}
+accessTokenMaxAgeSeconds: {{ .Values.auth.openshift.token_max_age }}
+{{- end }}
 ...
 {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/kiali-server/templates/role-controlplane.yaml
+++ b/platform-operator/thirdparty/charts/kiali-server/templates/role-controlplane.yaml
@@ -7,13 +7,6 @@ metadata:
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 rules:
-{{- if .Values.kiali_feature_flags.clustering.enabled }}
-- apiGroups: [""]
-  resources:
-  - secrets
-  verbs:
-  - list
-{{- end }}
 {{- if .Values.kiali_feature_flags.certificates_information_indicators.enabled }}
 - apiGroups: [""]
   resourceNames:

--- a/platform-operator/thirdparty/charts/kiali-server/templates/rolebinding.yaml
+++ b/platform-operator/thirdparty/charts/kiali-server/templates/rolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  {{- if .Values.deployment.view_only_mode }}
+  {{- if or (.Values.deployment.view_only_mode) (ne .Values.auth.strategy "anonymous") }}
   name: {{ include "kiali-server.fullname" . }}-viewer
   {{- else }}
   name: {{ include "kiali-server.fullname" . }}
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  {{- if .Values.deployment.view_only_mode }}
+  {{- if or (.Values.deployment.view_only_mode) (ne .Values.auth.strategy "anonymous") }}
   name: {{ include "kiali-server.fullname" . }}-viewer
   {{- else }}
   name: {{ include "kiali-server.fullname" . }}

--- a/platform-operator/thirdparty/charts/kiali-server/templates/service.yaml
+++ b/platform-operator/thirdparty/charts/kiali-server/templates/service.yaml
@@ -27,13 +27,16 @@ spec:
   ports:
   {{- if (include "kiali-server.identity.cert_file" .) }}
   - name: tcp
+    appProtocol: https
   {{- else }}
   - name: http
+    appProtocol: http
   {{- end }}
     protocol: TCP
     port: {{ .Values.server.port }}
   {{- if .Values.server.metrics_enabled }}
   - name: http-metrics
+    appProtocol: http
     protocol: TCP
     port: {{ .Values.server.metrics_port }}
   {{- end }}

--- a/platform-operator/thirdparty/charts/kiali-server/values.yaml
+++ b/platform-operator/thirdparty/charts/kiali-server/values.yaml
@@ -45,7 +45,7 @@ deployment:
   image_name: quay.io/kiali/kiali
   image_pull_policy: "Always"
   image_pull_secrets: []
-  image_version: v1.57.1 # version like "v1.39" (see: https://quay.io/repository/kiali/kiali?tab=tags) or a digest hash
+  image_version: v1.66.1 # version like "v1.39" (see: https://quay.io/repository/kiali/kiali?tab=tags) or a digest hash
   ingress:
     additional_labels: {}
     class_name: "nginx"
@@ -75,7 +75,7 @@ deployment:
   service_annotations: {}
   service_type: ""
   tolerations: []
-  version_label: v1.57.1 # v1.39 # v1.39.0 # see: https://quay.io/repository/kiali/kiali?tab=tags
+  version_label: v1.66.1 # v1.39 # v1.39.0 # see: https://quay.io/repository/kiali/kiali?tab=tags
   view_only_mode: false
 
 external_services:
@@ -95,7 +95,10 @@ kiali_feature_flags:
     - cacerts
     - istio-ca-secret
   clustering:
-    enabled: true
+    autodetect_secrets:
+      enabled: true
+      label: "kiali.io/multiCluster=true"
+    clusters: []
   disabled_features: []
   validations:
     ignore: ["KIA1201"]

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -496,7 +496,7 @@
     },
     {
       "name": "kiali-server",
-      "version": "1.57.1",
+      "version": "1.66.1",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -504,7 +504,7 @@
           "images": [
             {
               "image": "kiali",
-              "tag": "v1.57.1-20230601094106-d94b80c9",
+              "tag": "v1.66.1-20230808154952-c7e9a3fe",
               "helmFullImageKey": "deployment.image_name",
               "helmTagKey": "deployment.image_version"
             }


### PR DESCRIPTION
- After copying the Kiali Helm chart 1.66.1 to `kiali-server` folder, restored the custom changes done as part of the following PRs:
- - https://github.com/verrazzano/verrazzano/pull/5132
- - https://github.com/verrazzano/verrazzano/pull/5975
- Added "KIA0501" to `kiali_feature_flags.validations.ignore` override to fix the wrongly reported Istio config error for default PeerAuthentication in istio-system namespace