### PR TITLE
VZ-10635: Run console test in a separate stage in kind-acceptance test

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -544,6 +544,9 @@ pipeline {
                 stage('Run Acceptance Tests Deployments Group 2') {
                     parallel {
                         stage('opensearch-topology') {
+                            environment {
+                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/opensearch-topology"
+                            }
                             steps {
                                 runGinkgoRandomize('opensearch/topology')
                             }

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -310,6 +310,22 @@ pipeline {
                     }
                 }
 
+                stage ('console') {
+                    environment {
+                        DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh "CONSOLE_REPO_BRANCH=${params.CONSOLE_REPO_BRANCH} ${GO_REPO_PATH}/verrazzano/ci/scripts/run_console_tests.sh"
+                        }
+                    }
+                    post {
+                        always {
+                            sh "${GO_REPO_PATH}/verrazzano/ci/scripts/save_console_test_artifacts.sh"
+                        }
+                    }
+                }
+
                 stage('Run Acceptance Tests Infra') {
                     parallel {
                         stage('verify-scripts') {
@@ -355,21 +371,6 @@ pipeline {
                             }
                             steps {
                                 runGinkgo('metrics/syscomponents')
-                            }
-                        }
-                        stage ('console') {
-                            environment {
-                                DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
-                            }
-                            steps {
-                                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                                    sh "CONSOLE_REPO_BRANCH=${params.CONSOLE_REPO_BRANCH} ${GO_REPO_PATH}/verrazzano/ci/scripts/run_console_tests.sh"
-                                }
-                            }
-                            post {
-                                failure {
-                                    sh "${GO_REPO_PATH}/verrazzano/ci/scripts/save_console_test_artifacts.sh"
-                                }
                             }
                         }
                         stage ('grafana db') {


### PR DESCRIPTION
The console tests intermittently fails in the new-kind-acceptance tests with Grafana DB because the grafana-db tests deletes the grafana pods (and expects the pods to come back up) so the pages become inaccessible temporarily.

Since both the console and grafana-db tests are run parallely, this creates a sort of race condition between the tests. 

The PR is to run the console tests as a separate stage in the pipeline.