### PR TITLE
VZ-10757: Rancher Helm chart enhancement

### DIFF
--- a/platform-operator/thirdparty/charts/rancher/Chart.yaml
+++ b/platform-operator/thirdparty/charts/rancher/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rancher
 description: Install Rancher Server to manage Kubernetes clusters across providers.
-version: 2.7.5
+version: 2.7.5-1
 appVersion: 2.7.5
 kubeVersion: < 1.27.0-0
 home: https://rancher.com

--- a/platform-operator/thirdparty/charts/rancher/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/rancher/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
 {{ toYaml .Values.imagePullSecrets | indent 6 }}
 {{- end }}
       affinity:
+{{- if .Values.affinity }}
+{{ toYaml .Values.affinity | indent 8 }}
+{{- else }}
         podAntiAffinity:
 {{- if eq .Values.antiAffinity "required" }}
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -62,6 +65,7 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms: {{ include "linux-node-selector-terms" . | nindent 14 }}
+{{- end }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
       containers:
       - image: {{ .Values.rancherImage }}:{{ default .Chart.AppVersion .Values.rancherImageTag }}

--- a/platform-operator/thirdparty/charts/rancher/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/rancher/templates/deployment.yaml
@@ -40,7 +40,14 @@ spec:
 {{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
 {{- else }}
+{{- if .Values.podAffinity }}
+        podAffinity:
+{{ toYaml .Values.podAffinity | indent 10 }}
+{{- end }}
         podAntiAffinity:
+{{- if .Values.podAntiAffinity }}
+{{ toYaml .Values.podAntiAffinity | indent 10 }}
+{{- else }}
 {{- if eq .Values.antiAffinity "required" }}
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -62,9 +69,18 @@ spec:
                   - {{ template "rancher.fullname" . }}
               topologyKey: {{ .Values.topologyKey | default "kubernetes.io/hostname" }}
 {{- end }}
+{{- end }}
         nodeAffinity:
+{{- if .Values.nodeAffinity }}
+{{ toYaml .Values.nodeAffinity | indent 10 }}
+{{- else }}
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms: {{ include "linux-node-selector-terms" . | nindent 14 }}
+{{- end }}
+{{- end }}
+{{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
 {{- end }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
       containers:

--- a/platform-operator/thirdparty/charts/rancher/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/rancher/templates/deployment.yaml
@@ -81,6 +81,7 @@ spec:
 {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+{{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/platform-operator/thirdparty/charts/rancher/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/rancher/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
 {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
 {{- end }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
       containers:

--- a/platform-operator/thirdparty/charts/rancher/values.yaml
+++ b/platform-operator/thirdparty/charts/rancher/values.yaml
@@ -19,6 +19,9 @@ topologyKey: kubernetes.io/hostname
 # Optional topology spread constraints
 topologySpreadConstraints: []
 
+# Optional node selector
+nodeSelector: {}
+
 # Audit Logs https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/
 # The audit log is piped to the console of the rancher-audit-log container in the rancher pod.
 # https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/

--- a/platform-operator/thirdparty/charts/rancher/values.yaml
+++ b/platform-operator/thirdparty/charts/rancher/values.yaml
@@ -3,10 +3,21 @@
 # See README.md for details.
 additionalTrustedCAs: false
 
-# affinity optionally replaces the entire affinity section of the pod spec. If affinity is specified then the value of antiAffinity is ignored.
+
+# affinity optionally replaces the entire affinity section of the pod spec. If affinity is specified then the values of nodeAffinity, podAffinity, podAntiAffinity, and antiAffinity are ignored.
 affinity: {}
+# nodeAffinity optionally replaces the nodeAffinity section under affinity in the pod spec.
+nodeAffinity: {}
+# podAffinity optionally replaces the podAffinity section under affinity in the pod spec.
+podAffinity: {}
+# podAntiAffinity optionally replaces the podAntiAffinity section under affinity in the pod spec. If podAntiAffinity is specified then the value of antiAffinity is ignored.
+podAntiAffinity: {}
+
 antiAffinity: preferred
 topologyKey: kubernetes.io/hostname
+
+# Optional topology spread constraints
+topologySpreadConstraints: []
 
 # Audit Logs https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/
 # The audit log is piped to the console of the rancher-audit-log container in the rancher pod.

--- a/platform-operator/thirdparty/charts/rancher/values.yaml
+++ b/platform-operator/thirdparty/charts/rancher/values.yaml
@@ -3,6 +3,8 @@
 # See README.md for details.
 additionalTrustedCAs: false
 
+# affinity optionally replaces the entire affinity section of the pod spec. If affinity is specified then the value of antiAffinity is ignored.
+affinity: {}
 antiAffinity: preferred
 topologyKey: kubernetes.io/hostname
 


### PR DESCRIPTION
This PR gives users more control over the Rancher pod affinity, topologySpreadConstraints, and nodeSelector configuration in the pod spec. Updates are to the Rancher deployment pod spec, and preserve the existing behavior unless the user specifies overrides in the Verrazzano custom resource.

For affinity settings, the user can override the entire `affinity` section of the pod spec, or override `nodeAffinity`, `podAffinity`, and `podAntiAffinity` individually.

I tested various combinations of overrides. One example:
```
apiVersion: install.verrazzano.io/v1beta1
kind: Verrazzano
metadata:
  name: rancher-test
spec:
  profile: none
  environmentName: default
  components:
    ingressNGINX:
      enabled: true
    certManager:
      enabled: true
    rancher:
      enabled: true
      overrides:
        - values:
            nodeAffinity:
              preferredDuringSchedulingIgnoredDuringExecution:
              - weight: 100
                preference:
                  matchExpressions:
                  - key: node-type
                    operator: In
                    values:
                    - fc-csi
            topologySpreadConstraints:
            - maxSkew: 1
              topologyKey: topology.kubernetes.io/fc
              whenUnsatisfiable: ScheduleAnyway
            nodeSelector:
              node-type: fc-csi
```
