### PR TITLE
Switch over from OCI plugin 1.5 labels to JAO labels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ def VERRAZZANO_DEV_VERSION = ""
 def tarfilePrefix=""
 def storeLocation=""
 
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 
 pipeline {
     options {

--- a/JenkinsfileCopyrightTest
+++ b/JenkinsfileCopyrightTest
@@ -17,7 +17,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_5}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label "phxlarge_1_5"
+            label "1.5-large"
         }
     }
 

--- a/ci/JenkinsfileBackendTests
+++ b/ci/JenkinsfileBackendTests
@@ -7,7 +7,7 @@ import groovy.transform.Field
 def GIT_COMMIT_TO_USE = ""
 @Field
 def LAST_CLEAN_BACKEND_COMMIT = ""
-def agentLabel = "phxsmall_1_5"
+def agentLabel = "1.5-large"
 @Field
 def TESTS_FAILED = false
 @Field

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -13,7 +13,7 @@ def LAST_PERIODIC_RUN_COMMIT = ""
 def VERRAZZANO_DEV_VERSION = ""
 @Field
 def RELEASABLE_IMAGES_OBJECT_STORE = ""
-def agentLabel = "phxsmall_1_5"
+def agentLabel = "1.5-small"
 @Field
 def VERSIONED_IMAGES_FILENAME = ""
 @Field

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -3,7 +3,7 @@
 
 import groovy.transform.Field
 
-def agentLabel = "phxsmall_1_5"
+def agentLabel = "1.5-small"
 
 @Field
 def SUSPECT_LIST = ""

--- a/ci/backup/JenkinsfileAlllBackupKinDTest
+++ b/ci/backup/JenkinsfileAlllBackupKinDTest
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 // def agentLabel = "largeexperimental"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 def ociOsBucketName = UUID.randomUUID().toString().substring(0,6).replace('-','')

--- a/ci/backup/JenkinsfileAlllBackupOKETest
+++ b/ci/backup/JenkinsfileAlllBackupOKETest
@@ -22,7 +22,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_5}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label "phxlarge_1_5"
+            label "1.5-large"
         }
     }
 

--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {
@@ -452,7 +452,7 @@ pipeline {
                         do
                             echo "Waiting for Verrazzano to fail upgrade ..."
                             sleep 30
-                        done                        
+                        done
                         mkdir -p ${WORKSPACE}/verrazzano-platform-operator/logs
                         kubectl -n verrazzano-install logs --tail -1 --selector=app=verrazzano-platform-operator > ${WORKSPACE}/verrazzano-platform-operator/logs/verrazzano-platform-operator-before-final-upgrade-pod.log || echo "failed" > ${POST_DUMP_FAILED_FILE}
                         # Upgrade to the latest VPO

--- a/ci/chaos/JenkinsfileResiliencyTrigger
+++ b/ci/chaos/JenkinsfileResiliencyTrigger
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "phxsmall_1_5"
+def agentLabel = "1.5-small"
 
 pipeline {
     options {

--- a/ci/cron/Jenkinsfile
+++ b/ci/cron/Jenkinsfile
@@ -16,7 +16,7 @@ def periodicsUpToDate              = false // If true, indicates that the period
 @Field
 def periodicsUpToDateFailed        = false // If true, indicates that the periodics already ran and failed at the latest commit
 
-def agentLabel = env.JOB_NAME.contains('master') ? "phx-small" : "small"
+def agentLabel = "1.5-small"
 
 // Non Fields
 def branchSpecificSchedule = getCronSchedule()

--- a/ci/cron/JenkinsfileBackend
+++ b/ci/cron/JenkinsfileBackend
@@ -12,7 +12,7 @@ def backendTestsUpToDate = false // If true, indicates that the backend tests al
 @Field
 def backendTestsUpToDateFailed = false // If true, indicates that the backend tests already ran and failed at the latest commit
 
-def agentLabel = env.JOB_NAME.contains('master') ? "phx-small" : "small"
+def agentLabel = "1.5-small"
 
 // Non Fields
 def branchSpecificSchedule = getCronSchedule()

--- a/ci/dynamic-updates/Jenkinsfile
+++ b/ci/dynamic-updates/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/dynamic-updates/JenkinsfileTrigger
+++ b/ci/dynamic-updates/JenkinsfileTrigger
@@ -1,7 +1,7 @@
 // Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "phxsmall_1_5"
+def agentLabel = "1.5-small"
 
 pipeline {
     options {

--- a/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
+++ b/ci/dynamic-updates/JenkinsfileUpdateDuringInstall
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phx-large"
+def agentLabel = "1.5-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/examples/Jenkinsfile
+++ b/ci/examples/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/generic/Jenkinsfile
+++ b/ci/generic/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 targetsKey = "targets"

--- a/ci/generic/Jenkinsfile-singletarget
+++ b/ci/generic/Jenkinsfile-singletarget
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 def TESTS_FAILED = false
 

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -10,7 +10,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 
 installerFileName = "install-verrazzano.yaml"
 

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -8,7 +8,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 
 pipeline {
     options {

--- a/ci/no-injection/Jenkinsfile
+++ b/ci/no-injection/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -6,7 +6,7 @@
 def DEFAULT_REPO_URL
 def testEnvironments = [ "magicdns_oke" ]
 def installProfiles = [ "dev", "prod", "managed-cluster" ]
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1" ]

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -16,7 +16,7 @@ def testEnvironments = env.JOB_NAME.contains('oci-dns-acceptance')
                        : ["kind", "magicdns_oke", "ocidns_oke"]
 def acmeEnvironments = [ "staging", "production" ]
 def certIssuers = [ "self-signed", "acme" ]
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1" ]

--- a/ci/oke-ocidns/JenkinsfileDnsSweepTests
+++ b/ci/oke-ocidns/JenkinsfileDnsSweepTests
@@ -11,7 +11,7 @@ def LAST_CLEAN_PERIODIC_COMMIT = ""
 def VERRAZZANO_DEV_VERSION = ""
 @Field
 def RELEASABLE_IMAGES_OBJECT_STORE = ""
-def agentLabel = "phxsmall_1_5"
+def agentLabel = "1.5-small"
 @Field
 def TESTS_FAILED = false
 @Field

--- a/ci/oke-ocidns/JenknsfileDnsKind
+++ b/ci/oke-ocidns/JenknsfileDnsKind
@@ -16,7 +16,7 @@ def testEnvironments = env.JOB_NAME.contains('oci-dns-acceptance')
                        : ["kind_oci_dns", "magicdns_oke", "ocidns_oke"]
 def acmeEnvironments = [ "staging", "production" ]
 def certIssuers = [ "self-signed", "acme" ]
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "me-jeddah-1",

--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -11,7 +11,7 @@
 // -> Cleanup resources
 
 def testEnvironments=["OCNE"]
-def agentLabel= "phxlarge_1_5"
+def agentLabel= "1.5-large"
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions=["us-ashburn-1"]
 def availableDomains=["hXgQ:US-ASHBURN-AD-1", "hXgQ:US-ASHBURN-AD-2", "hXgQ:US-ASHBURN-AD-3"]

--- a/ci/periodic/JenkinsfileDistributions
+++ b/ci/periodic/JenkinsfileDistributions
@@ -18,6 +18,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_5}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
+            label "1.5-large"
         }
     }
 

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = params.DISTRIBUTION_VARIANT == "Lite" ? "phx-large" : "blocked-large"
+def agentLabel = params.DISTRIBUTION_VARIANT == "Lite" ? "1.5-large-phx" : "airgap-1.5-large"
 def ocirRegion = params.DISTRIBUTION_VARIANT == "Lite" ? "phx" : "fra"
 def ociRegionFull = params.DISTRIBUTION_VARIANT == "Lite" ? "us-phoenix-1" : "eu-frankfurt-1"
 def ocirRegistry = "${ocirRegion}.ocir.io"

--- a/ci/psr/Jenkinsfile
+++ b/ci/psr/Jenkinsfile
@@ -8,7 +8,7 @@ def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 def tarfilePrefix=""
 def storeLocation=""
 
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 
 pipeline {
     options {

--- a/ci/rolebased/Jenkinsfile
+++ b/ci/rolebased/Jenkinsfile
@@ -3,7 +3,7 @@
 
 def DOCKER_IMAGE_TAG
 def SKIP_ACCEPTANCE_TESTS = false
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 
 pipeline {
     options {

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
        docker {
             image "${RUNNER_DOCKER_IMAGE_1_5}"
             args "${RUNNER_DOCKER_ARGS_1_5}"
-            label "phxsmall_1_5"
+            label "1.5-small"
             registryCredentialsId 'ocir-pull-and-push-account'
         }
     }

--- a/ci/test-examples/Jenkinsfile
+++ b/ci/test-examples/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_5}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label "phxsmall_1_5"
+            label "1.5-small"
         }
     }
 

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS_1_5}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
-            label "phxsmall_1_5"
+            label "1.5-small"
         }
     }
 

--- a/ci/uninstall/JenkinsfileUninstallSuite
+++ b/ci/uninstall/JenkinsfileUninstallSuite
@@ -1,7 +1,7 @@
 // Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "phxsmall_1_5"
+def agentLabel = "1.5-small"
 
 pipeline {
     options {

--- a/ci/uninstall/JenkinsfileUninstallTest
+++ b/ci/uninstall/JenkinsfileUninstallTest
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -10,7 +10,7 @@ Collections.shuffle(availableRegions)
 def zoneId = UUID.randomUUID().toString().substring(0,6).replace('-','')
 def dns_zone_ocid = 'dummy'
 def OKE_CLUSTER_PREFIX = ""
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 
 def KUBECTL = "kubectl"
 def VZ_CLI = "vz cli"

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -1,7 +1,7 @@
 // Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 
 def listOfUpgradeJobs
 def upgradeJobsStageMapping

--- a/ci/vz-analyze/Jenkinsfile
+++ b/ci/vz-analyze/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = "phxlarge_1_5"
+def agentLabel = "1.5-large"
 def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 
 pipeline {


### PR DESCRIPTION
This switches the release-1.5 branch over to use the JAO for provisioning instances (from the OCI plugin).