### PR TITLE
VZ-10547: Add Verrazzano-specific Prometheus rules

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator_test.go
@@ -1453,3 +1453,101 @@ func TestAppendResourceRequestOverrides(t *testing.T) {
 		})
 	}
 }
+
+// TestAppendPrometheusRuleOverrides tests the appendPrometheusRuleOverrides function.
+func TestAppendPrometheusRuleOverrides(t *testing.T) {
+	tests := []struct {
+		name            string
+		vzCR            *vzapi.Verrazzano
+		expectOverrides []bom.KeyValue
+	}{
+		{
+			// GIVEN a default VZ CR
+			// WHEN the appendPrometheusRuleOverrides function is called
+			// THEN no key/value overrides are returned
+			name:            "default VZ CR, no Prometheus rules should be disabled",
+			vzCR:            &vzapi.Verrazzano{},
+			expectOverrides: []bom.KeyValue{},
+		},
+		{
+			// GIVEN a VZ CR with the application operator disabled
+			// WHEN the appendPrometheusRuleOverrides function is called
+			// THEN expected key/value overrides are returned
+			name: "VZ CR with VAO disabled, VAO Prometheus rules should be disabled",
+			vzCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						ApplicationOperator: &vzapi.ApplicationOperatorComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			expectOverrides: []bom.KeyValue{
+				{Key: "defaultRules.rules.verrazzanoApplicationOperator", Value: "false"},
+			},
+		},
+		{
+			// GIVEN a VZ CR with the application and cluster operators disabled
+			// WHEN the appendPrometheusRuleOverrides function is called
+			// THEN expected key/value overrides are returned
+			name: "VZ CR with VAO and VCO disabled, VAO and VCO Prometheus rules should be disabled",
+			vzCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						ApplicationOperator: &vzapi.ApplicationOperatorComponent{
+							Enabled: &falseValue,
+						},
+						ClusterOperator: &vzapi.ClusterOperatorComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			expectOverrides: []bom.KeyValue{
+				{Key: "defaultRules.rules.verrazzanoApplicationOperator", Value: "false"},
+				{Key: "defaultRules.rules.verrazzanoClusterOperator", Value: "false"},
+			},
+		},
+		{
+			// GIVEN a VZ CR with the application and cluster operators disabled, along with all of the VMO components
+			// WHEN the appendPrometheusRuleOverrides function is called
+			// THEN expected key/value overrides are returned
+			name: "VZ CR with VAO, VCO, and VMO components disabled, VAO, VCO, and VMO Prometheus rules should be disabled",
+			vzCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						ApplicationOperator: &vzapi.ApplicationOperatorComponent{
+							Enabled: &falseValue,
+						},
+						ClusterOperator: &vzapi.ClusterOperatorComponent{
+							Enabled: &falseValue,
+						},
+						Elasticsearch: &vzapi.ElasticsearchComponent{
+							Enabled: &falseValue,
+						},
+						Kibana: &vzapi.KibanaComponent{
+							Enabled: &falseValue,
+						},
+						Grafana: &vzapi.GrafanaComponent{
+							Enabled: &falseValue,
+						},
+					},
+				},
+			},
+			expectOverrides: []bom.KeyValue{
+				{Key: "defaultRules.rules.verrazzanoApplicationOperator", Value: "false"},
+				{Key: "defaultRules.rules.verrazzanoClusterOperator", Value: "false"},
+				{Key: "defaultRules.rules.verrazzanoMonitoringOperator", Value: "false"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := spi.NewFakeContext(nil, tt.vzCR, nil, false)
+			kvs := appendPrometheusRuleOverrides(ctx, []bom.KeyValue{})
+			assert.Equal(t, tt.expectOverrides, kvs)
+		})
+	}
+}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-application-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-application-operator.yaml
@@ -104,8 +104,8 @@ spec:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
 {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
 {{- end }}
-        description: Verrazzano Application Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
-        summary: Verrazzano Application Operator Webhook is not ready.
+        description: Verrazzano Application Operator webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
+        summary: Verrazzano Application Operator webhook is not ready.
       expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_pod_status_ready{job="kube-state-metrics", verrazzano_component="applicationOperator", pod=~"verrazzano-application-operator-webhook-.*", condition="true"}[5m])) == 0
       for: 10m
       labels:
@@ -136,8 +136,8 @@ spec:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
 {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
 {{- end }}
-        description: Verrazzano Application Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
-        summary: Verrazzano Application Operator Webhook is not running.
+        description: Verrazzano Application Operator webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
+        summary: Verrazzano Application Operator webhook is not running.
       expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_deployment_status_replicas{deployment="verrazzano-application-operator-webhook"}[5m])) == 0
       for: 10m
       labels:

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-application-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-application-operator.yaml
@@ -1,0 +1,109 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.verrazzanoApplicationOperator (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "verrazzano-application-operator" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: verrazzano-application-operator
+    rules:
+    - alert: VerrazzanoApplicationOperatorAppConfigReconcileErrorRate
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of application configuration reconcile operations failed in the Verrazzano Application Operator.'
+        summary: Verrazzano Application Operator high application configuration reconcile error rate.
+      expr: sum by (job, verrazzano_cluster) (rate(vz_application_operator_appconfig_error_reconcile_total[5m])) / (sum by (job, verrazzano_cluster) (rate(vz_application_operator_appconfig_successful_reconcile_total[5m])) + sum by (job, verrazzano_cluster) (rate(vz_application_operator_appconfig_error_reconcile_total[5m]))) > 0.1
+      for: 10m
+      labels:
+        severity: warning
+    - alert: VerrazzanoApplicationOperatorCoherenceWorkloadReconcileErrorRate
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of Coherence workload reconcile operations failed in the Verrazzano Application Operator.'
+        summary: Verrazzano Application Operator high Coherence workload reconcile error rate.
+      expr: sum by (job, verrazzano_cluster) (rate(vz_application_operator_cohworkload_error_reconcile_total[5m])) / (sum by (job, verrazzano_cluster) (rate(vz_application_operator_cohworkload_successful_reconcile_total[5m])) + sum by (job, verrazzano_cluster) (rate(vz_application_operator_cohworkload_error_reconcile_total[5m]))) > 0.1
+      for: 10m
+      labels:
+        severity: warning
+    - alert: VerrazzanoApplicationOperatorHelidonWorkloadReconcileErrorRate
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of Helidon workload reconcile operations failed in the Verrazzano Application Operator.'
+        summary: Verrazzano Application Operator high Helidon workload reconcile error rate.
+      expr: sum by (job, verrazzano_cluster) (rate(vz_application_operator_helidonworkload_error_reconcile_total[5m])) / (sum by (job, verrazzano_cluster) (rate(vz_application_operator_helidonworkload_successful_reconcile_total[5m])) + sum by (job, verrazzano_cluster) (rate(vz_application_operator_helidonworkload_error_reconcile_total[5m]))) > 0.1
+      for: 10m
+      labels:
+        severity: warning
+    - alert: VerrazzanoApplicationOperatorIngressTraitReconcileErrorRate
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of ingress trait reconcile operations failed in the Verrazzano Application Operator.'
+        summary: Verrazzano Application Operator high ingress trait reconcile error rate.
+      expr: sum by (job, verrazzano_cluster) (rate(vz_application_operator_ingresstrait_error_reconcile_total[5m])) / (sum by (job, verrazzano_cluster) (rate(vz_application_operator_ingresstrait_successful_reconcile_total[5m])) + sum by (job, verrazzano_cluster) (rate(vz_application_operator_ingresstrait_error_reconcile_total[5m]))) > 0.1
+      for: 10m
+      labels:
+        severity: warning
+    - alert: VerrazzanoApplicationOperatorNotReady
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Application Operator pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
+        summary: Verrazzano Application Operator is not ready.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_pod_status_ready{job="kube-state-metrics", verrazzano_component="applicationOperator", pod=~"verrazzano-application-operator-.*", pod!~"verrazzano-application-operator-webhook-.*", condition="true"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoApplicationOperatorWebhookNotReady
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Application Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
+        summary: Verrazzano Application Operator Webhook is not ready.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_pod_status_ready{job="kube-state-metrics", verrazzano_component="applicationOperator", pod=~"verrazzano-application-operator-webhook-.*", condition="true"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoApplicationOperatorNotRunning
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Application Operator pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
+        summary: Verrazzano Application Operator is not running.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_deployment_status_replicas{deployment="verrazzano-application-operator"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoApplicationOperatorWebhookNotRunning
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Application Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
+        summary: Verrazzano Application Operator Webhook is not running.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_deployment_status_replicas{deployment="verrazzano-application-operator-webhook"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-application-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-application-operator.yaml
@@ -18,6 +18,7 @@ spec:
   groups:
   - name: verrazzano-application-operator
     rules:
+{{- if not (.Values.defaultRules.disabled.VerrazzanoApplicationOperatorAppConfigReconcileErrorRate | default false) }}
     - alert: VerrazzanoApplicationOperatorAppConfigReconcileErrorRate
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -29,6 +30,11 @@ spec:
       for: 10m
       labels:
         severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoApplicationOperatorCoherenceWorkloadReconcileErrorRate | default false) }}
     - alert: VerrazzanoApplicationOperatorCoherenceWorkloadReconcileErrorRate
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -40,6 +46,11 @@ spec:
       for: 10m
       labels:
         severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoApplicationOperatorHelidonWorkloadReconcileErrorRate | default false) }}
     - alert: VerrazzanoApplicationOperatorHelidonWorkloadReconcileErrorRate
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -51,6 +62,11 @@ spec:
       for: 10m
       labels:
         severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoApplicationOperatorIngressTraitReconcileErrorRate | default false) }}
     - alert: VerrazzanoApplicationOperatorIngressTraitReconcileErrorRate
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -62,6 +78,11 @@ spec:
       for: 10m
       labels:
         severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoApplicationOperatorNotReady | default false) }}
     - alert: VerrazzanoApplicationOperatorNotReady
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -73,6 +94,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoApplicationOperatorWebhookNotReady | default false) }}
     - alert: VerrazzanoApplicationOperatorWebhookNotReady
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -84,6 +110,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoApplicationOperatorNotRunning | default false) }}
     - alert: VerrazzanoApplicationOperatorNotRunning
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -95,6 +126,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoApplicationOperatorWebhookNotRunning | default false) }}
     - alert: VerrazzanoApplicationOperatorWebhookNotRunning
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -106,4 +142,8 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-cluster-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-cluster-operator.yaml
@@ -18,6 +18,7 @@ spec:
   groups:
   - name: verrazzano-cluster-operator
     rules:
+{{- if not (.Values.defaultRules.disabled.VerrazzanoClusterOperatorVMCReconcileErrorRate | default false) }}
     - alert: VerrazzanoClusterOperatorVMCReconcileErrorRate
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -29,6 +30,11 @@ spec:
       for: 10m
       labels:
         severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoClusterOperatorNotReady | default false) }}
     - alert: VerrazzanoClusterOperatorNotReady
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -40,6 +46,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoClusterOperatorWebhookNotReady | default false) }}
     - alert: VerrazzanoClusterOperatorWebhookNotReady
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -51,6 +62,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoClusterOperatorNotRunning | default false) }}
     - alert: VerrazzanoClusterOperatorNotRunning
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -62,6 +78,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoClusterOperatorWebhookNotRunning | default false) }}
     - alert: VerrazzanoClusterOperatorWebhookNotRunning
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -73,4 +94,8 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-cluster-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-cluster-operator.yaml
@@ -56,8 +56,8 @@ spec:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
 {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
 {{- end }}
-        description: Verrazzano Cluster Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
-        summary: Verrazzano Cluster Operator Webhook is not ready.
+        description: Verrazzano Cluster Operator webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
+        summary: Verrazzano Cluster Operator webhook is not ready.
       expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_pod_status_ready{job="kube-state-metrics", verrazzano_component="clusterOperator", pod=~"verrazzano-cluster-operator-webhook-.*", condition="true"}[5m])) == 0
       for: 10m
       labels:
@@ -88,8 +88,8 @@ spec:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
 {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
 {{- end }}
-        description: Verrazzano Cluster Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
-        summary: Verrazzano Cluster Operator Webhook is not running.
+        description: Verrazzano Cluster Operator webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
+        summary: Verrazzano Cluster Operator webhook is not running.
       expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_deployment_status_replicas{deployment="verrazzano-cluster-operator-webhook"}[5m])) == 0
       for: 10m
       labels:

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-cluster-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-cluster-operator.yaml
@@ -1,0 +1,76 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.verrazzanoClusterOperator (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "verrazzano-cluster-operator" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: verrazzano-cluster-operator
+    rules:
+    - alert: VerrazzanoClusterOperatorVMCReconcileErrorRate
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of Verrazzano Managed Cluster reconcile operations failed in the Verrazzano Cluster Operator.'
+        summary: Verrazzano Cluster Operator high Verrazzano Managed Cluster reconcile error rate.
+      expr: sum by (job, verrazzano_cluster) (rate(vz_cluster_operator_reconcile_vmc_error_total[5m])) / (sum by (job, verrazzano_cluster) (rate(vz_cluster_operator_reconcile_vmc_success_total[5m])) + sum by (job, verrazzano_cluster) (rate(vz_cluster_operator_reconcile_vmc_error_total[5m]))) > 0.1
+      for: 10m
+      labels:
+        severity: warning
+    - alert: VerrazzanoClusterOperatorNotReady
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Cluster Operator pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
+        summary: Verrazzano Cluster Operator is not ready.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_pod_status_ready{job="kube-state-metrics", verrazzano_component="clusterOperator", pod=~"verrazzano-cluster-operator-.*", pod!~"verrazzano-cluster-operator-webhook-.*", condition="true"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoClusterOperatorWebhookNotReady
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Cluster Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
+        summary: Verrazzano Cluster Operator Webhook is not ready.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_pod_status_ready{job="kube-state-metrics", verrazzano_component="clusterOperator", pod=~"verrazzano-cluster-operator-webhook-.*", condition="true"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoClusterOperatorNotRunning
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Cluster Operator pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
+        summary: Verrazzano Cluster Operator is not running.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_deployment_status_replicas{deployment="verrazzano-cluster-operator"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoClusterOperatorWebhookNotRunning
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Cluster Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
+        summary: Verrazzano Cluster Operator Webhook is not running.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_deployment_status_replicas{deployment="verrazzano-cluster-operator-webhook"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-monitoring-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-monitoring-operator.yaml
@@ -1,0 +1,56 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.verrazzanoMonitoringOperator (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "verrazzano-monitor-operator" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: verrazzano-monitoring-operator
+    rules:
+    - record: job_verrazzano_cluster:vz_monitoring_operator_reconcile_error_total:sum
+      expr: sum by (job, verrazzano_cluster) (vz_monitoring_operator_reconcile_error_total)
+    - alert: VerrazzanoMonitoringOperatorReconcileErrorRate
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of reconcile operations failed in the Verrazzano Monitoring Operator.'
+        summary: Verrazzano Monitoring Operator high reconcile error rate.
+      expr: sum by (job, verrazzano_cluster) (rate(job_verrazzano_cluster:vz_monitoring_operator_reconcile_error_total:sum{prometheus=~".+"}[5m])) / sum by (job, verrazzano_cluster) (rate(vz_monitoring_operator_reconcile_total[5m])) > 0.1
+      for: 10m
+      labels:
+        severity: warning
+    - alert: VerrazzanoMonitoringOperatorNotReady
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Monitoring Operator pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
+        summary: Verrazzano Monitoring Operator is not ready.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_pod_status_ready{job="kube-state-metrics", verrazzano_component="monitoringOperator", pod=~"verrazzano-monitoring-operator-.*", condition="true"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoMonitoringOperatorNotRunning
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Monitoring Operator pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
+        summary: Verrazzano Monitoring Operator is not running.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_deployment_status_replicas{deployment="verrazzano-monitoring-operator"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-monitoring-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-monitoring-operator.yaml
@@ -20,6 +20,7 @@ spec:
     rules:
     - record: job_verrazzano_cluster:vz_monitoring_operator_reconcile_error_total:sum
       expr: sum by (job, verrazzano_cluster) (vz_monitoring_operator_reconcile_error_total)
+{{- if not (.Values.defaultRules.disabled.VerrazzanoMonitoringOperatorReconcileErrorRate | default false) }}
     - alert: VerrazzanoMonitoringOperatorReconcileErrorRate
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -31,6 +32,11 @@ spec:
       for: 10m
       labels:
         severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoMonitoringOperatorNotReady | default false) }}
     - alert: VerrazzanoMonitoringOperatorNotReady
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -42,6 +48,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoMonitoringOperatorNotRunning | default false) }}
     - alert: VerrazzanoMonitoringOperatorNotRunning
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -53,4 +64,8 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-platform-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-platform-operator.yaml
@@ -1,0 +1,87 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.verrazzanoPlatformOperator (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "verrazzano-platform-operator" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ template "kube-prometheus-stack.namespace" . }}
+  labels:
+    app: {{ template "kube-prometheus-stack.name" . }}
+{{ include "kube-prometheus-stack.labels" . | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: verrazzano-platform-operator
+    rules:
+    - alert: VerrazzanoPlatformOperatorReconcileErrorRate
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of reconcile operations failed in the Verrazzano Platform Operator.'
+        summary: Verrazzano Platform Operator high reconcile error rate.
+      expr: sum by (job, verrazzano_cluster) (rate(vz_platform_operator_error_reconcile_total[5m])) / sum by (job, verrazzano_cluster) (rate(vz_platform_operator_reconcile_total[5m])) > 0.2
+      for: 10m
+      labels:
+        severity: warning
+    - alert: VerrazzanoPlatformOperatorNotReady
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Platform Operator pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
+        summary: Verrazzano Platform Operator is not ready.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_pod_status_ready{job="kube-state-metrics", verrazzano_component="platformOperator", pod=~"verrazzano-platform-operator-.*", pod!~"verrazzano-platform-operator-webhook-.*", condition="true"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoPlatformOperatorWebhookNotReady
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Platform Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
+        summary: Verrazzano Platform Operator Webhook is not ready.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_pod_status_ready{job="kube-state-metrics", verrazzano_component="platformOperator", pod=~"verrazzano-platform-operator-webhook-.*", condition="true"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoPlatformOperatorNotRunning
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Platform Operator pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
+        summary: Verrazzano Platform Operator is not running.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_deployment_status_replicas{deployment="verrazzano-platform-operator"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoPlatformOperatorWebhookNotRunning
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: Verrazzano Platform Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
+        summary: Verrazzano Platform Operator Webhook is not running.
+      expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_deployment_status_replicas{deployment="verrazzano-platform-operator-webhook"}[5m])) == 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: VerrazzanoComponentsNotReady
+      annotations:
+{{- if .Values.defaultRules.additionalRuleAnnotations }}
+{{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
+{{- end }}
+        description: '{{`{{`}} $value {{`}}`}} Verrazzano components are not ready.'
+        summary: Verrazzano components are not ready.
+      expr: sum by (verrazzano_cluster) (vz_platform_operator_component_enabled_total) - sum by (verrazzano_cluster) (vz_platform_operator_component_health_total) > 0
+      for: 20m
+      labels:
+        severity: warning
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-platform-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-platform-operator.yaml
@@ -56,8 +56,8 @@ spec:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
 {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
 {{- end }}
-        description: Verrazzano Platform Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
-        summary: Verrazzano Platform Operator Webhook is not ready.
+        description: Verrazzano Platform Operator webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not ready.
+        summary: Verrazzano Platform Operator webhook is not ready.
       expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_pod_status_ready{job="kube-state-metrics", verrazzano_component="platformOperator", pod=~"verrazzano-platform-operator-webhook-.*", condition="true"}[5m])) == 0
       for: 10m
       labels:
@@ -88,8 +88,8 @@ spec:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
 {{ toYaml .Values.defaultRules.additionalRuleAnnotations | indent 8 }}
 {{- end }}
-        description: Verrazzano Platform Operator Webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
-        summary: Verrazzano Platform Operator Webhook is not running.
+        description: Verrazzano Platform Operator webhook pod in {{`{{`}} $labels.namespace {{`}}`}} namespace is not running.
+        summary: Verrazzano Platform Operator webhook is not running.
       expr: max by (namespace, verrazzano_cluster) (max_over_time(kube_deployment_status_replicas{deployment="verrazzano-platform-operator-webhook"}[5m])) == 0
       for: 10m
       labels:

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-platform-operator.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/templates/verrazzano/rules/verrazzano-platform-operator.yaml
@@ -18,6 +18,7 @@ spec:
   groups:
   - name: verrazzano-platform-operator
     rules:
+{{- if not (.Values.defaultRules.disabled.VerrazzanoPlatformOperatorReconcileErrorRate | default false) }}
     - alert: VerrazzanoPlatformOperatorReconcileErrorRate
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -29,6 +30,11 @@ spec:
       for: 10m
       labels:
         severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoPlatformOperatorNotReady | default false) }}
     - alert: VerrazzanoPlatformOperatorNotReady
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -40,6 +46,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoPlatformOperatorWebhookNotReady | default false) }}
     - alert: VerrazzanoPlatformOperatorWebhookNotReady
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -51,6 +62,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoPlatformOperatorNotRunning | default false) }}
     - alert: VerrazzanoPlatformOperatorNotRunning
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -62,6 +78,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoPlatformOperatorWebhookNotRunning | default false) }}
     - alert: VerrazzanoPlatformOperatorWebhookNotRunning
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -73,6 +94,11 @@ spec:
       for: 10m
       labels:
         severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if not (.Values.defaultRules.disabled.VerrazzanoComponentsNotReady | default false) }}
     - alert: VerrazzanoComponentsNotReady
       annotations:
 {{- if .Values.defaultRules.additionalRuleAnnotations }}
@@ -84,4 +110,8 @@ spec:
       for: 20m
       labels:
         severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml
@@ -60,6 +60,10 @@ defaultRules:
     nodeExporterRecording: true
     prometheus: true
     prometheusOperator: true
+    verrazzanoPlatformOperator: true
+    verrazzanoApplicationOperator: true
+    verrazzanoClusterOperator: true
+    verrazzanoMonitoringOperator: true
 
   ## Reduce app namespace alert scope
   appNamespacesTarget: ".*"

--- a/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack/values.yaml
@@ -83,6 +83,28 @@ defaultRules:
   runbookUrl: "https://runbooks.prometheus-operator.dev/runbooks"
 
   ## Disabled PrometheusRule alerts
+  ## @extra defaultRules.disabled.VerrazzanoPlatformOperatorReconcileErrorRate Disable VerrazzanoPlatformOperatorReconcileErrorRate rule when defaultRules.rules.verrazzanoPlatformOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoPlatformOperatorNotReady Disable VerrazzanoPlatformOperatorNotReady rule when defaultRules.rules.verrazzanoPlatformOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoPlatformOperatorWebhookNotReady Disable VerrazzanoPlatformOperatorWebhookNotReady rule when defaultRules.rules.verrazzanoPlatformOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoPlatformOperatorNotRunning Disable VerrazzanoPlatformOperatorNotRunning rule when defaultRules.rules.verrazzanoPlatformOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoPlatformOperatorWebhookNotRunning Disable VerrazzanoPlatformOperatorWebhookNotRunning rule when defaultRules.rules.verrazzanoPlatformOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoComponentsNotReady Disable VerrazzanoComponentsNotReady rule when defaultRules.rules.verrazzanoPlatformOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoApplicationOperatorAppConfigReconcileErrorRate Disable VerrazzanoApplicationOperatorAppConfigReconcileErrorRate rule when defaultRules.rules.verrazzanoApplicationOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoApplicationOperatorCoherenceWorkloadReconcileErrorRate Disable VerrazzanoApplicationOperatorCoherenceWorkloadReconcileErrorRate rule when defaultRules.rules.verrazzanoApplicationOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoApplicationOperatorHelidonWorkloadReconcileErrorRate Disable VerrazzanoApplicationOperatorHelidonWorkloadReconcileErrorRate rule when defaultRules.rules.verrazzanoApplicationOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoApplicationOperatorIngressTraitReconcileErrorRate Disable VerrazzanoApplicationOperatorIngressTraitReconcileErrorRate rule when defaultRules.rules.verrazzanoApplicationOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoApplicationOperatorNotReady Disable VerrazzanoApplicationOperatorNotReady rule when defaultRules.rules.verrazzanoApplicationOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoApplicationOperatorWebhookNotReady Disable VerrazzanoApplicationOperatorWebhookNotReady rule when defaultRules.rules.verrazzanoApplicationOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoApplicationOperatorNotRunning Disable VerrazzanoApplicationOperatorNotRunning rule when defaultRules.rules.verrazzanoApplicationOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoApplicationOperatorWebhookNotRunning Disable VerrazzanoApplicationOperatorWebhookNotRunning rule when defaultRules.rules.verrazzanoApplicationOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoClusterOperatorVMCReconcileErrorRate Disable VerrazzanoClusterOperatorVMCReconcileErrorRate rule when defaultRules.rules.verrazzanoClusterOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoClusterOperatorNotReady Disable VerrazzanoClusterOperatorNotReady rule when defaultRules.rules.verrazzanoClusterOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoClusterOperatorWebhookNotReady Disable VerrazzanoClusterOperatorWebhookNotReady rule when defaultRules.rules.verrazzanoClusterOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoClusterOperatorNotRunning Disable VerrazzanoClusterOperatorNotRunning rule when defaultRules.rules.verrazzanoClusterOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoClusterOperatorWebhookNotRunning Disable VerrazzanoClusterOperatorWebhookNotRunning rule when defaultRules.rules.verrazzanoClusterOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoMonitoringOperatorReconcileErrorRate Disable VerrazzanoMonitoringOperatorReconcileErrorRate rule when defaultRules.rules.verrazzanoMonitoringOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoMonitoringOperatorNotReady Disable VerrazzanoMonitoringOperatorNotReady rule when defaultRules.rules.verrazzanoMonitoringOperator is true
+  ## @extra defaultRules.disabled.VerrazzanoMonitoringOperatorNotRunning Disable VerrazzanoMonitoringOperatorNotRunning rule when defaultRules.rules.verrazzanoMonitoringOperator is true
   disabled: {}
   # KubeAPIDown: true
   # NodeRAIDDegraded: true


### PR DESCRIPTION
This PR adds Verrazzano-specific Prometheus rules (alerting and recording). Currently alerting is configured for the following operators: verrazzano-platform-operator, verrazzano-application-operator, verrazzano-cluster-operator, and the verrazzano-monitoring-operator.

The rules are installed via the kube-prometheus-stack helm chart. Rules are only created if the corresponding components are enabled in the Verrazzano custom resource.

I tested rule creation by starting with a "none" profile and then enabled the operators one by one. To test the alerting rules, I scaled down deployments, modified deployments to reference invalid images, and forced resource reconciliations to fail. I observed the pending alerts in Thanos Ruler and verified that alerts are eventually sent to Alertmanager. I also ran some tests with Prometheus (Thanos disabled).

Screenshots of some of the tests:

![Screen Shot 2023-08-09 at 1 27 32 PM](https://github.com/verrazzano/verrazzano/assets/44442080/38527d76-cdf8-486e-9170-a278bf9db8e4)

![Screen Shot 2023-08-10 at 5 34 06 PM](https://github.com/verrazzano/verrazzano/assets/44442080/a94995d7-d1b8-41df-8328-e3b8f04a7839)
