### PR TITLE
VZ-10809.  Config-to-Helm module integration mappings for remaining component layers 

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/modules_integration.go
@@ -12,7 +12,6 @@ import (
 // certManagerModuleConfig Internal component configuration used to communicate Verrazzano CR config for CertManager to
 // this component through the Module interface as Helm values
 type certManagerModuleConfig struct {
-	//v1alpha1.Certificate     `json:"certificate"`
 	ClusterResourceNamespace string `json:"clusterResourceNamespace,omitempty"`
 }
 
@@ -33,7 +32,6 @@ func (c certManagerComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.
 	}
 	return spi.NewModuleConfigHelmValuesWrapper(
 		certManagerModuleConfig{
-			//Certificate:              compConfig.Certificate,
 			ClusterResourceNamespace: clusterResourceNamespace,
 		},
 	)

--- a/platform-operator/controllers/verrazzano/component/fluentd/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/modules_integration.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package fluentd
+
+import (
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	ElasticsearchSecret string                            `json:"elasticsearchSecret,omitempty"`
+	ElasticsearchURL    string                            `json:"elasticsearchURL,omitempty"`
+	ExtraVolumeMounts   []v1alpha1.VolumeMount            `json:"extraVolumeMounts,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"source"`
+	OCI                 *v1alpha1.OciLoggingConfiguration `json:"oci,omitempty"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (f fluentdComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+	var configSnippet *valuesConfig
+	fluentd := effectiveCR.Spec.Components.Fluentd
+	if fluentd != nil {
+		configSnippet = &valuesConfig{
+			ElasticsearchSecret: fluentd.ElasticsearchSecret,
+			ElasticsearchURL:    fluentd.ElasticsearchURL,
+			OCI:                 fluentd.OCI.DeepCopy(),
+			ExtraVolumeMounts:   fluentd.ExtraVolumeMounts,
+		}
+	}
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/fluentd/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/modules_integration_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package fluentd
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"testing"
+)
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						Fluentd: &vzapi.FluentdComponent{
+							ElasticsearchSecret: "esSecret",
+							ElasticsearchURL:    "esURL",
+							Enabled:             &trueValue,
+							ExtraVolumeMounts: []vzapi.VolumeMount{
+								{Source: "asource", ReadOnly: &trueValue},
+								{Source: "bsource", ReadOnly: &falseValue},
+							},
+							OCI: &vzapi.OciLoggingConfiguration{
+								APISecret:       "ociSecret",
+								DefaultAppLogID: "defaultApp",
+								SystemLogID:     "systemLogID",
+							},
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte(`someJSON{}`)}},
+									{ConfigMapRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "cfgmap"}}},
+								},
+							},
+						},
+						Istio: &vzapi.IstioComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"elasticsearchSecret": "esSecret",
+					"elasticsearchURL": "esURL",
+					"extraVolumeMounts": [
+					  {
+						"readOnly": true,
+						"source": "asource"
+					  },
+					  {
+						"readOnly": false,
+						"source": "bsource"
+					  }
+					],
+					"oci": {
+					  "apiSecret": "ociSecret",
+					  "defaultAppLogId": "defaultApp",
+					  "systemLogId": "systemLogID"
+					}
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent().(fluentdComponent)
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
@@ -5,8 +5,6 @@ package grafana
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -61,16 +59,6 @@ func (g grafanaComponent) Namespace() string {
 // ShouldInstallBeforeUpgrade returns true if component can be installed before upgrade is done
 func (g grafanaComponent) ShouldInstallBeforeUpgrade() bool {
 	return false
-}
-
-// ShouldUseModule returns true if component is implemented using a Module
-func (g grafanaComponent) ShouldUseModule() bool {
-	return config.Get().ModuleIntegration
-}
-
-// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
-func (g grafanaComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
-	return nil
 }
 
 // GetDependencies returns the dependencies of the Grafana component

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -73,11 +71,6 @@ func (g grafanaComponent) ShouldUseModule() bool {
 // GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
 func (g grafanaComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 	return nil
-}
-
-// GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
-func (g grafanaComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
-	return nil, nil
 }
 
 // GetDependencies returns the dependencies of the Grafana component

--- a/platform-operator/controllers/verrazzano/component/grafana/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/modules_integration.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package grafana
+
+import (
+	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	Database *vzapi.DatabaseInfo `json:"database,omitempty"`
+	Replicas *int32              `json:"replicas,omitempty"`
+	SMTP     *vmov1.SMTPInfo     `json:"smtp,omitempty"`
+
+	Ingress         *vzapi.IngressNginxComponent `json:"ingress,omitempty"`
+	DNS             *vzapi.DNSComponent          `json:"dns,omitempty"`
+	EnvironmentName string                       `json:"environmentName,omitempty"`
+
+	ThanosEnabled             bool `json:"thanosEnabled"`
+	PrometheusEnabled         bool `json:"prometheusEnabled"`
+	PrometheusOperatorEnabled bool `json:"prometheusOperatorEnabled"`
+
+	DefaultVolumeSource      *corev1.VolumeSource            `json:"defaultVolumeSource,omitempty" patchStrategy:"replace"`
+	VolumeClaimSpecTemplates []vzapi.VolumeClaimSpecTemplate `json:"volumeClaimSpecTemplates,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (g grafanaComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		DefaultVolumeSource:      effectiveCR.Spec.DefaultVolumeSource,
+		VolumeClaimSpecTemplates: effectiveCR.Spec.VolumeClaimSpecTemplates,
+	}
+
+	grafana := effectiveCR.Spec.Components.Grafana
+	if grafana != nil {
+		configSnippet.Database = grafana.Database
+		configSnippet.SMTP = grafana.SMTP
+		configSnippet.Replicas = grafana.Replicas
+	}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = &vzapi.DNSComponent{
+			External:         dns.External,
+			InstallOverrides: vzapi.InstallOverrides{}, // always ignore the overrides here, those are handled separately
+			OCI:              dns.OCI,
+			Wildcard:         dns.Wildcard,
+		}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []vzapi.Overrides{}
+	}
+
+	if len(effectiveCR.Spec.EnvironmentName) > 0 {
+		configSnippet.EnvironmentName = effectiveCR.Spec.EnvironmentName
+	}
+
+	configSnippet.PrometheusEnabled = vzcr.IsPrometheusEnabled(effectiveCR)
+	configSnippet.ThanosEnabled = vzcr.IsThanosEnabled(effectiveCR)
+	configSnippet.PrometheusOperatorEnabled = vzcr.IsPrometheusOperatorEnabled(effectiveCR)
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/grafana/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/modules_integration.go
@@ -4,10 +4,12 @@
 package grafana
 
 import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
 	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
@@ -73,4 +75,14 @@ func (g grafanaComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazz
 	configSnippet.PrometheusOperatorEnabled = vzcr.IsPrometheusOperatorEnabled(effectiveCR)
 
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}
+
+// ShouldUseModule returns true if component is implemented using a Module
+func (g grafanaComponent) ShouldUseModule() bool {
+	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (g grafanaComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/grafana/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/modules_integration_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package grafana
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+var pvc100Gi, _ = resource.ParseQuantity("100Gi")
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	var replicas int32 = 3
+
+	ingressClassName := "myclass"
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "vmi",
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "vmi"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc100Gi,
+									},
+								},
+							},
+						},
+					},
+					Components: vzapi.ComponentSpec{
+						Grafana: &vzapi.GrafanaComponent{
+							Database: &vzapi.DatabaseInfo{
+								Host: "dbhost",
+								Name: "grafanadb",
+							},
+							Enabled:  &enabled,
+							Replicas: &replicas,
+							SMTP: &vmov1.SMTPInfo{
+								Enabled:        &enabled,
+								Host:           "smtphost.foo.com",
+								ExistingSecret: "secret",
+								FromAddress:    "me@foo.com",
+								FromName:       "Mike",
+							},
+						},
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						Prometheus: &vzapi.PrometheusComponent{
+							Enabled: &trueValue,
+						},
+						Thanos: &vzapi.ThanosComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"database": {
+					  "host": "dbhost",
+					  "name": "grafanadb"
+					},
+					"replicas": 3,
+					"smtp": {
+					  "enabled": true,
+					  "host": "smtphost.foo.com",
+					  "existingSecret": "secret",
+					  "fromAddress": "me@foo.com",
+					  "fromName": "Mike"
+					},
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					},
+					"environmentName": "Myenv",
+					"thanosEnabled": true,
+					"prometheusEnabled": true,
+					"prometheusOperatorEnabled": true,
+					"defaultVolumeSource": {
+					  "persistentVolumeClaim": {
+						"claimName": "vmi"
+					  }
+					},
+					"volumeClaimSpecTemplates": [
+					  {
+						"metadata": {
+						  "name": "vmi",
+						  "creationTimestamp": null
+						},
+						"spec": {
+						  "resources": {
+							"requests": {
+							  "storage": "100Gi"
+							}
+						  }
+						}
+					  }
+					]
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent().(grafanaComponent)
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -6,8 +6,6 @@ package istio
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"path/filepath"
 	"strings"
 
@@ -488,21 +486,6 @@ func (i istioComponent) GetCertificateNames(_ spi.ComponentContext) []types.Name
 // ShouldInstallBeforeUpgrade returns true if component can be installed before upgrade is done
 func (i istioComponent) ShouldInstallBeforeUpgrade() bool {
 	return false
-}
-
-// ShouldUseModule returns true if component is implemented using a Module
-func (i istioComponent) ShouldUseModule() bool {
-	return config.Get().ModuleIntegration
-}
-
-// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
-func (i istioComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
-	return nil
-}
-
-// GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
-func (i istioComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
-	return nil, nil
 }
 
 func deleteIstioCoreDNS(context spi.ComponentContext) error {

--- a/platform-operator/controllers/verrazzano/component/istio/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/istio/modules_integration.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package istio
+
+import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// issuerValuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	InjectionEnabled *bool `json:"injectionEnabled,omitempty"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON issuerValuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (i istioComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{}
+	istio := effectiveCR.Spec.Components.Istio
+	if istio != nil {
+		configSnippet.InjectionEnabled = istio.InjectionEnabled
+	}
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}
+
+// ShouldUseModule returns true if component is implemented using a Module
+func (i istioComponent) ShouldUseModule() bool {
+	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (i istioComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
+}

--- a/platform-operator/controllers/verrazzano/component/istio/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/modules_integration_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package istio
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"testing"
+)
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					Components: vzapi.ComponentSpec{
+						ClusterIssuer: &vzapi.ClusterIssuerComponent{
+							Enabled: &trueValue,
+							IssuerConfig: vzapi.IssuerConfig{
+								CA: &vzapi.CAIssuer{
+									SecretName: "secret",
+								},
+							},
+						},
+						Istio: &vzapi.IstioComponent{
+							Enabled:          &trueValue,
+							InjectionEnabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+				  "verrazzano": {
+					"module": {
+					  "spec": {
+						"injectionEnabled": true
+					  }
+					}
+				  }
+				}
+				`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent().(istioComponent)
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/modules_integration.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package operator
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	Ingress         *vzapi.IngressNginxComponent `json:"ingress,omitempty"`
+	DNS             *vzapi.DNSComponent          `json:"dns,omitempty"`
+	EnvironmentName string                       `json:"environmentName,omitempty"`
+
+	KeycloakEnabled   bool `json:"keycloakEnabled"`
+	PrometheusEnabled bool `json:"prometheusEnabled"`
+
+	OpenSearch *v1beta1.OpenSearchComponent `json:"opensearch,omitempty"`
+
+	DefaultVolumeSource      *corev1.VolumeSource            `json:"defaultVolumeSource,omitempty" patchStrategy:"replace"`
+	VolumeClaimSpecTemplates []vzapi.VolumeClaimSpecTemplate `json:"volumeClaimSpecTemplates,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (c jaegerOperatorComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		DefaultVolumeSource:      effectiveCR.Spec.DefaultVolumeSource,
+		VolumeClaimSpecTemplates: effectiveCR.Spec.VolumeClaimSpecTemplates,
+		KeycloakEnabled:          vzcr.IsKeycloakEnabled(effectiveCR),
+		PrometheusEnabled:        vzcr.IsPrometheusEnabled(effectiveCR),
+	}
+
+	opensearchV1Alpha1 := effectiveCR.Spec.Components.Elasticsearch
+	if opensearchV1Alpha1 != nil {
+		vzv1beta1 := &v1beta1.Verrazzano{}
+		effectiveCR.ConvertTo(vzv1beta1)
+		configSnippet.OpenSearch = vzv1beta1.Spec.Components.OpenSearch.DeepCopy()
+	}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = &vzapi.DNSComponent{
+			External:         dns.External,
+			InstallOverrides: vzapi.InstallOverrides{},
+			OCI:              dns.OCI,
+			Wildcard:         dns.Wildcard,
+		}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []vzapi.Overrides{}
+	}
+
+	if len(effectiveCR.Spec.EnvironmentName) > 0 {
+		configSnippet.EnvironmentName = effectiveCR.Spec.EnvironmentName
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/modules_integration_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package operator
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+var pvc100Gi, _ = resource.ParseQuantity("100Gi")
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	var replicas int32 = 3
+
+	ingressClassName := "myclass"
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "vmi",
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "vmi"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc100Gi,
+									},
+								},
+							},
+						},
+					},
+					Components: vzapi.ComponentSpec{
+						Grafana: &vzapi.GrafanaComponent{
+							Database: &vzapi.DatabaseInfo{
+								Host: "dbhost",
+								Name: "grafanadb",
+							},
+							Enabled:  &enabled,
+							Replicas: &replicas,
+							SMTP: &vmov1.SMTPInfo{
+								Enabled:        &enabled,
+								Host:           "smtphost.foo.com",
+								ExistingSecret: "secret",
+								FromAddress:    "me@foo.com",
+								FromName:       "Mike",
+							},
+						},
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						Prometheus: &vzapi.PrometheusComponent{
+							Enabled: &trueValue,
+						},
+						Thanos: &vzapi.ThanosComponent{
+							Enabled: &trueValue,
+						},
+						JaegerOperator: &vzapi.JaegerOperatorComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					},
+					"environmentName": "Myenv",
+					"keycloakEnabled": true,
+					"prometheusEnabled": true,
+					"defaultVolumeSource": {
+					  "persistentVolumeClaim": {
+						"claimName": "vmi"
+					  }
+					},
+					"volumeClaimSpecTemplates": [
+					  {
+						"metadata": {
+						  "name": "vmi",
+						  "creationTimestamp": null
+						},
+						"spec": {
+						  "resources": {
+							"requests": {
+							  "storage": "100Gi"
+							}
+						  }
+						}
+					  }
+					]
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent().(jaegerOperatorComponent)
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/keycloak/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/modules_integration.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package keycloak
+
+import (
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	Ingress         *vzapi.IngressNginxComponent `json:"ingress,omitempty"`
+	DNS             *vzapi.DNSComponent          `json:"dns,omitempty"`
+	EnvironmentName string                       `json:"environmentName,omitempty"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (c KeycloakComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		EnvironmentName: effectiveCR.Spec.EnvironmentName,
+	}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = &vzapi.DNSComponent{
+			External:         dns.External,
+			InstallOverrides: vzapi.InstallOverrides{}, // always ignore the overrides here, those are handled separately
+			OCI:              dns.OCI,
+			Wildcard:         dns.Wildcard,
+		}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []vzapi.Overrides{}
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/keycloak/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/modules_integration_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package keycloak
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+var pvc100Gi, _ = resource.ParseQuantity("100Gi")
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	ingressClassName := "myclass"
+
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "vmi",
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "vmi"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc100Gi,
+									},
+								},
+							},
+						},
+					},
+					Components: vzapi.ComponentSpec{
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						Prometheus: &vzapi.PrometheusComponent{
+							Enabled: &trueValue,
+						},
+						Thanos: &vzapi.ThanosComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					},
+					"environmentName": "Myenv"
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/kiali/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/modules_integration.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package kiali
+
+import (
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	Ingress         *vzapi.IngressNginxComponent `json:"ingress,omitempty"`
+	DNS             *vzapi.DNSComponent          `json:"dns,omitempty"`
+	EnvironmentName string                       `json:"environmentName,omitempty"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (c kialiComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = &vzapi.DNSComponent{
+			External:         dns.External,
+			InstallOverrides: vzapi.InstallOverrides{},
+			OCI:              dns.OCI,
+			Wildcard:         dns.Wildcard,
+		}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []vzapi.Overrides{}
+	}
+
+	if len(effectiveCR.Spec.EnvironmentName) > 0 {
+		configSnippet.EnvironmentName = effectiveCR.Spec.EnvironmentName
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/kiali/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/kiali/modules_integration_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package kiali
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+var pvc100Gi, _ = resource.ParseQuantity("100Gi")
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	enabled := true
+	var replicas int32 = 3
+
+	ingressClassName := "myclass"
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "vmi",
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "vmi"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc100Gi,
+									},
+								},
+							},
+						},
+					},
+					Components: vzapi.ComponentSpec{
+						Grafana: &vzapi.GrafanaComponent{
+							Database: &vzapi.DatabaseInfo{
+								Host: "dbhost",
+								Name: "grafanadb",
+							},
+							Enabled:  &enabled,
+							Replicas: &replicas,
+							SMTP: &vmov1.SMTPInfo{
+								Enabled:        &enabled,
+								Host:           "smtphost.foo.com",
+								ExistingSecret: "secret",
+								FromAddress:    "me@foo.com",
+								FromName:       "Mike",
+							},
+						},
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						Kiali: &vzapi.KialiComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					},
+					"environmentName": "Myenv"
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent().(kialiComponent)
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/mysql/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/modules_integration.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package mysql
+
+import (
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	VolumeSource             *corev1.VolumeSource            `json:"volumeSource,omitempty"`
+	DefaultVolumeSource      *corev1.VolumeSource            `json:"defaultVolumeSource,omitempty"`
+	VolumeClaimSpecTemplates []vzapi.VolumeClaimSpecTemplate `json:"volumeClaimSpecTemplates,omitempty"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (c mysqlComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		DefaultVolumeSource:      effectiveCR.Spec.DefaultVolumeSource,
+		VolumeClaimSpecTemplates: effectiveCR.Spec.VolumeClaimSpecTemplates,
+	}
+
+	keycloak := effectiveCR.Spec.Components.Keycloak
+	if keycloak != nil {
+		configSnippet.VolumeSource = keycloak.MySQL.VolumeSource.DeepCopy()
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/mysql/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/modules_integration_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package mysql
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	ingressClassName := "myclass"
+
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "vmi",
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "vmi"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc100Gi,
+									},
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "mysql"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc100Gi,
+									},
+								},
+							},
+						},
+					},
+					Components: vzapi.ComponentSpec{
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						Prometheus: &vzapi.PrometheusComponent{
+							Enabled: &trueValue,
+						},
+						Thanos: &vzapi.ThanosComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							MySQL: vzapi.MySQLComponent{
+								VolumeSource: &corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "mysql",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"volumeSource": {
+					  "persistentVolumeClaim": {
+						"claimName": "mysql"
+					  }
+					},
+					"defaultVolumeSource": {
+					  "persistentVolumeClaim": {
+						"claimName": "vmi"
+					  }
+					},
+					"volumeClaimSpecTemplates": [
+					  {
+						"metadata": {
+						  "name": "vmi",
+						  "creationTimestamp": null
+						},
+						"spec": {
+						  "resources": {
+							"requests": {
+							  "storage": "100Gi"
+							}
+						  }
+						}
+					  },
+					  {
+						"metadata": {
+						  "name": "mysql",
+						  "creationTimestamp": null
+						},
+						"spec": {
+						  "resources": {
+							"requests": {
+							  "storage": "100Gi"
+							}
+						  }
+						}
+					  }
+					]
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/opensearch/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/modules_integration.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package opensearch
+
+import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
+	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	Nodes                []vzapi.OpenSearchNode        `json:"nodes,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+	Policies             []vmov1.IndexManagementPolicy `json:"policies,omitempty"`
+	Plugins              vmov1.OpenSearchPlugins       `json:"plugins,omitempty"`
+	DisableDefaultPolicy bool                          `json:"disableDefaultPolicy,omitempty"`
+	ESInstallArgs        []vzapi.InstallArgs           `json:"installArgs,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+
+	Ingress         *vzapi.IngressNginxComponent `json:"ingress,omitempty"`
+	DNS             *vzapi.DNSComponent          `json:"dns,omitempty"`
+	EnvironmentName string                       `json:"environmentName,omitempty"`
+
+	DefaultVolumeSource      *corev1.VolumeSource            `json:"defaultVolumeSource,omitempty" patchStrategy:"replace"`
+	VolumeClaimSpecTemplates []vzapi.VolumeClaimSpecTemplate `json:"volumeClaimSpecTemplates,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (o opensearchComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		DefaultVolumeSource:      effectiveCR.Spec.DefaultVolumeSource,
+		VolumeClaimSpecTemplates: effectiveCR.Spec.VolumeClaimSpecTemplates,
+	}
+
+	opensearch := effectiveCR.Spec.Components.Elasticsearch
+	if opensearch != nil {
+		configSnippet.Nodes = opensearch.Nodes
+		configSnippet.Policies = opensearch.Policies
+		configSnippet.Plugins = opensearch.Plugins
+		configSnippet.DisableDefaultPolicy = opensearch.DisableDefaultPolicy
+		configSnippet.ESInstallArgs = opensearch.ESInstallArgs
+	}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = &vzapi.DNSComponent{
+			External:         dns.External,
+			InstallOverrides: vzapi.InstallOverrides{}, // always ignore the overrides here, those are handled separately
+			OCI:              dns.OCI,
+			Wildcard:         dns.Wildcard,
+		}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []vzapi.Overrides{}
+	}
+
+	if len(effectiveCR.Spec.EnvironmentName) > 0 {
+		configSnippet.EnvironmentName = effectiveCR.Spec.EnvironmentName
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}
+
+// ShouldUseModule returns true if component is implemented using a Module
+func (o opensearchComponent) ShouldUseModule() bool {
+	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (o opensearchComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
+}

--- a/platform-operator/controllers/verrazzano/component/opensearch/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/modules_integration_test.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package opensearch
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+var pvc100Gi, _ = resource.ParseQuantity("100Gi")
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	age := "1d"
+
+	ingressClassName := "myclass"
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "vmi",
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "vmi"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc100Gi,
+									},
+								},
+							},
+						},
+					},
+					Components: vzapi.ComponentSpec{
+						Elasticsearch: &vzapi.ElasticsearchComponent{
+							ESInstallArgs: createInstallArgs(3, 3, 3),
+							Nodes: []vzapi.OpenSearchNode{
+								createNG("a", 1, nil),
+								createNG("b", 2, nil),
+								createNG("c", 3, nil),
+							},
+							Policies: []vmov1.IndexManagementPolicy{
+								{
+									PolicyName:   "my-policy",
+									IndexPattern: "pattern",
+									MinIndexAge:  &age,
+								},
+							},
+							Plugins: vmov1.OpenSearchPlugins{
+								Enabled: false,
+								InstallList: []string{
+									"foo",
+									"bar",
+								},
+							},
+							DisableDefaultPolicy: true,
+						},
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						Prometheus: &vzapi.PrometheusComponent{
+							Enabled: &trueValue,
+						},
+						Thanos: &vzapi.ThanosComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					"nodes": [
+					  {
+						"name": "a",
+						"replicas": 1
+					  },
+					  {
+						"name": "b",
+						"replicas": 2
+					  },
+					  {
+						"name": "c",
+						"replicas": 3
+					  }
+					],
+					"policies": [
+					  {
+						"policyName": "my-policy",
+						"indexPattern": "pattern",
+						"minIndexAge": "1d",
+						"rollover": {}
+					  }
+					],
+					"plugins": {
+					  "enabled": false,
+					  "installList": [
+						"foo",
+						"bar"
+					  ]
+					},
+					"disableDefaultPolicy": true,
+					"installArgs": [
+					  {
+						"name": "nodes.master.replicas",
+						"value": "3"
+					  },
+					  {
+						"name": "nodes.data.replicas",
+						"value": "3"
+					  },
+					  {
+						"name": "nodes.ingest.replicas",
+						"value": "3"
+					  }
+					],
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					},
+					"environmentName": "Myenv",
+					"defaultVolumeSource": {
+					  "persistentVolumeClaim": {
+						"claimName": "vmi"
+					  }
+					},
+					"volumeClaimSpecTemplates": [
+					  {
+						"metadata": {
+						  "name": "vmi",
+						  "creationTimestamp": null
+						},
+						"spec": {
+						  "resources": {
+							"requests": {
+							  "storage": "100Gi"
+							}
+						  }
+						}
+					  }
+					]
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/opensearch/opensearch_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/opensearch_component.go
@@ -5,10 +5,6 @@ package opensearch
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
@@ -52,21 +48,6 @@ func (o opensearchComponent) Namespace() string {
 // ShouldInstallBeforeUpgrade returns true if component can be installed before upgrade is done
 func (o opensearchComponent) ShouldInstallBeforeUpgrade() bool {
 	return false
-}
-
-// ShouldUseModule returns true if component is implemented using a Module
-func (o opensearchComponent) ShouldUseModule() bool {
-	return config.Get().ModuleIntegration
-}
-
-// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
-func (o opensearchComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
-	return nil
-}
-
-// GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
-func (o opensearchComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
-	return nil, nil
 }
 
 // GetDependencies returns the dependencies of the OpenSearch component

--- a/platform-operator/controllers/verrazzano/component/opensearchdashboards/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchdashboards/modules_integration.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package opensearchdashboards
+
+import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
+	vmov1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	Replicas *int32                            `json:"replicas,omitempty"`
+	Plugins  vmov1.OpenSearchDashboardsPlugins `json:"plugins,omitempty"`
+
+	Ingress         *vzapi.IngressNginxComponent `json:"ingress,omitempty"`
+	DNS             *vzapi.DNSComponent          `json:"dns,omitempty"`
+	EnvironmentName string                       `json:"environmentName,omitempty"`
+
+	DefaultVolumeSource      *corev1.VolumeSource            `json:"defaultVolumeSource,omitempty" patchStrategy:"replace"`
+	VolumeClaimSpecTemplates []vzapi.VolumeClaimSpecTemplate `json:"volumeClaimSpecTemplates,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (d opensearchDashboardsComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		DefaultVolumeSource:      effectiveCR.Spec.DefaultVolumeSource,
+		VolumeClaimSpecTemplates: effectiveCR.Spec.VolumeClaimSpecTemplates,
+	}
+
+	osd := effectiveCR.Spec.Components.Kibana
+	if osd != nil {
+		configSnippet.Replicas = osd.Replicas
+		configSnippet.Plugins = osd.Plugins
+	}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = &vzapi.DNSComponent{
+			External:         dns.External,
+			InstallOverrides: vzapi.InstallOverrides{}, // always ignore the overrides here, those are handled separately
+			OCI:              dns.OCI,
+			Wildcard:         dns.Wildcard,
+		}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []vzapi.Overrides{}
+	}
+
+	if len(effectiveCR.Spec.EnvironmentName) > 0 {
+		configSnippet.EnvironmentName = effectiveCR.Spec.EnvironmentName
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}
+
+// ShouldUseModule returns true if component is implemented using a Module
+func (d opensearchDashboardsComponent) ShouldUseModule() bool {
+	return config.Get().ModuleIntegration
+}
+
+// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
+func (d opensearchDashboardsComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return nil
+}

--- a/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards_component.go
@@ -5,10 +5,6 @@ package opensearchdashboards
 
 import (
 	"fmt"
-	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -52,21 +48,6 @@ func (d opensearchDashboardsComponent) Namespace() string {
 // ShouldInstallBeforeUpgrade returns true if component can be installed before upgrade is done
 func (d opensearchDashboardsComponent) ShouldInstallBeforeUpgrade() bool {
 	return false
-}
-
-// ShouldUseModule returns true if component is implemented using a Module
-func (d opensearchDashboardsComponent) ShouldUseModule() bool {
-	return config.Get().ModuleIntegration
-}
-
-// GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
-func (d opensearchDashboardsComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
-	return nil
-}
-
-// GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
-func (d opensearchDashboardsComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
-	return nil, nil
 }
 
 // GetDependencies returns the dependencies of the OpenSearch-Dashbaords component

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/modules_integration.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package kubestatemetrics
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+type valuesConfig struct {
+	PrometheusOperatorEnabled bool `json:"prometheusOperatorEnabled"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
+func (c kubeStateMetricsComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		PrometheusOperatorEnabled: vzcr.IsPrometheusOperatorEnabled(effectiveCR),
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/kubestatemetrics/modules_integration_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package kubestatemetrics
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"testing"
+)
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					Components: vzapi.ComponentSpec{
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled: &trueValue,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						Prometheus: &vzapi.PrometheusComponent{
+							Enabled: &trueValue,
+						},
+						Thanos: &vzapi.ThanosComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					  "prometheusOperatorEnabled": true
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent().(kubeStateMetricsComponent)
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/modules_integration.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package nodeexporter
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+type valuesConfig struct {
+	PrometheusOperatorEnabled bool `json:"prometheusOperatorEnabled"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
+func (c prometheusNodeExporterComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		PrometheusOperatorEnabled: vzcr.IsPrometheusOperatorEnabled(effectiveCR),
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/modules_integration_test.go
@@ -58,7 +58,7 @@ func TestGetModuleSpec(t *testing.T) {
 						Prometheus: &vzapi.PrometheusComponent{
 							Enabled: &trueValue,
 						},
-						Thanos: &vzapi.ThanosComponent{
+						PrometheusNodeExporter: &vzapi.PrometheusNodeExporterComponent{
 							Enabled: &trueValue,
 						},
 						AuthProxy: &vzapi.AuthProxyComponent{

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/modules_integration_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package nodeexporter
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"testing"
+)
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					Components: vzapi.ComponentSpec{
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled: &trueValue,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						Prometheus: &vzapi.PrometheusComponent{
+							Enabled: &trueValue,
+						},
+						Thanos: &vzapi.ThanosComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					  "prometheusOperatorEnabled": true
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent().(prometheusNodeExporterComponent)
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/modules_integration.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package operator
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	EnvironmentName string                       `json:"environmentName,omitempty"`
+	Ingress         *vzapi.IngressNginxComponent `json:"ingress,omitempty"`
+	DNS             *vzapi.DNSComponent          `json:"dns,omitempty"`
+	Thanos          *vzapi.ThanosComponent       `json:"thanos,omitempty"`
+
+	PrometheusEnabled          bool `json:"prometheusEnabled"`
+	ClusterIssuerEnabled       bool `json:"clusterIssuerEnabled"`
+	ApplicationOperatorEnabled bool `json:"applicationOperatorEnabled"`
+	ClusterOperatorEnabled     bool `json:"clusterOperatorEnabled"`
+	IstioEnabled               bool `json:"istioEnabled"`
+	VMOEnabled                 bool `json:"vmoEnabled"`
+
+	DefaultVolumeSource      *corev1.VolumeSource            `json:"defaultVolumeSource,omitempty" patchStrategy:"replace"`
+	VolumeClaimSpecTemplates []vzapi.VolumeClaimSpecTemplate `json:"volumeClaimSpecTemplates,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (c prometheusComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		DefaultVolumeSource:        effectiveCR.Spec.DefaultVolumeSource,
+		VolumeClaimSpecTemplates:   effectiveCR.Spec.VolumeClaimSpecTemplates,
+		PrometheusEnabled:          vzcr.IsPrometheusEnabled(effectiveCR),
+		ClusterIssuerEnabled:       vzcr.IsClusterIssuerEnabled(effectiveCR),
+		ApplicationOperatorEnabled: vzcr.IsApplicationOperatorEnabled(effectiveCR),
+		ClusterOperatorEnabled:     vzcr.IsClusterOperatorEnabled(effectiveCR),
+		IstioEnabled:               vzcr.IsIstioEnabled(effectiveCR),
+		VMOEnabled:                 vzcr.IsVMOEnabled(effectiveCR),
+	}
+
+	thanos := effectiveCR.Spec.Components.Thanos
+	if thanos != nil {
+		// The prometheus operator digs into the Thanos overrides for the Thanos ruler settings, so we need to trigger on that
+		configSnippet.Thanos = thanos.DeepCopy()
+	}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = dns.DeepCopy()
+		configSnippet.DNS.InstallOverrides = vzapi.InstallOverrides{}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []vzapi.Overrides{}
+	}
+
+	if len(effectiveCR.Spec.EnvironmentName) > 0 {
+		configSnippet.EnvironmentName = effectiveCR.Spec.EnvironmentName
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/modules_integration.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package pushgateway
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+type valuesConfig struct {
+	PrometheusOperatorEnabled bool `json:"prometheusOperatorEnabled"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
+func (c prometheusPushgatewayComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		PrometheusOperatorEnabled: vzcr.IsPrometheusOperatorEnabled(effectiveCR),
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/modules_integration_test.go
@@ -58,7 +58,7 @@ func TestGetModuleSpec(t *testing.T) {
 						Prometheus: &vzapi.PrometheusComponent{
 							Enabled: &trueValue,
 						},
-						Thanos: &vzapi.ThanosComponent{
+						PrometheusPushgateway: &vzapi.PrometheusPushgatewayComponent{
 							Enabled: &trueValue,
 						},
 						AuthProxy: &vzapi.AuthProxyComponent{

--- a/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/pushgateway/modules_integration_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package pushgateway
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"testing"
+)
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					Components: vzapi.ComponentSpec{
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled: &trueValue,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						Prometheus: &vzapi.PrometheusComponent{
+							Enabled: &trueValue,
+						},
+						Thanos: &vzapi.ThanosComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					  "prometheusOperatorEnabled": true
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/rancher/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/modules_integration.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package rancher
+
+import (
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
+type valuesConfig struct {
+	KeycloakAuthEnabled *bool `json:"keycloakAuthEnabled,omitempty"`
+
+	Ingress         *vzapi.IngressNginxComponent `json:"ingress,omitempty"`
+	DNS             *vzapi.DNSComponent          `json:"dns,omitempty"`
+	EnvironmentName string                       `json:"environmentName,omitempty"`
+
+	ClusterIssuer *vzapi.ClusterIssuerComponent `json:"clusterIssuer,omitempty"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
+func (r rancherComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		EnvironmentName: effectiveCR.Spec.EnvironmentName,
+	}
+
+	rancher := effectiveCR.Spec.Components.Rancher
+	if rancher != nil {
+		// The prometheus operator digs into the Thanos overrides for the Thanos ruler settings, so we need to trigger on that
+		configSnippet.KeycloakAuthEnabled = rancher.KeycloakAuthEnabled
+	}
+
+	issuer := effectiveCR.Spec.Components.ClusterIssuer
+	if issuer != nil {
+		configSnippet.ClusterIssuer = issuer.DeepCopy()
+	}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = dns.DeepCopy()
+		configSnippet.DNS.InstallOverrides = vzapi.InstallOverrides{}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []vzapi.Overrides{}
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/rancher/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/modules_integration_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package rancher
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+var pvc100Gi, _ = resource.ParseQuantity("100Gi")
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	ingressClassName := "myclass"
+
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					DefaultVolumeSource: &corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "vmi",
+						},
+					},
+					VolumeClaimSpecTemplates: []vzapi.VolumeClaimSpecTemplate{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "vmi"},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"storage": pvc100Gi,
+									},
+								},
+							},
+						},
+					},
+					Components: vzapi.ComponentSpec{
+						Rancher: &vzapi.RancherComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte(`{"key": "rancherVal"}`)}},
+								},
+							},
+							KeycloakAuthEnabled: &trueValue,
+						},
+						ClusterIssuer: &vzapi.ClusterIssuerComponent{
+							Enabled:                  &trueValue,
+							ClusterResourceNamespace: "secretNS",
+							IssuerConfig: vzapi.IssuerConfig{
+								CA: &vzapi.CAIssuer{
+									SecretName: "secretName",
+								},
+							},
+						},
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+			        "keycloakAuthEnabled": true,
+					"clusterIssuer": {
+					  "enabled": true,
+					  "clusterResourceNamespace": "secretNS",
+					  "ca": {
+						"secretName": "secretName"
+					  }
+					},
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					},
+					"environmentName": "Myenv"
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/thanos/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/modules_integration.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package thanos
+
+import (
+	"github.com/verrazzano/verrazzano/pkg/vzcr"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+type valuesConfig struct {
+	IstioInjectionEnabled bool `json:"istioInjectionEnabled"`
+}
+
+// GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
+func (c ThanosComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+	if effectiveCR == nil {
+		return nil, nil
+	}
+
+	configSnippet := valuesConfig{
+		IstioInjectionEnabled: vzcr.IsIstioInjectionEnabled(effectiveCR),
+	}
+
+	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
+}

--- a/platform-operator/controllers/verrazzano/component/thanos/modules_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/modules_integration_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package thanos
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"testing"
+)
+
+// TestGetModuleSpec tests the GetModuleConfigAsHelmValues function impl for this component
+// GIVEN a call to GetModuleConfigAsHelmValues
+//
+//	WHEN for various Verrazzano CR configurations
+//	THEN the generated helm values JSON snippet is valid
+func TestGetModuleSpec(t *testing.T) {
+	trueValue := true
+	tests := []struct {
+		name        string
+		effectiveCR *vzapi.Verrazzano
+		want        string
+		wantErr     assert.ErrorAssertionFunc
+	}{
+		{
+			name: "BasicConfig",
+			effectiveCR: &vzapi.Verrazzano{
+				Spec: vzapi.VerrazzanoSpec{
+					EnvironmentName: "Myenv",
+					Components: vzapi.ComponentSpec{
+						Ingress: &vzapi.IngressNginxComponent{
+							Enabled: &trueValue,
+							Ports: []corev1.ServicePort{
+								{
+									Name:     "myport",
+									Protocol: "tcp",
+									Port:     8000,
+									NodePort: 80,
+								},
+							},
+							Type: vzapi.LoadBalancer,
+						},
+						DNS: &vzapi.DNSComponent{
+							OCI: &vzapi.OCI{
+								DNSScope:               "global",
+								DNSZoneCompartmentOCID: "ocid..compartment.mycomp",
+								DNSZoneOCID:            "ocid..zone.myzone",
+								DNSZoneName:            "myzone",
+								OCIConfigSecret:        "oci",
+							},
+						},
+						Istio: &vzapi.IstioComponent{
+							Enabled:          &trueValue,
+							InjectionEnabled: &trueValue,
+						},
+						PrometheusOperator: &vzapi.PrometheusOperatorComponent{
+							Enabled: &trueValue,
+						},
+						AuthProxy: &vzapi.AuthProxyComponent{
+							Enabled: &trueValue,
+							Kubernetes: &vzapi.AuthProxyKubernetesSection{
+								CommonKubernetesSpec: vzapi.CommonKubernetesSpec{
+									Replicas: 3,
+								},
+							},
+						},
+						Keycloak: &vzapi.KeycloakComponent{
+							Enabled: &trueValue,
+							InstallOverrides: vzapi.InstallOverrides{
+								MonitorChanges: &trueValue,
+								ValueOverrides: []vzapi.Overrides{
+									{Values: &apiextensionsv1.JSON{Raw: []byte("somevalue")}},
+								},
+							},
+							KeycloakInstallArgs: nil,
+							MySQL:               vzapi.MySQLComponent{},
+						},
+					},
+				},
+			},
+			wantErr: assert.NoError,
+			want: `{
+			  "verrazzano": {
+				"module": {
+				  "spec": {
+					  "istioInjectionEnabled": true
+				  }
+				}
+			  }
+			}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewComponent()
+			got, err := c.GetModuleConfigAsHelmValues(tt.effectiveCR)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
+				return
+			}
+			assert.JSONEq(t, tt.want, string(got.Raw))
+		})
+	}
+}

--- a/platform-operator/controllers/verrazzano/component/verrazzano/modules_integration.go
+++ b/platform-operator/controllers/verrazzano/component/verrazzano/modules_integration.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package verrazzano
+
+import (
+	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
+)
+
+// GetWatchDescriptors Returns a watch on the whole VZ CR spec, as the VZ "module" looks at a lot of settings; for now
+// just watch for any changes and trigger this to reconcile
+func (c verrazzanoComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
+	return watch.GetVerrazzanoSpecWatch()
+}


### PR DESCRIPTION
Adds module integration mappings for the remaining component layers (1, 2, and 3).  These map the VZ CR configuration consumed by each, minus the `InstallOverrides` which are tracked separately (with a few exceptions).

Also adds a VZ spec watch to the `verrazzano` module.

Compoents:
- fluentd
- grafana
- istio
- jaeger
- keycloak
- kiali
- mysql
- opensearch
- opensearchDashboards
- kubestatemetrics
- Prometheus nodexporter
- Prometheus Operator
- Prometheus pushgateway
- Rancher
- Thanos
