### PR TITLE
Backport VZ-10638: Increase timeout for verify-install/promstack and verify-infra/vmi in alacarte pipeline

### DIFF
--- a/tests/e2e/verify-infra/vmi/vmi_test.go
+++ b/tests/e2e/verify-infra/vmi/vmi_test.go
@@ -111,9 +111,9 @@ var (
 	ingressURLs            map[string]string
 	volumeClaims           map[string]*corev1.PersistentVolumeClaim
 	elastic                *vmi.Opensearch
-	waitTimeout            = 1 * time.Minute
+	waitTimeout            = 15 * time.Minute
 	pollingInterval        = 5 * time.Second
-	elasticWaitTimeout     = 1 * time.Minute
+	elasticWaitTimeout     = 15 * time.Minute
 	elasticPollingInterval = 5 * time.Second
 
 	vzMonitoringVolumeClaims map[string]*corev1.PersistentVolumeClaim

--- a/tests/e2e/verify-install/promstack/promstack_test.go
+++ b/tests/e2e/verify-install/promstack/promstack_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	waitTimeout                     = 3 * time.Minute
+	waitTimeout                     = 15 * time.Minute
 	pollingInterval                 = 10 * time.Second
 	prometheusTLSSecret             = "prometheus-operator-kube-p-admission"
 	prometheusOperatorDeployment    = "prometheus-operator-kube-p-operator"


### PR DESCRIPTION
Backport PR: https://github.com/verrazzano/verrazzano/pull/6839
