### PR TITLE
VZ-10627 Create a local API proxy

### DIFF
--- a/authproxy/Makefile
+++ b/authproxy/Makefile
@@ -42,6 +42,8 @@ ifndef RELEASE_BRANCH
 	RELEASE_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 endif
 
+VZ_BASE_IMAGE ?= ghcr.io/verrazzano/verrazzano-base:v1.0.0-20230327155846-4653b27
+
 DIST_DIR:=dist
 GO ?= CGO_ENABLED=0 GO111MODULE=on GOPRIVATE=github.com/verrazzano go
 GO_LDFLAGS ?= -extldflags -static -X main.buildVersion=${BUILDVERSION} -X main.buildDate=${BUILDDATE}

--- a/authproxy/main.go
+++ b/authproxy/main.go
@@ -23,7 +23,7 @@ func main() {
 	log := zap.S()
 
 	authproxy := proxy.InitializeProxy()
-	err := proxy.ConfigureKubernetesAPIProxy(authproxy, log)
+	err := proxy.ConfigureKubernetesAPIProxy(authproxy, kubeconfig, log)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/authproxy/main.go
+++ b/authproxy/main.go
@@ -14,16 +14,12 @@ import (
 	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-var (
-	kubeconfig string
-)
-
 func main() {
 	handleFlags()
 	log := zap.S()
 
 	authproxy := proxy.InitializeProxy()
-	err := proxy.ConfigureKubernetesAPIProxy(authproxy, kubeconfig, log)
+	err := proxy.ConfigureKubernetesAPIProxy(authproxy, log)
 	if err != nil {
 		os.Exit(1)
 	}
@@ -37,8 +33,6 @@ func main() {
 
 // handleFlags sets up the CLI flags, parses them, and initializes loggers
 func handleFlags() {
-	flag.StringVar(&kubeconfig, "kubeconfig-path", "", "Kubeconfig path for the Verrazzano Authproxy cluster.")
-
 	opts := kzap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/authproxy/main.go
+++ b/authproxy/main.go
@@ -37,7 +37,7 @@ func main() {
 
 // handleFlags sets up the CLI flags, parses them, and initializes loggers
 func handleFlags() {
-	flag.StringVar(&kubeconfig, "kubeconfig", "", "Kubeconfig path for the Verrazzano Authproxy cluster.")
+	flag.StringVar(&kubeconfig, "kubeconfig-path", "", "Kubeconfig path for the Verrazzano Authproxy cluster.")
 
 	opts := kzap.Options{}
 	opts.BindFlags(flag.CommandLine)

--- a/authproxy/main.go
+++ b/authproxy/main.go
@@ -3,8 +3,47 @@
 
 package main
 
-import "os"
+import (
+	"flag"
+	"os"
+
+	"github.com/verrazzano/verrazzano/authproxy/src/proxy"
+	vzlog "github.com/verrazzano/verrazzano/pkg/log"
+	"go.uber.org/zap"
+	ctrl "sigs.k8s.io/controller-runtime"
+	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	caCertPath string
+)
 
 func main() {
+	handleFlags()
+	log := zap.S()
+
+	authproxy := proxy.InitializeProxy()
+	err := proxy.ConfigureKubernetesAPIProxy(authproxy, caCertPath, log)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	err = authproxy.ListenAndServe()
+	if err != nil {
+		os.Exit(1)
+	}
 	os.Exit(0)
+}
+
+// handleFlags sets up the CLI flags, parses them, and initializes loggers
+func handleFlags() {
+	flag.StringVar(&caCertPath, "ca-cert-path", "/etc/kubernetes/pki/ca.crt", "The path of the trusted CA Cert chain for the Kubernetes API server.")
+
+	opts := kzap.Options{}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	kzap.UseFlagOptions(&opts)
+	vzlog.InitLogs(opts)
+	ctrl.SetLogger(kzap.New(kzap.UseFlagOptions(&opts)))
 }

--- a/authproxy/main.go
+++ b/authproxy/main.go
@@ -14,16 +14,12 @@ import (
 	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-var (
-	caCertPath string
-)
-
 func main() {
 	handleFlags()
 	log := zap.S()
 
 	authproxy := proxy.InitializeProxy()
-	err := proxy.ConfigureKubernetesAPIProxy(authproxy, caCertPath, log)
+	err := proxy.ConfigureKubernetesAPIProxy(authproxy, log)
 	if err != nil {
 		os.Exit(1)
 	}
@@ -37,8 +33,6 @@ func main() {
 
 // handleFlags sets up the CLI flags, parses them, and initializes loggers
 func handleFlags() {
-	flag.StringVar(&caCertPath, "ca-cert-path", "/etc/kubernetes/pki/ca.crt", "The path of the trusted CA Cert chain for the Kubernetes API server.")
-
 	opts := kzap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/authproxy/main.go
+++ b/authproxy/main.go
@@ -14,6 +14,10 @@ import (
 	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+var (
+	kubeconfig string
+)
+
 func main() {
 	handleFlags()
 	log := zap.S()
@@ -33,6 +37,8 @@ func main() {
 
 // handleFlags sets up the CLI flags, parses them, and initializes loggers
 func handleFlags() {
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "Kubeconfig path for the Verrazzano Authproxy cluster.")
+
 	opts := kzap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/authproxy/main.go
+++ b/authproxy/main.go
@@ -18,17 +18,20 @@ func main() {
 	handleFlags()
 	log := zap.S()
 
+	log.Info("Initializing the proxy server")
 	authproxy := proxy.InitializeProxy()
+
+	log.Info("Configuring the proxy Kubernetes API client")
 	err := proxy.ConfigureKubernetesAPIProxy(authproxy, log)
 	if err != nil {
 		os.Exit(1)
 	}
 
+	log.Info("Starting up proxy server to listen for requests")
 	err = authproxy.ListenAndServe()
 	if err != nil {
 		os.Exit(1)
 	}
-	os.Exit(0)
 }
 
 // handleFlags sets up the CLI flags, parses them, and initializes loggers

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"go.uber.org/zap"
 )
 
 const (

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
+	"go.uber.org/zap"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	localClusterPrefix = "/clusters/local"
+
+	kubernetesAPIServiceHostname = "kubernetes.default.svc.cluster.local"
+)
+
+type AuthProxy struct {
+	http.Server
+}
+
+type Handler struct {
+	Client *http.Client
+	Log    *zap.SugaredLogger
+}
+
+func InitializeProxy() *AuthProxy {
+	return &AuthProxy{
+		Server: http.Server{
+			Addr:         ":8777",
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		},
+	}
+}
+
+func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, path string, log *zap.SugaredLogger) error {
+	caCertData, err := os.ReadFile(path)
+	if err != nil {
+		log.Errorf("Failed to read given CA Cert file %s: %v", path, err)
+		return err
+	}
+
+	transport := http.DefaultTransport
+	transport.(*http.Transport).TLSClientConfig = &tls.Config{
+		RootCAs:    common.CertPool(caCertData),
+		ServerName: kubernetesAPIServiceHostname,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	authproxy.Handler = Handler{
+		Client: &http.Client{
+			Timeout:   5 * time.Minute,
+			Transport: transport,
+		},
+		Log: log,
+	}
+	return nil
+}
+
+func (h Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	h.Log.Debug("Incoming request: %+v", req)
+	err := validateRequest(req)
+	if err != nil {
+		h.Log.Infof("Failed to validate request: %s", err.Error())
+		return
+	}
+
+	reformattedReq, err := h.reformatAPIRequest(req)
+	if err != nil {
+		return
+	}
+	h.Log.Debug("Outgoing request: %+v", reformattedReq)
+
+	resp, err := h.Client.Do(reformattedReq)
+	if err != nil {
+		h.Log.Errorf("Failed to send request: %v", err)
+		return
+	}
+	if resp == nil {
+		h.Log.Errorf("Empty response from server: %v", err)
+		return
+	}
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			h.Log.Errorf("Failed to close response body: %v", err)
+		}
+	}()
+
+	_, err = io.Copy(rw, resp.Body)
+	if err != nil {
+		h.Log.Errorf("Failed to send request: %v", err)
+	}
+}
+
+func (h Handler) reformatAPIRequest(req *http.Request) (*http.Request, error) {
+	formattedReq := req.Clone(context.TODO())
+	formattedReq.Host = kubernetesAPIServiceHostname
+	formattedReq.RequestURI = ""
+
+	path := strings.Replace(req.URL.Path, localClusterPrefix, "", 1)
+	formattedURL, err := url.Parse(fmt.Sprintf("%s%s", kubernetesAPIServiceHostname, path))
+	if err != nil {
+		h.Log.Errorf("Failed to format incoming url: %v", err)
+		return nil, err
+	}
+	formattedReq.URL = formattedURL
+
+	return formattedReq, nil
+}
+
+func validateRequest(req *http.Request) error {
+	if !strings.HasPrefix(req.URL.String(), localClusterPrefix) {
+		return fmt.Errorf("request url: '%v' does not have cluster path", req.URL)
+	}
+	return nil
+}

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"go.uber.org/zap"
 	"io"
-	"k8s.io/client-go/tools/clientcmd"
 	"net/http"
 	"net/url"
 	"strings"
@@ -42,8 +42,8 @@ func InitializeProxy() *AuthProxy {
 	}
 }
 
-func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, kubeconfig string, log *zap.SugaredLogger) error {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, log *zap.SugaredLogger) error {
+	config, err := k8sutil.GetConfigFromController()
 	if err != nil {
 		log.Errorf("Failed to get Kubeconfig for the proxy: %v", err)
 	}

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -121,7 +121,7 @@ func (h Handler) reformatAPIRequest(req *http.Request) (*http.Request, error) {
 		h.Log.Errorf("Failed to format request path for path %s: %v", path, err)
 	}
 
-	formattedURL, err := url.Parse(fmt.Sprintf("https://%s", newReq))
+	formattedURL, err := url.Parse(newReq)
 	if err != nil {
 		h.Log.Errorf("Failed to format incoming url: %v", err)
 		return nil, err

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -8,12 +8,10 @@ import (
 	"crypto/tls"
 	"fmt"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 )
@@ -51,18 +49,9 @@ func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, log *zap.SugaredLogger) e
 		return err
 	}
 
-	caData := config.CAData
-	if len(caData) < 1 {
-		caData, err = os.ReadFile("/etc/ssl/certs/ca-bundle.crt")
-	}
-
-	log.Infof("CA Data: %s", caData)
-
 	transport := http.DefaultTransport
 	transport.(*http.Transport).TLSClientConfig = &tls.Config{
-		RootCAs:    common.CertPool(config.CAData),
-		ServerName: kubernetesAPIServerHostname,
-		MinVersion: tls.VersionTLS12,
+		InsecureSkipVerify: true,
 	}
 
 	authproxy.Handler = Handler{

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -140,7 +140,7 @@ func (h Handler) reformatAPIRequest(req *http.Request) (*http.Request, error) {
 // validateRequest performs request validation before the request is processed
 func validateRequest(req *http.Request) error {
 	if !strings.HasPrefix(req.URL.Path, localClusterPrefix) {
-		return fmt.Errorf("request url: '%v' does not have cluster path", req.URL)
+		return fmt.Errorf("request path: '%v' does not have expected cluster path, i.e. '/clusters/local/api/v1'", req.URL.Path)
 	}
 	return nil
 }

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -20,7 +20,7 @@ import (
 const (
 	localClusterPrefix = "/clusters/local"
 
-	kubernetesAPIServerHostname = "https://kubernetes.default.svc.cluster.local"
+	kubernetesAPIServerHostname = "kubernetes.default.svc.cluster.local"
 )
 
 type AuthProxy struct {
@@ -113,7 +113,7 @@ func (h Handler) reformatAPIRequest(req *http.Request) (*http.Request, error) {
 		h.Log.Errorf("Failed to format request path for path %s: %v", path, err)
 	}
 
-	formattedURL, err := url.Parse(newReq)
+	formattedURL, err := url.Parse(fmt.Sprintf("https://%s", newReq))
 	if err != nil {
 		h.Log.Errorf("Failed to format incoming url: %v", err)
 		return nil, err

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -56,6 +56,8 @@ func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, log *zap.SugaredLogger) e
 		caData, err = os.ReadFile("/etc/ssl/certs/ca-bundle.crt")
 	}
 
+	log.Infof("CA Data: %s", caData)
+
 	transport := http.DefaultTransport
 	transport.(*http.Transport).TLSClientConfig = &tls.Config{
 		RootCAs:    common.CertPool(config.CAData),
@@ -119,6 +121,7 @@ func (h Handler) reformatAPIRequest(req *http.Request) (*http.Request, error) {
 	newReq, err := url.JoinPath(h.URL, path)
 	if err != nil {
 		h.Log.Errorf("Failed to format request path for path %s: %v", path, err)
+		return nil, err
 	}
 
 	formattedURL, err := url.Parse(newReq)

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -20,7 +20,7 @@ import (
 const (
 	localClusterPrefix = "/clusters/local"
 
-	kubernetesAPIServerHostname = "kubernetes.default.svc.cluster.local"
+	kubernetesAPIServerHostname = "https://kubernetes.default.svc.cluster.local"
 )
 
 type AuthProxy struct {

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"go.uber.org/zap"
 	"io"
+	"k8s.io/client-go/tools/clientcmd"
 	"net/http"
 	"net/url"
 	"strings"
@@ -42,8 +42,8 @@ func InitializeProxy() *AuthProxy {
 	}
 }
 
-func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, log *zap.SugaredLogger) error {
-	config, err := k8sutil.GetKubeConfig()
+func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, kubeconfig string, log *zap.SugaredLogger) error {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		log.Errorf("Failed to get Kubeconfig for the proxy: %v", err)
 	}

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -60,7 +60,7 @@ func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, log *zap.SugaredLogger) e
 
 	transport := http.DefaultTransport
 	transport.(*http.Transport).TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: true, //nolint:gosec //#gosec G101
 	}
 
 	authproxy.Handler = Handler{

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 )
@@ -42,16 +42,15 @@ func InitializeProxy() *AuthProxy {
 	}
 }
 
-func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, path string, log *zap.SugaredLogger) error {
-	caCertData, err := os.ReadFile(path)
+func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, log *zap.SugaredLogger) error {
+	config, err := k8sutil.GetKubeConfig()
 	if err != nil {
-		log.Errorf("Failed to read given CA Cert file %s: %v", path, err)
-		return err
+		log.Errorf("Failed to get Kubeconfig for the proxy: %v", err)
 	}
 
 	transport := http.DefaultTransport
 	transport.(*http.Transport).TLSClientConfig = &tls.Config{
-		RootCAs:    common.CertPool(caCertData),
+		RootCAs:    common.CertPool(config.CAData),
 		ServerName: kubernetesAPIServiceHostname,
 		MinVersion: tls.VersionTLS12,
 	}

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -49,6 +49,8 @@ func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, log *zap.SugaredLogger) e
 		return err
 	}
 
+	log.Infof("CA Data: %s", config.CAData)
+
 	transport := http.DefaultTransport
 	transport.(*http.Transport).TLSClientConfig = &tls.Config{
 		RootCAs:    common.CertPool(config.CAData),

--- a/authproxy/src/proxy/proxy_test.go
+++ b/authproxy/src/proxy/proxy_test.go
@@ -64,15 +64,17 @@ func TestServeHTTP(t *testing.T) {
 }
 
 // TestReformatAPIRequest tests the reformatting of the request to be sent to the API server
-// GIVEN a request to the Auth proxy server
-// WHEN  the request is formatted correctly
-// THEN  the request is properly formatted to be sent to the API server
+
 func TestReformatAPIRequest(t *testing.T) {
 	handler := Handler{
 		URL:    "https://api-server.io",
 		Client: &http.Client{},
 		Log:    zap.S(),
 	}
+
+	// GIVEN a request to the Auth proxy server
+	// WHEN  the request is formatted correctly
+	// THEN  the request is properly formatted to be sent to the API server
 	url := fmt.Sprintf("https://authproxy.io/clusters/local%s", apiPath)
 	req, err := http.NewRequest(http.MethodGet, url, strings.NewReader(""))
 	assert.NoError(t, err)
@@ -80,6 +82,18 @@ func TestReformatAPIRequest(t *testing.T) {
 	formattedReq, err := handler.reformatAPIRequest(req)
 	assert.NoError(t, err)
 	expectedURL := fmt.Sprintf("%s%s", handler.URL, apiPath)
+	assert.Equal(t, expectedURL, formattedReq.URL.String())
+
+	// GIVEN a request to the Auth proxy server
+	// WHEN  the request is malformed
+	// THEN  a malformed request is returned
+	url = "malformed-request1234"
+	req, err = http.NewRequest(http.MethodGet, url, strings.NewReader(""))
+	assert.NoError(t, err)
+
+	formattedReq, err = handler.reformatAPIRequest(req)
+	assert.NoError(t, err)
+	expectedURL = fmt.Sprintf("%s/%s", handler.URL, url)
 	assert.Equal(t, expectedURL, formattedReq.URL.String())
 }
 

--- a/authproxy/src/proxy/proxy_test.go
+++ b/authproxy/src/proxy/proxy_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package proxy
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"go.uber.org/zap"
+	"io"
+	"k8s.io/client-go/rest"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const apiPath = "/api/v1/pods"
+
+// TestConfigureKubernetesAPIProxy tests the configuration of the API proxy
+// GIVEN an Auth proxy object
+// WHEN  the Kubernetes API proxy is configured
+// THEN  the handler exists and there is no error
+func TestConfigureKubernetesAPIProxy(t *testing.T) {
+	authproxy := InitializeProxy()
+	log := zap.S()
+
+	getConfigFunc = testConfig
+	defer func() { getConfigFunc = k8sutil.GetConfigFromController }()
+
+	err := ConfigureKubernetesAPIProxy(authproxy, log)
+	assert.NoError(t, err)
+	assert.NotNil(t, authproxy.Handler)
+}
+
+// TestServeHTTP tests the proxy server forwarding requests
+// GIVEN a request to the Auth proxy server
+// WHEN  the request is formatted correctly
+// THEN  the request is properly forwarded to the API server
+func TestServeHTTP(t *testing.T) {
+	testBody := "test-body"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NotNil(t, r)
+		assert.Equal(t, apiPath, r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, testBody, string(body))
+	}))
+	defer server.Close()
+
+	handler := Handler{
+		URL:    server.URL,
+		Client: &http.Client{},
+		Log:    zap.S(),
+	}
+
+	url := fmt.Sprintf("https://authproxy.io/clusters/local%s", apiPath)
+	r := httptest.NewRequest(http.MethodPost, url, strings.NewReader(testBody))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+}
+
+// TestReformatAPIRequest tests the reformatting of the request to be sent to the API server
+// GIVEN a request to the Auth proxy server
+// WHEN  the request is formatted correctly
+// THEN  the request is properly formatted to be sent to the API server
+func TestReformatAPIRequest(t *testing.T) {
+	handler := Handler{
+		URL:    "https://api-server.io",
+		Client: &http.Client{},
+		Log:    zap.S(),
+	}
+	url := fmt.Sprintf("https://authproxy.io/clusters/local%s", apiPath)
+	req, err := http.NewRequest(http.MethodGet, url, strings.NewReader(""))
+	assert.NoError(t, err)
+
+	formattedReq, err := handler.reformatAPIRequest(req)
+	assert.NoError(t, err)
+	expectedURL := fmt.Sprintf("%s%s", handler.URL, apiPath)
+	assert.Equal(t, expectedURL, formattedReq.URL.String())
+}
+
+// TestValidateRequest tests the request validation for the Auth Proxy
+func TestValidateRequest(t *testing.T) {
+	// GIVEN a request without the cluster path
+	// WHEN  the request is validated
+	// THEN  an error is returned
+	url := fmt.Sprintf("https://authproxy.io/%s", apiPath)
+	req, err := http.NewRequest(http.MethodGet, url, strings.NewReader(""))
+	assert.NoError(t, err)
+	err = validateRequest(req)
+	assert.Error(t, err)
+
+	// GIVEN a request with the cluster path
+	// WHEN  the request is validated
+	// THEN  no error is returned
+	url = fmt.Sprintf("https://authproxy.io/clusters/local%s", apiPath)
+	req, err = http.NewRequest(http.MethodGet, url, strings.NewReader(""))
+	assert.NoError(t, err)
+	err = validateRequest(req)
+	assert.NoError(t, err)
+}
+
+func testConfig() (*rest.Config, error) {
+	return &rest.Config{
+		Host: "test-host",
+	}, nil
+}

--- a/authproxy/src/proxy/proxy_test.go
+++ b/authproxy/src/proxy/proxy_test.go
@@ -5,15 +5,16 @@ package proxy
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"go.uber.org/zap"
 	"io"
-	"k8s.io/client-go/rest"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"go.uber.org/zap"
+	"k8s.io/client-go/rest"
 )
 
 const apiPath = "/api/v1/pods"


### PR DESCRIPTION
**Changes**
- Implement a local API proxy that will forward API requests with the leading path `/clusters/local`

**Testing**
- build image and use as a deployment in a Kubernetes cluster
- execute localhost requests on the pod with a bearer token and make sure they get properly forwarded to the API server