### PR TITLE
VZ-10388: Fix mysql webhook config to make it more restrictive.

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/mutatingWebHookConfiguration.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/mutatingWebHookConfiguration.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -12,7 +12,7 @@ webhooks:
     namespaceSelector:
       matchExpressions:
         - {key: istio-injection, operator: In, values: [enabled]}
-        - {key: verrazzano.io/namespace, operator: NotIn, values: [kube-system]}
+        - {key: verrazzano.io/namespace, operator: NotIn, values: [kube-system, verrazzano-monitoring]}
     clientConfig:
       service:
         name: {{ .Values.name }}-webhook

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/mutatingWebHookConfiguration.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/mutatingWebHookConfiguration.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -12,7 +12,7 @@ webhooks:
     namespaceSelector:
       matchExpressions:
         - {key: istio-injection, operator: In, values: [enabled]}
-        - {key: verrazzano.io/namespace, operator: In, values: [mysql-operator, keycloak]}
+        - {key: verrazzano.io/namespace, operator: NotIn, values: [kube-system, verrazzano-monitoring]}
     clientConfig:
       service:
         name: {{ .Values.name }}-webhook

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/mutatingWebHookConfiguration.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/mutatingWebHookConfiguration.yaml
@@ -12,7 +12,7 @@ webhooks:
     namespaceSelector:
       matchExpressions:
         - {key: istio-injection, operator: In, values: [enabled]}
-        - {key: verrazzano.io/namespace, operator: NotIn, values: [kube-system, verrazzano-monitoring]}
+        - {key: verrazzano.io/namespace, operator: In, values: [mysql-operator, keycloak]}
     clientConfig:
       service:
         name: {{ .Values.name }}-webhook

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/mutatingWebHookConfiguration.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/mutatingWebHookConfiguration.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, Oracle and/or its affiliates.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -12,7 +12,7 @@ webhooks:
     namespaceSelector:
       matchExpressions:
         - {key: istio-injection, operator: In, values: [enabled]}
-        - {key: verrazzano.io/namespace, operator: NotIn, values: [kube-system, verrazzano-monitoring]}
+        - {key: verrazzano.io/namespace, operator: In, values: [mysql-operator, keycloak, verrazzano-system]}
     clientConfig:
       service:
         name: {{ .Values.name }}-webhook


### PR DESCRIPTION
Making the more restrictive to only get triggered by cron jobs that are created by mysql operator, current behavior is any cron job triggers this webhook, and the cron job fails because of some validation inside mysql operator. Currently, jager operator creates a cron job `es-index-cleaner ` to clean the indices periodically, but this tiggers the mysql webhook which shoudn't be the case, this PR fixes that.