### PR TITLE
Fix upgrade resiliency tests

### DIFF
--- a/ci/chaos/Jenkinsfile
+++ b/ci/chaos/Jenkinsfile
@@ -321,8 +321,7 @@ pipeline {
                         fi
                     else
                         echo "Upgrading VPO to this commit version"
-                        ${GO_REPO_PATH}/vz upgrade --manifests ${WORKSPACE}/upgrade-test-operator.yaml --version ${VERRAZZANO_DEV_VERSION}
-                         kubectl wait --timeout=45m --for=condition=UpgradeComplete verrazzano/my-verrazzano
+                        kubectl apply -f ${WORKSPACE}/upgrade-test-operator.yaml
                     fi
 
 


### PR DESCRIPTION
This change repairs the upgrade resiliency tests so that they test what they say they are supposed to. Currently, 4 of the 6 tests perform the upgrade before they are supposed to and thus the resiliency aspect is not tested. This is because the test was modified to call vz install instead of applying the operator.yaml.
