### PR TITLE
Backport vmi test fix to 1.6

### DIFF
--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	waitTimeout     = 10 * time.Minute
-	pollingInterval = 5 * time.Second
+	waitTimeout     = 30 * time.Minute
+	pollingInterval = 10 * time.Second
 )
 
 const (

--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -594,7 +594,7 @@ func getExpectedPrometheusReplicaCount(kubeconfig string) (int32, error) {
 
 func ingressEnabled(vz *vzalpha1.Verrazzano) bool {
 	return vzcr.IsComponentStatusEnabled(vz, nginx.ComponentName) &&
-		vzcr.IsComponentStatusEnabled(vz, cmconstants.CertManagerComponentName) &&
+		vzcr.IsComponentStatusEnabled(vz, cmconstants.ClusterIssuerComponentName) &&
 		vzcr.IsComponentStatusEnabled(vz, keycloak.ComponentName)
 }
 


### PR DESCRIPTION
Backport of Fix VMI test ingress check (#6762). This fixes the issue where the vmi suite doesn't run most of the specs.