### PR TITLE
VZ-10472: fix managed cluster crash

### DIFF
--- a/cluster-operator/internal/operatorinit/run_operator.go
+++ b/cluster-operator/internal/operatorinit/run_operator.go
@@ -85,7 +85,7 @@ func StartClusterOperator(metricsAddr string, enableLeaderElection bool, probeAd
 		}
 	}
 
-	crdInstalled, err = isCRDInstalled(apiextv1Client, capiClustersCRDName)
+	capiCrdInstalled, err := isCRDInstalled(apiextv1Client, capiClustersCRDName)
 	if err != nil {
 		log.Error(err, "unable to determine if CAPI CRD is installed")
 		os.Exit(1)
@@ -96,7 +96,7 @@ func StartClusterOperator(metricsAddr string, enableLeaderElection bool, probeAd
 	}
 
 	// only start the Rancher cluster sync controller if the cattle clusters CRD is installed
-	if crdInstalled && rancherRegistrationEnabled {
+	if capiCrdInstalled && rancherRegistrationEnabled {
 		log.Infof("Starting CAPI Cluster controller")
 		if err = (&capi.CAPIClusterReconciler{
 			Client:             mgr.GetClient(),


### PR DESCRIPTION
crd installed flag was being re-used inappropriately to check on capi crd.