### PR TITLE
Scan job optimization 

### DIFF
--- a/release/scripts/get_ocir_scan_results.sh
+++ b/release/scripts/get_ocir_scan_results.sh
@@ -44,7 +44,7 @@ function get_scan_summaries() {
   # TBD: Add filtering here
   # TBD: Need to add more fields here so we can at least have the result OCIDs and may also want times in case there are multiple scan results to differentiate
   # TBD: For multiple scans assuming -u will be mostly a noop here, ie: if we include all fields we wouldn't see any duplicates
-  oci vulnerability-scanning container scan result list --compartment-id $OCIR_COMPARTMENT_ID --region $OCI_REGION --all > $SCAN_RESULTS_DIR/ocir-scan-all-summary.json
+  oci vulnerability-scanning container scan result list --compartment-id $OCIR_COMPARTMENT_ID --region $OCI_REGION --all --is-latest-only true > $SCAN_RESULTS_DIR/ocir-scan-all-summary.json
   cat $SCAN_RESULTS_DIR/ocir-scan-all-summary.json | jq -r '.data.items[] | { finished: ."time-finished", sev: ."highest-problem-severity", full: (.repository + ":" + .image), repo: .repository, image: .image, count: ."problem-count", id: .id } ' | jq -r '[.[]] | @csv' | sort -u > $SCAN_RESULTS_DIR/ocir-scan-all-summary.csv
 }
 


### PR DESCRIPTION
use --is-latest-only true to cut down the results we are fetching to the latest set.

This brings master scan job from taking 12 hours down to 30 minutes and generating the same results
