### PR TITLE
VZ-10802 add DNS field to the Thanos module values

### DIFF
--- a/platform-operator/controllers/verrazzano/component/thanos/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/module_integration.go
@@ -6,7 +6,7 @@ package thanos
 import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
+	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
@@ -16,17 +16,40 @@ import (
 )
 
 type valuesConfig struct {
-	IstioInjectionEnabled bool `json:"istioInjectionEnabled"`
+	IstioInjectionEnabled bool                         `json:"istioInjectionEnabled"`
+	Ingress               *vzapi.IngressNginxComponent `json:"ingress,omitempty"`
+	DNS                   *vzapi.DNSComponent          `json:"dns,omitempty"`
+	EnvironmentName       string                       `json:"environmentName,omitempty"`
 }
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
-func (c ThanosComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
+func (c ThanosComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
 	if effectiveCR == nil {
 		return nil, nil
 	}
 
 	configSnippet := valuesConfig{
 		IstioInjectionEnabled: vzcr.IsIstioInjectionEnabled(effectiveCR),
+	}
+
+	dns := effectiveCR.Spec.Components.DNS
+	if dns != nil {
+		configSnippet.DNS = &vzapi.DNSComponent{
+			External:         dns.External,
+			InstallOverrides: vzapi.InstallOverrides{},
+			OCI:              dns.OCI,
+			Wildcard:         dns.Wildcard,
+		}
+	}
+
+	nginx := effectiveCR.Spec.Components.Ingress
+	if nginx != nil {
+		configSnippet.Ingress = nginx.DeepCopy()
+		configSnippet.Ingress.InstallOverrides.ValueOverrides = []vzapi.Overrides{}
+	}
+
+	if len(effectiveCR.Spec.EnvironmentName) > 0 {
+		configSnippet.EnvironmentName = effectiveCR.Spec.EnvironmentName
 	}
 
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)

--- a/platform-operator/controllers/verrazzano/component/thanos/module_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/module_integration_test.go
@@ -19,6 +19,7 @@ import (
 //	THEN the generated helm values JSON snippet is valid
 func TestGetModuleSpec(t *testing.T) {
 	trueValue := true
+	ingressClassName := "myclass"
 	tests := []struct {
 		name        string
 		effectiveCR *vzapi.Verrazzano
@@ -32,7 +33,8 @@ func TestGetModuleSpec(t *testing.T) {
 					EnvironmentName: "Myenv",
 					Components: vzapi.ComponentSpec{
 						Ingress: &vzapi.IngressNginxComponent{
-							Enabled: &trueValue,
+							Enabled:          &trueValue,
+							IngressClassName: &ingressClassName,
 							Ports: []corev1.ServicePort{
 								{
 									Name:     "myport",
@@ -86,7 +88,31 @@ func TestGetModuleSpec(t *testing.T) {
 			  "verrazzano": {
 				"module": {
 				  "spec": {
-					  "istioInjectionEnabled": true
+				    "istioInjectionEnabled": true,
+					"ingress": {
+					  "enabled": true,
+					  "ingressClassName": "myclass",
+					  "ports": [
+						{
+						  "name": "myport",
+						  "protocol": "tcp",
+						  "port": 8000,
+						  "targetPort": 0,
+						  "nodePort": 80
+						}
+					  ],
+					  "type": "LoadBalancer"
+					},
+					"dns": {
+					  "oci": {
+						"dnsScope": "global",
+						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
+						"dnsZoneOCID": "ocid..zone.myzone",
+						"dnsZoneName": "myzone",
+						"ociConfigSecret": "oci"
+					  }
+					},
+					"environmentName": "Myenv"
 				  }
 				}
 			  }


### PR DESCRIPTION
This changes adds dns, nginx, and environment fields to the the Thanos valuesConfig. This will cause the Thanos module to do an update when any of those VZ CR fields are updated so the Thanos ingress can get properly updated.