### PR TITLE
VZ-6573: Coverting E2E tests to v1beta1

### DIFF
--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -595,7 +595,13 @@ func GetV1Beta1ControllerRuntimeClient(config *restclient.Config) (client.Client
 	if err := v1beta1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
-	vzClient, err := client.New(config, client.Options{Scheme: scheme})
+	options := client.Options{
+		Scheme: scheme,
+		// The default SuppressWarnings=false will override whatever WarningHandler was used by the config.
+		// Set this to true to use whatever WarningHandler was passed into this function.
+		Opts: client.WarningHandlerOptions{SuppressWarnings: true},
+	}
+	vzClient, err := client.New(config, options)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/pkg/kubernetes.go
+++ b/tests/e2e/pkg/kubernetes.go
@@ -588,6 +588,20 @@ func GetDynamicClientInCluster(kubeconfigPath string) (dynamic.Interface, error)
 	return k8sutil.GetDynamicClientInCluster(kubeconfigPath)
 }
 
+// GetV1Beta1ControllerRuntimeClient, given a kubeconfig,
+// returns a controller runtime client with verrazzano v1beta1 as part of its scheme.
+func GetV1Beta1ControllerRuntimeClient(config *restclient.Config) (client.Client, error) {
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	vzClient, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
+	return vzClient, nil
+}
+
 // GetVerrazzanoInstallResourceInCluster returns the installed Verrazzano CR in the given cluster
 // (there should only be 1 per cluster)
 func GetVerrazzanoInstallResourceInCluster(kubeconfigPath string) (*v1alpha1.Verrazzano, error) {
@@ -595,9 +609,7 @@ func GetVerrazzanoInstallResourceInCluster(kubeconfigPath string) (*v1alpha1.Ver
 	if err != nil {
 		return nil, err
 	}
-	scheme := runtime.NewScheme()
-	_ = v1beta1.AddToScheme(scheme)
-	vzClient, err := client.New(config, client.Options{Scheme: scheme})
+	vzClient, err := GetV1Beta1ControllerRuntimeClient(config)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/pkg/update/updater.go
+++ b/tests/e2e/pkg/update/updater.go
@@ -225,7 +225,7 @@ func UpdatePlugins(m CRModifier, kubeconfigPath string, waitForReady bool, polli
 		if err != nil {
 			pkg.Log(pkg.Error, err.Error())
 			return false
-		}	
+		}
 		if err = verrazzano.UpdateV1Alpha1(context.TODO(), vzClient, cr); err != nil {
 			pkg.Log(pkg.Error, err.Error())
 			return false

--- a/tests/e2e/pkg/update/updater.go
+++ b/tests/e2e/pkg/update/updater.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/k8s/verrazzano"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
@@ -93,13 +94,11 @@ func UpdateCR(m CRModifier) error {
 		return err
 	}
 	addWarningHandlerIfNecessary(m, config)
-	client, err := vpoClient.NewForConfig(config)
+	vzClient, err := pkg.GetV1Beta1ControllerRuntimeClient(config)
 	if err != nil {
 		return err
 	}
-	vzClient := client.VerrazzanoV1alpha1().Verrazzanos(cr.Namespace)
-	_, err = vzClient.Update(context.TODO(), cr, metav1.UpdateOptions{})
-	return err
+	return verrazzano.UpdateV1Alpha1(context.TODO(), vzClient, cr)
 }
 
 // UpdateCRV1beta1WithRetries updates the CR with the given CRModifierV1beta1.

--- a/tests/e2e/pkg/update/updater.go
+++ b/tests/e2e/pkg/update/updater.go
@@ -340,7 +340,7 @@ func IsCRReadyAfterUpdate(cr *v1beta1.Verrazzano, updatedTime time.Time) bool {
 			}
 		}
 		pkg.Log(pkg.Error, fmt.Sprintf("Could not find condition of type '%s' or '%s', transitioned after '%s'",
-			vzapi.CondInstallComplete, vzapi.CondUpgradeComplete, updatedTime.String()))
+			v1beta1.CondInstallComplete, v1beta1.CondUpgradeComplete, updatedTime.String()))
 	}
 	// Return true if the state is ready and there are no conditions updated in the status.
 	return len(cr.Status.Conditions) == 0

--- a/tests/e2e/pkg/update/updater.go
+++ b/tests/e2e/pkg/update/updater.go
@@ -221,14 +221,12 @@ func UpdatePlugins(m CRModifier, kubeconfigPath string, waitForReady bool, polli
 			return false
 		}
 		addWarningHandlerIfNecessary(m, config)
-		client, err := vpoClient.NewForConfig(config)
+		vzClient, err := pkg.GetV1Beta1ControllerRuntimeClient(config)
 		if err != nil {
 			pkg.Log(pkg.Error, err.Error())
 			return false
-		}
-		vzClient := client.VerrazzanoV1alpha1().Verrazzanos(cr.Namespace)
-		_, err = vzClient.Update(context.TODO(), cr, metav1.UpdateOptions{})
-		if err != nil {
+		}	
+		if err = verrazzano.UpdateV1Alpha1(context.TODO(), vzClient, cr); err != nil {
 			pkg.Log(pkg.Error, err.Error())
 			return false
 		}
@@ -264,14 +262,12 @@ func RetryUpdate(m CRModifier, kubeconfigPath string, waitForReady bool, polling
 			return false
 		}
 		addWarningHandlerIfNecessary(m, config)
-		client, err := vpoClient.NewForConfig(config)
+		vzClient, err := pkg.GetV1Beta1ControllerRuntimeClient(config)
 		if err != nil {
 			pkg.Log(pkg.Error, err.Error())
 			return false
 		}
-		vzClient := client.VerrazzanoV1alpha1().Verrazzanos(cr.Namespace)
-		_, err = vzClient.Update(context.TODO(), cr, metav1.UpdateOptions{})
-		if err != nil {
+		if err = verrazzano.UpdateV1Alpha1(context.TODO(), vzClient, cr); err != nil {
 			pkg.Log(pkg.Error, err.Error())
 			return false
 		}
@@ -304,14 +300,12 @@ func UpdateCRExpectError(m CRModifier) error {
 		return err
 	}
 	addWarningHandlerIfNecessary(m, config)
-	client, err := vpoClient.NewForConfig(config)
+	vzClient, err := pkg.GetV1Beta1ControllerRuntimeClient(config)
 	if err != nil {
 		pkg.Log(pkg.Error, err.Error())
 		return err
 	}
-	vzClient := client.VerrazzanoV1alpha1().Verrazzanos(cr.Namespace)
-	_, err = vzClient.Update(context.TODO(), cr, metav1.UpdateOptions{})
-	if err != nil {
+	if verrazzano.UpdateV1Alpha1(context.TODO(), vzClient, cr); err != nil {
 		pkg.Log(pkg.Error, err.Error())
 		return err
 	}


### PR DESCRIPTION
Another PR to convert the tests under `tests/e2e` to use Verrazzano version `v1beta1` when talking to the Kubernetes API server.

This is not necessarily comprehensive, and more PRs can follow if needed. This PR gets rid of the existing `v1alpha1` deprecation logs from the Kind acceptance tests and the dynamic configuration suite, at minimum.

This PR uses the helper functions from `pkg/k8s/verrazzano/talk_to_k8s_api.go` to replace instances of using Verrazzano `v1alpha1` talking to the K8s API server. 