### PR TITLE
VZ-10404: Incorporate modules into global pre-post

### DIFF
--- a/pkg/k8s/ready/deployment_ready.go
+++ b/pkg/k8s/ready/deployment_ready.go
@@ -31,7 +31,7 @@ func DeploymentsReadyBySelectors(log vzlog.VerrazzanoLogger, client clipkg.Clien
 		return false
 	}
 	if deploymentList.Items == nil || len(deploymentList.Items) < 1 {
-		logErrorf(log, "%s is waiting for deployments matching selector %s to exist", prefix, opts)
+		logProgressf(log, "%s is waiting for deployments matching selector %s to exist", prefix, opts)
 		return false
 	}
 	for idx := range deploymentList.Items {

--- a/platform-operator/controllers/verrazzano/component/common/watch/watch.go
+++ b/platform-operator/controllers/verrazzano/component/common/watch/watch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/verrazzano/verrazzano-modules/module-operator/controllers/module/status"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
+	vzapiv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -56,5 +57,18 @@ func GetModuleReadyWatches(moduleNames []string) []controllerspi.WatchDescriptor
 		},
 	})
 
+	return watches
+}
+
+// GetVerrazzanoCRWatch watches for any Verrazzano CR update.
+func GetVerrazzanoCRWatch() []controllerspi.WatchDescriptor {
+	// Use a single watch that looks up the name in the set for a match
+	var watches = []controllerspi.WatchDescriptor{}
+	watches = append(watches, controllerspi.WatchDescriptor{
+		WatchedResourceKind: source.Kind{Type: &vzapiv1beta1.Verrazzano{}},
+		FuncShouldReconcile: func(cli client.Client, wev controllerspi.WatchEvent) bool {
+			return wev.WatchEventType == controllerspi.Updated
+		},
+	})
 	return watches
 }

--- a/platform-operator/controllers/verrazzano/component/common/watch/watch.go
+++ b/platform-operator/controllers/verrazzano/component/common/watch/watch.go
@@ -10,7 +10,6 @@ import (
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
 	vzapiv1beta1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -71,9 +70,7 @@ func GetVerrazzanoSpecWatch() []controllerspi.WatchDescriptor {
 			if wev.WatchEventType != controllerspi.Updated {
 				return false
 			}
-			oldSpec := wev.OldWatchedObject.(*vzapiv1beta1.Verrazzano).Spec
-			newSpec := wev.NewWatchedObject.(*vzapiv1beta1.Verrazzano).Spec
-			return reflect.DeepEqual(oldSpec, newSpec)
+			return wev.OldWatchedObject.(*vzapiv1beta1.Verrazzano).Generation != wev.NewWatchedObject.(*vzapiv1beta1.Verrazzano).Generation
 		},
 	})
 	return watches

--- a/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_component.go
+++ b/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_component.go
@@ -25,6 +25,8 @@
 package networkpolicies
 
 import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -131,4 +133,8 @@ func (c networkPoliciesComponent) PreUninstall(ctx spi.ComponentContext) error {
 	}
 
 	return c.HelmComponent.PreUninstall(ctx)
+}
+
+func (c networkPoliciesComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return watch.GetVerrazzanoCRWatch()
 }

--- a/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_component.go
+++ b/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_component.go
@@ -136,5 +136,5 @@ func (c networkPoliciesComponent) PreUninstall(ctx spi.ComponentContext) error {
 }
 
 func (c networkPoliciesComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
-	return watch.GetVerrazzanoCRWatch()
+	return watch.GetVerrazzanoSpecWatch()
 }

--- a/platform-operator/controllers/verrazzano/reconcile/controller_context.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller_context.go
@@ -12,9 +12,20 @@ var vzControllerContext VerrazzanoControllerContext
 // VerrazzanoControllerContext is used to synchronize the two Verrazzano controllers, the legacy controller and
 // the module-based controller.  This will be removed when we finally have a single controller.
 type VerrazzanoControllerContext struct {
+	PreModuleWorkDone           atomic.Bool
 	ModuleCreateOrUpdateStarted atomic.Bool
 	ModuleCreateOrUpdateDone    atomic.Bool
 	ModuleUninstallDone         atomic.Bool
+}
+
+// SetPreModuleWorkDone sets the value of PreModuleWorkDone
+func SetPreModuleWorkDone(val bool) {
+	vzControllerContext.PreModuleWorkDone.Store(val)
+}
+
+// IsPreModuleWorkDone returns the value of PreModuleWorkDone
+func IsPreModuleWorkDone() bool {
+	return vzControllerContext.PreModuleWorkDone.Load()
 }
 
 // SetModuleCreateOrUpdateStarted sets the value of ModuleCreateOrUpdateStarted

--- a/platform-operator/controllers/verrazzano/reconcile/controller_context.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller_context.go
@@ -12,7 +12,29 @@ var vzControllerContext VerrazzanoControllerContext
 // VerrazzanoControllerContext is used to synchronize the two Verrazzano controllers, the legacy controller and
 // the module-based controller.  This will be removed when we finally have a single controller.
 type VerrazzanoControllerContext struct {
-	ModuleUninstallDone atomic.Bool
+	ModuleCreateOrUpdateStarted atomic.Bool
+	ModuleCreateOrUpdateDone    atomic.Bool
+	ModuleUninstallDone         atomic.Bool
+}
+
+// SetModuleCreateOrUpdateStarted sets the value of ModuleCreateOrUpdateStarted
+func SetModuleCreateOrUpdateStarted(val bool) {
+	vzControllerContext.ModuleCreateOrUpdateStarted.Store(val)
+}
+
+// IsModuleCreateOrUpdateStarted returns true if the Module createOrUpdate is started
+func IsModuleCreateOrUpdateStarted() bool {
+	return vzControllerContext.ModuleCreateOrUpdateStarted.Load()
+}
+
+// SetModuleCreateOrUpdateDone sets the value of ModuleCreateOrUpdateDone
+func SetModuleCreateOrUpdateDone(val bool) {
+	vzControllerContext.ModuleCreateOrUpdateDone.Store(val)
+}
+
+// IsModuleCreateOrUpdateDone returns true if the Module createOrUpdate is done
+func IsModuleCreateOrUpdateDone() bool {
+	return vzControllerContext.ModuleCreateOrUpdateDone.Load()
 }
 
 // SetModuleUninstallDone returns true if the Module uninstall is not done

--- a/platform-operator/controllers/verrazzano/reconcile/controller_context.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller_context.go
@@ -12,10 +12,9 @@ var vzControllerContext VerrazzanoControllerContext
 // VerrazzanoControllerContext is used to synchronize the two Verrazzano controllers, the legacy controller and
 // the module-based controller.  This will be removed when we finally have a single controller.
 type VerrazzanoControllerContext struct {
-	PreModuleWorkDone           atomic.Bool
-	ModuleCreateOrUpdateStarted atomic.Bool
-	ModuleCreateOrUpdateDone    atomic.Bool
-	ModuleUninstallDone         atomic.Bool
+	PreModuleWorkDone        atomic.Bool
+	ModuleCreateOrUpdateDone atomic.Bool
+	ModuleUninstallDone      atomic.Bool
 }
 
 // SetPreModuleWorkDone sets the value of PreModuleWorkDone
@@ -26,16 +25,6 @@ func SetPreModuleWorkDone(val bool) {
 // IsPreModuleWorkDone returns the value of PreModuleWorkDone
 func IsPreModuleWorkDone() bool {
 	return vzControllerContext.PreModuleWorkDone.Load()
-}
-
-// SetModuleCreateOrUpdateStarted sets the value of ModuleCreateOrUpdateStarted
-func SetModuleCreateOrUpdateStarted(val bool) {
-	vzControllerContext.ModuleCreateOrUpdateStarted.Store(val)
-}
-
-// IsModuleCreateOrUpdateStarted returns true if the Module createOrUpdate is started
-func IsModuleCreateOrUpdateStarted() bool {
-	return vzControllerContext.ModuleCreateOrUpdateStarted.Load()
 }
 
 // SetModuleCreateOrUpdateDone sets the value of ModuleCreateOrUpdateDone

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -32,9 +32,6 @@ const (
 	// vzStateInstallComponents is the state where the components are being installed
 	vzStateInstallComponents reconcileState = "vzInstallComponents"
 
-	// vzStateWaitModulesReady wait for components installed using Modules to be ready
-	vzStateWaitModulesReady reconcileState = "vzWaitModulesReady"
-
 	// vzStatePostInstall is the global PostInstall state
 	vzStatePostInstall reconcileState = "vzPostInstall"
 
@@ -152,7 +149,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 			if err != nil || res.Requeue {
 				return res, err
 			}
-			tracker.vzState = vzStateWaitModulesReady
+			tracker.vzState = vzStatePostInstall
 
 		case vzStatePostInstall:
 			if !preUpgrade {

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -158,9 +158,11 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 			tracker.vzState = vzStateWaitModulesReady
 
 		case vzStateWaitModulesReady:
-			ready, err := r.modulesReady(spiCtx)
-			if err != nil || !ready {
-				return ctrl.Result{Requeue: true}, err
+			if !preUpgrade {
+				ready, err := r.modulesReady(spiCtx)
+				if err != nil || !ready {
+					return ctrl.Result{Requeue: true}, err
+				}
 			}
 			tracker.vzState = vzStatePostInstall
 

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -178,10 +178,6 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 // checkGenerationUpdated loops through the components and calls checkConfigUpdated on each
 func checkGenerationUpdated(spiCtx spi.ComponentContext) bool {
 	for _, comp := range registry.GetComponents() {
-		if comp.ShouldUseModule() {
-			// Ignore if this component is being handled by a Module
-			continue
-		}
 		if comp.IsEnabled(spiCtx.EffectiveCR()) {
 			componentStatus, ok := spiCtx.ActualCR().Status.Components[comp.Name()]
 			if !ok {

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -138,6 +138,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 			}
 			tracker.vzState = vzStateInstallComponents
 			r.beforeInstallComponents(spiCtx)
+			SetPreModuleWorkDone(true)
 			// since we updated the status, requeue to pick up new changes
 			return ctrl.Result{Requeue: true}, nil
 
@@ -147,13 +148,6 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 				return res, err
 			}
 			tracker.vzState = vzStateWaitModulesReady
-
-		case vzStateWaitModulesReady:
-			res, err := r.waitForModulesReady(spiCtx)
-			if err != nil || res.Requeue {
-				return res, err
-			}
-			tracker.vzState = vzStatePostInstall
 
 		case vzStatePostInstall:
 			if !preUpgrade {

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -5,7 +5,6 @@ package reconcile
 
 import (
 	"fmt"
-
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/argocd"
 
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -149,6 +148,9 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 			if err != nil || res.Requeue {
 				return res, err
 			}
+			if !IsModuleCreateOrUpdateDone() {
+				return newRequeueWithDelay(), nil
+			}
 			tracker.vzState = vzStatePostInstall
 
 		case vzStatePostInstall:
@@ -165,6 +167,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 	}
 
 	deleteInstallTracker(spiCtx.ActualCR())
+	SetPreModuleWorkDone(false)
 	return ctrl.Result{}, nil
 }
 

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -175,6 +175,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 					return ctrl.Result{Requeue: true}, err
 				}
 				SetPreModuleWorkDone(false)
+				SetModuleCreateOrUpdateDone(false)
 			}
 			tracker.vzState = vzStateReconcileEnd
 		}

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -74,10 +74,6 @@ func (r *Reconciler) installComponents(spiCtx spi.ComponentContext, tracker *ins
 	// Loop through all the Verrazzano components and install each one
 	for _, comp := range registry.GetComponents() {
 		if comp.ShouldUseModule() {
-			// Requeue until the module is gone
-			if !IsModuleCreateOrUpdateDone() {
-				requeue = true
-			}
 			// Ignore if this component is being handled by a Module
 			continue
 		}

--- a/platform-operator/controllers/verrazzano/reconcile/install_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_component.go
@@ -74,9 +74,14 @@ func (r *Reconciler) installComponents(spiCtx spi.ComponentContext, tracker *ins
 	// Loop through all the Verrazzano components and install each one
 	for _, comp := range registry.GetComponents() {
 		if comp.ShouldUseModule() {
+			// Requeue until the module is gone
+			if !IsModuleCreateOrUpdateDone() {
+				requeue = true
+			}
 			// Ignore if this component is being handled by a Module
 			continue
 		}
+
 		installContext := tracker.getComponentInstallContext(comp.Name())
 		result, err := r.installSingleComponent(spiCtx, installContext, comp, preUpgrade)
 		if result.Requeue || err != nil {

--- a/platform-operator/controllers/verrazzano/reconcile/status.go
+++ b/platform-operator/controllers/verrazzano/reconcile/status.go
@@ -390,7 +390,7 @@ func (r *Reconciler) modulesReady(ctx spi.ComponentContext) (bool, error) {
 			return false, err
 		}
 
-		if module.Status.Conditions[len(module.Status.Conditions)-1].Type != moduleapi.ModuleConditionReady {
+		if module.Status.Conditions != nil && module.Status.Conditions[len(module.Status.Conditions)-1].Type != moduleapi.ModuleConditionReady {
 			return false, nil
 		}
 		if module.Status.LastSuccessfulGeneration != module.Generation {

--- a/platform-operator/controllers/verrazzano/reconcile/status.go
+++ b/platform-operator/controllers/verrazzano/reconcile/status.go
@@ -370,7 +370,10 @@ func (r *Reconciler) setUninstallCondition(log vzlog.VerrazzanoLogger, vz *insta
 	return r.updateStatus(log, vz, msg, newCondition, nil)
 }
 
-func (r Reconciler) modulesReady(ctx spi.ComponentContext) (bool, error) {
+func (r *Reconciler) modulesReady(ctx spi.ComponentContext) (bool, error) {
+	if !IsModuleCreateOrUpdateDone() {
+		return false, nil
+	}
 	for _, comp := range registry.GetComponents() {
 		if !comp.IsEnabled(ctx.EffectiveCR()) {
 			continue

--- a/platform-operator/controllers/verrazzano/reconcile/status.go
+++ b/platform-operator/controllers/verrazzano/reconcile/status.go
@@ -6,6 +6,9 @@ package reconcile
 import (
 	"context"
 	"fmt"
+	moduleapi "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
@@ -365,4 +368,34 @@ func (r *Reconciler) setUninstallCondition(log vzlog.VerrazzanoLogger, vz *insta
 		}
 	}
 	return r.updateStatus(log, vz, msg, newCondition, nil)
+}
+
+func (r Reconciler) modulesReady(ctx spi.ComponentContext) (bool, error) {
+	for _, comp := range registry.GetComponents() {
+		if !comp.IsEnabled(ctx.EffectiveCR()) {
+			continue
+		}
+		if !comp.ShouldUseModule() {
+			continue
+		}
+
+		module := moduleapi.Module{}
+		nsn := types.NamespacedName{Namespace: vzconst.VerrazzanoInstallNamespace, Name: comp.Name()}
+		err := r.Client.Get(context.TODO(), nsn, &module, &client.GetOptions{})
+		if err != nil {
+			ctx.Log().ErrorfThrottled("Failed to get Module %s, retrying: %v", comp.Name(), err)
+			return false, err
+		}
+
+		if module.Status.Conditions[len(module.Status.Conditions)-1].Type != moduleapi.ModuleConditionReady {
+			return false, nil
+		}
+		if module.Status.LastSuccessfulGeneration != module.Generation {
+			return false, nil
+		}
+		if module.Status.LastSuccessfulVersion != module.Spec.Version {
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall.go
@@ -141,6 +141,7 @@ func (r *Reconciler) reconcileUninstall(log vzlog.VerrazzanoLogger, cr *installv
 			if err := r.deleteMCResources(spiCtx); err != nil {
 				return ctrl.Result{}, err
 			}
+			SetPreModuleWorkDone(true)
 			tracker.vzState = vzStateUninstallComponents
 
 		case vzStateUninstallComponents:
@@ -167,6 +168,7 @@ func (r *Reconciler) reconcileUninstall(log vzlog.VerrazzanoLogger, cr *installv
 			tracker.vzState = vzStateUninstallEnd
 
 		case vzStateUninstallEnd:
+			SetPreModuleWorkDone(false)
 			done = true
 		}
 	}

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade.go
@@ -178,6 +178,7 @@ func (r *Reconciler) reconcileUpgrade(log vzlog.VerrazzanoLogger, cr *installv1a
 			// Upgrade completely done
 			deleteUpgradeTracker(cr)
 			SetPreModuleWorkDone(false)
+			SetModuleCreateOrUpdateDone(false)
 		}
 	}
 	// Upgrade done, no need to requeue

--- a/platform-operator/experimental/catalog/catalog.yaml
+++ b/platform-operator/experimental/catalog/catalog.yaml
@@ -35,9 +35,9 @@ modules:
   - name: verrazzano-application-operator
     version: 2.0.0
   - name: weblogic-operator
-    version: 4.1.0
+    version: 4.1.0-1
   - name: coherence-operator
-    version: 3.2.11
+    version: 3.2.11-1
   - name: fluent-operator
     version: 2.2.0
   - name: fluentbit-opensearch-output

--- a/platform-operator/experimental/controllers/module/component-handler/migration/migration.go
+++ b/platform-operator/experimental/controllers/module/component-handler/migration/migration.go
@@ -62,5 +62,5 @@ func (h migrationHandler) UpdateStatusIfAlreadyInstalled(ctx handlerspi.HandlerC
 	}
 
 	// Set the module status condition, installed generation and installed version
-	return modulestatus.UpdateModuleStatusToInstalled(ctx, module, vzcr.Status.Version, compStatus.LastReconciledGeneration)
+	return modulestatus.UpdateModuleStatusToInstalled(ctx, module, vzcr.Status.Version, 0)
 }

--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -63,7 +63,7 @@ func (r Reconciler) Reconcile(spictx controllerspi.ReconcileContext, u *unstruct
 		return result.NewResultShortRequeueDelay()
 	}
 
-	vzReconcile.SetModuleCreateOrUpdateStarted(true)
+	vzReconcile.SetModuleCreateOrUpdateDone(true)
 
 	// All the modules have been reconciled and are ready
 	return result.NewResult()

--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/result"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"github.com/verrazzano/verrazzano/pkg/semver"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
@@ -22,8 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -58,125 +55,73 @@ func (r Reconciler) Reconcile(spictx controllerspi.ReconcileContext, u *unstruct
 	// VZ components can be installed, updated, upgraded, or uninstalled independently
 	// Process all the components and only requeue are the end, so that operations
 	// (like uninstall) are not blocked by a different component's failure
-	res1 := r.deleteModules(log, effectiveCR)
-	res2 := r.reconcileModules(log, effectiveCR)
+	res1 := r.createOrUpdateModules(log, effectiveCR)
+	res2 := r.deleteModules(log, effectiveCR)
 
 	// Requeue if any of the previous operations indicate a requeue is needed
 	if res1.ShouldRequeue() || res2.ShouldRequeue() {
 		return result.NewResultShortRequeueDelay()
 	}
 
-	vzReconcile.SetModuleCreateOrUpdateStarted(false)
-	vzReconcile.SetModuleCreateOrUpdateDone(true)
+	vzReconcile.SetModuleCreateOrUpdateStarted(true)
 
 	// All the modules have been reconciled and are ready
 	return result.NewResult()
 }
 
-// reconcileModules creates or updates all the modules
-func (r Reconciler) reconcileModules(log vzlog.VerrazzanoLogger, effectiveCR *vzapi.Verrazzano) result.Result {
-	// if modules are not reconciling yet, then createOrUpdate them
-	if !vzReconcile.IsModuleCreateOrUpdateStarted() {
-		catalog, err := moduleCatalog.NewCatalog(config.GetCatalogPath())
-		if err != nil {
-			log.ErrorfThrottled("Error loading module catalog: %v", err)
+// createOrUpdateModules creates or updates all the modules
+func (r Reconciler) createOrUpdateModules(log vzlog.VerrazzanoLogger, effectiveCR *vzapi.Verrazzano) result.Result {
+	catalog, err := moduleCatalog.NewCatalog(config.GetCatalogPath())
+	if err != nil {
+		log.ErrorfThrottled("Error loading module catalog: %v", err)
+		return result.NewResultShortRequeueDelayWithError(err)
+	}
+
+	// Create or Update a Module for each enabled resource
+	for _, comp := range registry.GetComponents() {
+		if !comp.IsEnabled(effectiveCR) {
+			continue
+		}
+		if !comp.ShouldUseModule() {
+			continue
+		}
+
+		version := catalog.GetVersion(comp.Name())
+		if version == nil {
+			err = log.ErrorfThrottledNewErr("Failed to find version for module %s in the module catalog", comp.Name())
 			return result.NewResultShortRequeueDelayWithError(err)
 		}
 
-		// Create or Update a Module for each enabled resource
-		for _, comp := range registry.GetComponents() {
-			if err = r.mutateModule(log, effectiveCR, comp, catalog.GetVersion(comp.Name())); err != nil {
-				return result.NewResultShortRequeueDelayWithError(err)
-			}
+		module := moduleapi.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      comp.Name(),
+				Namespace: vzconst.VerrazzanoInstallNamespace,
+			},
 		}
-		vzReconcile.SetModuleCreateOrUpdateStarted(true)
-		return result.NewResultShortRequeueDelay()
-	}
-
-	// if modules are reconciling see if they are all ready
-	if !vzReconcile.IsModuleCreateOrUpdateDone() {
-		for _, comp := range registry.GetComponents() {
-			ready, err := r.modulesReady(log, effectiveCR, comp)
-			if err != nil {
-				return result.NewResultShortRequeueDelayWithError(err)
+		_, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, &module, func() error {
+			return r.mutateModule(log, effectiveCR, &module, comp, version.ToString())
+		})
+		if err != nil {
+			if !errors.IsConflict(err) {
+				log.ErrorfThrottled("Failed createOrUpdate module %s: %v", module.Name, err)
 			}
-			if !ready {
-				return result.NewResultShortRequeueDelay()
-			}
+			return result.NewResultShortRequeueDelayWithError(err)
 		}
-		vzReconcile.SetModuleCreateOrUpdateDone(true)
 	}
 	return result.NewResult()
 }
 
 // mutateModule mutates the module for the create or update callback
-func (r Reconciler) mutateModule(log vzlog.VerrazzanoLogger, effectiveCR *vzapi.Verrazzano, comp componentspi.Component, moduleVersion *semver.SemVersion) error {
-	if !comp.IsEnabled(effectiveCR) {
-		return nil
+func (r Reconciler) mutateModule(log vzlog.VerrazzanoLogger, effectiveCR *vzapi.Verrazzano, module *moduleapi.Module, comp componentspi.Component, moduleVersion string) error {
+	if module.Annotations == nil {
+		module.Annotations = make(map[string]string)
 	}
-	if !comp.ShouldUseModule() {
-		return nil
-	}
+	module.Annotations[vzconst.VerrazzanoCRNameAnnotation] = effectiveCR.Name
+	module.Annotations[vzconst.VerrazzanoCRNamespaceAnnotation] = effectiveCR.Namespace
 
-	if moduleVersion == nil {
-		return log.ErrorfThrottledNewErr("Failed to find version for module %s in the module catalog", comp.Name())
-	}
+	module.Spec.ModuleName = module.Name
+	module.Spec.TargetNamespace = comp.Namespace()
+	module.Spec.Version = moduleVersion
 
-	module := moduleapi.Module{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      comp.Name(),
-			Namespace: vzconst.VerrazzanoInstallNamespace,
-		},
-	}
-	_, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, &module, func() error {
-		if module.Annotations == nil {
-			module.Annotations = make(map[string]string)
-		}
-		module.Annotations[vzconst.VerrazzanoCRNameAnnotation] = effectiveCR.Name
-		module.Annotations[vzconst.VerrazzanoCRNamespaceAnnotation] = effectiveCR.Namespace
-
-		module.Spec.ModuleName = module.Name
-		module.Spec.TargetNamespace = comp.Namespace()
-		module.Spec.Version = moduleVersion.ToString()
-
-		return r.setModuleValues(log, effectiveCR, &module, comp)
-	})
-	if err != nil {
-		if !errors.IsConflict(err) {
-			log.ErrorfThrottled("Failed createOrUpdate module %s: %v", module.Name, err)
-		}
-		return err
-	}
-	return nil
-}
-
-func (r Reconciler) modulesReady(log vzlog.VerrazzanoLogger, effectiveCR *vzapi.Verrazzano, comp componentspi.Component) (bool, error) {
-	if !comp.IsEnabled(effectiveCR) {
-		return true, nil
-	}
-	if !comp.ShouldUseModule() {
-		return true, nil
-	}
-
-	readyCondition := false
-	generationEqual := false
-	versionEqual := false
-	module := moduleapi.Module{}
-	nsn := types.NamespacedName{Namespace: vzconst.VerrazzanoInstallNamespace, Name: comp.Name()}
-	err := r.Client.Get(context.TODO(), nsn, &module, &client.GetOptions{})
-	if err != nil {
-		log.ErrorfThrottled("Failed to get Module %s, retrying: %v", comp.Name(), err)
-		return false, err
-	}
-
-	if module.Status.Conditions[len(module.Status.Conditions)-1].Type == moduleapi.ModuleConditionReady {
-		readyCondition = true
-	}
-	if module.Status.LastSuccessfulGeneration == module.Generation {
-		generationEqual = true
-	}
-	if module.Status.LastSuccessfulVersion == module.Spec.Version {
-		versionEqual = true
-	}
-	return readyCondition && generationEqual && versionEqual, nil
+	return r.setModuleValues(log, effectiveCR, module, comp)
 }

--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -29,6 +29,9 @@ import (
 
 // Reconcile reconciles the Verrazzano CR
 func (r Reconciler) Reconcile(spictx controllerspi.ReconcileContext, u *unstructured.Unstructured) result.Result {
+	if !vzReconcile.IsPreModuleWorkDone() {
+		return result.NewResultShortRequeueDelay()
+	}
 	actualCR := &vzapi.Verrazzano{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, actualCR); err != nil {
 		spictx.Log.ErrorfThrottled(err.Error())
@@ -64,7 +67,7 @@ func (r Reconciler) Reconcile(spictx controllerspi.ReconcileContext, u *unstruct
 	}
 
 	vzReconcile.SetModuleCreateOrUpdateStarted(false)
-	vzReconcile.SetModuleCreateOrUpdateDone(false)
+	vzReconcile.SetModuleCreateOrUpdateDone(true)
 
 	// All the modules have been reconciled and are ready
 	return result.NewResult()


### PR DESCRIPTION
This change creates global atomics that synchronize the new experimental verrazzano controller and the legacy verrazzano controller to facilitate module install and upgrade.