### PR TITLE
VZ-10809.  Module integration only, force VZ CR status fields to align with last reconciled generation after successful install/update

### DIFF
--- a/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/operator/promoperator.go
@@ -241,7 +241,7 @@ func getPrometheusPersistentVolumes(ctx spi.ComponentContext) (*corev1.Persisten
 // "retain" so that we can migrate it to the new Prometheus. Now that it has been migrated, we reset the reclaim policy
 // to its original value.
 func resetVolumeReclaimPolicy(ctx spi.ComponentContext) error {
-	ctx.Log().Info("Resetting reclaim policy on Prometheus persistent volume if a volume exists")
+	ctx.Log().Progressf("Resetting reclaim policy on Prometheus persistent volume if a volume exists")
 
 	pvList, err := getPrometheusPersistentVolumes(ctx)
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/reconcile/controller.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller.go
@@ -1121,6 +1121,10 @@ func (r *Reconciler) IsWatchedComponent(compName string) bool {
 // forceSyncComponentReconciledGeneration Force all Ready components' lastReconciledGeneration to match the VZ CR generation;
 // this is applied at the end of a successful VZ CR reconcile.
 func (r *Reconciler) forceSyncComponentReconciledGeneration(actualCR *installv1alpha1.Verrazzano) error {
+	if !config.Get().ModuleIntegration {
+		// only do this with modules integration enabled
+		return nil
+	}
 	targetVersion := actualCR.Spec.Version
 	componentsToUpdate := map[string]*installv1alpha1.ComponentStatusDetails{}
 	for compName, componentStatus := range actualCR.Status.Components {

--- a/platform-operator/controllers/verrazzano/reconcile/controller.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller.go
@@ -1118,15 +1118,9 @@ func (r *Reconciler) IsWatchedComponent(compName string) bool {
 	return r.WatchedComponents[compName]
 }
 
-// forceSyncComponentReconciledGeneration Force all Ready components' lastReconciledGeneration to match the VZ CR generation
+// forceSyncComponentReconciledGeneration Force all Ready components' lastReconciledGeneration to match the VZ CR generation;
+// this is applied at the end of a successful VZ CR reconcile.
 func (r *Reconciler) forceSyncComponentReconciledGeneration(actualCR *installv1alpha1.Verrazzano) error {
-	//for compName, compStatus := range actualCR.Status.Components {
-	//	if compStatus.State == installv1alpha1.CompStateReady {
-	//		ctx.Log().Debugf("Updating last reconciled generation for %s", compName)
-	//		compStatus.LastReconciledGeneration = actualCR.Generation
-	//	}
-	//}
-	//return ctx.Client().Status().Update(context.TODO(), actualCR)
 	targetVersion := actualCR.Spec.Version
 	componentsToUpdate := map[string]*installv1alpha1.ComponentStatusDetails{}
 	for compName, componentStatus := range actualCR.Status.Components {

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -133,7 +133,7 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 			tracker.vzState = vzStatePreInstall
 
 		case vzStateSetGlobalInstallStatus:
-			spiCtx.Log().Oncef("Writing Install Started condition to the Verrazzano status for generation: %d", spiCtx.ActualCR().Generation)
+			spiCtx.Log().Progressf("Writing Install Started condition to the Verrazzano status for generation: %d", spiCtx.ActualCR().Generation)
 			if err := r.setInstallingState(vzctx.Log, spiCtx.ActualCR()); err != nil {
 				spiCtx.Log().ErrorfThrottled("Error writing Install Started condition to the Verrazzano status: %v", err)
 				return ctrl.Result{Requeue: true}, err
@@ -171,6 +171,9 @@ func (r *Reconciler) reconcileComponents(vzctx vzcontext.VerrazzanoContext, preU
 					return ctrl.Result{Requeue: true}, err
 				}
 			}
+			if err := r.forceSyncComponentReconciledGeneration(spiCtx.ActualCR()); err != nil {
+				return newRequeueWithDelay(), err
+			}
 			tracker.vzState = vzStateReconcileEnd
 		}
 	}
@@ -190,7 +193,7 @@ func checkGenerationUpdated(spiCtx spi.ComponentContext) bool {
 				return true
 			}
 			if checkConfigUpdated(spiCtx, componentStatus) && comp.MonitorOverrides(spiCtx) {
-				spiCtx.Log().Oncef("Verrazzano CR generation change detected, generation: %v, component: %s, component reconciling generation: %v, component lastreconciling generation %v",
+				spiCtx.Log().Progressf("Verrazzano CR generation change detected, generation: %v, component: %s, component reconciling generation: %v, component lastreconciling generation %v",
 					spiCtx.ActualCR().Generation, comp.Name(), componentStatus.ReconcilingGeneration, componentStatus.LastReconciledGeneration)
 				return true
 			}

--- a/platform-operator/controllers/verrazzano/reconcile/install_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_test.go
@@ -317,7 +317,7 @@ func TestUpdateFalseMonitorChanges(t *testing.T) {
 
 	asserts.Equal(vzapi.VzStateReady, vz.Status.State)
 	asserts.False(*fakeCompUpdated)
-	asserts.Equal(int64(3), vz.Status.Components[fakeCompReleaseName].LastReconciledGeneration)
+	asserts.Equal(lastReconciledGeneration, vz.Status.Components[fakeCompReleaseName].LastReconciledGeneration)
 	asserts.False(result.Requeue)
 	assertKeycloakAuthConfig(asserts, ctx)
 	assertArgoCDConfig(asserts, ctx)

--- a/platform-operator/controllers/verrazzano/reconcile/install_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install_test.go
@@ -317,7 +317,7 @@ func TestUpdateFalseMonitorChanges(t *testing.T) {
 
 	asserts.Equal(vzapi.VzStateReady, vz.Status.State)
 	asserts.False(*fakeCompUpdated)
-	asserts.Equal(lastReconciledGeneration, vz.Status.Components[fakeCompReleaseName].LastReconciledGeneration)
+	asserts.Equal(int64(3), vz.Status.Components[fakeCompReleaseName].LastReconciledGeneration)
 	asserts.False(result.Requeue)
 	assertKeycloakAuthConfig(asserts, ctx)
 	assertArgoCDConfig(asserts, ctx)

--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -109,9 +109,10 @@ func (r Reconciler) createOrUpdateModules(log vzlog.VerrazzanoLogger, effectiveC
 				Namespace: vzconst.VerrazzanoInstallNamespace,
 			},
 		}
-		_, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, &module, func() error {
+		opResult, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, &module, func() error {
 			return r.mutateModule(log, effectiveCR, &module, comp, version.ToString())
 		})
+		log.Debugf("Module %s update result: %v", module.Name, opResult)
 		if err != nil {
 			if !errors.IsConflict(err) {
 				log.ErrorfThrottled("Failed createOrUpdate module %s: %v", module.Name, err)


### PR DESCRIPTION
At the end of a VZ reconcile force all VZ component status fields to align `lastReconciledGeneration` with the CR generation.  This behavior is guarded by the `ModuleIntegration` flag in the VPO.

This largely addresses the module integration case where each VZ CR reconcile may not cause an individual module to reconcile (if the Module CR update is a no-op), the VZ CR status for the component should reflect that it was processed.

Each module will still track it's own generation independently.