### PR TITLE
Vz-10767: Console Image Too Large

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -271,7 +271,7 @@
             },
             {
               "image": "console",
-              "tag": "v2.0.0-20230724214803-d6adc4e",
+              "tag": "v2.0.0-20230828163609-10891b3",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },


### PR DESCRIPTION
Reduced console image from 926MB to 402MB.