### PR TITLE
VZ-10561: support old and new locations for Rancher branding images

### DIFF
--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -773,16 +773,16 @@ func getRancherLogoContentWithRetry(log vzlog.VerrazzanoLogger, cli kubernetes.I
 		var err error
 		logoContent, stderr, err = k8sutil.ExecPod(cli, cfg, pod, "rancher", logoCommand)
 		if err != nil {
-			return false, log.ErrorfThrottledNewErr("Failed execing into Rancher pod %s: %v", stderr, err)
+			return false, fmt.Errorf("Failed execing into Rancher pod %s: %v", stderr, err)
 		}
 
 		if len(logoContent) == 0 {
-			return false, log.ErrorfThrottledNewErr("Invalid empty output from Rancher pod")
+			return false, fmt.Errorf("Invalid empty output from Rancher pod")
 		}
 
 		decodedLogo, err := base64.StdEncoding.DecodeString(logoContent)
 		if err != nil {
-			return false, log.ErrorfThrottledNewErr("Error while decoding logo: %v", err)
+			return false, fmt.Errorf("Error while decoding logo: %v", err)
 		}
 
 		if !(strings.HasSuffix(strings.TrimSpace(string(decodedLogo)), "</svg>")) {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -121,10 +121,10 @@ const (
 	SettingUIPLValueVerrazzano          = "Verrazzano"
 	SettingUILogoLight                  = "ui-logo-light"
 	SettingUILogoFolderBeforeRancher275 = "/usr/share/rancher/ui-dashboard/dashboard/_nuxt/pkg/verrazzano/assets/images"
-	SettingUILogoFolder                 = "/usr/share/rancher/ui-dashboard/dashboard/img"
-	SettingUILogoLightPrefix            = "verrazzano-light"
+	SettingUILogoFolder                 = "/usr/share/rancher/ui-dashboard/dashboard/assets/images"
+	SettingUILogoLightFile              = "verrazzano-light.svg"
 	SettingUILogoDark                   = "ui-logo-dark"
-	SettingUILogoDarkPrefix             = "verrazzano-dark"
+	SettingUILogoDarkFile               = "verrazzano-dark.svg"
 	SettingUILogoValueprefix            = "data:image/svg+xml;base64,"
 	SettingUIPrimaryColor               = "ui-primary-color"
 	SettingUIPrimaryColorValue          = "rgb(48, 99, 142)"
@@ -648,7 +648,7 @@ func createOrUpdateUIPlSetting(ctx spi.ComponentContext) error {
 }
 
 // createOrUpdateUILogoSetting updates the ui-logo-* settings
-func createOrUpdateUILogoSetting(ctx spi.ComponentContext, settingName string, logoFilePrefix string) error {
+func createOrUpdateUILogoSetting(ctx spi.ComponentContext, settingName string, logoFilename string) error {
 	log := ctx.Log()
 	c := ctx.Client()
 	pod, err := k8sutil.GetRunningPodForLabel(c, "app=rancher", "cattle-system", log)
@@ -663,19 +663,19 @@ func createOrUpdateUILogoSetting(ctx spi.ComponentContext, settingName string, l
 
 	// The location of the logo files changed starting with Rancher 2.7.5.  First look for the logo file
 	// in the new location.  If not found there, check the old location.
-	logoCommand := []string{"/bin/sh", "-c", fmt.Sprintf("base64 %s/%s*.svg", SettingUILogoFolder, logoFilePrefix)}
+	logoCommand := []string{"/bin/sh", "-c", fmt.Sprintf("base64 %s/%s", SettingUILogoFolder, logoFilename)}
 	// The api request to pod was seen to be returning only first few bytes of the logo content,
 	// therefore we retry a few times until we get valid logo content which will be a svg
 	logoContent, err := getRancherLogoContentWithRetry(log, cli, cfg, pod, logoCommand)
 
 	if err != nil {
 		// Try the pre-Rancher 2.7.5 location
-		logoCommand = []string{"/bin/sh", "-c", fmt.Sprintf("base64 %s/%s*.svg", SettingUILogoFolderBeforeRancher275, logoFilePrefix)}
+		logoCommand = []string{"/bin/sh", "-c", fmt.Sprintf("base64 %s/%s", SettingUILogoFolderBeforeRancher275, logoFilename)}
 		// The api request to pod was seen to be returning only first few bytes of the logo content,
 		// therefore we retry a few times until we get valid logo content which will be a svg
 		logoContent, err = getRancherLogoContentWithRetry(log, cli, cfg, pod, logoCommand)
 		if err != nil {
-			return log.ErrorfThrottledNewErr("failed getting actual logo content from rancher pod from %s: %v", logoFilePrefix, err.Error())
+			return log.ErrorfThrottledNewErr("failed getting actual logo content from rancher pod from %s: %v", logoFilename, err.Error())
 		}
 	}
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -454,19 +454,19 @@ func DeleteLocalCluster(log vzlog.VerrazzanoLogger, c client.Client) {
 }
 
 // putServerURL updates the server-url Setting
-func putServerURL(log vzlog.VerrazzanoLogger, c client.Client, serverURL string) error {
+func putServerURL(c client.Client, serverURL string) error {
 	serverURLSetting := unstructured.Unstructured{}
 	serverURLSetting.SetGroupVersionKind(common.GVKSetting)
 	serverURLSettingName := types.NamespacedName{Name: SettingServerURL}
 	err := c.Get(context.Background(), serverURLSettingName, &serverURLSetting)
 	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed getting server-url Setting: %s", err.Error())
+		return fmt.Errorf("waiting to get server-url setting: %s", err.Error())
 	}
 
 	serverURLSetting.UnstructuredContent()["value"] = serverURL
 	err = c.Update(context.Background(), &serverURLSetting)
 	if err != nil {
-		return log.ErrorfThrottledNewErr("Failed updating server-url Setting: %s", err.Error())
+		return fmt.Errorf("Failed updating server-url setting: %s", err.Error())
 	}
 
 	return nil

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -121,7 +121,7 @@ const (
 	SettingUIPLValueVerrazzano          = "Verrazzano"
 	SettingUILogoLight                  = "ui-logo-light"
 	SettingUILogoFolderBeforeRancher275 = "/usr/share/rancher/ui-dashboard/dashboard/_nuxt/pkg/verrazzano/assets/images"
-	SettingUILogoFolder                 = "usr/share/rancher/ui-dashboard/dashboard/img"
+	SettingUILogoFolder                 = "/usr/share/rancher/ui-dashboard/dashboard/img"
 	SettingUILogoLightPrefix            = "verrazzano-light"
 	SettingUILogoDark                   = "ui-logo-dark"
 	SettingUILogoDarkPrefix             = "verrazzano-dark"

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -707,12 +707,12 @@ func configureUISettings(ctx spi.ComponentContext) error {
 		return log.ErrorfThrottledNewErr("failed configuring ui-pl setting: %s", err.Error())
 	}
 
-	if err := createOrUpdateUILogoSetting(ctx, SettingUILogoLight, SettingUILogoLightLogoFilePath); err != nil {
-		return log.ErrorfThrottledNewErr("failed configuring %s setting for logo path %s: %s", SettingUILogoLight, SettingUILogoLightLogoFilePath, err.Error())
+	if err := createOrUpdateUILogoSetting(ctx, SettingUILogoLight, SettingUILogoLightPrefix); err != nil {
+		return log.ErrorfThrottledNewErr("failed configuring %s setting for logo %s: %s", SettingUILogoLight, SettingUILogoLightPrefix, err.Error())
 	}
 
-	if err := createOrUpdateUILogoSetting(ctx, SettingUILogoDark, SettingUILogoDarkLogoFilePath); err != nil {
-		return log.ErrorfThrottledNewErr("failed configuring %s setting for logo path %s: %s", SettingUILogoDark, SettingUILogoDarkLogoFilePath, err.Error())
+	if err := createOrUpdateUILogoSetting(ctx, SettingUILogoDark, SettingUILogoDarkPrefix); err != nil {
+		return log.ErrorfThrottledNewErr("failed configuring %s setting for logo path %s: %s", SettingUILogoDark, SettingUILogoDarkPrefix, err.Error())
 	}
 
 	if err := createOrUpdateUIColorSettings(ctx); err != nil {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -741,12 +741,12 @@ func configureUISettings(ctx spi.ComponentContext) error {
 		return log.ErrorfThrottledNewErr("failed configuring ui-pl setting: %s", err.Error())
 	}
 
-	if err := createOrUpdateUILogoSetting(ctx, SettingUILogoLight, SettingUILogoLightPrefix); err != nil {
-		return log.ErrorfThrottledNewErr("failed configuring %s setting for logo %s: %s", SettingUILogoLight, SettingUILogoLightPrefix, err.Error())
+	if err := createOrUpdateUILogoSetting(ctx, SettingUILogoLight, SettingUILogoLightFile); err != nil {
+		return log.ErrorfThrottledNewErr("failed configuring %s setting for logo %s: %s", SettingUILogoLight, SettingUILogoLightFile, err.Error())
 	}
 
-	if err := createOrUpdateUILogoSetting(ctx, SettingUILogoDark, SettingUILogoDarkPrefix); err != nil {
-		return log.ErrorfThrottledNewErr("failed configuring %s setting for logo path %s: %s", SettingUILogoDark, SettingUILogoDarkPrefix, err.Error())
+	if err := createOrUpdateUILogoSetting(ctx, SettingUILogoDark, SettingUILogoDarkFile); err != nil {
+		return log.ErrorfThrottledNewErr("failed configuring %s setting for logo path %s: %s", SettingUILogoDark, SettingUILogoDarkFile, err.Error())
 	}
 
 	if err := createOrUpdateUIColorSettings(ctx); err != nil {

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component.go
@@ -524,7 +524,7 @@ func (r rancherComponent) Install(ctx spi.ComponentContext) error {
 		return log.ErrorfThrottledNewErr("Failed getting Rancher hostname: %s", err.Error())
 	}
 
-	if err := putServerURL(log, c, fmt.Sprintf("https://%s", rancherHostName)); err != nil {
+	if err := putServerURL(c, fmt.Sprintf("https://%s", rancherHostName)); err != nil {
 		return log.ErrorfThrottledNewErr("Failed setting Rancher server URL: %s", err.Error())
 	}
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -1341,11 +1341,11 @@ func prepareContexts() (spi.ComponentContext, spi.ComponentContext) {
 	k8sutilfake.PodExecResult = func(url *url.URL) (string, string, error) {
 		var commands []string
 		if commands = url.Query()["command"]; len(commands) == 3 {
-			if strings.Contains(commands[2], fmt.Sprintf("base64 %s", SettingUILogoDarkLogoFilePath)) {
+			if strings.Contains(commands[2], fmt.Sprintf("base64 %s/%s*.svg", SettingUILogoFolder, SettingUILogoDarkPrefix)) {
 				return base64.StdEncoding.EncodeToString([]byte("<svg>dark</svg>")), "", nil
 			}
 
-			if strings.Contains(commands[2], fmt.Sprintf("base64 %s", SettingUILogoLightLogoFilePath)) {
+			if strings.Contains(commands[2], fmt.Sprintf("base64 %s/%s*.svg", SettingUILogoFolder, SettingUILogoLightPrefix)) {
 				return base64.StdEncoding.EncodeToString([]byte("<svg>light</svg>")), "", nil
 			}
 

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher_component_test.go
@@ -1341,11 +1341,11 @@ func prepareContexts() (spi.ComponentContext, spi.ComponentContext) {
 	k8sutilfake.PodExecResult = func(url *url.URL) (string, string, error) {
 		var commands []string
 		if commands = url.Query()["command"]; len(commands) == 3 {
-			if strings.Contains(commands[2], fmt.Sprintf("base64 %s/%s*.svg", SettingUILogoFolder, SettingUILogoDarkPrefix)) {
+			if strings.Contains(commands[2], fmt.Sprintf("base64 %s/%s", SettingUILogoFolder, SettingUILogoDarkFile)) {
 				return base64.StdEncoding.EncodeToString([]byte("<svg>dark</svg>")), "", nil
 			}
 
-			if strings.Contains(commands[2], fmt.Sprintf("base64 %s/%s*.svg", SettingUILogoFolder, SettingUILogoLightPrefix)) {
+			if strings.Contains(commands[2], fmt.Sprintf("base64 %s/%s", SettingUILogoFolder, SettingUILogoLightFile)) {
 				return base64.StdEncoding.EncodeToString([]byte("<svg>light</svg>")), "", nil
 			}
 

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -285,7 +285,7 @@ func verifyUILogoSetting(settingName string, logoFilename string, dynamicClient 
 
 		logoCommand := []string{"/bin/sh", "-c", fmt.Sprintf("cat %s/%s | base64", rancher.SettingUILogoFolder, logoFilename)}
 		stdout, stderr, err := k8sutil.ExecPod(k8sClient, cfg, pod, "rancher", logoCommand)
-		if err != nil {
+		if err != nil || strings.Contains(stdout, "No such file or directory") {
 			// Try pre-Rancher 2.7.5 location
 			logoCommand = []string{"/bin/sh", "-c", fmt.Sprintf("cat %s/%s | base64", rancher.SettingUILogoFolderBeforeRancher275, logoFilename)}
 			stdout, stderr, err = k8sutil.ExecPod(k8sClient, cfg, pod, "rancher", logoCommand)

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -285,7 +285,7 @@ func verifyUILogoSetting(settingName string, logoFilename string, dynamicClient 
 
 		logoCommand := []string{"/bin/sh", "-c", fmt.Sprintf("cat %s/%s | base64", rancher.SettingUILogoFolder, logoFilename)}
 		var stdout, stderr string
-		stdout, stderr, err = k8sutil.ExecPod(k8sClient, cfg, pod, "rancher", logoCommand)
+		stdout, _, err = k8sutil.ExecPod(k8sClient, cfg, pod, "rancher", logoCommand)
 		if err != nil || strings.Contains(stdout, "No such file or directory") {
 			// Try pre-Rancher 2.7.5 location
 			logoCommand = []string{"/bin/sh", "-c", fmt.Sprintf("cat %s/%s | base64", rancher.SettingUILogoFolderBeforeRancher275, logoFilename)}

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -283,11 +283,11 @@ func verifyUILogoSetting(settingName string, logoFilename string, dynamicClient 
 			return false, err
 		}
 
-		logoCommand := []string{"/bin/sh", "-c", fmt.Sprintf("cat %s | base64 %s/%s", rancher.SettingUILogoFolder, logoFilename)}
+		logoCommand := []string{"/bin/sh", "-c", fmt.Sprintf("cat %s/%s | base64", rancher.SettingUILogoFolder, logoFilename)}
 		stdout, stderr, err := k8sutil.ExecPod(k8sClient, cfg, pod, "rancher", logoCommand)
 		if err != nil {
 			// Try pre-Rancher 2.7.5 location
-			logoCommand = []string{"/bin/sh", "-c", fmt.Sprintf("cat %s | base64 %s/%s", rancher.SettingUILogoFolderBeforeRancher275, logoFilename)}
+			logoCommand = []string{"/bin/sh", "-c", fmt.Sprintf("cat %s/%s | base64", rancher.SettingUILogoFolderBeforeRancher275, logoFilename)}
 			stdout, stderr, err = k8sutil.ExecPod(k8sClient, cfg, pod, "rancher", logoCommand)
 			if err != nil {
 				t.Logs.Error(fmt.Sprintf("Error executing command in rancher pod to verify value of %s setting: %v, stderr: %v", settingName, err, stderr))

--- a/tests/e2e/verify-infra/restapi/rancher_url_test.go
+++ b/tests/e2e/verify-infra/restapi/rancher_url_test.go
@@ -284,7 +284,8 @@ func verifyUILogoSetting(settingName string, logoFilename string, dynamicClient 
 		}
 
 		logoCommand := []string{"/bin/sh", "-c", fmt.Sprintf("cat %s/%s | base64", rancher.SettingUILogoFolder, logoFilename)}
-		stdout, stderr, err := k8sutil.ExecPod(k8sClient, cfg, pod, "rancher", logoCommand)
+		var stdout, stderr string
+		stdout, stderr, err = k8sutil.ExecPod(k8sClient, cfg, pod, "rancher", logoCommand)
 		if err != nil || strings.Contains(stdout, "No such file or directory") {
 			// Try pre-Rancher 2.7.5 location
 			logoCommand = []string{"/bin/sh", "-c", fmt.Sprintf("cat %s/%s | base64", rancher.SettingUILogoFolderBeforeRancher275, logoFilename)}


### PR DESCRIPTION
The location of the branding logo images changed in Rancher 2.7.5.  These changes support locating those images in the old and new locations.