### PR TITLE
VZ-10472, VZ-1057 Backport capi cluster controller to release 1.6

### DIFF
--- a/cluster-operator/controllers/capi/capi_cluster_controller.go
+++ b/cluster-operator/controllers/capi/capi_cluster_controller.go
@@ -1,0 +1,384 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package capi
+
+import (
+	"context"
+	"fmt"
+	"github.com/verrazzano/verrazzano/cluster-operator/controllers/vmc"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/rancherutil"
+	vzstring "github.com/verrazzano/verrazzano/pkg/string"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	finalizerName                = "verrazzano.io/capi-cluster"
+	clusterProvisionerLabel      = "cluster.verrazzano.io/provisioner"
+	clusterStatusSuffix          = "-cluster-status"
+	clusterIDKey                 = "clusterId"
+	clusterRegistrationStatusKey = "clusterRegistration"
+	registrationRetrieved        = "started"
+	registrationInitiated        = "completed"
+)
+
+type CAPIClusterReconciler struct {
+	client.Client
+	Scheme             *runtime.Scheme
+	Log                *zap.SugaredLogger
+	RancherIngressHost string
+}
+
+type ClusterRegistrationFnType func(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) (ctrl.Result, error)
+
+var clusterRegistrationFn ClusterRegistrationFnType = ensureRancherRegistration
+
+func SetClusterRegistrationFunction(f ClusterRegistrationFnType) {
+	clusterRegistrationFn = f
+}
+
+func SetDefaultClusterRegistrationFunction() {
+	clusterRegistrationFn = ensureRancherRegistration
+}
+
+type ClusterUnregistrationFnType func(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) error
+
+var clusterUnregistrationFn ClusterUnregistrationFnType = UnregisterRancherCluster
+
+func SetClusterUnregistrationFunction(f ClusterUnregistrationFnType) {
+	clusterUnregistrationFn = f
+}
+
+func SetDefaultClusterUnregistrationFunction() {
+	clusterUnregistrationFn = UnregisterRancherCluster
+}
+
+var gvk = schema.GroupVersionKind{
+	Group:   "cluster.x-k8s.io",
+	Version: "v1beta1",
+	Kind:    "Cluster",
+}
+
+func CAPIClusterClientObject() client.Object {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	return obj
+}
+
+// SetupWithManager creates a new controller and adds it to the manager
+func (r *CAPIClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(CAPIClusterClientObject()).
+		Complete(r)
+}
+
+// Reconcile is the main controller reconcile function
+func (r *CAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Log.Infof("Reconciling CAPI cluster: %v", req.NamespacedName)
+
+	// Is Rancher available
+	err := ready.DeploymentsAreAvailable(r.Client, []types.NamespacedName{{
+		Namespace: common.CattleSystem,
+		Name:      common.RancherName,
+	}})
+	if err != nil {
+		return vzctrl.LongRequeue(), nil
+	}
+
+	cluster := &unstructured.Unstructured{}
+	cluster.SetGroupVersionKind(gvk)
+	err = r.Get(context.TODO(), req.NamespacedName, cluster)
+	if err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	if errors.IsNotFound(err) {
+		r.Log.Debugf("CAPI cluster %v not found, nothing to do", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	// only process CAPI cluster instances not managed by Rancher/container driver
+	_, ok := cluster.GetLabels()[clusterProvisionerLabel]
+	if ok {
+		r.Log.Infof("CAPI cluster %v created by Rancher is registered via VMC processing", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	// if the deletion timestamp is set, unregister the corresponding Rancher cluster
+	if !cluster.GetDeletionTimestamp().IsZero() {
+		if vzstring.SliceContainsString(cluster.GetFinalizers(), finalizerName) {
+			if err := clusterUnregistrationFn(ctx, r, cluster); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
+		if err := r.removeFinalizer(cluster); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// delete the cluster id secret
+		clusterRegistrationStatusSecret, err := r.getClusterRegistrationStatusSecret(ctx, cluster)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		err = r.Delete(ctx, clusterRegistrationStatusSecret)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// add a finalizer to the CAPI cluster if it doesn't already exist
+	if err = r.ensureFinalizer(cluster); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if registrationInitiated != r.getClusterRegistrationStatus(ctx, cluster) {
+		// wait for kubeconfig and complete registration on workload cluster
+		if result, err := clusterRegistrationFn(ctx, r, cluster); err != nil {
+			return result, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// ensureFinalizer adds a finalizer to the CAPI cluster if the finalizer is not already present
+func (r *CAPIClusterReconciler) ensureFinalizer(cluster *unstructured.Unstructured) error {
+	if finalizers, added := vzstring.SliceAddString(cluster.GetFinalizers(), finalizerName); added {
+		cluster.SetFinalizers(finalizers)
+		if err := r.Update(context.TODO(), cluster); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// removeFinalizer removes the finalizer from the Rancher cluster resource
+func (r *CAPIClusterReconciler) removeFinalizer(cluster *unstructured.Unstructured) error {
+	finalizers := vzstring.RemoveStringFromSlice(cluster.GetFinalizers(), finalizerName)
+	cluster.SetFinalizers(finalizers)
+
+	if err := r.Update(context.TODO(), cluster); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureRancherRegistration ensures that the CAPI cluster is registered with Rancher.
+func ensureRancherRegistration(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) (ctrl.Result, error) {
+	kubeconfig, err := r.getWorkloadClusterKubeconfig(ctx, cluster)
+	if err != nil {
+		// requeue since we're waiting for cluster
+		return vzctrl.ShortRequeue(), err
+	}
+
+	rc, log, err := r.GetRancherAPIResources(cluster)
+	if err != nil {
+		r.Log.Infof("Failed getting rancher api resources")
+		return ctrl.Result{}, err
+	}
+
+	clusterID := r.getClusterID(ctx, cluster)
+	registryYaml, clusterID, registryErr := vmc.RegisterManagedClusterWithRancher(rc, cluster.GetName(), clusterID, log)
+	// persist the cluster ID, if present, even if the registry yaml was not returned
+	err = r.persistClusterStatus(ctx, cluster, clusterID, registrationRetrieved)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// handle registry failure error
+	if registryErr != nil {
+		r.Log.Error(err, "failed to obtain registration manifest from Rancher")
+		return ctrl.Result{}, registryErr
+	}
+	// it appears that in some circumstances the registry yaml may be empty so need to re-queue to re-attempt retrieval
+	if len(registryYaml) == 0 {
+		return vzctrl.ShortRequeue(), nil
+	}
+	// create workload cluster client
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		r.Log.Warnf("Failed getting rest config from workload kubeconfig")
+		return ctrl.Result{}, err
+	}
+	workloadClient, err := r.getWorkloadClusterClient(restConfig)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// apply registration yaml to managed cluster
+	yamlApplier := k8sutil.NewYAMLApplier(workloadClient, "")
+	err = yamlApplier.ApplyS(registryYaml)
+	if err != nil {
+		r.Log.Infof("Failed applying Rancher registration yaml in workload cluster")
+		return ctrl.Result{}, err
+	}
+	err = r.persistClusterStatus(ctx, cluster, clusterID, registrationInitiated)
+	if err != nil {
+		r.Log.Infof("Failed to perist cluster status")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// getWorkloadClusterClient returns a controller runtime client configured for the workload cluster
+func (r *CAPIClusterReconciler) getWorkloadClusterClient(restConfig *rest.Config) (client.Client, error) {
+	scheme := runtime.NewScheme()
+	_ = rbacv1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+	_ = netv1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	return client.New(restConfig, client.Options{Scheme: scheme})
+}
+
+// getClusterID returns the cluster ID assigned by Rancher for the given cluster
+func (r *CAPIClusterReconciler) getClusterID(ctx context.Context, cluster *unstructured.Unstructured) string {
+	clusterID := ""
+
+	regStatusSecret, err := r.getClusterRegistrationStatusSecret(ctx, cluster)
+	if err != nil {
+		return clusterID
+	}
+	clusterID = string(regStatusSecret.Data[clusterIDKey])
+
+	return clusterID
+}
+
+// getClusterRegistrationStatus returns the Rancher registration status for the cluster
+func (r *CAPIClusterReconciler) getClusterRegistrationStatus(ctx context.Context, cluster *unstructured.Unstructured) string {
+	clusterStatus := registrationRetrieved
+
+	regStatusSecret, err := r.getClusterRegistrationStatusSecret(ctx, cluster)
+	if err != nil {
+		return clusterStatus
+	}
+	clusterStatus = string(regStatusSecret.Data[clusterRegistrationStatusKey])
+
+	return clusterStatus
+}
+
+// getClusterRegistrationStatusSecret returns the secret that stores cluster status information
+func (r *CAPIClusterReconciler) getClusterRegistrationStatusSecret(ctx context.Context, cluster *unstructured.Unstructured) (*v1.Secret, error) {
+	clusterIDSecret := &v1.Secret{}
+	secretName := types.NamespacedName{
+		Namespace: constants.VerrazzanoCAPINamespace,
+		Name:      cluster.GetName() + clusterStatusSuffix,
+	}
+	err := r.Get(ctx, secretName, clusterIDSecret)
+	if err != nil {
+		return nil, err
+	}
+	return clusterIDSecret, err
+}
+
+// persistClusterStatus stores the cluster status in the cluster status secret
+func (r *CAPIClusterReconciler) persistClusterStatus(ctx context.Context, cluster *unstructured.Unstructured, clusterID string, status string) error {
+	r.Log.Debugf("Persisting cluster %s cluster id: %s", cluster.GetName(), clusterID)
+	clusterRegistrationStatusSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.GetName() + clusterStatusSuffix,
+			Namespace: constants.VerrazzanoCAPINamespace,
+		},
+	}
+	_, err := ctrl.CreateOrUpdate(ctx, r.Client, clusterRegistrationStatusSecret, func() error {
+		// Build the secret data
+		if clusterRegistrationStatusSecret.Data == nil {
+			clusterRegistrationStatusSecret.Data = make(map[string][]byte)
+		}
+		clusterRegistrationStatusSecret.Data[clusterIDKey] = []byte(clusterID)
+		clusterRegistrationStatusSecret.Data[clusterRegistrationStatusKey] = []byte(status)
+
+		return nil
+	})
+	if err != nil {
+		r.Log.Errorf("Unable to persist status for cluster %s: %v", cluster.GetName(), err)
+		return err
+	}
+
+	return nil
+}
+
+// getWorkloadClusterKubeconfig returns a kubeconfig for accessing the workload cluster
+func (r *CAPIClusterReconciler) getWorkloadClusterKubeconfig(ctx context.Context, cluster *unstructured.Unstructured) ([]byte, error) {
+	// get the cluster kubeconfig
+	kubeconfigSecret := &v1.Secret{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s-kubeconfig", cluster.GetName()), Namespace: "default"}, kubeconfigSecret)
+	if err != nil {
+		r.Log.Warn(err, "failed to obtain workload cluster kubeconfig resource. Re-queuing...")
+		return nil, err
+	}
+	kubeconfig, ok := kubeconfigSecret.Data["value"]
+	if !ok {
+		r.Log.Error(err, "failed to read kubeconfig from resource")
+		return nil, fmt.Errorf("Unable to read kubeconfig from retrieved cluster resource")
+	}
+
+	return kubeconfig, nil
+}
+
+// GetRancherAPIResources returns the set of resources required for interacting with Rancher
+func (r *CAPIClusterReconciler) GetRancherAPIResources(cluster *unstructured.Unstructured) (*rancherutil.RancherConfig, vzlog.VerrazzanoLogger, error) {
+	// Get the resource logger needed to log message using 'progress' and 'once' methods
+	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
+		Name:           cluster.GetName(),
+		Namespace:      cluster.GetNamespace(),
+		ID:             string(cluster.GetUID()),
+		Generation:     cluster.GetGeneration(),
+		ControllerName: "capicluster",
+	})
+	if err != nil {
+		r.Log.Errorf("Failed to create controller logger for CAPI cluster controller", err)
+		return nil, nil, err
+	}
+
+	// using direct rancher API to register cluster
+	rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.RancherIngressHost, log)
+	if err != nil {
+		r.Log.Error(err, "failed to create Rancher API client")
+		return nil, nil, err
+	}
+	return rc, log, nil
+}
+
+// UnregisterRancherCluster performs the operations required to de-register the cluster from Rancher
+func UnregisterRancherCluster(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) error {
+	clusterID := r.getClusterID(ctx, cluster)
+	if len(clusterID) == 0 {
+		// no cluster id found
+		return fmt.Errorf("No cluster ID found for cluster %s", cluster.GetName())
+	}
+	rc, log, err := r.GetRancherAPIResources(cluster)
+	if err != nil {
+		return err
+	}
+	_, err = vmc.DeleteClusterFromRancher(rc, clusterID, log)
+	if err != nil {
+		log.Errorf("Unable to unregister cluster %s from Rancher: %v", cluster.GetName(), err)
+		return err
+	}
+
+	return nil
+}

--- a/cluster-operator/controllers/capi/capi_cluster_controller_test.go
+++ b/cluster-operator/controllers/capi/capi_cluster_controller_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package capi
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+const (
+	clusterName = "capi1"
+)
+
+// GIVEN a CAPI cluster resource is created
+// WHEN  the reconciler runs
+// THEN  a rancher registration and associated artifacts are created
+func TestClusterRegistration(t *testing.T) {
+	asserts := assert.New(t)
+
+	rancherDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.RancherName,
+			Namespace: common.CattleSystem,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      1,
+			ReadyReplicas: 1,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(newCAPICluster(clusterName), rancherDeployment).Build()
+	reconciler := newCAPIClusterReconciler(fakeClient)
+	request := newRequest(clusterName)
+
+	SetClusterRegistrationFunction(func(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) (ctrl.Result, error) {
+		r.persistClusterStatus(ctx, cluster, "capi1Id", registrationInitiated)
+		return ctrl.Result{}, nil
+	})
+	defer SetDefaultClusterRegistrationFunction()
+
+	_, err := reconciler.Reconcile(context.TODO(), request)
+	asserts.NoError(err)
+
+	clusterRegistrationSecret := &v1.Secret{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: clusterName + clusterStatusSuffix, Namespace: constants.VerrazzanoCAPINamespace}, clusterRegistrationSecret)
+	asserts.NoError(err)
+	asserts.Equal(registrationInitiated, string(clusterRegistrationSecret.Data[clusterRegistrationStatusKey]))
+	cluster := &unstructured.Unstructured{}
+	cluster.SetGroupVersionKind(gvk)
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: clusterName}, cluster)
+	asserts.NoError(err)
+	asserts.Equal(finalizerName, cluster.GetFinalizers()[0])
+}
+
+// GIVEN a CAPI cluster resource is deleted
+// WHEN  the reconciler runs
+// THEN  a rancher registration and associated artifacts are removed
+func TestClusterUnregistration(t *testing.T) {
+	asserts := assert.New(t)
+
+	rancherDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.RancherName,
+			Namespace: common.CattleSystem,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      1,
+			ReadyReplicas: 1,
+		},
+	}
+
+	clusterRegistrationSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName + clusterStatusSuffix,
+			Namespace: constants.VerrazzanoCAPINamespace,
+		},
+		Data: map[string][]byte{clusterIDKey: []byte("capi1Id"), clusterRegistrationStatusKey: []byte(registrationInitiated)},
+	}
+
+	cluster := newCAPICluster(clusterName)
+	now := metav1.Now()
+	cluster.SetDeletionTimestamp(&now)
+	cluster.SetFinalizers([]string{finalizerName})
+
+	fakeClient := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cluster, rancherDeployment, clusterRegistrationSecret).Build()
+	reconciler := newCAPIClusterReconciler(fakeClient)
+	request := newRequest(clusterName)
+
+	SetClusterUnregistrationFunction(func(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) error {
+		return nil
+	})
+	defer SetDefaultClusterUnregistrationFunction()
+
+	_, err := reconciler.Reconcile(context.TODO(), request)
+	asserts.NoError(err)
+
+	remainingSecret := &v1.Secret{}
+	asserts.Error(fakeClient.Get(context.TODO(), types.NamespacedName{Name: clusterName + clusterStatusSuffix, Namespace: constants.VerrazzanoCAPINamespace}, remainingSecret))
+	deletedCluster := &unstructured.Unstructured{}
+	deletedCluster.SetGroupVersionKind(gvk)
+	asserts.Error(fakeClient.Get(context.TODO(), types.NamespacedName{Name: clusterName}, deletedCluster))
+}
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	clientgoscheme.AddToScheme(scheme)
+
+	return scheme
+}
+
+func newCAPICluster(name string) *unstructured.Unstructured {
+	cluster := &unstructured.Unstructured{}
+	cluster.SetGroupVersionKind(gvk)
+	cluster.SetName(name)
+	return cluster
+}
+
+func newCAPIClusterReconciler(c client.Client) CAPIClusterReconciler {
+	return CAPIClusterReconciler{
+		Client: c,
+		Scheme: newScheme(),
+		Log:    zap.S(),
+	}
+}
+
+func newRequest(name string) ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: name,
+		},
+	}
+}

--- a/cluster-operator/controllers/vmc/rancher.go
+++ b/cluster-operator/controllers/vmc/rancher.go
@@ -50,9 +50,9 @@ type RancherCluster struct {
 	ID   string
 }
 
-// registerManagedClusterWithRancher registers a managed cluster with Rancher and returns a chunk of YAML that
+// RegisterManagedClusterWithRancher registers a managed cluster with Rancher and returns a chunk of YAML that
 // must be applied on the managed cluster to complete the registration.
-func registerManagedClusterWithRancher(rc *rancherutil.RancherConfig, clusterName string, rancherClusterID string, log vzlog.VerrazzanoLogger) (string, string, error) {
+func RegisterManagedClusterWithRancher(rc *rancherutil.RancherConfig, clusterName string, rancherClusterID string, log vzlog.VerrazzanoLogger) (string, string, error) {
 	clusterID := rancherClusterID
 	var err error
 	if clusterID == "" {

--- a/cluster-operator/controllers/vmc/sync_manifest_secret.go
+++ b/cluster-operator/controllers/vmc/sync_manifest_secret.go
@@ -75,7 +75,7 @@ func (r *VerrazzanoManagedClusterReconciler) syncManifestSecret(ctx context.Cont
 			r.updateRancherStatus(ctx, vmc, clusterapi.RegistrationFailed, "", msg)
 		} else {
 			var rancherYAML string
-			rancherYAML, clusterID, err = registerManagedClusterWithRancher(rc, vmc.Name, vmc.Status.RancherRegistration.ClusterID, r.log)
+			rancherYAML, clusterID, err = RegisterManagedClusterWithRancher(rc, vmc.Name, vmc.Status.RancherRegistration.ClusterID, r.log)
 			if err != nil {
 				msg := "Failed to register managed cluster with Rancher"
 				// Even if there was a failure, if the cluster id was retrieved and is currently empty

--- a/cluster-operator/controllers/vmc/vmc_controller_test.go
+++ b/cluster-operator/controllers/vmc/vmc_controller_test.go
@@ -1389,7 +1389,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 	rc, err = rancherutil.NewVerrazzanoClusterRancherConfig(mock, rancherutil.RancherIngressServiceHost(), vzlog.DefaultLogger())
 	asserts.NoError(err)
 
-	regYAML, _, err := registerManagedClusterWithRancher(rc, testManagedCluster, "", vzlog.DefaultLogger())
+	regYAML, _, err := RegisterManagedClusterWithRancher(rc, testManagedCluster, "", vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -1466,7 +1466,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 	rc, err = rancherutil.NewVerrazzanoClusterRancherConfig(mock, rancherutil.RancherIngressServiceHost(), vzlog.DefaultLogger())
 	asserts.NoError(err)
 
-	regYAML, _, err = registerManagedClusterWithRancher(rc, testManagedCluster, "", vzlog.DefaultLogger())
+	regYAML, _, err = RegisterManagedClusterWithRancher(rc, testManagedCluster, "", vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)
@@ -1544,7 +1544,7 @@ func TestRegisterClusterWithRancherHTTPErrorCases(t *testing.T) {
 	rc, err = rancherutil.NewVerrazzanoClusterRancherConfig(mock, rancherutil.RancherIngressServiceHost(), vzlog.DefaultLogger())
 	asserts.NoError(err)
 
-	regYAML, _, err = registerManagedClusterWithRancher(rc, testManagedCluster, "", vzlog.DefaultLogger())
+	regYAML, _, err = RegisterManagedClusterWithRancher(rc, testManagedCluster, "", vzlog.DefaultLogger())
 
 	mocker.Finish()
 	asserts.Error(err)

--- a/cluster-operator/internal/operatorinit/run_operator.go
+++ b/cluster-operator/internal/operatorinit/run_operator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/verrazzano/verrazzano/cluster-operator/controllers/capi"
 	"github.com/verrazzano/verrazzano/cluster-operator/controllers/rancher"
 	"github.com/verrazzano/verrazzano/cluster-operator/controllers/vmc"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -31,10 +32,11 @@ const (
 	clusterSelectorFilePath = "/var/syncClusters/selector.yaml"
 	syncClustersEnvVarName  = "CLUSTER_SYNC_ENABLED"
 	cattleClustersCRDName   = "clusters.management.cattle.io"
+	capiClustersCRDName     = "clusters.cluster.x-k8s.io"
 )
 
 // StartClusterOperator Cluster operator execution entry point
-func StartClusterOperator(metricsAddr string, enableLeaderElection bool, probeAddr string, ingressHost string, log *zap.SugaredLogger, scheme *runtime.Scheme) error {
+func StartClusterOperator(metricsAddr string, enableLeaderElection bool, probeAddr string, ingressHost string, rancherRegistrationDisabled bool, log *zap.SugaredLogger, scheme *runtime.Scheme) error {
 	options := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
@@ -57,7 +59,7 @@ func StartClusterOperator(metricsAddr string, enableLeaderElection bool, probeAd
 	}
 
 	apiextv1Client := apiextv1.NewForConfigOrDie(ctrlConfig)
-	crdInstalled, err := isCattleClustersCRDInstalled(apiextv1Client)
+	crdInstalled, err := isCRDInstalled(apiextv1Client, cattleClustersCRDName)
 	if err != nil {
 		log.Error(err, "unable to determine if cattle CRD is installed")
 		os.Exit(1)
@@ -83,8 +85,28 @@ func StartClusterOperator(metricsAddr string, enableLeaderElection bool, probeAd
 		}
 	}
 
+	capiCrdInstalled, err := isCRDInstalled(apiextv1Client, capiClustersCRDName)
+	if err != nil {
+		log.Error(err, "unable to determine if CAPI CRD is installed")
+		os.Exit(1)
+	}
+
 	if ingressHost == "" {
 		ingressHost = rancherutil.DefaultRancherIngressHostPrefix + nginxutil.IngressNGINXNamespace()
+	}
+
+	// only start the CAPI cluster controller if the clusters CRD is installed and the controller is enabled
+	if capiCrdInstalled && !rancherRegistrationDisabled {
+		log.Infof("Starting CAPI Cluster controller")
+		if err = (&capi.CAPIClusterReconciler{
+			Client:             mgr.GetClient(),
+			Log:                log,
+			Scheme:             mgr.GetScheme(),
+			RancherIngressHost: ingressHost,
+		}).SetupWithManager(mgr); err != nil {
+			log.Errorf("Failed to create CAPI cluster controller: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	// Set up the reconciler for VerrazzanoManagedCluster objects
@@ -149,9 +171,9 @@ func shouldSyncClusters(clusterSelectorFile string) (bool, *metav1.LabelSelector
 	return true, selector, err
 }
 
-// isCattleClustersCRDInstalled returns true if the clusters.management.cattle.io CRD is installed
-func isCattleClustersCRDInstalled(client apiextv1.ApiextensionsV1Interface) (bool, error) {
-	_, err := client.CustomResourceDefinitions().Get(context.TODO(), cattleClustersCRDName, metav1.GetOptions{})
+// isCRDInstalled returns true if the clusters.management.cattle.io CRD is installed
+func isCRDInstalled(client apiextv1.ApiextensionsV1Interface, crdName string) (bool, error) {
+	_, err := client.CustomResourceDefinitions().Get(context.TODO(), crdName, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return false, nil
 	}
@@ -168,7 +190,7 @@ func isCattleClustersCRDInstalled(client apiextv1.ApiextensionsV1Interface) (boo
 func watchCattleClustersCRD(cancel context.CancelFunc, client apiextv1.ApiextensionsV1Interface, crdInstalled bool, log *zap.SugaredLogger) {
 	log.Infof("Watching for CRD %s to be installed or uninstalled", cattleClustersCRDName)
 	for {
-		installed, err := isCattleClustersCRDInstalled(client)
+		installed, err := isCRDInstalled(client, cattleClustersCRDName)
 		if err != nil {
 			log.Debugf("Unable to determine if CRD %s is installed: %v", cattleClustersCRDName, err)
 			continue

--- a/cluster-operator/internal/operatorinit/run_operator_test.go
+++ b/cluster-operator/internal/operatorinit/run_operator_test.go
@@ -125,20 +125,20 @@ func TestShouldSyncClusters(t *testing.T) {
 	}
 }
 
-// TestIsCattleClustersCRDInstalled tests the isCattleClustersCRDInstalled function
+// TestIsCattleClustersCRDInstalled tests the isCRDInstalled function
 func TestIsCattleClustersCRDInstalled(t *testing.T) {
 	asserts := assert.New(t)
 
 	// GIVEN a cluster that does not have the cattle clusters CRD installed
-	// WHEN  a call is made to isCattleClustersCRDInstalled
+	// WHEN  a call is made to isCRDInstalled
 	// THEN  the function returns false
 	client := fake.NewSimpleClientset().ApiextensionsV1()
-	isInstalled, err := isCattleClustersCRDInstalled(client)
+	isInstalled, err := isCRDInstalled(client, cattleClustersCRDName)
 	asserts.NoError(err)
 	asserts.False(isInstalled)
 
 	// GIVEN a cluster that does have the cattle clusters CRD installed
-	// WHEN  a call is made to isCattleClustersCRDInstalled
+	// WHEN  a call is made to isCRDInstalled
 	// THEN  the function returns true
 	crd := &apiextv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
@@ -146,7 +146,7 @@ func TestIsCattleClustersCRDInstalled(t *testing.T) {
 		},
 	}
 	client = fake.NewSimpleClientset(crd).ApiextensionsV1()
-	isInstalled, err = isCattleClustersCRDInstalled(client)
+	isInstalled, err = isCRDInstalled(client, cattleClustersCRDName)
 	asserts.NoError(err)
 	asserts.True(isInstalled)
 }

--- a/cluster-operator/main.go
+++ b/cluster-operator/main.go
@@ -26,13 +26,14 @@ import (
 var (
 	scheme = runtime.NewScheme()
 
-	metricsAddr          string
-	enableLeaderElection bool
-	probeAddr            string
-	runWebhooks          bool
-	runWebhookInit       bool
-	certDir              string
-	ingressHost          string
+	metricsAddr                    string
+	enableLeaderElection           bool
+	probeAddr                      string
+	runWebhooks                    bool
+	runWebhookInit                 bool
+	certDir                        string
+	ingressHost                    string
+	disableCAPIRancherRegistration bool
 )
 
 func init() {
@@ -60,7 +61,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		err := operatorinit.StartClusterOperator(metricsAddr, enableLeaderElection, probeAddr, ingressHost, log, scheme)
+		err := operatorinit.StartClusterOperator(metricsAddr, enableLeaderElection, probeAddr, ingressHost, disableCAPIRancherRegistration, log, scheme)
 		if err != nil {
 			os.Exit(1)
 		}
@@ -80,6 +81,8 @@ func handleFlags() {
 		"Runs the webhook initialization code")
 	flag.StringVar(&certDir, "cert-dir", "/etc/certs/", "The directory containing tls.crt and tls.key.")
 	flag.StringVar(&ingressHost, "ingress-host", "", "The host used for Rancher API requests.")
+	flag.BoolVar(&disableCAPIRancherRegistration, "disable-capi-rancher-registration", false,
+		"Disables the registration of CAPI-based clusters with Rancher")
 
 	opts := kzap.Options{}
 	opts.BindFlags(flag.CommandLine)

--- a/pkg/controller/requeue.go
+++ b/pkg/controller/requeue.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package controller
 
@@ -9,11 +9,21 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// Create a new Result that will cause a reconcile requeue after a short delay
+// Create a new Result that will cause a reconcile requeue after a delay within the specified range
 func NewRequeueWithDelay(min int, max int, units time.Duration) ctrl.Result {
 	var seconds = rand.IntnRange(min, max)
 	delaySecs := time.Duration(seconds) * units
 	return ctrl.Result{Requeue: true, RequeueAfter: delaySecs}
+}
+
+// ShortRequeue returns a new Result that will cause a reconcile requeue after a short delay
+func ShortRequeue() ctrl.Result {
+	return NewRequeueWithDelay(2, 3, time.Second)
+}
+
+// LongRequeue returns a new Result that will cause a reconcile requeue after a long delay (2 -3 minutes)
+func LongRequeue() ctrl.Result {
+	return NewRequeueWithDelay(2, 3, time.Minute)
 }
 
 // Return true if requeue is needed

--- a/pkg/k8sutil/apply_yaml.go
+++ b/pkg/k8sutil/apply_yaml.go
@@ -103,6 +103,11 @@ func (y *YAMLApplier) ApplyF(filePath string) error {
 	return y.doFileAction(filePath, y.applyAction)
 }
 
+// ApplyB applies a spec to Kubernetes via a byte slice
+func (y *YAMLApplier) ApplyS(spec string) error {
+	return y.doStringAction(spec, y.applyAction)
+}
+
 // ApplyFT applies a file template spec (go text.template) to Kubernetes
 func (y *YAMLApplier) ApplyFT(filePath string, args map[string]interface{}) error {
 	return y.doTemplatedFileAction(filePath, y.applyAction, args)
@@ -292,7 +297,11 @@ func (y *YAMLApplier) doFileAction(filePath string, f action) error {
 	}
 	defer file.Close()
 	return y.doAction(bufio.NewReader(file), f)
+}
 
+// doStringAction runs the action against a string
+func (y *YAMLApplier) doStringAction(spec string, f action) error {
+	return y.doAction(bufio.NewReader(strings.NewReader(spec)), f)
 }
 
 // doTemplatedFileAction runs the action against a template file

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
@@ -118,6 +118,15 @@ rules:
       - list
       - watch
   - apiGroups:
+      - cluster.x-k8s.io
+    resources:
+      - clusters
+    verbs:
+      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -148,16 +148,16 @@
             {
               "image": "rancher",
               "dashboard": "v2.7.5-20230818161107-07044c506",
-              "rancherUI": "v2.7.2-9/release-2.7.2",
-              "ocneDriverVersion": "v0.23.0",
-              "ocneDriverChecksum": "e410fd9b7ac5533b656277e82f1a321a995a5cd5e0329c2e79091e26e2516313",
-              "tag": "v2.7.5-20230818162112-c6f745626",
+              "rancherUI": "v2.7.2-11/release-2.7.2",
+              "ocneDriverVersion": "v0.24.0",
+              "ocneDriverChecksum": "0d537a9e810ce23f7727b4ad70d884acc9648afa4d600be9036b0c4893d7311a",
+              "tag": "v2.7.5-20230831191011-c6f745626",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.5-20230818162112-c6f745626"
+              "tag": "v2.7.5-20230831191011-c6f745626"
             }
           ]
         },


### PR DESCRIPTION
Backport the two commits to enable the CAPI cluster controller in the cluster operator to process cluster instances and register them with Rancher (when available)