### PR TITLE
Ensure Jenkinfiles are giving explicit label when pipeline label is n…

### DIFF
--- a/ci/periodic/JenkinsfileDistributions
+++ b/ci/periodic/JenkinsfileDistributions
@@ -4,6 +4,7 @@
 import groovy.transform.Field
 
 @Field def verrazzanoPrefix="verrazzano-"
+def agentLabel = env.JOB_NAME.contains('master') ? "phx-large" : "large"
 
 pipeline {
     options {
@@ -18,6 +19,7 @@ pipeline {
             args "${RUNNER_DOCKER_ARGS}"
             registryUrl "${RUNNER_DOCKER_REGISTRY_URL}"
             registryCredentialsId 'ocir-pull-and-push-account'
+            label "${agentLabel}"
         }
     }
 


### PR DESCRIPTION
Ensure Jenkinfiles are giving explicit label when pipeline label is not desired.

In verrazzano we only had one, in the other repos there are more
