### PR TITLE
VZ-10598.  Additional config generation impls for modules integration

### DIFF
--- a/platform-operator/controllers/verrazzano/component/authproxy/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/modules_integration.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package authproxy
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	Ingress                   *v1alpha1.IngressNginxComponent      `json:"ingress,omitempty"`
+	DNS                       *v1alpha1.DNSComponent               `json:"dns,omitempty"`
+	EnvironmentName           string                               `json:"environmentName,omitempty"`
+	Kubernetes                *v1alpha1.AuthProxyKubernetesSection `json:"kubernetes,omitempty"`
+	PrometheusOperatorEnabled bool                                 `json:"prometheusOperatorEnabled"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (c authProxyComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = &v1alpha1.DNSComponent{
+			External:         dns.External,
+			InstallOverrides: v1alpha1.InstallOverrides{}, // always ignore the overrides here, those are handled separately
+			OCI:              dns.OCI,
+			Wildcard:         dns.Wildcard,
+		}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []v1alpha1.Overrides{}
+	}
+
+	authProxy := effectiveCR.Spec.Components.AuthProxy
+	if authProxy.Kubernetes != nil {
+		configSnippet.Kubernetes = authProxy.Kubernetes.DeepCopy()
+	}
+
+	configSnippet.PrometheusOperatorEnabled = vzcr.IsPrometheusOperatorEnabled(effectiveCR)
+
+	if len(effectiveCR.Spec.EnvironmentName) > 0 {
+		configSnippet.EnvironmentName = effectiveCR.Spec.EnvironmentName
+	}
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/authproxy/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/modules_integration_test.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package authproxy
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"testing"
+)
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	ingressClassName := "myclass"
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					Components: vzapi.ComponentSpec{
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"environmentName": "Myenv",
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					},
+					"kubernetes": {
+					  "replicas": 3
+					},
+					"prometheusOperatorEnabled": true
+				  }
+				}
+			  }
+			}`,
+		},
+		{
+			name: "OtherComponentConfigsHaveNoEffect",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					Components: vzapi.ComponentSpec{
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"environmentName": "Myenv",
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					},
+					"kubernetes": {
+					  "replicas": 3
+					},
+					"prometheusOperatorEnabled": true
+				  }
+				}
+			  }
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent().(authProxyComponent)
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/modules_integration.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package webhookoci
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// webhookOCIValuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type webhookOCIValuesConfig struct {
+	OCIConfigSecret          string `json:"ociConfigSecret,omitempty"`
+	ClusterResourceNamespace string `json:"clusterResourceNamespace,omitempty"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON webhookOCIValuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (c certManagerWebhookOCIComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	clusterIssuer := effectiveCR.Spec.Components.ClusterIssuer
+	dns := effectiveCR.Spec.Components.DNS
+
+	var ociConfigSecret string
+	if dns != nil && dns.OCI != nil {
+		ociConfigSecret = dns.OCI.OCIConfigSecret
+	}
+
+	clusterResourceNamespace := constants.CertManagerNamespace
+	if clusterIssuer != nil && len(clusterIssuer.ClusterResourceNamespace) > 0 {
+		clusterResourceNamespace = clusterIssuer.ClusterResourceNamespace
+	}
+
+	configSnippet := webhookOCIValuesConfig{
+		OCIConfigSecret:          ociConfigSecret,
+		ClusterResourceNamespace: clusterResourceNamespace,
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/modules_integration_test.go
@@ -12,6 +12,11 @@ import (
 	"testing"
 )
 
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
 func TestGetModuleSpec(t *testing.T) {
 	trueValue := true
 	const secretName = "ca-secret"

--- a/platform-operator/controllers/verrazzano/component/externaldns/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/externaldns/modules_integration.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package externaldns
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	DNS          *v1alpha1.DNSComponent `json:"dns,omitempty"`
+	IstioEnabled bool                   `json:"istioEnabled"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (c externalDNSComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = &v1alpha1.DNSComponent{
+			External:         dns.External,
+			InstallOverrides: v1alpha1.InstallOverrides{}, // always ignore the overrides here, those are handled separately
+			OCI:              dns.OCI,
+			Wildcard:         dns.Wildcard,
+		}
+	}
+
+	configSnippet.IstioEnabled = vzcr.IsIstioEnabled(effectiveCR)
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/nginx/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/modules_integration.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package nginx
+
+import (
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	Ingress         *v1alpha1.IngressNginxComponent `json:"ingress,omitempty"`
+	DNS             *v1alpha1.DNSComponent          `json:"dns,omitempty"`
+	EnvironmentName string                          `json:"environmentName,omitempty"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (c nginxComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = &v1alpha1.DNSComponent{
+			External:         dns.External,
+			InstallOverrides: v1alpha1.InstallOverrides{}, // always ignore the overrides here, those are handled separately
+			OCI:              dns.OCI,
+			Wildcard:         dns.Wildcard,
+		}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []v1alpha1.Overrides{}
+	}
+
+	if len(effectiveCR.Spec.EnvironmentName) > 0 {
+		configSnippet.EnvironmentName = effectiveCR.Spec.EnvironmentName
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/nginx/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/modules_integration_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package nginx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	ingressClassName := "myclass"
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					Components: vzapi.ComponentSpec{
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"environmentName": "Myenv",
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					}
+				  }
+				}
+			  }
+			}`,
+		},
+		{
+			name: "OtherComponentConfigsHaveNoEffect",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					Components: vzapi.ComponentSpec{
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"environmentName": "Myenv",
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					}
+				  }
+				}
+			  }
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent().(nginxComponent)
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			t.Logf("got: %s", got.Raw)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}


### PR DESCRIPTION
Add GetModuleConfigAsHelmValues impls and unit tests for remaining layer 0 components
- authproxy
- webhook OCI
- external-dns
- nginx

The approach is to map the parts of the Verrazzano CR that are used by each component to an internal (at present unused by the components) Helm value/structure, `verrazzano.module.spec`.  At present these aren't used by the components, but are used to leverage k8s to optimize the reconciles of individual components and only reconcile a module when the parts of the configuration it's interested in have changed.

The mappings do *NOT* generally include the following from the Verrazzano CR:
* The `enabled` flag for the component, as enabled/disabled state is implicit by the existence or deletion of the Module CR
* The `overrides` section for the component, which is mapped directly to the `Module` CR overrides 

This is purely internal at present, and may be thrown away or mapped to new CRs in the future.

External-DNS Mapping

```
	DNS          *v1alpha1.DNSComponent `json:"dns,omitempty"`
	IstioEnabled bool                   `json:"istioEnabled"`
```

Authproxy Mapping

```
	Ingress                   *v1alpha1.IngressNginxComponent      `json:"ingress,omitempty"`
	DNS                       *v1alpha1.DNSComponent               `json:"dns,omitempty"`
	EnvironmentName           string                               `json:"environmentName,omitempty"`
	Kubernetes                *v1alpha1.AuthProxyKubernetesSection `json:"kubernetes,omitempty"`
	PrometheusOperatorEnabled bool                                 `json:"prometheusOperatorEnabled"`
```

Webhook OCI

```
	OCIConfigSecret          string `json:"ociConfigSecret,omitempty"`
	ClusterResourceNamespace string `json:"clusterResourceNamespace,omitempty"`
```

NGINX

```
	Ingress         *v1alpha1.IngressNginxComponent `json:"ingress,omitempty"`
	DNS             *v1alpha1.DNSComponent          `json:"dns,omitempty"`
	EnvironmentName string                          `json:"environmentName,omitempty"`
```

