### PR TITLE
WebLogic Kubernetes Operator 4.1.2 and WebLogic Monitoring Exporter 2.1.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 ### v2.0.0
+Component version updates:
 
-Feature:
+- WebLogic Kubernetes Operator v4.1.2
+- WebLogic Monitoring Exporter v2.1.5
+
+Features:
 
 - Enabled status updates for Istio reconciled objects
 - Support for Thanos Ruler and Compactor

--- a/platform-operator/thirdparty/charts/weblogic-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/weblogic-operator/Chart.yaml
@@ -2,8 +2,8 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: v1
-appVersion: 4.1.0
+appVersion: 4.1.2
 description: Helm chart for configuring the WebLogic operator.
 name: weblogic-operator
 type: application
-version: 4.1.0
+version: 4.1.2

--- a/platform-operator/thirdparty/charts/weblogic-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/weblogic-operator/values.yaml
@@ -54,7 +54,7 @@ domainNamespaceSelectionStrategy: LabelSelector
 enableClusterRoleBinding: true
 
 # image specifies the container image containing the operator.
-image: "ghcr.io/oracle/weblogic-kubernetes-operator:4.1.0"
+image: "ghcr.io/oracle/weblogic-kubernetes-operator:4.1.2"
 
 # imagePullPolicy specifies the image pull policy for the operator's container image.
 imagePullPolicy: IfNotPresent

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -443,7 +443,7 @@
     },
     {
       "name": "weblogic-operator",
-      "version": "4.1.0",
+      "version": "4.1.2",
       "subcomponents": [
         {
           "repository": "oracle",
@@ -451,12 +451,12 @@
           "images": [
             {
               "image": "weblogic-kubernetes-operator",
-              "tag": "4.1.0",
+              "tag": "4.1.2",
               "helmFullImageKey": "image"
             },
             {
               "image": "weblogic-monitoring-exporter",
-              "tag": "2.1.4",
+              "tag": "2.1.5",
               "helmFullImageKey": "weblogicMonitoringExporterImage"
             }
           ]


### PR DESCRIPTION
Update Verrazzano to use WKO 4.1.2 and WME 2.1.5.
