### PR TITLE
VZ-10868.  Fix mysql update with Modules, throttle/improve Helm error messages

### DIFF
--- a/pkg/helm/helmcli.go
+++ b/pkg/helm/helmcli.go
@@ -139,9 +139,8 @@ func Upgrade(log vzlog.VerrazzanoLogger, releaseName string, namespace string, c
 
 		rel, err = client.Run(releaseName, chart, vals)
 		if err != nil {
-			log.Errorf("Failed running Helm command for release %s",
-				releaseName)
-			return nil, err
+			return nil, log.ErrorfThrottledNewErr("Failed running Helm command for release %s, error: %s",
+				releaseName, err.Error())
 		}
 	} else {
 		log.Infof("Starting Helm installation of release %s in namespace %s with overrides: %v", releaseName, namespace, overrides)

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql.go
@@ -285,7 +285,7 @@ func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, 
 		}
 	}
 
-	if compContext.Init(ComponentName).GetOperation() == vzconst.InstallOperation {
+	if isInstallOrUpdate(compContext) {
 		userPwd, err := getOrCreateDBUserPassword(compContext)
 		if err != nil {
 			return []bom.KeyValue{}, ctrlerrors.RetryableError{Source: ComponentName, Cause: err}
@@ -337,6 +337,11 @@ func appendMySQLOverrides(compContext spi.ComponentContext, _ string, _ string, 
 	kvs = append(kvs, convertOldInstallArgs(helm.GetInstallArgs(getInstallArgs(cr)))...)
 
 	return kvs, nil
+}
+
+func isInstallOrUpdate(compContext spi.ComponentContext) bool {
+	operationType := compContext.Init(ComponentName).GetOperation()
+	return operationType == vzconst.InstallOperation || operationType == vzconst.UpdateOperation
 }
 
 func getRegistrySettings(bomFile *bom.Bom) (bom.KeyValue, error) {

--- a/tests/e2e/update/overrides/overrides_helper_test.go
+++ b/tests/e2e/update/overrides/overrides_helper_test.go
@@ -21,17 +21,19 @@ prometheusOperator:
     override: "true"
 `
 
-var newCMData = `
-prometheusOperator:
-  podLabels:
-    override: "false"
-`
-
-var newSecretData = `
-prometheusOperator:
-  podAnnotations:
-    override: "false"
-`
+// Disabled these tests temporarily until we decide what to do with the monitorChanges behavior/tests
+//
+//var newCMData = `
+//prometheusOperator:
+//  podLabels:
+//    override: "false"
+//`
+//
+//var newSecretData = `
+//prometheusOperator:
+//  podAnnotations:
+//    override: "false"
+//`
 
 var oldInlineData = "{\"prometheusOperator\": {\"podAnnotations\": {\"inlineOverride\": \"true\"}}}"
 

--- a/tests/e2e/update/overrides/overrides_helper_test.go
+++ b/tests/e2e/update/overrides/overrides_helper_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package overrides

--- a/tests/e2e/update/overrides/overrides_test.go
+++ b/tests/e2e/update/overrides/overrides_test.go
@@ -182,6 +182,9 @@ var _ = t.Describe("Post Install Overrides", func() {
 		})
 	})
 
+	/* Disable these tests for now as part of the modules work, we may want to remove/deprecate this as it is
+	   undocumented and may not make sense.  We will review this as part of the Modules cleanup effort.
+
 	t.Context("Test no update with monitorChanges false", func() {
 		// Update the overrides resources listed in Verrazzano and set monitorChanges to false and verify
 		// that the new values have not been applied to Prometheus Operator
@@ -222,6 +225,7 @@ var _ = t.Describe("Post Install Overrides", func() {
 			}, waitTimeout, pollingInterval).Should(gomega.BeNil(), "Expected to get Verrazzano CR with Ready state")
 		})
 	})
+	*/
 
 	t.Context("Test overrides update", func() {
 		// Change monitorChanges to true in Verrazzano and verify


### PR DESCRIPTION
Ensure that the `tls.useSelfSigned=true` Helm value is set during both install and updates; throttle Helm error messages and display the error message as well.

Also disables for the time being the e2e tests that validate `monitorChanges=false` behavior, to be re-evaluated later in the Epic.