### PR TITLE
VZ-10766, VZ-10667.  Backport to release-1.5

### DIFF
--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -325,6 +325,15 @@ func IsReleaseInstalled(releaseName string, namespace string) (found bool, err e
 	return false, err
 }
 
+// ReleaseExists returns true if the helm Release exists in the cluster in any state
+func ReleaseExists(releaseName string, namespace string) (found bool, err error) {
+	status, err := chartStatusFn(releaseName, namespace)
+	if err != nil {
+		return false, err
+	}
+	return status != ChartNotFound, nil
+}
+
 // getChartStatus extracts the Helm deployment status of the specified chart from the JSON output as a string
 func getChartStatus(releaseName string, namespace string) (string, error) {
 	args := []string{"status", releaseName}

--- a/pkg/helm/helmcli_test.go
+++ b/pkg/helm/helmcli_test.go
@@ -234,6 +234,93 @@ func TestIsReleaseInstalledFailed(t *testing.T) {
 	assert.False(found, "Release should not be found")
 }
 
+// TestReleaseExists tests checking if a Helm release is exists
+// GIVEN a call to ReleaseExists
+//
+//	WHEN for a Helm release in the Deployed state
+//	THEN the function returns true and no error
+func TestReleaseExists(t *testing.T) {
+	assertion := assert.New(t)
+
+	SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return ChartStatusDeployed, nil
+	})
+	defer SetDefaultChartStatusFunction()
+
+	exists, err := ReleaseExists(release, ns)
+	assertion.NoError(err, "ReleaseExists returned an error")
+	assertion.True(exists, "Release not found")
+}
+
+// TestReleaseExistsUninstallingStatus tests checking if a Helm release is exists
+// GIVEN a call to ReleaseExists
+//
+//	WHEN for a Helm release in the Uninstalling state
+//	THEN the function returns true and no error
+func TestReleaseExistsUninstallingStatus(t *testing.T) {
+	assertion := assert.New(t)
+
+	SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return "uninstalling", nil
+	})
+	defer SetDefaultChartStatusFunction()
+
+	exists, err := ReleaseExists(release, ns)
+	assertion.NoError(err, "ReleaseExists returned an error")
+	assertion.True(exists, "Release not found")
+}
+
+// TestReleaseExistsUnknownStatus tests checking if a Helm release is exists
+// GIVEN a call to ReleaseExists
+//
+//	WHEN for a Helm release in the Unknown state
+//	THEN the function returns true and no error
+func TestReleaseExistsUnknownStatus(t *testing.T) {
+	assertion := assert.New(t)
+	SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return "unknown", nil
+	})
+	defer SetDefaultChartStatusFunction()
+
+	exists, err := ReleaseExists(release, ns)
+	assertion.NoError(err, "ReleaseExists returned an error")
+	assertion.True(exists, "Release not found")
+}
+
+// TestReleaseExistsNotInstalled tests the ReleaseExists func
+// GIVEN a call to ReleaseExists
+//
+//	WHEN for a Helm release that does not exist
+//	THEN the function returns false and no error
+func TestReleaseExistsNotInstalled(t *testing.T) {
+	assertion := assert.New(t)
+	SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return ChartNotFound, nil
+	})
+	defer SetDefaultChartStatusFunction()
+
+	exists, err := ReleaseExists(release, ns)
+	assertion.NoError(err, "IsReleaseInstalled returned an error")
+	assertion.False(exists, "Release should not be exists")
+}
+
+// TestReleaseExistsError tests the ReleaseExists func
+// GIVEN a bad helmRelease name and namespace
+//
+//	WHEN I call ReleaseExists
+//	THEN the function returns false and an error
+func TestReleaseExistsError(t *testing.T) {
+	assertion := assert.New(t)
+	SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return "", fmt.Errorf("error running helm status")
+	})
+	defer SetDefaultChartStatusFunction()
+
+	exists, err := ReleaseExists(release, ns)
+	assertion.Error(err, "IsReleaseInstalled should have returned an error")
+	assertion.False(exists, "Release should not be found")
+}
+
 // TestIsReleaseDeployed tests checking if a Helm release is installed
 // GIVEN a release name and namespace
 //

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package authproxy
@@ -211,12 +211,18 @@ func TestValidateUpdateV1beta1(t *testing.T) {
 //	WHEN I call Uninstall with the Fluentd helm chart installed
 //	THEN no error is returned
 func TestUninstallHelmChartInstalled(t *testing.T) {
+	helmcli.SetChartStatusFunction(func(releaseName string, namespace string) (string, error) {
+		return helmcli.ChartStatusDeployed, nil
+	})
 	helmcli.SetCmdRunner(os.GenericTestRunner{
 		StdOut: []byte(""),
 		StdErr: []byte{},
 		Err:    nil,
 	})
-	defer helmcli.SetDefaultRunner()
+	defer func() {
+		helmcli.SetDefaultChartStatusFunction()
+		helmcli.SetDefaultRunner()
+	}()
 
 	err := NewComponent().Uninstall(spi.NewFakeContext(fake.NewClientBuilder().Build(), &vzapi.Verrazzano{}, nil, false))
 	assert.NoError(t, err)

--- a/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/grafana_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package grafana
@@ -128,6 +128,10 @@ func (g grafanaComponent) IsEnabled(effectiveCR runtime.Object) bool {
 // IsInstalled returns true if the Grafana component is installed
 func (g grafanaComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
 	return isGrafanaInstalled(ctx), nil
+}
+
+func (g grafanaComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return g.IsInstalled(context)
 }
 
 func (g grafanaComponent) IsAvailable(ctx spi.ComponentContext) (reason string, available vzapi.ComponentAvailability) {

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install.go
@@ -113,6 +113,10 @@ func (i istioComponent) IsInstalled(compContext spi.ComponentContext) (bool, err
 	return true, nil
 }
 
+func (i istioComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return i.IsInstalled(context)
+}
+
 // Install - istioComponent install
 //
 // This utilizes the istioctl utility for install, which blocks during the entire installation process.  This can

--- a/platform-operator/controllers/verrazzano/component/opensearch/opensearch_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/opensearch_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package opensearch
@@ -81,6 +81,10 @@ func (o opensearchComponent) IsOperatorInstallSupported() bool {
 
 func (o opensearchComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
 	return doesOSExist(ctx), nil
+}
+
+func (o opensearchComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return o.IsInstalled(context)
 }
 
 func (o opensearchComponent) Reconcile(_ spi.ComponentContext) error {

--- a/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchdashboards/opensearchdashboards_component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package opensearchdashboards
@@ -83,6 +83,10 @@ func (d opensearchDashboardsComponent) IsOperatorInstallSupported() bool {
 // IsInstalled OpenSearch-Dashboards component function
 func (d opensearchDashboardsComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
 	return doesOSDExist(ctx), nil
+}
+
+func (d opensearchDashboardsComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return d.IsInstalled(context)
 }
 
 // Reconcile OpenSearch-Dashboards component function

--- a/platform-operator/controllers/verrazzano/component/registry/registry_test.go
+++ b/platform-operator/controllers/verrazzano/component/registry/registry_test.go
@@ -796,6 +796,10 @@ func (f fakeComponent) IsInstalled(_ spi.ComponentContext) (bool, error) {
 	return true, nil
 }
 
+func (f fakeComponent) Exists(context spi.ComponentContext) (bool, error) {
+	return f.IsInstalled(context)
+}
+
 func (f fakeComponent) PreInstall(_ spi.ComponentContext) error {
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/spi/component.go
+++ b/platform-operator/controllers/verrazzano/component/spi/component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package spi
@@ -87,6 +87,8 @@ type ComponentInstaller interface {
 
 // ComponentUninstaller interface defines uninstall operations
 type ComponentUninstaller interface {
+	// Exists returns true if the component exists in the cluster (may not be fully installed/available) and may be uninstalled
+	Exists(context ComponentContext) (bool, error)
 	// IsOperatorUninstallSupported Returns true if the component supports uninstall directly via the platform operator
 	// - scaffolding while we move components from the scripts to the operator
 	IsOperatorUninstallSupported() bool

--- a/platform-operator/controllers/verrazzano/reconcile/fake_component_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/fake_component_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package reconcile
 
@@ -21,6 +21,8 @@ type installFuncSig func(ctx spi.ComponentContext) error
 // isInstalledFuncSig is a function needed for unit test override
 type isInstalledFuncSig func(ctx spi.ComponentContext) (bool, error)
 
+type uninstallFuncSig func(ctx spi.ComponentContext) error
+
 // fakeComponent allows for using dummy Component implementations for controller testing
 type fakeComponent struct {
 	helm.HelmComponent
@@ -28,12 +30,15 @@ type fakeComponent struct {
 	upgradeFunc     upgradeFuncSig
 	installFunc     installFuncSig
 	isInstalledFunc isInstalledFuncSig
+	uninstallFunc   uninstallFuncSig
 	installed       string `default:"true"`
 	ready           string `default:"true"`
 	enabled         string `default:"true"`
 	monitorChanges  string `default:"true"`
 	minVersion      string
 }
+
+var _ spi.Component = fakeComponent{}
 
 func (f fakeComponent) Name() string {
 	return f.ReleaseName
@@ -101,7 +106,26 @@ func (f fakeComponent) IsInstalled(ctx spi.ComponentContext) (bool, error) {
 	return getBool(f.installed, "installed"), nil
 }
 
-func (f fakeComponent) IsReady(x spi.ComponentContext) bool {
+func (f fakeComponent) Exists(ctx spi.ComponentContext) (bool, error) {
+	return f.IsInstalled(ctx)
+}
+
+func (f fakeComponent) PreUninstall(ctx spi.ComponentContext) error {
+	return nil
+}
+
+func (f fakeComponent) Uninstall(ctx spi.ComponentContext) error {
+	if f.uninstallFunc != nil {
+		return f.uninstallFunc(ctx)
+	}
+	return nil
+}
+
+func (f fakeComponent) PostUninstall(ctx spi.ComponentContext) error {
+	return nil
+}
+
+func (f fakeComponent) IsReady(_ spi.ComponentContext) bool {
 	return getBool(f.ready, "ready")
 }
 

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_component.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_component.go
@@ -93,14 +93,14 @@ func (r *Reconciler) uninstallSingleComponent(spiCtx spi.ComponentContext, Unins
 				UninstallContext.state = compStateUninstallEnd
 				continue
 			}
-			// Check if component is installed, if not continue
-			installed, err := comp.IsInstalled(compContext)
+			// Check if component is ex, if not continue
+			exists, err := comp.Exists(compContext)
 			if err != nil {
-				compLog.Errorf("Failed checking if component %s is installed: %v", compName, err)
+				compLog.Errorf("Failed checking if component %s exists in the cluster: %v", compName, err)
 				return ctrl.Result{}, err
 			}
-			if !installed {
-				compLog.Oncef("Component %s is not installed, nothing to do for uninstall", compName)
+			if !exists {
+				compLog.Debugf("Component %s does not exist in cluster, nothing to do for uninstall", compName)
 				UninstallContext.state = compStateUninstallEnd
 				continue
 			}

--- a/platform-operator/controllers/verrazzano/reconcile/uninstall_test.go
+++ b/platform-operator/controllers/verrazzano/reconcile/uninstall_test.go
@@ -239,6 +239,8 @@ func TestReconcileUninstall(t *testing.T) {
 
 	// call reconcile once with installed true, then again with installed false
 	reconciler := newVerrazzanoReconciler(c)
+	reconciler.DryRun = true
+
 	DeleteUninstallTracker(vzcr)
 	result, err := reconciler.reconcileUninstall(vzlog.DefaultLogger(), vzcr)
 	asserts.NoError(err)

--- a/platform-operator/mocks/component_mock.go
+++ b/platform-operator/mocks/component_mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 //
 
@@ -598,6 +598,21 @@ func NewMockComponent(ctrl *gomock.Controller) *MockComponent {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockComponent) EXPECT() *MockComponentMockRecorder {
 	return m.recorder
+}
+
+// Exists mocks base method.
+func (m *MockComponent) Exists(arg0 spi.ComponentContext) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exists", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Exists indicates an expected call of Exists.
+func (mr *MockComponentMockRecorder) Exists(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockComponent)(nil).Exists), arg0)
 }
 
 // GetCertificateNames mocks base method.


### PR DESCRIPTION
Backports fix for VZ-10766 to `release-1.5`.  Required some changes in the impl since releases < 1.6.x use the Helm CLI.