### PR TITLE
VZ-10570 Enable by default CAPI cluster controller in cluster operator

### DIFF
--- a/cluster-operator/controllers/capi/capi_cluster_controller.go
+++ b/cluster-operator/controllers/capi/capi_cluster_controller.go
@@ -120,7 +120,7 @@ func (r *CAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// only process CAPI cluster instances not managed by Rancher/container driver
 	_, ok := cluster.GetLabels()[clusterProvisionerLabel]
 	if ok {
-		r.Log.Debugf("CAPI cluster created by Rancher, nothing to do", req.NamespacedName)
+		r.Log.Infof("CAPI cluster %v created by Rancher is registered via VMC processing", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 

--- a/cluster-operator/controllers/capi/capi_cluster_controller.go
+++ b/cluster-operator/controllers/capi/capi_cluster_controller.go
@@ -38,8 +38,8 @@ const (
 	clusterStatusSuffix          = "-cluster-status"
 	clusterIDKey                 = "clusterId"
 	clusterRegistrationStatusKey = "clusterRegistration"
-	registrationStarted          = "started"
-	registrationCompleted        = "completed"
+	registrationRetrieved        = "started"
+	registrationInitiated        = "completed"
 )
 
 type CAPIClusterReconciler struct {
@@ -156,7 +156,7 @@ func (r *CAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	if registrationCompleted != r.getClusterRegistrationStatus(ctx, cluster) {
+	if registrationInitiated != r.getClusterRegistrationStatus(ctx, cluster) {
 		// wait for kubeconfig and complete registration on workload cluster
 		if result, err := clusterRegistrationFn(ctx, r, cluster); err != nil {
 			return result, err
@@ -205,7 +205,7 @@ func ensureRancherRegistration(ctx context.Context, r *CAPIClusterReconciler, cl
 	clusterID := r.getClusterID(ctx, cluster)
 	registryYaml, clusterID, registryErr := vmc.RegisterManagedClusterWithRancher(rc, cluster.GetName(), clusterID, log)
 	// persist the cluster ID, if present, even if the registry yaml was not returned
-	err = r.persistClusterStatus(ctx, cluster, clusterID, registrationStarted)
+	err = r.persistClusterStatus(ctx, cluster, clusterID, registrationRetrieved)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -235,7 +235,7 @@ func ensureRancherRegistration(ctx context.Context, r *CAPIClusterReconciler, cl
 		r.Log.Infof("Failed applying Rancher registration yaml in workload cluster")
 		return ctrl.Result{}, err
 	}
-	err = r.persistClusterStatus(ctx, cluster, clusterID, registrationCompleted)
+	err = r.persistClusterStatus(ctx, cluster, clusterID, registrationInitiated)
 	if err != nil {
 		r.Log.Infof("Failed to perist cluster status")
 		return ctrl.Result{}, err
@@ -269,7 +269,7 @@ func (r *CAPIClusterReconciler) getClusterID(ctx context.Context, cluster *unstr
 
 // getClusterRegistrationStatus returns the Rancher registration status for the cluster
 func (r *CAPIClusterReconciler) getClusterRegistrationStatus(ctx context.Context, cluster *unstructured.Unstructured) string {
-	clusterStatus := registrationStarted
+	clusterStatus := registrationRetrieved
 
 	regStatusSecret, err := r.getClusterRegistrationStatusSecret(ctx, cluster)
 	if err != nil {
@@ -303,7 +303,7 @@ func (r *CAPIClusterReconciler) persistClusterStatus(ctx context.Context, cluste
 			Namespace: constants.VerrazzanoCAPINamespace,
 		},
 	}
-	_, err := ctrl.CreateOrUpdate(context.TODO(), r.Client, clusterRegistrationStatusSecret, func() error {
+	_, err := ctrl.CreateOrUpdate(ctx, r.Client, clusterRegistrationStatusSecret, func() error {
 		// Build the secret data
 		if clusterRegistrationStatusSecret.Data == nil {
 			clusterRegistrationStatusSecret.Data = make(map[string][]byte)

--- a/cluster-operator/controllers/capi/capi_cluster_controller_test.go
+++ b/cluster-operator/controllers/capi/capi_cluster_controller_test.go
@@ -48,7 +48,7 @@ func TestClusterRegistration(t *testing.T) {
 	request := newRequest(clusterName)
 
 	SetClusterRegistrationFunction(func(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) (ctrl.Result, error) {
-		r.persistClusterStatus(ctx, cluster, "capi1Id", registrationCompleted)
+		r.persistClusterStatus(ctx, cluster, "capi1Id", registrationInitiated)
 		return ctrl.Result{}, nil
 	})
 	defer SetDefaultClusterRegistrationFunction()
@@ -59,7 +59,7 @@ func TestClusterRegistration(t *testing.T) {
 	clusterRegistrationSecret := &v1.Secret{}
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: clusterName + clusterStatusSuffix, Namespace: constants.VerrazzanoCAPINamespace}, clusterRegistrationSecret)
 	asserts.NoError(err)
-	asserts.Equal(registrationCompleted, string(clusterRegistrationSecret.Data[clusterRegistrationStatusKey]))
+	asserts.Equal(registrationInitiated, string(clusterRegistrationSecret.Data[clusterRegistrationStatusKey]))
 	cluster := &unstructured.Unstructured{}
 	cluster.SetGroupVersionKind(gvk)
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: clusterName}, cluster)
@@ -89,7 +89,7 @@ func TestClusterUnregistration(t *testing.T) {
 			Name:      clusterName + clusterStatusSuffix,
 			Namespace: constants.VerrazzanoCAPINamespace,
 		},
-		Data: map[string][]byte{clusterIDKey: []byte("capi1Id"), clusterRegistrationStatusKey: []byte(registrationCompleted)},
+		Data: map[string][]byte{clusterIDKey: []byte("capi1Id"), clusterRegistrationStatusKey: []byte(registrationInitiated)},
 	}
 
 	cluster := newCAPICluster(clusterName)

--- a/cluster-operator/internal/operatorinit/run_operator.go
+++ b/cluster-operator/internal/operatorinit/run_operator.go
@@ -38,14 +38,14 @@ const (
 )
 
 type Properties struct {
-	Scheme                        *runtime.Scheme
-	CertificateDir                string
-	MetricsAddress                string
-	ProbeAddress                  string
-	IngressHost                   string
-	EnableLeaderElection          bool
-	EnableQuickCreate             bool
-	EnableCAPIRancherRegistration bool
+	Scheme                         *runtime.Scheme
+	CertificateDir                 string
+	MetricsAddress                 string
+	ProbeAddress                   string
+	IngressHost                    string
+	EnableLeaderElection           bool
+	EnableQuickCreate              bool
+	DisableCAPIRancherRegistration bool
 }
 
 // StartClusterOperator Cluster operator execution entry point
@@ -109,7 +109,7 @@ func StartClusterOperator(log *zap.SugaredLogger, props Properties) error {
 	}
 
 	// only start the CAPI cluster controller if the clusters CRD is installed and the controller is enabled
-	if capiCrdInstalled && props.EnableCAPIRancherRegistration {
+	if capiCrdInstalled && !props.DisableCAPIRancherRegistration {
 		log.Infof("Starting CAPI Cluster controller")
 		if err = (&capi.CAPIClusterReconciler{
 			Client:             mgr.GetClient(),

--- a/cluster-operator/main.go
+++ b/cluster-operator/main.go
@@ -27,15 +27,15 @@ import (
 var (
 	scheme = runtime.NewScheme()
 
-	metricsAddr                   string
-	enableLeaderElection          bool
-	probeAddr                     string
-	runWebhooks                   bool
-	runWebhookInit                bool
-	certDir                       string
-	ingressHost                   string
-	enableQuickCreate             bool
-	enableCAPIRancherRegistration bool
+	metricsAddr                    string
+	enableLeaderElection           bool
+	probeAddr                      string
+	runWebhooks                    bool
+	runWebhookInit                 bool
+	certDir                        string
+	ingressHost                    string
+	enableQuickCreate              bool
+	disableCAPIRancherRegistration bool
 )
 
 func init() {
@@ -85,8 +85,8 @@ func handleFlags() operatorinit.Properties {
 	flag.BoolVar(&enableQuickCreate, "quick-create", false, "If true, enables Quick Create Clusters")
 	flag.StringVar(&certDir, "cert-dir", "/etc/certs/", "The directory containing tls.crt and tls.key.")
 	flag.StringVar(&ingressHost, "ingress-host", "", "The host used for Rancher API requests.")
-	flag.BoolVar(&enableCAPIRancherRegistration, "enable-capi-rancher-registration", true,
-		"Enables the registration of CAPI-based clusters with Rancher")
+	flag.BoolVar(&disableCAPIRancherRegistration, "disable-capi-rancher-registration", false,
+		"Disables the registration of CAPI-based clusters with Rancher")
 
 	opts := kzap.Options{}
 	opts.BindFlags(flag.CommandLine)
@@ -96,13 +96,13 @@ func handleFlags() operatorinit.Properties {
 	vzlog.InitLogs(opts)
 	ctrl.SetLogger(kzap.New(kzap.UseFlagOptions(&opts)))
 	return operatorinit.Properties{
-		Scheme:                        scheme,
-		CertificateDir:                certDir,
-		MetricsAddress:                metricsAddr,
-		ProbeAddress:                  probeAddr,
-		IngressHost:                   ingressHost,
-		EnableLeaderElection:          enableLeaderElection,
-		EnableQuickCreate:             enableQuickCreate,
-		EnableCAPIRancherRegistration: enableCAPIRancherRegistration,
+		Scheme:                         scheme,
+		CertificateDir:                 certDir,
+		MetricsAddress:                 metricsAddr,
+		ProbeAddress:                   probeAddr,
+		IngressHost:                    ingressHost,
+		EnableLeaderElection:           enableLeaderElection,
+		EnableQuickCreate:              enableQuickCreate,
+		DisableCAPIRancherRegistration: disableCAPIRancherRegistration,
 	}
 }

--- a/cluster-operator/main.go
+++ b/cluster-operator/main.go
@@ -85,8 +85,8 @@ func handleFlags() operatorinit.Properties {
 	flag.BoolVar(&enableQuickCreate, "quick-create", false, "If true, enables Quick Create Clusters")
 	flag.StringVar(&certDir, "cert-dir", "/etc/certs/", "The directory containing tls.crt and tls.key.")
 	flag.StringVar(&ingressHost, "ingress-host", "", "The host used for Rancher API requests.")
-	flag.BoolVar(&enableCAPIRancherRegistration, "enable-capi-rancher-registration", false,
-		"Runs the webhook initialization code")
+	flag.BoolVar(&enableCAPIRancherRegistration, "enable-capi-rancher-registration", true,
+		"Enables the registration of CAPI-based clusters with Rancher")
 
 	opts := kzap.Options{}
 	opts.BindFlags(flag.CommandLine)

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -155,15 +155,15 @@
               "image": "rancher",
               "dashboard": "v2.7.5-20230818161107-07044c506",
               "rancherUI": "v2.7.2-11/release-2.7.2",
-              "ocneDriverVersion": "v0.23.0",
-              "ocneDriverChecksum": "e410fd9b7ac5533b656277e82f1a321a995a5cd5e0329c2e79091e26e2516313",
-              "tag": "v2.7.5-20230818162112-c6f745626",
+              "ocneDriverVersion": "v0.24.0",
+              "ocneDriverChecksum": "0d537a9e810ce23f7727b4ad70d884acc9648afa4d600be9036b0c4893d7311a",
+              "tag": "v2.7.5-20230831191011-c6f745626",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.5-20230818162112-c6f745626"
+              "tag": "v2.7.5-20230831191011-c6f745626"
             }
           ]
         },


### PR DESCRIPTION
- Maintained command line arg/feature flag but "reversed" the semantics
- Changed state names for clarity
- pickup kontainer driver via Rancher that labels CAPI cluster instances created by Rancher
