### PR TITLE
VZ-10576: ingress-nginx-controller image size too large

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -28,7 +28,7 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20230712031907-3ae8a8da4",
+              "tag": "v1.7.1-20230817215350-c8315d559",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -277,7 +277,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20230712031907-3ae8a8da4",
+              "tag": "v1.7.1-20230817215350-c8315d559",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
@@ -332,7 +332,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20230712031907-3ae8a8da4",
+              "tag": "v1.7.1-20230817215350-c8315d559",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -34,7 +34,7 @@
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "v1.7.1-20230712031907-3ae8a8da4",
+              "tag": "v1.7.1-20230817215350-c8315d559",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -610,7 +610,7 @@
             },
             {
               "image": "kube-webhook-certgen",
-              "tag": "v1.7.1-20230712031907-3ae8a8da4",
+              "tag": "v1.7.1-20230817215350-c8315d559",
               "helmRegKey": "prometheusOperator.admissionWebhooks.patch.image.registry",
               "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
               "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"


### PR DESCRIPTION
Ingress-nginx-controller img tag bom update
