### PR TITLE
VZ-3261 Add override to update Istio resources' status

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -556,6 +556,9 @@ func getOverridesString(ctx spi.ComponentContext) (string, error) {
 		return "", err
 	}
 
+	// Add override to enable the status on Istio reconciled objects
+	kvs = append(kvs, bom.KeyValue{Key: "values.pilot.env.PILOT_ENABLE_STATUS", Value: "true"})
+
 	// Build comma separated string of overrides that will be passed to
 	// isioctl as --set values.
 	// This include BOM image overrides as well as other overrides

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -556,8 +556,12 @@ func getOverridesString(ctx spi.ComponentContext) (string, error) {
 		return "", err
 	}
 
-	// Add override to enable the status on Istio reconciled objects
-	kvs = append(kvs, bom.KeyValue{Key: "values.pilot.env.PILOT_ENABLE_STATUS", Value: "true"})
+	// Add overrides to enable the status on Istio reconciled objects
+	kvs = append(kvs, []bom.KeyValue{
+		{Key: "values.pilot.env.PILOT_ENABLE_STATUS", Value: "true"},
+		{Key: "values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING", Value: "true"},
+		{Key: "values.global.istiod.enableAnalysis", Value: "true"},
+	}...)
 
 	// Build comma separated string of overrides that will be passed to
 	// isioctl as --set values.


### PR DESCRIPTION
**Changes**
- Enable the status update of Istio Reconciled resources through an istioctl override

**Testing**
- Install Verrazzano and make sure Istio resources have statuses
- Install an example app and make sure we can wait for resources to be reconciled by monitoring their statuses

Source for the overrides: https://istio.io/latest/docs/ops/configuration/mesh/config-resource-ready/