### PR TITLE
Auth Proxy v2 unit test fixes

### DIFF
--- a/authproxy/main.go
+++ b/authproxy/main.go
@@ -25,7 +25,7 @@ func main() {
 	handleFlags()
 	log := zap.S()
 
-	err := config.InitConfiguration(log, nil)
+	err := config.InitConfiguration(log)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/authproxy/main.go
+++ b/authproxy/main.go
@@ -25,7 +25,7 @@ func main() {
 	handleFlags()
 	log := zap.S()
 
-	err := config.InitConfiguration(log)
+	err := config.InitConfiguration(log, nil)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/authproxy/src/config/config.go
+++ b/authproxy/src/config/config.go
@@ -12,8 +12,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultWatchInterval = time.Minute
-
 // these can be changed for unit testing
 var (
 	serviceURLFilename  = "/etc/config/oidcServiceURL"
@@ -35,6 +33,11 @@ var (
 
 	mutex sync.RWMutex
 )
+
+func init() {
+	watchInterval.Store(uint64(time.Minute))
+	keepWatching.Store(true)
+}
 
 // GetServiceURL returns the in-cluster service URL of the OIDC provider
 func GetServiceURL() string {
@@ -131,8 +134,6 @@ func InitConfiguration(log *zap.SugaredLogger) error {
 		return err
 	}
 
-	watchInterval.Store(uint64(defaultWatchInterval))
-	keepWatching.Store(true)
 	go watchConfigForChanges(log)
 	return nil
 }

--- a/authproxy/src/config/config_test.go
+++ b/authproxy/src/config/config_test.go
@@ -109,7 +109,7 @@ func makeTempFile(content string) (*os.File, error) {
 
 // eventually executes the provided function until it either returns true or exceeds a number of attempts
 func eventually(f func() bool) bool {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 30; i++ {
 		if f() == true {
 			return true
 		}

--- a/authproxy/src/config/config_test.go
+++ b/authproxy/src/config/config_test.go
@@ -79,6 +79,9 @@ func TestInitConfiguration(t *testing.T) {
 	err = os.WriteFile(externalURLFilename, []byte(newTestExternalURL), 0)
 	assert.NoError(t, err)
 
+	err = os.WriteFile(clientIDFilename, []byte(newTestClientID), 0)
+	assert.NoError(t, err)
+
 	updated := eventually(func() bool { return GetServiceURL() == newTestServiceURL })
 	assert.True(t, updated, "Expected service URL to be updated")
 

--- a/authproxy/src/config/config_test.go
+++ b/authproxy/src/config/config_test.go
@@ -51,9 +51,9 @@ func TestInitConfiguration(t *testing.T) {
 	clientIDFilename = clientIDFile.Name()
 
 	// override the watch interval
-	oldWatchInterval := watchInterval
-	defer func() { watchInterval = oldWatchInterval }()
-	watchInterval = 500 * time.Millisecond
+	oldWatchInterval := watchInterval.Load()
+	defer func() { watchInterval.Store(oldWatchInterval) }()
+	watchInterval.Store(uint64(500 * time.Millisecond))
 
 	// GIVEN initial configuration files
 	// WHEN the InitConfiguration function is called
@@ -108,7 +108,7 @@ func eventually(f func() bool) bool {
 		if f() == true {
 			return true
 		}
-		time.Sleep(watchInterval)
+		time.Sleep(500 * time.Millisecond)
 	}
 	return false
 }

--- a/authproxy/src/config/config_test.go
+++ b/authproxy/src/config/config_test.go
@@ -58,7 +58,8 @@ func TestInitConfiguration(t *testing.T) {
 	// GIVEN initial configuration files
 	// WHEN the InitConfiguration function is called
 	// THEN the fetched configuration values match the file contents
-	err = InitConfiguration(zap.S())
+	ch := make(chan struct{})
+	err = InitConfiguration(zap.S(), ch)
 	assert.NoError(t, err)
 
 	assert.Equal(t, testServiceURL, GetServiceURL())
@@ -100,15 +101,4 @@ func makeTempFile(content string) (*os.File, error) {
 
 	_, err = tmpFile.Write([]byte(content))
 	return tmpFile, err
-}
-
-// eventually executes the provided function until it either returns true or exceeds a number of attempts
-func eventually(f func() bool) bool {
-	for i := 0; i < 10; i++ {
-		if f() == true {
-			return true
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	return false
 }


### PR DESCRIPTION
This PR fixes two issues:
1. A race condition in the unit tests caused by a goroutine reading the `watchInterval` variable and the unit test resetting the value of `watchInterval` in a `defer`. This was noticed when running `go test -race`.
2. An intermittent test failure waiting for the config values to get updated by the watcher goroutine. Instead of waiting and rechecking the values of the config settings, we use a channel to signal that the update has been detected and the values reloaded.