### PR TITLE
VZ-10327: Targetted hostnames should be obfuscated

### DIFF
--- a/tools/vz/pkg/helpers/vzcapture.go
+++ b/tools/vz/pkg/helpers/vzcapture.go
@@ -302,6 +302,7 @@ func captureCertificates(client clipkg.Client, namespace, captureDir string, vzH
 	if err != nil {
 		LogError(fmt.Sprintf("An error occurred while getting the Certificates in namespace %s: %s\n", namespace, err.Error()))
 	}
+	collectHostNames(certificateList)
 	if len(certificateList.Items) > 0 {
 		LogMessage(fmt.Sprintf("Certificates in namespace: %s ...\n", namespace))
 		if err = createFile(certificateList, namespace, constants.CertificatesJSON, captureDir, vzHelper); err != nil {
@@ -309,6 +310,20 @@ func captureCertificates(client clipkg.Client, namespace, captureDir string, vzH
 		}
 	}
 	return nil
+}
+
+func collectHostNames(certificateList v1.CertificateList) {
+	for _, cert := range certificateList.Items {
+		for _, hostname := range cert.Spec.DNSNames {
+			KnownHostNames[hostname] = true
+		}
+	}
+
+	for _, cert := range certificateList.Items {
+		for _, ipAddress := range cert.Spec.IPAddresses {
+			KnownHostNames[ipAddress] = true
+		}
+	}
 }
 
 // CapturePodLog captures the log from the pod in the captureDir

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -6,7 +6,10 @@ package helpers
 import (
 	"bytes"
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"os"
+	"path/filepath"
+	"regexp"
 	"testing"
 
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -399,7 +402,13 @@ func TestCreateCertificateFile(t *testing.T) {
 	schemeForClient := k8scheme.Scheme
 	err := v1.AddToScheme(schemeForClient)
 	assert.NoError(t, err)
-	sampleCert := v1.Certificate{ObjectMeta: metav1.ObjectMeta{Name: "testcertificate", Namespace: "cattle-system"}}
+	sampleCert := v1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "testcertificate", Namespace: "cattle-system"},
+		Spec: v1.CertificateSpec{
+			DNSNames:    []string{"example.com", "www.example.com", "api.example.com"},
+			IPAddresses: []string{"1.2.3.4", "5.6.7.8"},
+		},
+	}
 	client := fake.NewClientBuilder().WithScheme(schemeForClient).WithObjects(&sampleCert).Build()
 	captureDir, err := os.MkdirTemp("", "testcaptureforcertificates")
 	assert.NoError(t, err)
@@ -413,4 +422,50 @@ func TestCreateCertificateFile(t *testing.T) {
 	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
 	err = captureCertificates(client, "cattle-system", captureDir, rc)
 	assert.NoError(t, err)
+}
+
+// TestRedactHostNamesForCertificates tests the captureCertificates function
+// GIVEN when sample cert with DNSNames and IPAddresses which are sensitive information
+// WHEN captureCertificates is called on certain namespace
+// THEN it should obfuscate the known hostnames with hashed value
+// AND the output certificates.json file should NOT contain any of the sensitive information from KnownHostNames
+func TestRedactHostNamesForCertificates(t *testing.T) {
+	sampleCert := &v1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-certificate",
+			Namespace: "cattle-system",
+		},
+		Spec: v1.CertificateSpec{
+			DNSNames:    []string{"example.com", "www.example.com", "api.example.com"},
+			IPAddresses: []string{"1.2.3.4", "5.6.7.8"},
+		},
+	}
+
+	schemeForClient := k8scheme.Scheme
+	err := v1.AddToScheme(schemeForClient)
+	assert.NoError(t, err)
+	client := fake.NewClientBuilder().WithScheme(schemeForClient).WithObjects(sampleCert).Build()
+	captureDir, err := os.MkdirTemp("", "testcaptureforcertificates")
+	assert.NoError(t, err)
+	t.Log(captureDir)
+	defer cleanupTempDir(t, captureDir)
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	tempFile, err := os.CreateTemp(captureDir, "temporary-log-file-for-test")
+	assert.NoError(t, err)
+	SetMultiWriterOut(buf, tempFile)
+	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+
+	err = captureCertificates(client, common.CattleSystem, captureDir, rc)
+	assert.NoError(t, err)
+
+	// Check if the file is Sanitized as expected
+	certLocation := filepath.Join(captureDir, common.CattleSystem, constants.CertificatesJSON)
+	f, err := os.ReadFile(certLocation)
+	assert.NoError(t, err, "Should not error reading certificates.json file")
+	for k, _ := range KnownHostNames {
+		keyMatch, err := regexp.Match(k, f)
+		assert.NoError(t, err, "Error while regex matching")
+		assert.Falsef(t, keyMatch, "%s should be obfuscated from certificates.json file", k)
+	}
 }

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -463,7 +463,7 @@ func TestRedactHostNamesForCertificates(t *testing.T) {
 	certLocation := filepath.Join(captureDir, common.CattleSystem, constants.CertificatesJSON)
 	f, err := os.ReadFile(certLocation)
 	assert.NoError(t, err, "Should not error reading certificates.json file")
-	for k, _ := range KnownHostNames {
+	for k := range KnownHostNames {
 		keyMatch, err := regexp.Match(k, f)
 		assert.NoError(t, err, "Error while regex matching")
 		assert.Falsef(t, keyMatch, "%s should be obfuscated from certificates.json file", k)

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -32,8 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-const dummyIp1 = "0.0.0.0"
-const dummyIp2 = "5.6.x.x"
+const dummyIP1 = "0.0.0.0"
+const dummyIP2 = "5.6.x.x"
 
 // TestCreateReportArchive
 // GIVEN a directory containing some files
@@ -409,7 +409,7 @@ func TestCreateCertificateFile(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "testcertificate", Namespace: "cattle-system"},
 		Spec: v1.CertificateSpec{
 			DNSNames:    []string{"example.com", "www.example.com", "api.example.com"},
-			IPAddresses: []string{dummyIp1, dummyIp2},
+			IPAddresses: []string{dummyIP1, dummyIP2},
 		},
 	}
 	client := fake.NewClientBuilder().WithScheme(schemeForClient).WithObjects(&sampleCert).Build()
@@ -440,7 +440,7 @@ func TestRedactHostNamesForCertificates(t *testing.T) {
 		},
 		Spec: v1.CertificateSpec{
 			DNSNames:    []string{"example.com", "www.example.com", "api.example.com"},
-			IPAddresses: []string{dummyIp1, dummyIp2},
+			IPAddresses: []string{dummyIP1, dummyIP2},
 		},
 	}
 

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -32,6 +32,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const dummyIp1 = "0.0.0.0"
+const dummyIp2 = "5.6.x.x"
+
 // TestCreateReportArchive
 // GIVEN a directory containing some files
 //
@@ -406,7 +409,7 @@ func TestCreateCertificateFile(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "testcertificate", Namespace: "cattle-system"},
 		Spec: v1.CertificateSpec{
 			DNSNames:    []string{"example.com", "www.example.com", "api.example.com"},
-			IPAddresses: []string{"1.2.3.4", "5.6.7.8"},
+			IPAddresses: []string{dummyIp1, dummyIp2},
 		},
 	}
 	client := fake.NewClientBuilder().WithScheme(schemeForClient).WithObjects(&sampleCert).Build()
@@ -437,7 +440,7 @@ func TestRedactHostNamesForCertificates(t *testing.T) {
 		},
 		Spec: v1.CertificateSpec{
 			DNSNames:    []string{"example.com", "www.example.com", "api.example.com"},
-			IPAddresses: []string{"1.2.3.4", "5.6.7.8"},
+			IPAddresses: []string{dummyIp1, dummyIp2},
 		},
 	}
 

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -466,6 +466,6 @@ func TestRedactHostNamesForCertificates(t *testing.T) {
 	for k := range KnownHostNames {
 		keyMatch, err := regexp.Match(k, f)
 		assert.NoError(t, err, "Error while regex matching")
-		assert.Falsef(t, keyMatch, "%s should be obfuscated from certificates.json file", k)
+		assert.Falsef(t, keyMatch, "%s should be obfuscated from certificates.json file %s", k, string(f))
 	}
 }

--- a/tools/vz/pkg/helpers/vzsanitize.go
+++ b/tools/vz/pkg/helpers/vzsanitize.go
@@ -10,6 +10,7 @@ import (
 )
 
 var regexToReplacementList = []string{}
+var KnownHostNames = make(map[string]bool)
 
 const ipv4Regex = "[[:digit:]]{1,3}\\.[[:digit:]]{1,3}\\.[[:digit:]]{1,3}\\.[[:digit:]]{1,3}"
 const userData = "\"user_data\":\\s+\"[A-Za-z0-9=+]+\""
@@ -23,6 +24,9 @@ func InitRegexToReplacementMap() {
 	regexToReplacementList = append(regexToReplacementList, userData)
 	regexToReplacementList = append(regexToReplacementList, sshAuthKeys)
 	regexToReplacementList = append(regexToReplacementList, ocid)
+	for k, _ := range KnownHostNames {
+		regexToReplacementList = append(regexToReplacementList, k)
+	}
 }
 
 // SanitizeString sanitizes each line in a given file,

--- a/tools/vz/pkg/helpers/vzsanitize.go
+++ b/tools/vz/pkg/helpers/vzsanitize.go
@@ -24,7 +24,7 @@ func InitRegexToReplacementMap() {
 	regexToReplacementList = append(regexToReplacementList, userData)
 	regexToReplacementList = append(regexToReplacementList, sshAuthKeys)
 	regexToReplacementList = append(regexToReplacementList, ocid)
-	for k, _ := range KnownHostNames {
+	for k := range KnownHostNames {
 		regexToReplacementList = append(regexToReplacementList, k)
 	}
 }

--- a/tools/vz/pkg/helpers/vzsanitize.go
+++ b/tools/vz/pkg/helpers/vzsanitize.go
@@ -24,9 +24,6 @@ func InitRegexToReplacementMap() {
 	regexToReplacementList = append(regexToReplacementList, userData)
 	regexToReplacementList = append(regexToReplacementList, sshAuthKeys)
 	regexToReplacementList = append(regexToReplacementList, ocid)
-	for k := range KnownHostNames {
-		regexToReplacementList = append(regexToReplacementList, k)
-	}
 }
 
 // SanitizeString sanitizes each line in a given file,
@@ -34,6 +31,10 @@ func InitRegexToReplacementMap() {
 func SanitizeString(l string) string {
 	if len(regexToReplacementList) == 0 {
 		InitRegexToReplacementMap()
+	}
+	for knownHost := range KnownHostNames {
+		wholeOccurrenceHostPattern := "\"" + knownHost + "\""
+		l = regexp.MustCompile(wholeOccurrenceHostPattern).ReplaceAllString(l, "\""+getSha256Hash(knownHost)+"\"")
 	}
 	for _, eachRegex := range regexToReplacementList {
 		l = regexp.MustCompile(eachRegex).ReplaceAllString(l, getSha256Hash(l))


### PR DESCRIPTION
This PR introduces changes to aggregate hostnames (DNSNames and IPAddresses) from cert-manager certificates into a map. Additionally, any occurrences of these hostnames are sanitized and replaced with their hashed values
