### PR TITLE
VZ-10667, VZ-10766.   Backport to release-1.6

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer_component.go
@@ -58,6 +58,10 @@ func (c clusterIssuerComponent) IsInstalled(ctx spi.ComponentContext) (bool, err
 	return c.verrazzanoCertManagerResourcesReady(ctx), nil
 }
 
+func (c clusterIssuerComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return c.IsInstalled(context)
+}
+
 // PreInstall runs before cert-manager-config component is executed
 func (c clusterIssuerComponent) PreInstall(compContext spi.ComponentContext) error {
 	return nil

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -117,6 +117,10 @@ func (c clusterAPIComponent) IsEnabled(effectiveCR runtime.Object) bool {
 	return vzcr.IsClusterAPIEnabled(effectiveCR)
 }
 
+func (c clusterAPIComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return c.IsInstalled(context)
+}
+
 // GetMinVerrazzanoVersion returns the minimum Verrazzano version required by the component
 func (c clusterAPIComponent) GetMinVerrazzanoVersion() string {
 	return vpoconstants.VerrazzanoVersion1_6_0

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
@@ -134,6 +134,10 @@ func (g grafanaComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
 	return isGrafanaInstalled(ctx), nil
 }
 
+func (g grafanaComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return g.IsInstalled(context)
+}
+
 func (g grafanaComponent) IsAvailable(ctx spi.ComponentContext) (reason string, available vzapi.ComponentAvailability) {
 	return (&ready.AvailabilityObjects{DeploymentNames: newDeployments()}).IsAvailable(ctx.Log(), ctx.Client())
 }

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -227,6 +227,26 @@ func (h HelmComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
 	return installed, nil
 }
 
+func (h HelmComponent) Exists(ctx spi.ComponentContext) (bool, error) {
+	if ctx.IsDryRun() {
+		ctx.Log().Debugf("Exists() dry run for %s", h.ReleaseName)
+		return true, nil
+	}
+	resolvedNamespace := h.resolveNamespace(ctx)
+	vzManaged, err := namespace.CheckIfVerrazzanoManagedNamespaceExists(resolvedNamespace)
+	if err != nil {
+		return false, err
+	}
+	if !vzManaged {
+		return false, nil
+	}
+	releaseExists, err := helm.ReleaseExists(h.ReleaseName, resolvedNamespace)
+	if err != nil {
+		return false, err
+	}
+	return releaseExists, nil
+}
+
 // IsAvailable Indicates whether a component is available for end users
 // Components should implement comprehensive availability checks, supplying an appropriate reason
 // if the check fails.
@@ -422,12 +442,12 @@ func (h HelmComponent) PreUninstall(context spi.ComponentContext) error {
 }
 
 func (h HelmComponent) Uninstall(context spi.ComponentContext) error {
-	installed, err := h.IsInstalled(context)
+	existsInCluster, err := h.Exists(context)
 	if err != nil {
 		return err
 	}
-	if !installed {
-		context.Log().Infof("%s already uninstalled", h.Name())
+	if !existsInCluster {
+		context.Log().Infof("%s does not exist in cluster, skipping uninstall", h.Name())
 		return nil
 	}
 	err = helm.Uninstall(context.Log(), h.ReleaseName, h.resolveNamespace(context), context.IsDryRun())

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component_test.go
@@ -126,6 +126,10 @@ func testActionConfigWithInstallation(log vzlog.VerrazzanoLogger, settings *cli.
 	return helm.CreateActionConfig(true, "my-release", release.StatusDeployed, vzlog.DefaultLogger(), createRelease)
 }
 
+func testActionConfigWithUninstallingStatus(log vzlog.VerrazzanoLogger, settings *cli.EnvSettings, namespace string) (*action.Configuration, error) {
+	return helm.CreateActionConfig(true, "my-release", release.StatusUninstalling, vzlog.DefaultLogger(), createRelease)
+}
+
 func init() {
 	_ = k8scheme.AddToScheme(testScheme)
 	_ = v1alpha1.AddToScheme(testScheme)
@@ -1411,18 +1415,36 @@ func TestUninstall(t *testing.T) {
 			ctx:           fakeContextWithSecret,
 			expectSuccess: true,
 		},
-		// GIVEN Helm component
-		// WHEN Uninstall is called
-		// THEN uninstallation is skipped if specified namespace is not found
+		// GIVEN a call to Uninstall
+		// WHEN the Helm release does not exist
+		// THEN no error is returned
 		{
-			name: "TestUninstall when namespace is not found",
+			name: "TestUninstall when release does not exist",
 			helmComponent: HelmComponent{
+				ReleaseName: releaseName,
 				ResolveNamespaceFunc: func(ns string) string {
 					return testNs
 				},
 			},
 			helmOverride: func() {
-				helm.SetActionConfigFunction(testActionConfigWithInstallation)
+				helm.SetActionConfigFunction(testActionConfigWithoutInstallation)
+			},
+			ctx:           fakeContextWithSecret,
+			expectSuccess: true,
+		},
+		// GIVEN Helm component
+		// WHEN Uninstall is called and the release status is already "uninstalling"
+		// THEN no error is returned
+		{
+			name: "TestUninstall Uninstalling status",
+			helmComponent: HelmComponent{
+				ReleaseName: releaseName,
+				ResolveNamespaceFunc: func(ns string) string {
+					return testNs
+				},
+			},
+			helmOverride: func() {
+				helm.SetActionConfigFunction(testActionConfigWithUninstallingStatus)
 			},
 			ctx:           fakeContextWithSecret,
 			expectSuccess: true,

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install.go
@@ -115,6 +115,10 @@ func (i istioComponent) IsInstalled(compContext spi.ComponentContext) (bool, err
 	return true, nil
 }
 
+func (i istioComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return i.IsInstalled(context)
+}
+
 // Install - istioComponent install
 //
 // This utilizes the istioctl utility for install, which blocks during the entire installation process.  This can

--- a/platform-operator/controllers/verrazzano/component/opensearch/opensearch_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/opensearch_component.go
@@ -89,6 +89,10 @@ func (o opensearchComponent) IsInstalled(ctx spi.ComponentContext) (bool, error)
 	return doesOSExist(ctx), nil
 }
 
+func (o opensearchComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return o.IsInstalled(context)
+}
+
 func (o opensearchComponent) Reconcile(_ spi.ComponentContext) error {
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards_component.go
@@ -91,6 +91,10 @@ func (d opensearchDashboardsComponent) IsInstalled(ctx spi.ComponentContext) (bo
 	return doesOSDExist(ctx), nil
 }
 
+func (d opensearchDashboardsComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return d.IsInstalled(context)
+}
+
 // Reconcile OpenSearch-Dashboards component function
 func (d opensearchDashboardsComponent) Reconcile(ctx spi.ComponentContext) error {
 	return nil

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -926,6 +926,10 @@ func (f fakeComponent) IsInstalled(_ spi.ComponentContext) (bool, error) {
 	return true, nil
 }
 
+func (f fakeComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return f.IsInstalled(context)
+}
+
 func (f fakeComponent) PreInstall(_ spi.ComponentContext) error {
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/spi/component.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package spi

--- a/platform-operator/controllers/verrazzano/component/spi/component.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component.go
@@ -87,6 +87,8 @@ type ComponentInstaller interface {
 
 // ComponentUninstaller interface defines uninstall operations
 type ComponentUninstaller interface {
+	// Exists returns true if the component exists in the cluster (may not be fully installed/available) and may be uninstalled
+	Exists(context ComponentContext) (bool, error)
 	// IsOperatorUninstallSupported Returns true if the component supports uninstall directly via the platform operator
 	// - scaffolding while we move components from the scripts to the operator
 	IsOperatorUninstallSupported() bool

--- a/platform-operator/controllers/verrazzano/reconcile/fake_component_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/fake_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package reconcile
 
@@ -21,6 +21,8 @@ type installFuncSig func(ctx spi.ComponentContext) error
 // isInstalledFuncSig is a function needed for unit test override
 type isInstalledFuncSig func(ctx spi.ComponentContext) (bool, error)
 
+type uninstallFuncSig func(ctx spi.ComponentContext) error
+
 // fakeComponent allows for using dummy Component implementations for controller testing
 type fakeComponent struct {
 	helm.HelmComponent
@@ -28,12 +30,15 @@ type fakeComponent struct {
 	upgradeFunc     upgradeFuncSig
 	installFunc     installFuncSig
 	isInstalledFunc isInstalledFuncSig
+	uninstallFunc   uninstallFuncSig
 	installed       string `default:"true"`
 	ready           string `default:"true"`
 	enabled         string `default:"true"`
 	monitorChanges  string `default:"true"`
 	minVersion      string
 }
+
+var _ spi.Component = fakeComponent{}
 
 func (f fakeComponent) Name() string {
 	return f.ReleaseName
@@ -101,7 +106,26 @@ func (f fakeComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
 	return getBool(f.installed, "installed"), nil
 }
 
-func (f fakeComponent) IsReady(x spi.ComponentContext) bool {
+func (f fakeComponent) Exists(ctx spi.ComponentContext) (bool, error) {
+	return f.IsInstalled(ctx)
+}
+
+func (f fakeComponent) PreUninstall(ctx spi.ComponentContext) error {
+	return nil
+}
+
+func (f fakeComponent) Uninstall(ctx spi.ComponentContext) error {
+	if f.uninstallFunc != nil {
+		return f.uninstallFunc(ctx)
+	}
+	return nil
+}
+
+func (f fakeComponent) PostUninstall(ctx spi.ComponentContext) error {
+	return nil
+}
+
+func (f fakeComponent) IsReady(_ spi.ComponentContext) bool {
 	return getBool(f.ready, "ready")
 }
 

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_component.go
@@ -88,14 +88,14 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 				UninstallContext.uninstallState = compStateUninstallEnd
 				continue
 			}
-			// Check if component is installed, if not continue
-			installed, err := comp.IsInstalled(compContext)
+			// Check if component is ex, if not continue
+			exists, err := comp.Exists(compContext)
 			if err != nil {
-				compLog.Errorf("Failed checking if component %s is installed: %v", compName, err)
+				compLog.Errorf("Failed checking if component %s exists in the cluster: %v", compName, err)
 				return ctrl.Result{}, err
 			}
-			if !installed {
-				compLog.Debugf("Component %s is not installed, nothing to do for uninstall", compName)
+			if !exists {
+				compLog.Debugf("Component %s does not exist in cluster, nothing to do for uninstall", compName)
 				UninstallContext.uninstallState = compStateUninstallEnd
 				continue
 			}

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_component_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_component_test.go
@@ -41,12 +41,7 @@ func TestReconcilerUninstallSingleComponent(t *testing.T) {
 			},
 		},
 	}
-	//defer helm.SetDefaultRunner()
-	//helm.SetCmdRunner(vzos.GenericTestRunner{
-	//	StdOut: []byte(""),
-	//	StdErr: []byte("not found"),
-	//	Err:    fmt.Errorf(unExpectedError),
-	//})
+
 	k8sutil.GetCoreV1Func = common.MockGetCoreV1()
 	k8sutil.GetDynamicClientFunc = common.MockDynamicClient()
 	defer func() {

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_test.go
@@ -244,6 +244,8 @@ func TestReconcileUninstall(t *testing.T) {
 
 	// call reconcile once with installed true, then again with installed false
 	reconciler := newVerrazzanoReconciler(c)
+	reconciler.DryRun = true
+
 	DeleteUninstallTracker(vzcr)
 	result, err := reconciler.reconcileUninstall(vzlog.DefaultLogger(), vzcr)
 	asserts.NoError(err)

--- a/platform-operator/controllers/verrazzano/reconcile/upgrade_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/upgrade_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
 	"math/big"
 	"path/filepath"
 	"testing"
@@ -16,6 +17,8 @@ import (
 	oamapi "github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	vzappclusters "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
+	clustersapi "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/helm"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -43,6 +46,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -397,8 +401,14 @@ func TestDeleteDuringUpgrade(t *testing.T) {
 	defer config.Set(config.Get())
 	config.Set(config.OperatorConfig{VersionCheckEnabled: false})
 
-	_ = vzapi.AddToScheme(k8scheme.Scheme)
-	c := fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
+	registry.OverrideGetComponentsFn(func() []spi.Component {
+		return []spi.Component{
+			fakeComponent{},
+		}
+	})
+	defer registry.ResetGetComponentsFn()
+
+	c := fake.NewClientBuilder().WithScheme(getTestScheme()).WithObjects(
 		&vzapi.Verrazzano{
 			ObjectMeta: func() metav1.ObjectMeta {
 				om := createObjectMeta(namespace, name, []string{finalizerName})
@@ -446,6 +456,16 @@ func TestDeleteDuringUpgrade(t *testing.T) {
 	err = c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &verrazzano)
 	asserts.Error(err)
 	asserts.True(errors2.IsNotFound(err))
+}
+
+func getTestScheme() *runtime.Scheme {
+	scheme := newScheme()
+	_ = vzapi.AddToScheme(scheme)
+	_ = vzappclusters.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+	_ = clustersapi.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+	return scheme
 }
 
 // TestUpgradeStartedWhenPrevFailures tests the reconcileUpgrade method for the following use case

--- a/platform-operator/mocks/component_mock.go
+++ b/platform-operator/mocks/component_mock.go
@@ -600,6 +600,21 @@ func (m *MockComponent) EXPECT() *MockComponentMockRecorder {
 	return m.recorder
 }
 
+// Exists mocks base method
+func (m *MockComponent) Exists(arg0 spi.ComponentContext) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Exists indicates an expected call of Exists
+func (mr *MockComponentMockRecorder) Exists(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockComponent)(nil).Exists), arg0)
+}
+
 // GetCertificateNames mocks base method.
 func (m *MockComponent) GetCertificateNames(arg0 spi.ComponentContext) []types.NamespacedName {
 	m.ctrl.T.Helper()

--- a/platform-operator/mocks/component_mock.go
+++ b/platform-operator/mocks/component_mock.go
@@ -600,7 +600,7 @@ func (m *MockComponent) EXPECT() *MockComponentMockRecorder {
 	return m.recorder
 }
 
-// Exists mocks base method
+// Exists mocks base method.
 func (m *MockComponent) Exists(arg0 spi.ComponentContext) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Exists", arg0)
@@ -609,7 +609,7 @@ func (m *MockComponent) Exists(arg0 spi.ComponentContext) (bool, error) {
 	return ret0, ret1
 }
 
-// Exists indicates an expected call of Exists
+// Exists indicates an expected call of Exists.
 func (mr *MockComponentMockRecorder) Exists(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockComponent)(nil).Exists), arg0)


### PR DESCRIPTION
Backport to `release-1.6`, fix issues with orphaned resources when the VPO is restarted during uninstall. Particularly Helm-based components can get into a state where the release exists in the cluster but is stuck in an uninstalling state.

See https://github.com/verrazzano/verrazzano/pull/6893 for original PR description.
