### PR TITLE
VZ-10365:Fluentd Daemonset Image Too Large Bom Update (#6786)

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -188,7 +188,7 @@
             },
             {
               "image": "fluentd-kubernetes-daemonset",
-              "tag": "v1.14.5-20230606042435-f4b532f",
+              "tag": "v1.14.5-20230810212038-8777b84",
               "helmFullImageKey": "logging.fluentdImage"
             },
             {


### PR DESCRIPTION
Updated VZ Bom for the Fluentd-kuberenetes-daemonset image tag