### PR TITLE
VZ-10547: Fix VPO reconcile error metric

### DIFF
--- a/platform-operator/controllers/verrazzano/reconcile/controller.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller.go
@@ -161,6 +161,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	log.Oncef("Reconciling Verrazzano resource %v, generation %v, version %s", req.NamespacedName, vz.Generation, vz.Status.Version)
 	res, err := r.doReconcile(ctx, log, vz)
+	if err != nil {
+		errorCounterMetricObject.Inc()
+	}
 	if vzctrl.ShouldRequeue(res) {
 		return res, nil
 	}
@@ -168,7 +171,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Never return an error since it has already been logged and we don't want the
 	// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
 	if err != nil {
-		errorCounterMetricObject.Inc()
 		return newRequeueWithDelay(), nil
 	}
 	// The Verrazzano resource has been reconciled.

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -4,6 +4,9 @@
 package reconcile
 
 import (
+	"fmt"
+	"strings"
+
 	ctrlerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/semver"
@@ -66,6 +69,7 @@ func (r *Reconciler) installComponents(spiCtx spi.ComponentContext, tracker *ins
 	spiCtx.Log().Once("Installing components")
 
 	var requeue bool
+	var errors []string
 
 	// Loop through all the Verrazzano components and install each one
 	for _, comp := range registry.GetComponents() {
@@ -74,21 +78,29 @@ func (r *Reconciler) installComponents(spiCtx spi.ComponentContext, tracker *ins
 			continue
 		}
 		installContext := tracker.getComponentInstallContext(comp.Name())
-		if result := r.installSingleComponent(spiCtx, installContext, comp, preUpgrade); result.Requeue {
+		result, err := r.installSingleComponent(spiCtx, installContext, comp, preUpgrade)
+		if result.Requeue || err != nil {
 			requeue = true
 		}
+		if err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
 
+	var err error
+	if len(errors) > 0 {
+		err = fmt.Errorf(strings.Join(errors, "\n"))
 	}
 	if requeue {
-		return newRequeueWithDelay(), nil
+		return newRequeueWithDelay(), err
 	}
 
 	// All components have been installed
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, err
 }
 
 // installSingleComponent installs a single component
-func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTracker *componentTrackerContext, comp spi.Component, preUpgrade bool) ctrl.Result {
+func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTracker *componentTrackerContext, comp spi.Component, preUpgrade bool) (ctrl.Result, error) {
 	compName := comp.Name()
 	compContext := spiCtx.Init(compName).Operation(vzconst.InstallOperation)
 	compLog := compContext.Log()
@@ -99,7 +111,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 		var err error
 		if err = r.initComponentStatus(compContext, comp); err != nil {
 			compLog.Errorf("Error initializing the component status for component %s: %v", comp.Name(), err)
-			return newRequeueWithDelay()
+			return newRequeueWithDelay(), err
 		}
 	}
 
@@ -107,7 +119,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 	// requeue until we do
 	if componentStatus == nil {
 		compLog.Debugf("Component status is not yet present for component %s, requeueing", comp.Name())
-		return newRequeueWithDelay()
+		return newRequeueWithDelay(), nil
 	}
 
 	for compTracker.installState != compStateInstallEnd {
@@ -152,7 +164,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 			componentStatus.ReconcilingGeneration = 0
 			if err := r.updateComponentStatus(compContext, "Install started", vzapi.CondInstallStarted); err != nil {
 				compLog.ErrorfThrottled("Error writing component Installing state to the status: %v", err)
-				return ctrl.Result{Requeue: true}
+				return ctrl.Result{Requeue: true}, err
 			}
 			if oldGen != 0 {
 				compLog.Oncef("CR.generation: %v reset component %s state: %v generation: %v to state: %v generation: %v ",
@@ -162,7 +174,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 
 		case compStatePreInstall:
 			if !registry.ComponentDependenciesMet(comp, compContext) {
-				return ctrl.Result{Requeue: true}
+				return ctrl.Result{Requeue: true}, nil
 			}
 			compLog.Oncef("Component %s pre-install is running ", compName)
 			if err := comp.PreInstall(compContext); err != nil {
@@ -175,7 +187,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 					compLog.ErrorfThrottled("Error running PreInstall for component %s: %v", compName, err)
 				}
 
-				return ctrl.Result{Requeue: true}
+				return ctrl.Result{Requeue: true}, err
 			}
 
 			compTracker.installState = compStateInstall
@@ -193,7 +205,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 					compLog.ErrorfThrottled("Error running Install for component %s: %v", compName, err)
 				}
 
-				return ctrl.Result{Requeue: true}
+				return ctrl.Result{Requeue: true}, err
 			}
 
 			compTracker.installState = compStateInstallWaitReady
@@ -201,7 +213,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 		case compStateInstallWaitReady:
 			if !comp.IsReady(compContext) {
 				compLog.Oncef("Component %s has been installed. Waiting for the component to be ready", compName)
-				return ctrl.Result{Requeue: true}
+				return ctrl.Result{Requeue: true}, nil
 			}
 			compLog.Oncef("Component %s successfully installed", comp.Name())
 
@@ -219,7 +231,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 					compLog.ErrorfThrottled("Error running PostInstall for component %s: %v", compName, err)
 				}
 
-				return ctrl.Result{Requeue: true}
+				return ctrl.Result{Requeue: true}, err
 			}
 
 			compTracker.installState = compStateInstallComplete
@@ -227,7 +239,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 		case compStateInstallComplete:
 			if err := r.updateComponentStatus(compContext, "Install complete", vzapi.CondInstallComplete); err != nil {
 				compLog.ErrorfThrottled("Error writing component Ready state to the status: %v", err)
-				return ctrl.Result{Requeue: true}
+				return ctrl.Result{Requeue: true}, err
 			}
 
 			compTracker.installState = compStateInstallEnd
@@ -236,7 +248,7 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 			// Delegates the component uninstall work to
 			result, err := r.uninstallSingleComponent(compContext, compTracker, comp)
 			if err != nil || result.Requeue {
-				return ctrl.Result{Requeue: true}
+				return ctrl.Result{Requeue: true}, err
 			}
 			compTracker.installState = compStateInstallEnd
 		}
@@ -246,14 +258,15 @@ func (r *Reconciler) installSingleComponent(spiCtx spi.ComponentContext, compTra
 	// which may require restarting the component's installation from the beginning
 	if restartComponentInstallFromEndState(compContext, comp, componentStatus) {
 		compTracker.installState = compStateInstallInitDetermineComponentState
-		if err := r.updateComponentStatus(compContext, "PreInstall started", vzapi.CondPreInstall); err != nil {
+		err := r.updateComponentStatus(compContext, "PreInstall started", vzapi.CondPreInstall)
+		if err != nil {
 			compLog.ErrorfThrottled("Error writing component PreInstall state to the status: %v", err)
 		}
-		return ctrl.Result{Requeue: true}
+		return ctrl.Result{Requeue: true}, err
 	}
 
 	// Component has been installed
-	return ctrl.Result{}
+	return ctrl.Result{}, nil
 }
 
 // checkConfigUpdated checks if the component config in the VZ CR has been updated

--- a/platform-operator/controllers/verrazzano/reconcile/install_component_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component_test.go
@@ -4,11 +4,14 @@
 package reconcile
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -206,8 +209,86 @@ func TestReconcilerInstallSingleComponent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newVerrazzanoReconciler(tt.k8sClient)
-			result := r.installSingleComponent(tt.args.spiCtx, tt.args.installContext, tt.args.comp, tt.args.preUpgrade)
+			result, _ := r.installSingleComponent(tt.args.spiCtx, tt.args.installContext, tt.args.comp, tt.args.preUpgrade)
 			assert.Equal(t, tt.want.Requeue, result.Requeue)
 		})
 	}
+}
+
+// TestReconcilerInstallComponentsWithErrors tests the installComponents function when one or more components return errors.
+//
+// GIVEN a component registry with components
+// WHEN the installComponentsFunction is called and some of the component installations return errors
+// THEN the expected error is returned
+func TestReconcilerInstallComponentsWithErrors(t *testing.T) {
+	const (
+		failingCompName        = "failing-comp"
+		anotherFailingCompName = "another-failing-comp"
+		goodCompName           = "good-comp"
+	)
+
+	mockClient := fake.NewClientBuilder().Build()
+	vz := &vzapi.Verrazzano{
+		Status: vzapi.VerrazzanoStatus{
+			Components: map[string]*vzapi.ComponentStatusDetails{
+				failingCompName: {
+					State: vzapi.ComponentAvailable,
+				},
+				anotherFailingCompName: {
+					State: vzapi.ComponentAvailable,
+				},
+			},
+		},
+	}
+
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComponent{
+				HelmComponent: helm.HelmComponent{
+					ReleaseName: failingCompName,
+				},
+				installed:   "false",
+				ready:       "false",
+				enabled:     "true",
+				installFunc: func(ctx spi.ComponentContext) error { return fmt.Errorf("%s error", failingCompName) },
+			},
+			fakeComponent{
+				HelmComponent: helm.HelmComponent{
+					ReleaseName: anotherFailingCompName,
+				},
+				installed:   "false",
+				ready:       "false",
+				enabled:     "true",
+				installFunc: func(ctx spi.ComponentContext) error { return fmt.Errorf("%s error", anotherFailingCompName) },
+			},
+			fakeComponent{
+				HelmComponent: helm.HelmComponent{
+					ReleaseName: goodCompName,
+				},
+				installed: "false",
+				ready:     "false",
+				enabled:   "true",
+			},
+		}
+	})
+	defer registry.ResetGetComponentsFn()
+
+	tracker := getInstallTracker(vz)
+	tracker.compMap[failingCompName] = &componentTrackerContext{
+		installState: compStatePreInstall,
+	}
+	tracker.compMap[anotherFailingCompName] = &componentTrackerContext{
+		installState: compStatePreInstall,
+	}
+	tracker.compMap[goodCompName] = &componentTrackerContext{
+		installState: compStatePreInstall,
+	}
+
+	r := newVerrazzanoReconciler(mockClient)
+	result, err := r.installComponents(spi.NewFakeContext(mockClient, vz, nil, true), tracker, false)
+	assert.True(t, result.Requeue)
+
+	// The error should have two error strings joined with a newline
+	assert.Error(t, err)
+	assert.Equal(t, "failing-comp error\nanother-failing-comp error", err.Error())
 }


### PR DESCRIPTION
While testing new VPO Prometheus alert rules, I discovered a problem with the VPO reconcile error metric. The main problem with the metric was that the component install code was eating errors in most cases. The result was that the error metric was rarely being incremented and reconcile errors were severely undercounted.

To fix the problem, the component install code now bubbles up errors. This allows the reconcile function to check for errors and then increment the error counter.

I tested this by forcing reconcile errors with a bad VZ CR (after deleting the validating webhook) and confirmed that the error metric now accurately reflects the number of reconcile errors.