### PR TITLE
VZ-10788: Add OIDC config to Auth Proxy v2

### DIFF
--- a/authproxy/main.go
+++ b/authproxy/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/verrazzano/verrazzano/authproxy/src/config"
 	"github.com/verrazzano/verrazzano/authproxy/src/proxy"
 	vzlog "github.com/verrazzano/verrazzano/pkg/log"
 	"go.uber.org/zap"
@@ -19,6 +20,8 @@ var proxyPort int
 func main() {
 	handleFlags()
 	log := zap.S()
+
+	config.InitConfiguration(log)
 
 	log.Info("Initializing the proxy server")
 	authproxy := proxy.InitializeProxy(proxyPort)

--- a/authproxy/src/config/config.go
+++ b/authproxy/src/config/config.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package config
+
+import (
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// these can be changed for unit testing
+var (
+	issuerURLFilename = "/etc/config/oidcIssuerURL"
+	clientIDFilename  = "/etc/config/oidcClientID"
+
+	watchInterval = time.Minute
+	keepWatching  atomic.Bool
+)
+
+var (
+	issuerURL string
+	clientID  string
+
+	issuerURLFileModTime time.Time
+	clientIDFileModTime  time.Time
+
+	mutex sync.RWMutex
+)
+
+// GetIssuerURL returns the issuer URL
+func GetIssuerURL() string {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	return issuerURL
+}
+
+// GetClientID returns the client ID
+func GetClientID() string {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	return clientID
+}
+
+// loadIssuerURL loads the issuer URL from a file and stores the file modification time
+func loadIssuerURL() error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	value, modTime, err := loadConfigValue(issuerURLFilename)
+	if err != nil {
+		return err
+	}
+
+	issuerURL = value
+	issuerURLFileModTime = *modTime
+	return nil
+}
+
+// loadClientID loads the client ID from a file and stores the file modification time
+func loadClientID() error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	value, modTime, err := loadConfigValue(clientIDFilename)
+	if err != nil {
+		return err
+	}
+
+	clientID = value
+	clientIDFileModTime = *modTime
+	return nil
+}
+
+// loadConfigValue loads a configuration value from a file and stores the file modification time
+func loadConfigValue(filename string) (string, *time.Time, error) {
+	bytes, err := os.ReadFile(filename)
+	if err != nil {
+		return "", nil, err
+	}
+
+	fileInfo, err := os.Stat(filename)
+	if err != nil {
+		return "", nil, err
+	}
+
+	modTime := fileInfo.ModTime()
+	return string(bytes), &modTime, nil
+}
+
+// InitConfiguration loads the configuration from files and starts a goroutine to watch for configuration changes and reloads
+// config values when changes are detected
+func InitConfiguration(log *zap.SugaredLogger) error {
+	if err := loadIssuerURL(); err != nil {
+		return err
+	}
+	if err := loadClientID(); err != nil {
+		return err
+	}
+
+	keepWatching.Store(true)
+	go watchConfigForChanges(log)
+	return nil
+}
+
+// watchConfigForChanges watches the configuration files for changes and reloads as necessary. This function generally
+// runs forever but the keepWatching atomic bool can be set to false in unit tests to stop the loop.
+func watchConfigForChanges(log *zap.SugaredLogger) {
+	for keepWatching.Load() {
+		if err := reloadConfigWhenChanged(log); err != nil {
+			log.Warnf("Error reloading configuration: %v", err)
+		}
+		time.Sleep(watchInterval)
+	}
+}
+
+// reloadConfigWhenChanged compares the config file modification times and reloads config values
+func reloadConfigWhenChanged(log *zap.SugaredLogger) error {
+	fileInfo, err := os.Stat(issuerURLFilename)
+	if err != nil {
+		return err
+	}
+	if fileInfo.ModTime().After(issuerURLFileModTime) {
+		// file has changed
+		log.Debugf("Detected change in file %s, reloading contents", issuerURLFilename)
+		if err := loadIssuerURL(); err != nil {
+			return err
+		}
+	}
+
+	fileInfo, err = os.Stat(clientIDFilename)
+	if err != nil {
+		return err
+	}
+	if fileInfo.ModTime().After(clientIDFileModTime) {
+		// file has changed
+		log.Debugf("Detected change in file %s, reloading contents", clientIDFilename)
+		if err := loadClientID(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/authproxy/src/config/config_test.go
+++ b/authproxy/src/config/config_test.go
@@ -90,7 +90,7 @@ func makeTempFile(content string) (*os.File, error) {
 
 // eventually executes the provided function until it either returns true or exceeds a number of attempts
 func eventually(f func() bool) bool {
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 10; i++ {
 		if f() == true {
 			return true
 		}

--- a/authproxy/src/config/config_test.go
+++ b/authproxy/src/config/config_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// TestInitConfiguration tests the InitConfiguration function
+func TestInitConfiguration(t *testing.T) {
+	const testIssuerURL = "http://issuer.com"
+	const testClientID = "unit-test-client-id"
+
+	// create temporary files with test data and override the filenames
+	issuerURLFile, err := makeTempFile(testIssuerURL)
+	if issuerURLFile != nil {
+		defer os.Remove(issuerURLFile.Name())
+	}
+	assert.NoError(t, err)
+
+	clientIDFile, err := makeTempFile(testClientID)
+	if clientIDFile != nil {
+		defer os.Remove(clientIDFile.Name())
+	}
+	assert.NoError(t, err)
+
+	// restore the filenames when this test is done
+	oldIssuerURLFilename := issuerURLFilename
+	defer func() { issuerURLFilename = oldIssuerURLFilename }()
+	issuerURLFilename = issuerURLFile.Name()
+
+	oldClientIDFilename := clientIDFilename
+	defer func() { clientIDFilename = oldClientIDFilename }()
+	clientIDFilename = clientIDFile.Name()
+
+	// override the watch interval
+	oldWatchInterval := watchInterval
+	defer func() { watchInterval = oldWatchInterval }()
+	watchInterval = 500 * time.Millisecond
+
+	// GIVEN initial configuration files
+	// WHEN the InitConfiguration function is called
+	// THEN the fetched configuration values match the file contents
+	err = InitConfiguration(zap.S())
+	assert.NoError(t, err)
+
+	assert.Equal(t, testIssuerURL, GetIssuerURL())
+	assert.Equal(t, testClientID, GetClientID())
+
+	// GIVEN the file contents are changed
+	// WHEN we fetch the configuration values
+	// THEN the values eventually match the expected updated file contents
+	const newTestIssuerURL = "http://new-issuer.com"
+	const newTestClientID = "new-unit-test-client-id"
+
+	// update the file contents and validate that the new values are loaded
+	err = os.WriteFile(issuerURLFilename, []byte(newTestIssuerURL), 0)
+	assert.NoError(t, err)
+
+	err = os.WriteFile(clientIDFilename, []byte(newTestClientID), 0)
+	assert.NoError(t, err)
+
+	updated := eventually(func() bool { return GetIssuerURL() == newTestIssuerURL })
+	assert.True(t, updated, "Expected the issuer URL to be updated")
+
+	updated = eventually(func() bool { return GetClientID() == newTestClientID })
+	assert.True(t, updated, "Expected the client id to be updated")
+
+	// stop the goroutine
+	keepWatching.Store(false)
+}
+
+// makeTempFile creates a temporary file and writes the specified contents
+func makeTempFile(content string) (*os.File, error) {
+	tmpFile, err := os.CreateTemp("", "")
+	if err != nil {
+		return nil, err
+	}
+	defer tmpFile.Close()
+
+	_, err = tmpFile.Write([]byte(content))
+	return tmpFile, err
+}
+
+// eventually executes the provided function until it either returns true or exceeds a number of attempts
+func eventually(f func() bool) bool {
+	for i := 0; i < 3; i++ {
+		if f() == true {
+			return true
+		}
+		time.Sleep(watchInterval)
+	}
+	return false
+}

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/authproxy-oidc-config.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/authproxy-oidc-config.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.v2.oidcConfigSecret }}
+  namespace: {{ .Values.namespace }}
+type: Opaque
+data:
+  oidcIssuerURL: {{ .Values.v2.oidcIssuerURL | b64enc | quote }}
+  oidcClientID: {{ .Values.v2.oidcClientID | b64enc | quote }}

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -96,6 +96,9 @@ spec:
                   - key: reload.sh
                     path: reload.sh
                     mode: 0755
+       - name: oidc-config-secret
+         secret:
+           secretName: {{ .Values.v2.oidcConfigSecret }}
       {{- with .Values.affinity }}
       affinity:
         {{- tpl . $ | nindent 8 }}
@@ -205,6 +208,9 @@ spec:
           capabilities:
             drop:
               - ALL
+        volumeMounts:
+        - name: oidc-config-secret
+          mountPath: /etc/config
       serviceAccountName: {{ .Values.name }}
       securityContext:
         runAsUser: 101  # nginx container user

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
@@ -44,3 +44,7 @@ dns:
 v2:
   image:
   port: 8777
+
+  oidcIssuerURL: placeholder
+  oidcClientID: verrazzano-pkce
+  oidcConfigSecret: verrazzano-authproxy-oidc-config


### PR DESCRIPTION
This PR adds OIDC configuration to Auth Proxy v2. Configuration is stored in a secret and mounted into the Auth Proxy pod. A watcher checks for updates to the secret data and automatically reloads the values when changes are detected.

The configuration currently allows for an issuer URL and a client id. We can extend this as needed.