### PR TITLE
Fix a couple of versions in BOM

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -375,7 +375,7 @@
     },
     {
       "name": "verrazzano-cluster-operator",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -409,7 +409,7 @@
     },
     {
       "name": "verrazzano-application-operator",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "subcomponents": [
         {
           "repository": "verrazzano",


### PR DESCRIPTION
Two of the Verrazzano operator components had old versions. Updated so they are all 2.0 now.