### PR TITLE
VZ-10752 Make verify-upgrade-required tests more resilient (#5792)

### DIFF
--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -1051,6 +1051,7 @@ def upgradePlatformOperatorOnCluster(count) {
 
                 # ensure operator pod is up
                 kubectl --kubeconfig=${kubeClusterConfig} -n verrazzano-install rollout status deployment/verrazzano-platform-operator
+                kubectl --kubeconfig=${kubeClusterConfig} -n verrazzano-install rollout status deployment/verrazzano-platform-operator-webhook
             """
         }
     }


### PR DESCRIPTION
Cherry-pick 4900793025ace7a41737eae88022bfa3cff0e05e

Add eventually around getting Verrazzano CR
Wait until webhook pod rolls out.