### PR TITLE
Fix bug to tolerate the absence of the VMC caSecret field (#6856)

### DIFF
--- a/application-operator/mcagent/mcagent_cluster_secrets.go
+++ b/application-operator/mcagent/mcagent_cluster_secrets.go
@@ -6,6 +6,7 @@ package mcagent
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/verrazzano/verrazzano/application-operator/constants"
 	clustersapi "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
 	"github.com/verrazzano/verrazzano/pkg/certs"
@@ -169,6 +170,11 @@ func (s *Syncer) syncLocalClusterCA() error {
 	}, &vmc)
 	if err != nil {
 		return err
+	}
+
+	// No CA secret for this managed cluster - nothing to sync.
+	if vmc.Spec.CASecret == "" {
+		return nil
 	}
 
 	vmcCASecret := corev1.Secret{}

--- a/application-operator/mcagent/testdata/no-clusterca-vmc.yaml
+++ b/application-operator/mcagent/testdata/no-clusterca-vmc.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#VerrazzanoManagedCluster with no caSecret specified
+apiVersion: clusters.verrazzano.io
+kind: VerrazzanoManagedCluster
+metadata:
+  name: managed1
+  namespace: verrazzano-mc
+spec:
+  description: managed1-description
+  managedClusterManifestSecret: managed1-manifest-secret
+  serviceAccount: managed1-sa


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
