### PR TITLE
VZ-10583: Uptake Istio 1.15.7 in release-1.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+### v1.5.6
+Component version updates:
+
+- Istio v1.15.7
+
+### v1.5.5
+Fixes:
+
+- Fixed issues with Rancher certificates that were out of sync or expired.
+- Fixed issues with certificates in multicluster environments.
+- Fixed issue where Istio was incorrectly waiting for disabled deployments.
+- Fixed upgrade issues in the command-line tool (CLI).
+- Fixed issues in the Verrazzano validating webhook.
+
 ### v1.5.4
 Component version updates:
 

--- a/pkg/k8s/webhook/webhook.go
+++ b/pkg/k8s/webhook/webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package webhook
@@ -13,16 +13,18 @@ import (
 	ctrlcli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func DeleteMutatingWebhookConfiguration(log vzlog.VerrazzanoLogger, client ctrlcli.Client, name string) error {
-	wh := adminv1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-	}
-	log.Progressf("Deleting MutatingWebhookConfiguration %s", name)
-	if err := client.Delete(context.TODO(), &wh); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
+func DeleteMutatingWebhookConfiguration(log vzlog.VerrazzanoLogger, client ctrlcli.Client, names []string) error {
+	for _, name := range names {
+		wh := adminv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
 		}
-		return log.ErrorfThrottledNewErr("Failed to delete MutatingWebhookConfiguration %:, %v", name, err)
+		log.Progressf("Deleting MutatingWebhookConfiguration %s", name)
+		if err := client.Delete(context.TODO(), &wh); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return log.ErrorfThrottledNewErr("Failed to delete MutatingWebhookConfiguration %:, %v", name, err)
+		}
 	}
 	return nil
 }

--- a/pkg/k8s/webhook/webhook_test.go
+++ b/pkg/k8s/webhook/webhook_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package webhook
@@ -96,7 +96,7 @@ func TestDeleteMutating(t *testing.T) {
 	asserts.NoError(err)
 
 	// Delete the webhook
-	err = DeleteMutatingWebhookConfiguration(vzlog.DefaultLogger(), c, name)
+	err = DeleteMutatingWebhookConfiguration(vzlog.DefaultLogger(), c, []string{name})
 
 	// Validate that webhook is deleted
 	asserts.NoError(err)
@@ -124,6 +124,6 @@ func TestDeleteMutatingNotExists(t *testing.T) {
 	asserts.True(errors.IsNotFound(err))
 
 	// Delete the webhook
-	err = DeleteMutatingWebhookConfiguration(vzlog.DefaultLogger(), c, name)
+	err = DeleteMutatingWebhookConfiguration(vzlog.DefaultLogger(), c, []string{name})
 	asserts.NoError(err)
 }

--- a/platform-operator/Dockerfile
+++ b/platform-operator/Dockerfile
@@ -24,7 +24,7 @@ ARG VERRAZZANO_APPLICATION_OPERATOR_IMAGE
 COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano/platform-operator/repos/*.repo /etc/yum.repos.d/
 
 RUN microdnf update -y \
-    && microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs openssl jq kubectl-1.23.11-1.el8 istio-istioctl-1.15.3-1.el8 helm-3.9.4-1.el8 \
+    && microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs openssl jq kubectl-1.23.11-1.el8 istio-istioctl-1.15.7-1.el8 helm-3.9.4-1.el8 \
     && microdnf clean all \
     && rm -rf /var/cache/yum /var/lib/rpm/* \
     && groupadd -r verrazzano \

--- a/platform-operator/controllers/verrazzano/component/coherence/coherence_component.go
+++ b/platform-operator/controllers/verrazzano/component/coherence/coherence_component.go
@@ -109,7 +109,8 @@ func (c coherenceComponent) PostUninstall(context spi.ComponentContext) error {
 	if err := webhook.DeleteValidatingWebhookConfiguration(context.Log(), context.Client(), "coherence-operator-validating-webhook-configuration"); err != nil {
 		return err
 	}
-	if err := webhook.DeleteMutatingWebhookConfiguration(context.Log(), context.Client(), "coherence-operator-mutating-webhook-configuration"); err != nil {
+	webhooks := []string{"coherence-operator-mutating-webhook-configuration"}
+	if err := webhook.DeleteMutatingWebhookConfiguration(context.Log(), context.Client(), webhooks); err != nil {
 		return err
 	}
 	return nil

--- a/platform-operator/controllers/verrazzano/component/coherence/coherence_component.go
+++ b/platform-operator/controllers/verrazzano/component/coherence/coherence_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package coherence

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -77,6 +77,8 @@ const istiodIstioSystem = "istiod-istio-system"
 
 const istioSidecarMutatingWebhook = "istio-sidecar-injector"
 
+const istioRevisionMutatingWebhook = "istio-revision-tag-default"
+
 var istioLabelSelector = clipkg.ListOptions{LabelSelector: labels.Set(map[string]string{"release": "istio"}).AsSelector()}
 
 const (
@@ -442,7 +444,8 @@ func (i istioComponent) PreUpgrade(context spi.ComponentContext) error {
 		}
 	}
 	// Upgrading Istio may result in a duplicate mutating webhook configuration. Istioctl will recreate the webhook during upgrade.
-	return webhook.DeleteMutatingWebhookConfiguration(context.Log(), context.Client(), istioSidecarMutatingWebhook)
+	webhooks := []string{istioSidecarMutatingWebhook, istioRevisionMutatingWebhook}
+	return webhook.DeleteMutatingWebhookConfiguration(context.Log(), context.Client(), webhooks)
 }
 
 func (i istioComponent) PostUpgrade(context spi.ComponentContext) error {

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -98,7 +98,7 @@
     },
     {
       "name": "istio",
-      "version": "1.15.3",
+      "version": "1.15.7",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -106,12 +106,12 @@
           "images": [
             {
               "image": "pilot",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.15.7-20230822201106-52185b9e",
               "helmFullImageKey": "values.pilot.image"
             },
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.15.7-20230822201106-52185b9e",
               "helmImageKey": "values.global.proxy.image",
               "helmTagKey": "values.global.tag",
               "helmRegistryAndRepoKey": "values.global.hub"
@@ -183,7 +183,7 @@
           "images": [
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.15.7-20230822201106-52185b9e",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {
@@ -229,7 +229,7 @@
             },
             {
               "image": "proxyv2",
-              "tag": "1.15.3-20230209181608-900a5c7b",
+              "tag": "1.15.7-20230822201106-52185b9e",
               "helmFullImageKey": "monitoringOperator.istioProxyImage"
             },
             {


### PR DESCRIPTION
Uptake Istio 1.15.7 in release-1.5

Additional updates:
Cherry-picking https://github.com/verrazzano/verrazzano/pull/6391/commits/95d31251a039ced92c6450e65ebb792fb6dc318b to avoid error Deleting mutating webhook istio-revision-tag-default on preupgrade due to conflicting errors (error code IST0139) with MutatingWebhookConfiguration istio-sidecar-injector on Verrazzano upgrade - upgrading Verrazzano v1.4.6 (Istio v1.14.3) to release-1.5 (Istio v1.15.7)
```
{"level":"info","@timestamp":"2023-08-24T18:32:12.847Z","caller":"istio/istioctl.go:128","message":"Failed running istioctl command /usr/local/bin/istioctl install -y -f /verrazzano/platform-operator/helm_config/overrides/istio-cr.yaml -f /tmp/istio-3956802907.yaml -f /tmp/istio-706172992.yaml --set values.pilot.image=ghcr.io/verrazzano/pilot:1.15.7-20230822201106-52185b9e --set values.global.hub=ghcr.io/verrazzano --set values.global.proxy.image=proxyv2 --set values.global.tag=1.15.7-20230822201106-52185b9e --set values.global.imagePullSecrets[0]=verrazzano-container-registry: WARNING: Istio control planes installed: 1.14.3.\nWARNING: A newer installed version of Istio has been detected. Running this command will overwrite it.\nError: failed to install manifests: errors occurred during operation: creating default tag would conflict:\nError [IST0139] (MutatingWebhookConfiguration istio-sidecar-injector ) Webhook overlaps with others: [istio-revision-tag-default/namespace.sidecar-injector.istio.io]. This may cause injection to occur twice.\nError [IST0139] (MutatingWebhookConfiguration istio-sidecar-injector ) Webhook overlaps with others: [istio-revision-tag-default/object.sidecar-injector.istio.io]. This may cause injection to occur twice.\nError [IST0139] (MutatingWebhookConfiguration istio-sidecar-injector ) Webhook overlaps with others: [istio-revision-tag-default/rev.namespace.sidecar-injector.istio.io]. This may cause injection to occur twice.\nError [IST0139] (MutatingWebhookConfiguration istio-sidecar-injector ) Webhook overlaps with others: [istio-revision-tag-default/rev.object.sidecar-injector.istio.io]. This may cause injection to occur twice.\n","resource_namespace":"default","resource_name":"my-verrazzano","controller":"verrazzano","component":"istio","operation":"upgrade"}
```
