### PR TITLE
VZ-10488 Add Check To VZ Job to See If VZ Helper Was Ran

### DIFF
--- a/.verrazzano-development-version
+++ b/.verrazzano-development-version
@@ -1,4 +1,4 @@
 # Copyright (C) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-verrazzano-development-version=2.0.0
+verrazzano-development-version=1.0.0

--- a/.verrazzano-development-version
+++ b/.verrazzano-development-version
@@ -1,4 +1,4 @@
 # Copyright (C) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-verrazzano-development-version=1.0.0
+verrazzano-development-version=2.0.0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -233,7 +233,7 @@ pipeline {
                          script {
                             VERRAZZANO_DEV_VERSION_CHECK = sh (script: "git ls-remote --tags origin | grep -F ${VERRAZZANO_DEV_VERSION}", returnStatus: true )
                             if (VERRAZZANO_DEV_VERSION_CHECK == 0) {
-                                if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
+                                if (env.JOB_NAME ==~ "verrazzano/release-*") {
                                     slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,7 +240,9 @@ pipeline {
                         failure {
                             script {
                                 SKIP_TRIGGERED_TESTS = true
-                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
+                                if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
+                                    slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
+                                }
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,7 +240,7 @@ pipeline {
                             script {
                                 RELEASE_OWNERS = credentials('release-version-owners')
                                 SKIP_TRIGGERED_TESTS = true
-                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${RELEASE_OWNERS}\n)
+                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${RELEASE_OWNERS}\n")
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,7 @@ pipeline {
         NETRC_FILE = credentials('netrc')
         GITHUB_PKGS_CREDS = credentials('github-packages-credentials-rw')
         SERVICE_KEY = credentials('PAGERDUTY_SERVICE_KEY')
+        RELEASE_OWNERS = credentials('release-version-owners')
 
         CLUSTER_NAME = 'verrazzano'
         POST_DUMP_FAILED_FILE = "${WORKSPACE}/post_dump_failed_file.tmp"
@@ -238,9 +239,8 @@ pipeline {
                     post {
                         failure {
                             script {
-                                RELEASE_OWNERS = credentials('release-version-owners')
                                 SKIP_TRIGGERED_TESTS = true
-                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${RELEASE_OWNERS}\n")
+                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${RELEASE_OWNERS}\n")
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -318,7 +318,8 @@ pipeline {
                 when { not { buildingTag() } }
                 steps {
                     sh """
-                git tag | awk '/v[0-9][.]/'
+                git tag | awk '/v[0-9][.]/' | grep > VerrazzanoTagsForDevelopmentCheck.txt
+                cat VerrazzanoTagsForDevelopmentCheck.txt
                 [[ -z \$(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -318,7 +318,7 @@ pipeline {
                 when { not { buildingTag() } }
                 steps {
                     sh """
-                [[-z \$(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
+                [[ -z \$(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
 
 
             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -231,7 +231,7 @@ pipeline {
                     when { not { buildingTag() } }
                     steps {
                         sh """
-                    [[ -z \$(git ls-remote --tags origin | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
+                    [[ -z \$(git ls-remote --tags origin | grep refs/tags/v${VERRAZZANO_DEV_VERSION}) ]] || exit 1
 
 
                 """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,19 +230,17 @@ pipeline {
        stage('Verrazzano development version check') {
                     when { not { buildingTag() } }
                     steps {
-                        sh """
-                    [[ -z \$(git ls-remote --tags origin | grep -F ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
-
-
-                """
+                        VERRAZZANO_DEV_VERSION_CHECK = sh (script: "git ls-remote --tags origin | grep -F ${VERRAZZANO_DEV_VERSION}", returnStatus: true )
+                        if (VERRAZZANO_DEV_VERSION_CHECK == 0) {
+                            if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
+                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
+                            }
+                        }
                     }
                     post {
                         failure {
                             script {
                                 SKIP_TRIGGERED_TESTS = true
-                                if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
-                                    slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
-                                }
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -319,7 +319,7 @@ pipeline {
                                 when { not { buildingTag() } }
                                 steps {
                                     sh """
-                                [[-z $(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
+                                [[-z \$(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
 
 
                             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -315,6 +315,23 @@ pipeline {
                     }
                 }
             }
+            stage('Verrazzano development version check') {
+                                when { not { buildingTag() } }
+                                steps {
+                                    sh """
+                                [[-z $(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
+
+
+                            """
+                                }
+                                post {
+                                    failure {
+                                        script {
+                                            RELEASE_OWNERS = credentials('release-version-owners')
+                                            SKIP_TRIGGERED_TESTS = true
+                                            slackSend( channel: "$SLACK_ALERT_CHANNEL",message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${PIPELINE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
+                                        }
+                                    }
 
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,12 +230,14 @@ pipeline {
        stage('Verrazzano development version check') {
                     when { not { buildingTag() } }
                     steps {
-                        VERRAZZANO_DEV_VERSION_CHECK = sh (script: "git ls-remote --tags origin | grep -F ${VERRAZZANO_DEV_VERSION}", returnStatus: true )
-                        if (VERRAZZANO_DEV_VERSION_CHECK == 0) {
-                            if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
-                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
+                         script {
+                            VERRAZZANO_DEV_VERSION_CHECK = sh (script: "git ls-remote --tags origin | grep -F ${VERRAZZANO_DEV_VERSION}", returnStatus: true )
+                            if (VERRAZZANO_DEV_VERSION_CHECK == 0) {
+                                if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
+                                    slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
+                                }
                             }
-                        }
+                         }
                     }
                     post {
                         failure {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -328,7 +328,7 @@ pipeline {
                         script {
                             RELEASE_OWNERS = credentials('release-version-owners')
                             SKIP_TRIGGERED_TESTS = true
-                            slackSend( channel: "$SLACK_ALERT_CHANNEL",message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${PIPELINE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
+                            slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${PIPELINE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -318,6 +318,7 @@ pipeline {
                 when { not { buildingTag() } }
                 steps {
                     sh """
+                cd ${workspace}
                 git tag | awk '/v[0-9][.]/' > VerrazzanoTagsForDevelopmentCheck.txt
                 cat VerrazzanoTagsForDevelopmentCheck.txt
                 [[ -z \$(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,6 +238,9 @@ pipeline {
                     post {
                         failure {
                             script {
+                                sh """
+                                echo "TEST"
+                              """
                                 RELEASE_OWNERS = credentials('release-version-owners')
                                 SKIP_TRIGGERED_TESTS = true
                                 slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${PIPELINE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,7 +240,7 @@ pipeline {
                         failure {
                             script {
                                 SKIP_TRIGGERED_TESTS = true
-                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${RELEASE_OWNERS}\n")
+                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -318,7 +318,7 @@ pipeline {
                 when { not { buildingTag() } }
                 steps {
                     sh """
-                git tag | awk '/v[0-9][.]/' | grep > VerrazzanoTagsForDevelopmentCheck.txt
+                git tag | awk '/v[0-9][.]/' > VerrazzanoTagsForDevelopmentCheck.txt
                 cat VerrazzanoTagsForDevelopmentCheck.txt
                 [[ -z \$(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,7 +240,7 @@ pipeline {
                             script {
                                 RELEASE_OWNERS = credentials('release-version-owners')
                                 SKIP_TRIGGERED_TESTS = true
-                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${RELEASE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
+                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${RELEASE_OWNERS}\n)
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,12 +238,9 @@ pipeline {
                     post {
                         failure {
                             script {
-                                sh """
-                                echo "TEST"
-                              """
                                 RELEASE_OWNERS = credentials('release-version-owners')
                                 SKIP_TRIGGERED_TESTS = true
-                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${PIPELINE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
+                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${RELEASE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -231,7 +231,7 @@ pipeline {
                     when { not { buildingTag() } }
                     steps {
                         sh """
-                    [[ -z \$(git ls-remote --tags origin | grep refs/tags/v${VERRAZZANO_DEV_VERSION}) ]] || exit 1
+                    [[ -z \$(git ls-remote --tags origin | grep -F ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
 
 
                 """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -318,10 +318,7 @@ pipeline {
                 when { not { buildingTag() } }
                 steps {
                     sh """
-                cd ${workspace}
-                git tag | awk '/v[0-9][.]/' > VerrazzanoTagsForDevelopmentCheck.txt
-                cat VerrazzanoTagsForDevelopmentCheck.txt
-                [[ -z \$(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
+                [[ -z \$(git ls-remote --tags origin | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
 
 
             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -318,6 +318,7 @@ pipeline {
                 when { not { buildingTag() } }
                 steps {
                     sh """
+                git tag | awk '/v[0-9][.]/'
                 [[ -z \$(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -332,6 +332,7 @@ pipeline {
                                             slackSend( channel: "$SLACK_ALERT_CHANNEL",message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${PIPELINE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
                                         }
                                     }
+                                }
 
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,6 +226,25 @@ pipeline {
                 }
             }
         }
+       stage('Verrazzano development version check') {
+                    when { not { buildingTag() } }
+                    steps {
+                        sh """
+                    [[ -z \$(git ls-remote --tags origin | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
+
+
+                """
+                    }
+                    post {
+                        failure {
+                            script {
+                                RELEASE_OWNERS = credentials('release-version-owners')
+                                SKIP_TRIGGERED_TESTS = true
+                                slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${PIPELINE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
+                            }
+                        }
+                    }
+                }
 
         stage('Parallel Build, Test, and Compliance') {
             parallel {
@@ -314,25 +333,6 @@ pipeline {
                         }
                     }
                 }
-            stage('Verrazzano development version check') {
-                when { not { buildingTag() } }
-                steps {
-                    sh """
-                [[ -z \$(git ls-remote --tags origin | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
-
-
-            """
-                }
-                post {
-                    failure {
-                        script {
-                            RELEASE_OWNERS = credentials('release-version-owners')
-                            SKIP_TRIGGERED_TESTS = true
-                            slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${PIPELINE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
-                        }
-                    }
-                }
-            }
 
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -316,23 +316,24 @@ pipeline {
                 }
             }
             stage('Verrazzano development version check') {
-                                when { not { buildingTag() } }
-                                steps {
-                                    sh """
-                                [[-z \$(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
+                when { not { buildingTag() } }
+                steps {
+                    sh """
+                [[-z \$(git tag | awk '/v[0-9][.]/' | grep ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
 
 
-                            """
-                                }
-                                post {
-                                    failure {
-                                        script {
-                                            RELEASE_OWNERS = credentials('release-version-owners')
-                                            SKIP_TRIGGERED_TESTS = true
-                                            slackSend( channel: "$SLACK_ALERT_CHANNEL",message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${PIPELINE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
-                                        }
-                                    }
-                                }
+            """
+                }
+                post {
+                    failure {
+                        script {
+                            RELEASE_OWNERS = credentials('release-version-owners')
+                            SKIP_TRIGGERED_TESTS = true
+                            slackSend( channel: "$SLACK_ALERT_CHANNEL",message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release,n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nReleaseOwners:\n ${PIPELINE_OWNERS}\n\nChange comparison: ${COMPARISON_URL_ON_FAILURE}")
+                        }
+                    }
+                }
+            }
 
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -314,7 +314,6 @@ pipeline {
                         }
                     }
                 }
-            }
             stage('Verrazzano development version check') {
                 when { not { buildingTag() } }
                 steps {
@@ -336,6 +335,7 @@ pipeline {
             }
 
         }
+    }
 
         stage('Scan Image') {
             when {

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -63,6 +63,7 @@ pipeline {
         OCI_CLI_AUTH="instance_principal"
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
         OCI_OS_BUCKET="verrazzano-builds"
+        RELEASE_OWNERS = credentials('release-version-owners')
     }
 
     stages {
@@ -121,6 +122,26 @@ pipeline {
                 }
             }
         }
+
+        stage('Verrazzano development version check') {
+                           steps {
+                               sh """
+                           [[ -z \$(git ls-remote --tags origin | grep -F ${VERRAZZANO_DEV_VERSION}) ]] || exit 1
+
+
+                       """
+                           }
+                           post {
+                               failure {
+                                   script {
+                                       SKIP_TRIGGERED_TESTS = true
+                                       if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
+                                           slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
+                                       }
+                                   }
+                               }
+                           }
+                       }
 
         stage ('Kick off resiliency tests') {
             parallel {

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -135,7 +135,7 @@ pipeline {
                                failure {
                                    script {
                                        SKIP_TRIGGERED_TESTS = true
-                                       if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
+                                       if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*" || env.JOB_NAME ==~ "gfaeill*") {
                                            slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
                                        }
                                    }

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -135,7 +135,7 @@ pipeline {
                                failure {
                                    script {
                                        SKIP_TRIGGERED_TESTS = true
-                                       if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*" || env.JOB_NAME ==~ "*") {
+                                       if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*" || env.JOB_NAME == "verrazzano/gfaeillo%2FVZ-10488") {
                                            slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
                                        }
                                    }

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -134,7 +134,6 @@ pipeline {
                            post {
                                failure {
                                    script {
-                                       SKIP_TRIGGERED_TESTS = true
                                        if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
                                            slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
                                        }

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -134,7 +134,7 @@ pipeline {
                            post {
                                failure {
                                    script {
-                                       if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
+                                       if (env.JOB_NAME ==~ "verrazzano/release-*") {
                                            slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
                                        }
                                    }

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -135,7 +135,7 @@ pipeline {
                                failure {
                                    script {
                                        SKIP_TRIGGERED_TESTS = true
-                                       if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*" || env.JOB_NAME ==~ "gfaeill*") {
+                                       if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*" || env.JOB_NAME ==~ "*") {
                                            slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
                                        }
                                    }

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -135,9 +135,7 @@ pipeline {
                                failure {
                                    script {
                                        SKIP_TRIGGERED_TESTS = true
-                                       if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*" || env.JOB_NAME == "verrazzano/gfaeillo%2FVZ-10488") {
                                            slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
-                                       }
                                    }
                                }
                            }

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -135,7 +135,9 @@ pipeline {
                                failure {
                                    script {
                                        SKIP_TRIGGERED_TESTS = true
+                                       if (env.JOB_NAME == "verrazzano/master" || env.JOB_NAME ==~ "verrazzano/release-*") {
                                            slackSend ( channel: "$SLACK_ALERT_CHANNEL", message: "Job Failed - \"${env.JOB_NAME}\" build: ${env.BUILD_NUMBER}\n\nVZ Helper was not run, the Verrazzano Development Version ${VERRAZZANO_DEV_VERSION} matches a prior release\n\nBlue Ocean:\n${env.RUN_DISPLAY_URL}\n\nRelease Owners:\n ${RELEASE_OWNERS}\n")
+                                       }
                                    }
                                }
                            }


### PR DESCRIPTION
This ticket adds an additional stage to the verrazzano job, which checks that the current verrazzano development version does not match a release version. If this check fails on master, or a release branch, it sends a slack message to the release owners, but does not fail the test. This ticket also adds an additional stage to the release job to the upgrade resiliency job. On this job, it is the same logic, as the Verrazzano job, except that the job will not only send a slack message to the release owners if the check fails, the job will also fail outright. 
