### PR TITLE
VZ-10856: Fix bug where WLS cluster resource was not being updated

### DIFF
--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -401,7 +401,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, workload *vzapi.Verrazzano
 
 		return nil
 	}); err != nil {
-		log.Errorf("Failed creating or updating WebLogic domaiin CR: %v", err)
+		log.Errorf("Failed creating or updating WebLogic domain CR: %v", err)
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
This pull request fixes a bug where the WLS cluster resource was not being updated when the component containing a VerrazzanoWeblogicWorkload was updated for a cluster.

E2E test will be updated in a followup pull request.