### PR TITLE
VZ-10868.  Respect `monitorOverrides` flag on components for module status updates

### DIFF
--- a/platform-operator/controllers/verrazzano/reconcile/controller.go
+++ b/platform-operator/controllers/verrazzano/reconcile/controller.go
@@ -1117,24 +1117,3 @@ func (r *Reconciler) IsWatchedComponent(compName string) bool {
 	defer r.WatchMutex.RUnlock()
 	return r.WatchedComponents[compName]
 }
-
-// forceSyncComponentReconciledGeneration Force all Ready components' lastReconciledGeneration to match the VZ CR generation;
-// this is applied at the end of a successful VZ CR reconcile.
-func (r *Reconciler) forceSyncComponentReconciledGeneration(actualCR *installv1alpha1.Verrazzano) error {
-	if !config.Get().ModuleIntegration {
-		// only do this with modules integration enabled
-		return nil
-	}
-	componentsToUpdate := map[string]*installv1alpha1.ComponentStatusDetails{}
-	for compName, componentStatus := range actualCR.Status.Components {
-		if componentStatus.State == installv1alpha1.CompStateReady {
-			componentStatus.LastReconciledGeneration = actualCR.Generation
-			componentsToUpdate[compName] = componentStatus
-		}
-	}
-	// Update the status with the new version and component generations
-	r.StatusUpdater.Update(&vzstatus.UpdateEvent{
-		Components: componentsToUpdate,
-	})
-	return nil
-}

--- a/platform-operator/controllers/verrazzano/reconcile/install.go
+++ b/platform-operator/controllers/verrazzano/reconcile/install.go
@@ -12,6 +12,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	vzcontext "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/context"
 	vzstatus "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/healthcheck"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -229,6 +230,10 @@ func (r *Reconciler) beforeInstallComponents(ctx spi.ComponentContext) {
 // forceSyncComponentReconciledGeneration Force all Ready components' lastReconciledGeneration to match the VZ CR generation;
 // this is applied at the end of a successful VZ CR reconcile.
 func (r *Reconciler) forceSyncComponentReconciledGeneration(ctx spi.ComponentContext) error {
+	if !config.Get().ModuleIntegration {
+		// only do this with modules integration enabled
+		return nil
+	}
 	actualCR := ctx.ActualCR()
 	componentsToUpdate := map[string]*vzapi.ComponentStatusDetails{}
 	for compName, componentStatus := range actualCR.Status.Components {


### PR DESCRIPTION
Fixes the code that sync up the reconciled generation state with the VZ generation post-install/update to honor the `monitorOverrides` flag
* Move `forceSyncComponentReconciledGeneration` to `install.go`
* Move call to inside the `!preUpgrade` check in the install state machine
* Update the `lastReconciledGeneration` for a comp IFF it is in `Ready` state **and** `monitorOverrides` is true
* Removes the modules feature-gate guard to run in all cases