### PR TITLE
VZ-10365:Fluentd Daemonset Image Too Large Bom Update

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -266,7 +266,7 @@
             },
             {
               "image": "fluentd-kubernetes-daemonset",
-              "tag": "v1.14.5-20230606042435-f4b532f",
+              "tag": "20230810212038-8777b84",
               "helmFullImageKey": "logging.fluentdImage"
             },
             {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -266,7 +266,7 @@
             },
             {
               "image": "fluentd-kubernetes-daemonset",
-              "tag": "20230810212038-8777b84",
+              "tag": "v1.14.5-20230810212038-8777b84",
               "helmFullImageKey": "logging.fluentdImage"
             },
             {


### PR DESCRIPTION
Updated VZ Bom for the Fluentd-kuberenetes-daemonset image tag