### PR TITLE
VZ-10626 Add the ingress path for the new authproxy

### DIFF
--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-ingress.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-ingress.yaml
@@ -47,6 +47,13 @@ spec:
               service:
                 name: {{ .Values.name }}
                 port:
+                  number: {{ .Values.v2.port }}
+            path: /clusters
+            pathType: Prefix
+          - backend:
+              service:
+                name: {{ .Values.name }}
+                port:
                   number: {{ .Values.port }}
             path: /()(.*)
             pathType: ImplementationSpecific

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-ingress.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-ingress.yaml
@@ -11,7 +11,6 @@ metadata:
     {{- end }}
     external-dns.alpha.kubernetes.io/target: verrazzano-ingress.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
     kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_hide_header X-Powered-By;

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-ingress.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- end }}
     external-dns.alpha.kubernetes.io/target: verrazzano-ingress.{{ .Values.config.envName }}.{{ .Values.config.dnsSuffix }}
     kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1$2
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_hide_header X-Powered-By;
@@ -47,7 +48,7 @@ spec:
                 name: {{ .Values.name }}
                 port:
                   number: {{ .Values.v2.port }}
-            path: /clusters
+            path: /(clusters)(.*)
             pathType: Prefix
           - backend:
               service:

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/networkpolicy.yaml
@@ -30,6 +30,8 @@ spec:
           port: 8775
         - protocol: TCP
           port: 8776
+        - protocol: TCP
+          port: 8777
     - from:
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
**Changes**
- Update the network policy to allow ingress traffic to the new authproxy port
- Add cluster path to the ingress to forward to the new authproxy

**Testing**
- Deploy in cluster and access the API server through the ingress