### PR TITLE
VZ-10404 Delete CAPI RBAC resources before upgrade

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -328,7 +328,8 @@ func deleteRBACComponents(ctx spi.ComponentContext, components []unstructured.Un
 				ctx.Log().Errorf("Unexpected error getting %s %s: %v", component.GetKind(), component.GetName(), err)
 				return err
 			}
-			return ctx.Log().ErrorfThrottledNewErr("Waiting for cluster-api RBAC resources to be deleted before upgrade")
+			ctx.Log().Progress("Waiting for cluster-api RBAC resources to be deleted before upgrade")
+			return err
 		}
 	}
 	return nil

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -7,14 +7,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"os"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	clusterapi "sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -303,7 +303,8 @@ func getComponentsToUpgrade(client clusterapi.Client, options clusterapi.ApplyUp
 
 // deleteRBACComponents deletes all the RBAC resources and check to ensure they were deleted
 func deleteRBACComponents(ctx spi.ComponentContext, components []unstructured.Unstructured) error {
-	for _, component := range components {
+	for i := range components {
+		component := components[i]
 		if component.GroupVersionKind().Group == rbacGroup {
 			err := ctx.Client().Delete(context.TODO(), &component)
 			if err != nil && !errors.IsNotFound(err) {
@@ -313,7 +314,8 @@ func deleteRBACComponents(ctx spi.ComponentContext, components []unstructured.Un
 		}
 	}
 
-	for _, component := range components {
+	for i := range components {
+		component := components[i]
 		if component.GroupVersionKind().Group == rbacGroup {
 			err := ctx.Client().Get(context.TODO(),
 				types.NamespacedName{Name: component.GetName(), Namespace: component.GetNamespace()}, &component)

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -6,6 +6,7 @@ package clusterapi
 import (
 	"context"
 	"fmt"
+
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
@@ -16,6 +17,7 @@ import (
 	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
+	
 	appsv1 "k8s.io/api/apps/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -319,7 +319,7 @@ func (c clusterAPIComponent) Upgrade(ctx spi.ComponentContext) error {
 		// get all the resource that will be deleted and recreated
 		components, err := getComponentsToUpgrade(capiClient, applyUpgradeOptions)
 		if err != nil {
-			ctx.Log().Errorf("Error generating CAPI components to be upgraded")
+			ctx.Log().ErrorfThrottled("Error generating cluster-api provider components to be upgraded")
 			return err
 		}
 

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -17,7 +17,7 @@ import (
 	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	
+
 	appsv1 "k8s.io/api/apps/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
This changes fixes a problem where Rancher finalizer will prevent CAPI RBAC resources from deleting before they get recreated during upgrade. This had the effect of the CAPI RBAC resources that got upgraded being permanently removed from the cluster during upgrade.