### PR TITLE
VZ-10702 move VZ owner UID to labels from annotations

### DIFF
--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -113,7 +113,11 @@ func (r Reconciler) mutateModule(log vzlog.VerrazzanoLogger, effectiveCR *vzapi.
 	}
 	module.Annotations[vzconst.VerrazzanoCRNameAnnotation] = effectiveCR.Name
 	module.Annotations[vzconst.VerrazzanoCRNamespaceAnnotation] = effectiveCR.Namespace
-	module.Annotations[vzconst.VerrazzanoOwnerLabel] = string(effectiveCR.UID)
+
+	if module.Labels == nil {
+		module.Labels = make(map[string]string)
+	}
+	module.Labels[vzconst.VerrazzanoOwnerLabel] = string(effectiveCR.UID)
 
 	module.Spec.ModuleName = module.Name
 	module.Spec.TargetNamespace = comp.Namespace()


### PR DESCRIPTION
Previous PR put owner UID in annotations instead of labels.  Use labels since we may want to select using this UID in the future.