### PR TITLE
VZ-1045 pre-install must requeue if error

### DIFF
--- a/platform-operator/experimental/controllers/module/component-handler/installupdate/install_update_handler.go
+++ b/platform-operator/experimental/controllers/module/component-handler/installupdate/install_update_handler.go
@@ -94,8 +94,10 @@ func (h ComponentHandler) PreWork(ctx handlerspi.HandlerContext) result.Result {
 	}
 
 	// Do the pre-install
-	if err := comp.PreInstall(compCtx); err != nil && !vzerrors.IsRetryableError(err) {
-		h.updateReadyConditionStartedOrFailed(ctx, err.Error(), true)
+	if err := comp.PreInstall(compCtx); err != nil {
+		if !vzerrors.IsRetryableError(err) {
+			h.updateReadyConditionStartedOrFailed(ctx, err.Error(), true)
+		}
 		return result.NewResultShortRequeueDelayWithError(err)
 	}
 	h.updateReadyConditionStartedOrFailed(ctx, "", false)


### PR DESCRIPTION
Fix the module component handler to always requeue if there is a pre-install error.  This was causing Jaeger install to fail.