### PR TITLE
Fix verrazzano-cluster-operator VMC reconcile error metric counting

### DIFF
--- a/cluster-operator/controllers/vmc/vmc_controller.go
+++ b/cluster-operator/controllers/vmc/vmc_controller.go
@@ -108,13 +108,13 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(ctx context.Context, req 
 	r.log = log
 	log.Oncef("Reconciling Verrazzano resource %v", req.NamespacedName)
 	res, err := r.doReconcile(ctx, log, cr)
-	if err != nil || vzctrl.ShouldRequeue(res) {
-		if err != nil {
-			// Never return an error since it has already been logged and we don't want the
-			// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
-			reconcileErrorCount.Inc()
-			return newRequeueWithDelay(), nil
-		}
+	if err != nil {
+		// Never return an error since it has already been logged and we don't want the
+		// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
+		reconcileErrorCount.Inc()
+		return newRequeueWithDelay(), nil
+	}
+	if vzctrl.ShouldRequeue(res) {
 		reconcileSuccessCount.Inc()
 		return res, nil
 	}

--- a/cluster-operator/controllers/vmc/vmc_controller.go
+++ b/cluster-operator/controllers/vmc/vmc_controller.go
@@ -108,16 +108,15 @@ func (r *VerrazzanoManagedClusterReconciler) Reconcile(ctx context.Context, req 
 	r.log = log
 	log.Oncef("Reconciling Verrazzano resource %v", req.NamespacedName)
 	res, err := r.doReconcile(ctx, log, cr)
-	if vzctrl.ShouldRequeue(res) {
+	if err != nil || vzctrl.ShouldRequeue(res) {
+		if err != nil {
+			// Never return an error since it has already been logged and we don't want the
+			// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
+			reconcileErrorCount.Inc()
+			return newRequeueWithDelay(), nil
+		}
 		reconcileSuccessCount.Inc()
 		return res, nil
-	}
-
-	// Never return an error since it has already been logged and we don't want the
-	// controller runtime to log again (with stack trace).  Just re-queue if there is an error.
-	if err != nil {
-		reconcileErrorCount.Inc()
-		return newRequeueWithDelay(), nil
 	}
 
 	// The resource has been reconciled.


### PR DESCRIPTION
The VMC reconcile error metric was not being incremented correctly. Any errors during reconciliation were being ignored and the success metric was incremented in all cases.