### PR TITLE
Vz-10767: Console Image Too Large 

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -265,7 +265,7 @@
             },
             {
               "image": "console",
-              "tag": "v2.0.0-20230828163609-10891b3",
+              "tag": "v1.6.6-20230829224554-0fa31df",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -265,7 +265,7 @@
             },
             {
               "image": "console",
-              "tag": "v1.6.5-20230816190952-15dc52c",
+              "tag": "v2.0.0-20230828163609-10891b3",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },


### PR DESCRIPTION
Backport from #6886. Reduced console image from 926MB to 402MB.