### PR TITLE
VZ-10836: Updates to Auth Proxy v2 configuration

### DIFF
--- a/authproxy/src/config/config_test.go
+++ b/authproxy/src/config/config_test.go
@@ -14,14 +14,14 @@ import (
 
 // TestInitConfiguration tests the InitConfiguration function
 func TestInitConfiguration(t *testing.T) {
-	const testIssuerURL = "http://issuer.com"
-	const testExternalURL = "https://issuer.com"
+	const testServiceURL = "provider.namespace.svc.cluster.local"
+	const testExternalURL = "provider.com"
 	const testClientID = "unit-test-client-id"
 
 	// create temporary files with test data and override the filenames
-	issuerURLFile, err := makeTempFile(testIssuerURL)
-	if issuerURLFile != nil {
-		defer os.Remove(issuerURLFile.Name())
+	serviceURLFile, err := makeTempFile(testServiceURL)
+	if serviceURLFile != nil {
+		defer os.Remove(serviceURLFile.Name())
 	}
 	assert.NoError(t, err)
 
@@ -38,9 +38,9 @@ func TestInitConfiguration(t *testing.T) {
 	assert.NoError(t, err)
 
 	// restore the filenames when this test is done
-	oldIssuerURLFilename := issuerURLFilename
-	defer func() { issuerURLFilename = oldIssuerURLFilename }()
-	issuerURLFilename = issuerURLFile.Name()
+	oldServiceURLFilename := serviceURLFilename
+	defer func() { serviceURLFilename = oldServiceURLFilename }()
+	serviceURLFilename = serviceURLFile.Name()
 
 	oldExternalURLFilename := externalURLFilename
 	defer func() { externalURLFilename = oldExternalURLFilename }()
@@ -61,19 +61,19 @@ func TestInitConfiguration(t *testing.T) {
 	err = InitConfiguration(zap.S())
 	assert.NoError(t, err)
 
-	assert.Equal(t, testIssuerURL, GetIssuerURL())
+	assert.Equal(t, testServiceURL, GetServiceURL())
 	assert.Equal(t, testExternalURL, GetExternalURL())
 	assert.Equal(t, testClientID, GetClientID())
 
 	// GIVEN the file contents are changed
 	// WHEN we fetch the configuration values
 	// THEN the values eventually match the expected updated file contents
-	const newTestIssuerURL = "http://new-issuer.com"
-	const newTestExternalURL = "https://new-issuer.com"
+	const newTestServiceURL = "new-provider.namespace.svc.cluster.local"
+	const newTestExternalURL = "new-provider.com"
 	const newTestClientID = "new-unit-test-client-id"
 
 	// update the file contents and validate that the new values are loaded
-	err = os.WriteFile(issuerURLFilename, []byte(newTestIssuerURL), 0)
+	err = os.WriteFile(serviceURLFilename, []byte(newTestServiceURL), 0)
 	assert.NoError(t, err)
 
 	err = os.WriteFile(externalURLFilename, []byte(newTestExternalURL), 0)
@@ -82,7 +82,7 @@ func TestInitConfiguration(t *testing.T) {
 	err = os.WriteFile(clientIDFilename, []byte(newTestClientID), 0)
 	assert.NoError(t, err)
 
-	eventually(func() bool { return GetIssuerURL() == newTestIssuerURL })
+	eventually(func() bool { return GetServiceURL() == newTestServiceURL })
 	eventually(func() bool { return GetExternalURL() == newTestExternalURL })
 	eventually(func() bool { return GetClientID() == newTestClientID })
 

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -154,7 +154,7 @@ func (h Handler) handleAPIRequest(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	oidcConfig := auth.OIDCConfiguration{
-		IssuerURL:   config.GetIssuerURL(),
+		IssuerURL:   config.GetServiceURL(),
 		ClientID:    config.GetClientID(),
 		CallbackURL: fmt.Sprintf("https://%s%s", ingressHost, callbackPath),
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -247,3 +247,6 @@ const LetsEncryptProduction = "production"
 
 // LetsEncryptStaging - LetsEncrypt staging env
 const LetsEncryptStaging = "staging"
+
+// VerrazzanoOIDCSystemRealm is the OIDC realm used for Verrazzano system auth
+const VerrazzanoOIDCSystemRealm = "verrazzano-system"

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
@@ -346,12 +346,10 @@ func appendAuthProxyImageOverrides(kvs []bom.KeyValue) []bom.KeyValue {
 
 // appendOIDCOverrides appends overrides related to OIDC configuration
 func appendOIDCOverrides(kvs []bom.KeyValue, oidcServiceHost, oidcExternalHost, realm string) []bom.KeyValue {
-	realmPath := "/auth/realms/" + realm
-
-	oidcServiceURL := fmt.Sprintf("http://%s/%s", oidcServiceHost, realmPath)
+	oidcServiceURL := fmt.Sprintf("http://%s/auth/realms/%s", oidcServiceHost, realm)
 	kvs = append(kvs, bom.KeyValue{Key: "v2.oidcServiceURL", Value: oidcServiceURL})
 
-	oidcExternalURL := fmt.Sprintf("https://%s/%s", oidcExternalHost, realmPath)
+	oidcExternalURL := fmt.Sprintf("https://%s/auth/realms/%s", oidcExternalHost, realm)
 	kvs = append(kvs, bom.KeyValue{Key: "v2.oidcExternalURL", Value: oidcExternalURL})
 
 	return kvs

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
@@ -132,6 +132,7 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 	kvs = append(kvs, bom.KeyValue{Value: overridesFileName, IsFile: true})
 
 	// Append auth proxy v2 overrides
+	kvs = append(kvs, bom.KeyValue{Key: "v2.oidcServiceURL", Value: keycloakInClusterURL})
 	kvs = append(kvs, bom.KeyValue{Key: "v2.oidcExternalURL", Value: oidcProviderHost})
 
 	return appendAuthProxyImageOverrides(kvs), nil

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
@@ -6,13 +6,14 @@ package authproxy
 import (
 	"context"
 	"fmt"
+	"io/fs"
+	"os"
+
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	"io/fs"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
 
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,8 +88,9 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 		mgdClusterOidcClient = fmt.Sprintf("verrazzano-%s", clusterName)
 	}
 
+	oidcProviderHost := fmt.Sprintf("keycloak.%s.%s", overrides.Config.EnvName, dnsSuffix)
 	overrides.Proxy = &proxyValues{
-		OidcProviderHost:          fmt.Sprintf("keycloak.%s.%s", overrides.Config.EnvName, dnsSuffix),
+		OidcProviderHost:          oidcProviderHost,
 		OidcProviderHostInCluster: keycloakInClusterURL,
 		PKCEClientID:              adminClusterOidcID,
 	}
@@ -128,6 +130,9 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 
 	// Append any installArgs overrides in vzkvs after the file overrides to ensure precedence of those
 	kvs = append(kvs, bom.KeyValue{Value: overridesFileName, IsFile: true})
+
+	// Append auth proxy v2 overrides
+	kvs = append(kvs, bom.KeyValue{Key: "v2.oidcExternalURL", Value: oidcProviderHost})
 
 	return appendAuthProxyImageOverrides(kvs), nil
 }

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_test.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_test.go
@@ -6,14 +6,15 @@ package authproxy
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"github.com/verrazzano/verrazzano/pkg/nginxutil"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"io/fs"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/nginxutil"
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 
 	netv1 "k8s.io/api/networking/v1"
 
@@ -175,7 +176,7 @@ func TestAppendOverrides(t *testing.T) {
 			description:  "Test default configuration of AuthProxy with no overrides",
 			expectedYAML: "testdata/noOverrideValues.yaml",
 			actualCR:     "testdata/noOverrideVz.yaml",
-			numKeyValues: 2,
+			numKeyValues: 3,
 			expectedErr:  nil,
 		},
 		{
@@ -183,7 +184,7 @@ func TestAppendOverrides(t *testing.T) {
 			description:  "Test override of replica count",
 			expectedYAML: "testdata/replicasOverrideValues.yaml",
 			actualCR:     "testdata/replicasOverrideVz.yaml",
-			numKeyValues: 2,
+			numKeyValues: 3,
 			expectedErr:  nil,
 		},
 		{
@@ -191,7 +192,7 @@ func TestAppendOverrides(t *testing.T) {
 			description:  "Test override of affinity configuration for AuthProxy",
 			expectedYAML: "testdata/affinityOverrideValues.yaml",
 			actualCR:     "testdata/affinityOverrideVz.yaml",
-			numKeyValues: 2,
+			numKeyValues: 3,
 			expectedErr:  nil,
 		},
 		{
@@ -199,7 +200,7 @@ func TestAppendOverrides(t *testing.T) {
 			description:  "Test overriding DNS wildcard domain",
 			expectedYAML: "testdata/dnsWildcardDomainOverrideValues.yaml",
 			actualCR:     "testdata/dnsWildcardDomainOverrideVz.yaml",
-			numKeyValues: 2,
+			numKeyValues: 3,
 			expectedErr:  nil,
 		},
 		{
@@ -207,7 +208,7 @@ func TestAppendOverrides(t *testing.T) {
 			description:  "Test overriding AuthProxy to be disabled",
 			expectedYAML: "testdata/enabledOverrideValues.yaml",
 			actualCR:     "testdata/enabledOverrideVz.yaml",
-			numKeyValues: 2,
+			numKeyValues: 3,
 			expectedErr:  nil,
 		},
 		{
@@ -258,9 +259,9 @@ func TestAppendOverrides(t *testing.T) {
 			cleanTempFiles(fakeContext)
 
 			// Check authproxy image
-			if len(kvs) > 1 {
-				asserts.Equal("v2.image", kvs[1].Key)
-				asserts.Equal(testImageVar, kvs[1].Value)
+			if len(kvs) >= 2 {
+				asserts.Equal("v2.image", kvs[2].Key)
+				asserts.Equal(testImageVar, kvs[2].Value)
 			}
 
 		})

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_test.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_test.go
@@ -176,7 +176,7 @@ func TestAppendOverrides(t *testing.T) {
 			description:  "Test default configuration of AuthProxy with no overrides",
 			expectedYAML: "testdata/noOverrideValues.yaml",
 			actualCR:     "testdata/noOverrideVz.yaml",
-			numKeyValues: 3,
+			numKeyValues: 4,
 			expectedErr:  nil,
 		},
 		{
@@ -184,7 +184,7 @@ func TestAppendOverrides(t *testing.T) {
 			description:  "Test override of replica count",
 			expectedYAML: "testdata/replicasOverrideValues.yaml",
 			actualCR:     "testdata/replicasOverrideVz.yaml",
-			numKeyValues: 3,
+			numKeyValues: 4,
 			expectedErr:  nil,
 		},
 		{
@@ -192,7 +192,7 @@ func TestAppendOverrides(t *testing.T) {
 			description:  "Test override of affinity configuration for AuthProxy",
 			expectedYAML: "testdata/affinityOverrideValues.yaml",
 			actualCR:     "testdata/affinityOverrideVz.yaml",
-			numKeyValues: 3,
+			numKeyValues: 4,
 			expectedErr:  nil,
 		},
 		{
@@ -200,7 +200,7 @@ func TestAppendOverrides(t *testing.T) {
 			description:  "Test overriding DNS wildcard domain",
 			expectedYAML: "testdata/dnsWildcardDomainOverrideValues.yaml",
 			actualCR:     "testdata/dnsWildcardDomainOverrideVz.yaml",
-			numKeyValues: 3,
+			numKeyValues: 4,
 			expectedErr:  nil,
 		},
 		{
@@ -208,7 +208,7 @@ func TestAppendOverrides(t *testing.T) {
 			description:  "Test overriding AuthProxy to be disabled",
 			expectedYAML: "testdata/enabledOverrideValues.yaml",
 			actualCR:     "testdata/enabledOverrideVz.yaml",
-			numKeyValues: 3,
+			numKeyValues: 4,
 			expectedErr:  nil,
 		},
 		{
@@ -259,9 +259,9 @@ func TestAppendOverrides(t *testing.T) {
 			cleanTempFiles(fakeContext)
 
 			// Check authproxy image
-			if len(kvs) >= 2 {
-				asserts.Equal("v2.image", kvs[2].Key)
-				asserts.Equal(testImageVar, kvs[2].Value)
+			if len(kvs) >= 3 {
+				asserts.Equal("v2.image", kvs[3].Key)
+				asserts.Equal(testImageVar, kvs[3].Value)
 			}
 
 		})

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/authproxy-oidc-config.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/authproxy-oidc-config.yaml
@@ -8,4 +8,5 @@ metadata:
 type: Opaque
 data:
   oidcIssuerURL: {{ .Values.v2.oidcIssuerURL | b64enc | quote }}
+  oidcExternalURL: {{ .Values.v2.oidcExternalURL | b64enc | quote }}
   oidcClientID: {{ .Values.v2.oidcClientID | b64enc | quote }}

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/authproxy-oidc-config.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/authproxy-oidc-config.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: {{ .Values.namespace }}
 type: Opaque
 data:
-  oidcIssuerURL: {{ .Values.v2.oidcIssuerURL | b64enc | quote }}
+  oidcServiceURL: {{ .Values.v2.oidcServiceURL | b64enc | quote }}
   oidcExternalURL: {{ .Values.v2.oidcExternalURL | b64enc | quote }}
   oidcClientID: {{ .Values.v2.oidcClientID | b64enc | quote }}

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
@@ -46,5 +46,7 @@ v2:
   port: 8777
 
   oidcIssuerURL: placeholder
+  # The URL to access the OIDC provider from outside of the cluster
+  oidcExternalURL:
   oidcClientID: verrazzano-pkce
   oidcConfigSecret: verrazzano-authproxy-oidc-config

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
@@ -45,8 +45,9 @@ v2:
   image:
   port: 8777
 
-  oidcIssuerURL: placeholder
-  # The URL to access the OIDC provider from outside of the cluster
-  oidcExternalURL:
+  # The in-cluster service URL to access the OIDC provider (configured at install time)
+  # oidcServiceURL:
+  # The URL to access the OIDC provider from outside of the cluster (configured at install time)
+  # oidcExternalURL:
   oidcClientID: verrazzano-pkce
   oidcConfigSecret: verrazzano-authproxy-oidc-config

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg"
 	"github.com/verrazzano/verrazzano/tests/e2e/pkg/test/framework"
@@ -25,7 +26,6 @@ const (
 	pollingInterval   = 30 * time.Second
 	keycloakNamespace = "keycloak"
 	vzUser            = "verrazzano"
-	vzSysRealm        = "verrazzano-system"
 	realmMgmt         = "realm-management"
 	viewUsersRole     = "view-users"
 	osdURI            = "osd.vmi.system."
@@ -254,7 +254,7 @@ var _ = t.Describe("Verify client role", Label("f:platform-lcm.install"), func()
 })
 
 func verifyKeycloakVerrazzanoRealmPasswordPolicyIsCorrect() bool {
-	return verifyKeycloakRealmPasswordPolicyIsCorrect(vzSysRealm)
+	return verifyKeycloakRealmPasswordPolicyIsCorrect(constants.VerrazzanoOIDCSystemRealm)
 }
 
 func verifyKeycloakMasterRealmPasswordPolicyIsCorrect() bool {
@@ -324,7 +324,7 @@ func verifyKeycloakClientURIs() bool {
 	}
 
 	// Get the Client ID JSON array
-	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get", "clients", "-r", vzSysRealm, "--fields", "id,clientId")
+	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get", "clients", "-r", constants.VerrazzanoOIDCSystemRealm, "--fields", "id,clientId")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Logs.Error(fmt.Printf("Error retrieving ID for client ID, zero length: %s\n", err))
@@ -425,7 +425,7 @@ func getKeycloakClientByClientID(keycloakClients KeycloakClients, clientID strin
 
 	// Get the client Info
 	client := "clients/" + id
-	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get", client, "-r", vzSysRealm)
+	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get", client, "-r", constants.VerrazzanoOIDCSystemRealm)
 	out, err := cmd.Output()
 	if err != nil {
 		err := fmt.Errorf("error retrieving clientID json: %s", err)
@@ -644,7 +644,7 @@ func verifyUserClientRole(user, userRole string) bool {
 	}
 
 	// Get the roles for the user
-	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get-roles", "-r", vzSysRealm, "--uusername", user, "--cclientid", realmMgmt, "--effective", "--fields", "name")
+	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get-roles", "-r", constants.VerrazzanoOIDCSystemRealm, "--uusername", user, "--cclientid", realmMgmt, "--effective", "--fields", "name")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Logs.Error(fmt.Printf("Error retrieving client role for the user %s: %s\n", vzUser, err.Error()))

--- a/tests/e2e/verify-install/keycloak/keycloak_test.go
+++ b/tests/e2e/verify-install/keycloak/keycloak_test.go
@@ -324,7 +324,7 @@ func verifyKeycloakClientURIs() bool {
 	}
 
 	// Get the Client ID JSON array
-	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get", "clients", "-r", constants.VerrazzanoOIDCSystemRealm, "--fields", "id,clientId")
+	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get", "clients", "-r", constants.VerrazzanoOIDCSystemRealm, "--fields", "id,clientId") //nolint:gosec //#nosec G204
 	out, err := cmd.Output()
 	if err != nil {
 		t.Logs.Error(fmt.Printf("Error retrieving ID for client ID, zero length: %s\n", err))
@@ -425,7 +425,7 @@ func getKeycloakClientByClientID(keycloakClients KeycloakClients, clientID strin
 
 	// Get the client Info
 	client := "clients/" + id
-	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get", client, "-r", constants.VerrazzanoOIDCSystemRealm)
+	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get", client, "-r", constants.VerrazzanoOIDCSystemRealm) //nolint:gosec //#nosec G204
 	out, err := cmd.Output()
 	if err != nil {
 		err := fmt.Errorf("error retrieving clientID json: %s", err)
@@ -644,7 +644,7 @@ func verifyUserClientRole(user, userRole string) bool {
 	}
 
 	// Get the roles for the user
-	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get-roles", "-r", constants.VerrazzanoOIDCSystemRealm, "--uusername", user, "--cclientid", realmMgmt, "--effective", "--fields", "name")
+	cmd := exec.Command("kubectl", "exec", "keycloak-0", "-n", "keycloak", "-c", "keycloak", "--", kcAdminScript, "get-roles", "-r", constants.VerrazzanoOIDCSystemRealm, "--uusername", user, "--cclientid", realmMgmt, "--effective", "--fields", "name") //nolint:gosec //#nosec G204
 	out, err := cmd.Output()
 	if err != nil {
 		t.Logs.Error(fmt.Printf("Error retrieving client role for the user %s: %s\n", vzUser, err.Error()))


### PR DESCRIPTION
This PR includes:
1. Adding a new `oidcExternalURL` configuration field to the Auth Proxy v2 secret and Helm chart. The value is the externally accessible OIDC provider URL.
2. Renamed the `oidcIssuerURL` configuration field to `oidcServiceURL`. The value is the in-cluster URL to access the OIDC provider.
3. Implemented Helm overrides in the authproxy component that set `oidcServiceURL` and `oidcExternalURL` appropriately.
4. Refactoring to use a constant for the Verrazzano OIDC system realm.

After installing in a cluster, the OIDC config secret has these values for the URLs:
```
oidcExternalURL: https://keycloak.default.172.18.0.230.nip.io/auth/realms/verrazzano-system
oidcServiceURL: http://keycloak-http.keycloak.svc.cluster.local/auth/realms/verrazzano-system
```