### PR TITLE
VZ-10616.  New controller must not reconcile if upgrade is required but not active

### DIFF
--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -132,11 +132,11 @@ func (r Reconciler) mutateModule(log vzlog.VerrazzanoLogger, effectiveCR *vzapi.
 	return r.setModuleValues(log, effectiveCR, module, comp)
 }
 
-// isUpgradeRequired Returns true if the Spec version is set but doesn't match what's in the BOM.
-//   - if spec version is empty then it's either an initial install or an update within the same version
-//   - if the Spec version IS NOT empty and matches the BOM, we're either in an upgrade or updating within the same version
-//   - if the Spec version IS empty and does NOT match the BOM, then we have updated the VPO but not yet upgraded, so we should
-//     skip reconciling
+// isUpgradeRequired Returns true if we detect that an upgrade is required but not (at least) in progress:
+//   - if the Spec version IS NOT empty is less than the BOM version, an upgrade is required
+//   - if the Spec version IS empty the Status version is less than the BOM, then an upgrade is required (upgrade of initial install scenario)
+//
+// If we return true here, it means we should stop reconciling until an upgrade has been requested
 func (r Reconciler) isUpgradeRequired(actualCR *vzapi.Verrazzano) (bool, error) {
 	if actualCR == nil {
 		return false, fmt.Errorf("no Verrazzano CR provided")

--- a/platform-operator/experimental/controllers/verrazzano/reconciler_test.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package verrazzano
+
+import (
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	"testing"
+)
+
+func TestIsUpgradePending(t *testing.T) {
+	defaultTestBomFile := "./testdata/test_bom.json"
+
+	tests := []struct {
+		name        string
+		actualCR    *vzapi.Verrazzano
+		testBOMPath string
+		want        bool
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "VerrazzanoCRIsNil",
+			wantErr: assert.Error,
+		},
+		{
+			name: "BothEmpty",
+			actualCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{},
+			},
+		},
+		{
+			name: "UpdateInstall",
+			actualCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{},
+				Status: vzapi.VerrazzanoStatus{
+					Version: "2.0.2",
+				},
+			},
+		},
+		{
+			name: "UpgradeIsPending",
+			actualCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Version: "2.0.1",
+				},
+				Status: vzapi.VerrazzanoStatus{
+					Version: "2.0.1",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "UpgradeInProgress",
+			actualCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Version: "2.0.2",
+				},
+				Status: vzapi.VerrazzanoStatus{
+					Version: "2.0.1",
+				},
+			},
+		},
+		{
+			name: "UpgradeComplete",
+			actualCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Version: "2.0.2",
+				},
+				Status: vzapi.VerrazzanoStatus{
+					Version: "2.0.2",
+				},
+			},
+		},
+		{
+			name: "BOM Error",
+			actualCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{},
+				Status: vzapi.VerrazzanoStatus{
+					Version: "2.0.2",
+				},
+			},
+			testBOMPath: "badpath",
+			wantErr:     assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the test BOM path
+			testBOM := tt.testBOMPath
+			if len(testBOM) == 0 {
+				testBOM = defaultTestBomFile
+			}
+			config.SetDefaultBomFilePath(testBOM)
+			defer func() { config.SetDefaultBomFilePath("") }()
+
+			// Set up the err check assertion
+			wantErr := tt.wantErr
+			if wantErr == nil {
+				wantErr = assert.NoError
+			}
+
+			r := Reconciler{}
+			got, err := r.isUpgradePending(tt.actualCR)
+			if !wantErr(t, err, "Did not get expected error result") {
+				return
+			}
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/platform-operator/experimental/controllers/verrazzano/reconciler_test.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler_test.go
@@ -10,7 +10,12 @@ import (
 	"testing"
 )
 
-func TestIsUpgradePending(t *testing.T) {
+// TestIsUpgradeRequired tests that isUpgradeRequired method tells us when an upgrade is required before we can apply
+// any module updates
+// GIVEN a call to isUpgradeRequired
+// WHEN the Verrazzano spec version is out of sync with the BOM version
+// THEN true is returned
+func TestIsUpgradeRequired(t *testing.T) {
 	defaultTestBomFile := "./testdata/test_bom.json"
 
 	tests := []struct {
@@ -102,7 +107,7 @@ func TestIsUpgradePending(t *testing.T) {
 			}
 
 			r := Reconciler{}
-			got, err := r.isUpgradePending(tt.actualCR)
+			got, err := r.isUpgradeRequired(tt.actualCR)
 			if !wantErr(t, err, "Did not get expected error result") {
 				return
 			}

--- a/platform-operator/experimental/controllers/verrazzano/testdata/test_bom.json
+++ b/platform-operator/experimental/controllers/verrazzano/testdata/test_bom.json
@@ -1,0 +1,4 @@
+{
+  "registry": "ghcr.io",
+  "version": "2.0.2"
+}


### PR DESCRIPTION
Short-circuit reconcile of new controller if an upgrade is required but not yet started.  This is the case where

* The VPO has been updated
* The VZ CR spec has not been set to the version in the updated BOM

An upgrade is deemed required when
* the Spec.Version field is NOT empty and is less than the BOM version
* the Spec.Version field is empty, and the Status.Version is less than the BOM version

