### PR TITLE
VZ-10451 delete helm integration release when module is deleted

### DIFF
--- a/platform-operator/experimental/controllers/module/component-handler/delete/delete_handler.go
+++ b/platform-operator/experimental/controllers/module/component-handler/delete/delete_handler.go
@@ -11,6 +11,7 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/experimental/controllers/module/component-handler/common"
+	"github.com/verrazzano/verrazzano/platform-operator/experimental/event"
 )
 
 type ComponentHandler struct{}
@@ -147,5 +148,11 @@ func (h ComponentHandler) WorkCompletedUpdateStatus(ctx handlerspi.HandlerContex
 	}
 
 	// Update the module status
-	return modulestatus.UpdateReadyConditionSucceeded(ctx, module, moduleapi.ReadyReasonUninstallSucceeded)
+	res = modulestatus.UpdateReadyConditionSucceeded(ctx, module, moduleapi.ReadyReasonUninstallSucceeded)
+	if res.ShouldRequeue() {
+		return res
+	}
+
+	// Create an event requesting that integration be deleted for this module
+	return event.CreateModuleIntegrationEvent(ctx.Log, ctx.Client, module, event.Deleted)
 }

--- a/platform-operator/experimental/controllers/module/component-handler/installupdate/install_update_handler.go
+++ b/platform-operator/experimental/controllers/module/component-handler/installupdate/install_update_handler.go
@@ -89,7 +89,7 @@ func (h ComponentHandler) PreWork(ctx handlerspi.HandlerContext) result.Result {
 
 	// Wait for dependencies
 	if !registry.ComponentDependenciesMet(comp, compCtx) {
-		ctx.Log.Oncef("Component %s is waiting for dependenct components to be installed", comp.Name())
+		ctx.Log.Oncef("Component %s is waiting for dependent components to be installed", comp.Name())
 		return result.NewResultShortRequeueDelayWithError(err)
 	}
 
@@ -190,6 +190,7 @@ func (h ComponentHandler) WorkCompletedUpdateStatus(ctx handlerspi.HandlerContex
 	if res.ShouldRequeue() {
 		return res
 	}
+
 	// Create an event requesting that integration happen for this module
 	return event.CreateModuleIntegrationEvent(ctx.Log, ctx.Client, module, event.Installed)
 }

--- a/platform-operator/experimental/controllers/module/component-handler/upgrade/upgrade_handler.go
+++ b/platform-operator/experimental/controllers/module/component-handler/upgrade/upgrade_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	"github.com/verrazzano/verrazzano/platform-operator/experimental/controllers/module/component-handler/common"
+	"github.com/verrazzano/verrazzano/platform-operator/experimental/event"
 )
 
 type ComponentHandler struct{}
@@ -158,5 +159,11 @@ func (h ComponentHandler) WorkCompletedUpdateStatus(ctx handlerspi.HandlerContex
 	}
 
 	// Update the module status
-	return modulestatus.UpdateReadyConditionSucceeded(ctx, module, moduleapi.ReadyReasonUpgradeSucceeded)
+	res = modulestatus.UpdateReadyConditionSucceeded(ctx, module, moduleapi.ReadyReasonUpgradeSucceeded)
+	if res.ShouldRequeue() {
+		return res
+	}
+
+	// Create an event requesting that integration happen for this module
+	return event.CreateModuleIntegrationEvent(ctx.Log, ctx.Client, module, event.Upgraded)
 }

--- a/platform-operator/experimental/controllers/verrazzano/delete.go
+++ b/platform-operator/experimental/controllers/verrazzano/delete.go
@@ -13,9 +13,9 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -28,7 +28,7 @@ func (r Reconciler) deleteModules(log vzlog.VerrazzanoLogger, effectiveCR *vzapi
 	// If deletion timestamp is non-zero then the VZ CR got deleted
 	fullUninstall := !effectiveCR.GetDeletionTimestamp().IsZero()
 
-	// Delete all modules.  Loop through all the components once even if error occurs.
+	// Delete all modules.  Loop through all the modules once even if error occurs.
 	for _, comp := range registry.GetComponents() {
 		if !comp.ShouldUseModule() {
 			continue
@@ -38,11 +38,20 @@ func (r Reconciler) deleteModules(log vzlog.VerrazzanoLogger, effectiveCR *vzapi
 		if !fullUninstall && comp.IsEnabled(effectiveCR) {
 			continue
 		}
+
+		// Check if the module exists before trying to delete the other related resources
+		module := moduleapi.Module{}
+		nsn := types.NamespacedName{Namespace: comp.Name(), Name: vzconst.VerrazzanoInstallNamespace}
+		err := r.Client.Get(context.TODO(), nsn, &module, &client.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			log.Progressf("Failed to get Module %s, retrying: %v", comp.Name(), err)
+			return result.NewResultShortRequeueDelayIfError(err)
+		}
+
 		moduleCount++
-		module := moduleapi.Module{ObjectMeta: metav1.ObjectMeta{
-			Name:      comp.Name(),
-			Namespace: vzconst.VerrazzanoInstallNamespace,
-		}}
 
 		// Delete all the configuration secrets that were referenced by the module
 		res := r.deleteConfigSecrets(log, module.Namespace, comp.Name())
@@ -56,14 +65,15 @@ func (r Reconciler) deleteModules(log vzlog.VerrazzanoLogger, effectiveCR *vzapi
 			return res
 		}
 
-		err := r.Client.Delete(context.TODO(), &module, &client.DeleteOptions{})
+		// Delete the Module
+		err = r.Client.Delete(context.TODO(), &module, &client.DeleteOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				deletedCount++
 				continue
 			}
 			if !errors.IsConflict(err) {
-				log.Progressf("Failed to delete Component %s, retrying: %v", comp.Name(), err)
+				log.Progressf("Failed to delete Module %s, retrying: %v", comp.Name(), err)
 			}
 			reterr = err
 			continue

--- a/platform-operator/experimental/controllers/verrazzano/delete.go
+++ b/platform-operator/experimental/controllers/verrazzano/delete.go
@@ -41,7 +41,7 @@ func (r Reconciler) deleteModules(log vzlog.VerrazzanoLogger, effectiveCR *vzapi
 
 		// Check if the module exists before trying to delete the other related resources
 		module := moduleapi.Module{}
-		nsn := types.NamespacedName{Namespace: comp.Name(), Name: vzconst.VerrazzanoInstallNamespace}
+		nsn := types.NamespacedName{Namespace: vzconst.VerrazzanoInstallNamespace, Name: comp.Name()}
 		err := r.Client.Get(context.TODO(), nsn, &module, &client.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -87,6 +87,7 @@ func (r Reconciler) deleteModules(log vzlog.VerrazzanoLogger, effectiveCR *vzapi
 	if reterr != nil {
 		return result.NewResultShortRequeueDelayWithError(reterr)
 	}
+
 	// All modules have been deleted and the Module CRs are gone
 	return result.NewResult()
 }


### PR DESCRIPTION
1. Delete helm integration release when module is deleted.  Also, create cascaded event  if needed when delete occurs.
2. Optimize module delete to check if module exists before proceeding.
3. Create event for delete and upgrade in the module handlers.
