### PR TITLE
VZ-10770: Remove deprecated VZ releases from release-1.4 upgrade jobs

### DIFF
--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -45,7 +45,7 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "1.21", "1.22", "1.23", "1.24" ])
         string (name: 'EXCLUDE_RELEASES',
-                defaultValue: "v1.0, v1.1",
+                defaultValue: "v1.0, v1.1, v1.2, v1.3",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)
         string (name: 'VERRAZZANO_OPERATOR_IMAGE',
                         defaultValue: 'NONE',


### PR DESCRIPTION
This PR removes deprecated VZ releases v1.2.x and v1.3.x from release-1.4 upgrade jobs. 