### PR TITLE
Add skipping of jaeger-operator-jaeger-es-index-cleaner pods

### DIFF
--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -55,6 +55,9 @@ var skipPods = map[string][]string{
 	"verrazzano-backup": {
 		"^restic.*$",
 	},
+	"verrazzano-monitoring": {
+		"^jaeger-operator-jaeger-es-index-cleaner.*$",
+	},
 }
 
 var skipContainers = []string{"jaeger-agent"}


### PR DESCRIPTION
This pull request fixes a dev LRE issue where  jaeger-operator-jaeger-es-index-cleaner pods needed to be skipped during verify install.