### PR TITLE
VZ-10706 fix VPO-module a-la-cart tests

### DIFF
--- a/platform-operator/controllers/verrazzano/component/argocd/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/module_integration.go
@@ -8,7 +8,6 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/keycloak"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -56,5 +55,5 @@ func (c argoCDComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazza
 
 // GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
 func (c argoCDComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
-	return watch.GetModuleInstalledWatches([]string{istio.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName, keycloak.ComponentName})
+	return watch.GetModuleInstalledWatches([]string{nginx.ComponentName, cmconstants.CertManagerComponentName, keycloak.ComponentName})
 }

--- a/platform-operator/controllers/verrazzano/component/authproxy/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/module_integration.go
@@ -10,6 +10,7 @@ import (
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -64,7 +65,7 @@ func (c authProxyComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Ve
 // GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
 func (c authProxyComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 	return watch.CombineWatchDescriptors(
-		watch.GetModuleInstalledWatches([]string{nginx.ComponentName, fluentoperator.ComponentName}),
+		watch.GetModuleInstalledWatches([]string{istio.ComponentName, nginx.ComponentName, fluentoperator.ComponentName}),
 		watch.GetCreateSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),
 		watch.GetUpdateSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),
 		watch.GetDeleteSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),

--- a/platform-operator/controllers/verrazzano/component/authproxy/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/module_integration.go
@@ -10,7 +10,6 @@ import (
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -65,7 +64,7 @@ func (c authProxyComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Ve
 // GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
 func (c authProxyComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 	return watch.CombineWatchDescriptors(
-		watch.GetModuleInstalledWatches([]string{istio.ComponentName, nginx.ComponentName, fluentoperator.ComponentName}),
+		watch.GetModuleInstalledWatches([]string{nginx.ComponentName, fluentoperator.ComponentName}),
 		watch.GetCreateSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),
 		watch.GetUpdateSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),
 		watch.GetDeleteSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),

--- a/platform-operator/controllers/verrazzano/component/clusteragent/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/clusteragent/module_integration.go
@@ -6,11 +6,10 @@ package clusteragent
 import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/oam"
 )
 
 // GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
 func (c clusterAgentComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
-	return watch.GetModuleInstalledWatches([]string{oam.ComponentName, istio.ComponentName})
+	return watch.GetModuleInstalledWatches([]string{oam.ComponentName})
 }

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -81,11 +81,11 @@ const istioSidecarMutatingWebhook = "istio-sidecar-injector"
 
 const istioRevisionMutatingWebhook = "istio-revision-tag-default"
 
-var istioLabelSelector = clipkg.ListOptions{LabelSelector: labels.Set(map[string]string{"release": "istio"}).AsSelector()}
-
 // for unit testing
 type funcCreateNamespaces func(ctx spi.ComponentContext) error
+
 var callCreateNamespaces funcCreateNamespaces = common.CreateAndLabelNamespaces
+var istioLabelSelector = clipkg.ListOptions{LabelSelector: labels.Set(map[string]string{"release": "istio"}).AsSelector()}
 
 const (
 	// ExternalIPArg is used in a special case where Istio helm chart no longer supports ExternalIPs.

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -456,12 +456,21 @@ func (i istioComponent) PreUpgrade(context spi.ComponentContext) error {
 	return webhook.DeleteMutatingWebhookConfiguration(context.Log(), context.Client(), webhooks)
 }
 
-func (i istioComponent) PostUpgrade(context spi.ComponentContext) error {
-	err := deleteIstioCoreDNS(context)
+func (i istioComponent) PostUpgrade(compContext spi.ComponentContext) error {
+	// Make sure namespaces get updated with Istio Enabled
+	common.CreateAndLabelNamespaces(compContext)
+
+	// During upgrade there is a window where the latest Istio envoy sidecar container is not included in a pod.
+	// Restart system components that are missing the sidecar.
+	if err := restart.RestartComponents(compContext.Log(), config.GetInjectedSystemNamespaces(), compContext.ActualCR().Generation, &restart.OutdatedSidecarPodMatcher{}); err != nil {
+		return err
+	}
+
+	err := deleteIstioCoreDNS(compContext)
 	if err != nil {
 		return err
 	}
-	err = removeIstioHelmSecrets(context)
+	err = removeIstioHelmSecrets(compContext)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -83,6 +83,10 @@ const istioRevisionMutatingWebhook = "istio-revision-tag-default"
 
 var istioLabelSelector = clipkg.ListOptions{LabelSelector: labels.Set(map[string]string{"release": "istio"}).AsSelector()}
 
+// for unit testing
+type funcCreateNamespaces func(ctx spi.ComponentContext) error
+var callCreateNamespaces funcCreateNamespaces = common.CreateAndLabelNamespaces
+
 const (
 	// ExternalIPArg is used in a special case where Istio helm chart no longer supports ExternalIPs.
 	// Put external IPs into the IstioOperator YAML, which does support it
@@ -458,7 +462,7 @@ func (i istioComponent) PreUpgrade(context spi.ComponentContext) error {
 
 func (i istioComponent) PostUpgrade(compContext spi.ComponentContext) error {
 	// Make sure namespaces get updated with Istio Enabled
-	common.CreateAndLabelNamespaces(compContext)
+	callCreateNamespaces(compContext)
 
 	// During upgrade there is a window where the latest Istio envoy sidecar container is not included in a pod.
 	// Restart system components that are missing the sidecar.

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -336,6 +336,9 @@ func fakeUpgrade(log vzlog.VerrazzanoLogger, imageOverridesString string, overri
 func TestPostUpgrade(t *testing.T) {
 	a := assert.New(t)
 
+	callCreateNamespaces = func(ctx spi.ComponentContext) error {
+		return nil
+	}
 	comp := istioComponent{}
 
 	// Setup fake client to provide workloads for restart platform testing

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/istio"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/test/ip"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -41,7 +40,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	gofake "k8s.io/client-go/kubernetes/fake"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -333,25 +331,25 @@ func fakeUpgrade(log vzlog.VerrazzanoLogger, imageOverridesString string, overri
 	return []byte("success"), []byte(""), nil
 }
 
-func TestPostUpgrade(t *testing.T) {
-	a := assert.New(t)
-
-	comp := istioComponent{}
-
-	// Setup fake client to provide workloads for restart platform testing
-	clientSet := gofake.NewSimpleClientset()
-	k8sutil.SetFakeClient(clientSet)
-
-	config.SetDefaultBomFilePath(testBomFilePath)
-	defer helm.SetDefaultActionConfigFunction()
-
-	helm.SetActionConfigFunction(testActionConfigWithInstallation)
-
-	SetHelmUninstallFunction(fakeHelmUninstall)
-	SetDefaultHelmUninstallFunction()
-	err := comp.PostUpgrade(spi.NewFakeContext(getMock(t), crInstall, nil, false))
-	a.NoError(err, "PostUpgrade returned an error")
-}
+//func TestPostUpgrade(t *testing.T) {
+//	a := assert.New(t)
+//
+//	comp := istioComponent{}
+//
+//	// Setup fake client to provide workloads for restart platform testing
+//	clientSet := gofake.NewSimpleClientset()
+//	k8sutil.SetFakeClient(clientSet)
+//
+//	config.SetDefaultBomFilePath(testBomFilePath)
+//	defer helm.SetDefaultActionConfigFunction()
+//
+//	helm.SetActionConfigFunction(testActionConfigWithInstallation)
+//
+//	SetHelmUninstallFunction(fakeHelmUninstall)
+//	SetDefaultHelmUninstallFunction()
+//	err := comp.PostUpgrade(spi.NewFakeContext(getMock(t), crInstall, nil, false))
+//	a.NoError(err, "PostUpgrade returned an error")
+//}
 
 func fakeHelmUninstall(_ vzlog.VerrazzanoLogger, releaseName string, namespace string, dryRun bool) (err error) {
 	if releaseName != "istiocoredns" {

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/pkg/istio"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/test/ip"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -40,6 +41,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	gofake "k8s.io/client-go/kubernetes/fake"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -331,25 +333,25 @@ func fakeUpgrade(log vzlog.VerrazzanoLogger, imageOverridesString string, overri
 	return []byte("success"), []byte(""), nil
 }
 
-//func TestPostUpgrade(t *testing.T) {
-//	a := assert.New(t)
-//
-//	comp := istioComponent{}
-//
-//	// Setup fake client to provide workloads for restart platform testing
-//	clientSet := gofake.NewSimpleClientset()
-//	k8sutil.SetFakeClient(clientSet)
-//
-//	config.SetDefaultBomFilePath(testBomFilePath)
-//	defer helm.SetDefaultActionConfigFunction()
-//
-//	helm.SetActionConfigFunction(testActionConfigWithInstallation)
-//
-//	SetHelmUninstallFunction(fakeHelmUninstall)
-//	SetDefaultHelmUninstallFunction()
-//	err := comp.PostUpgrade(spi.NewFakeContext(getMock(t), crInstall, nil, false))
-//	a.NoError(err, "PostUpgrade returned an error")
-//}
+func TestPostUpgrade(t *testing.T) {
+	a := assert.New(t)
+
+	comp := istioComponent{}
+
+	// Setup fake client to provide workloads for restart platform testing
+	clientSet := gofake.NewSimpleClientset()
+	k8sutil.SetFakeClient(clientSet)
+
+	config.SetDefaultBomFilePath(testBomFilePath)
+	defer helm.SetDefaultActionConfigFunction()
+
+	helm.SetActionConfigFunction(testActionConfigWithInstallation)
+
+	SetHelmUninstallFunction(fakeHelmUninstall)
+	SetDefaultHelmUninstallFunction()
+	err := comp.PostUpgrade(spi.NewFakeContext(getMock(t), crInstall, nil, false))
+	a.NoError(err, "PostUpgrade returned an error")
+}
 
 func fakeHelmUninstall(_ vzlog.VerrazzanoLogger, releaseName string, namespace string, dryRun bool) (err error) {
 	if releaseName != "istiocoredns" {

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install.go
@@ -202,11 +202,15 @@ func (i istioComponent) PreInstall(compContext spi.ComponentContext) error {
 }
 
 func (i istioComponent) PostInstall(compContext spi.ComponentContext) error {
+	// Make sure namespaces get updated with Istio Enabled
+	common.CreateAndLabelNamespaces(compContext)
+
 	// During install there is a window where the Istio envoy sidecar container is not included in a pod.
 	// Restart system components that are missing the sidecar.
 	if err := restart.RestartComponents(compContext.Log(), config.GetInjectedSystemNamespaces(), compContext.ActualCR().Generation, &restart.OutdatedSidecarPodMatcher{}); err != nil {
 		return err
 	}
+
 	if err := createPeerAuthentication(compContext); err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/module_integration.go
@@ -12,6 +12,7 @@ import (
 	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/opensearch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	corev1 "k8s.io/api/core/v1"
@@ -79,7 +80,7 @@ func (c jaegerOperatorComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.
 // GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
 func (c jaegerOperatorComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 	return watch.CombineWatchDescriptors(
-		watch.GetModuleInstalledWatches([]string{cmconstants.CertManagerComponentName, opensearch.ComponentName, fluentoperator.ComponentName}),
+		watch.GetModuleInstalledWatches([]string{istio.ComponentName, cmconstants.CertManagerComponentName, opensearch.ComponentName, fluentoperator.ComponentName}),
 		watch.GetCreateSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),
 		watch.GetUpdateSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),
 		watch.GetDeleteSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),

--- a/platform-operator/controllers/verrazzano/component/keycloak/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/keycloak/module_integration.go
@@ -11,7 +11,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysql"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -29,7 +28,6 @@ type valuesConfig struct {
 func (c KeycloakComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 	return watch.CombineWatchDescriptors(
 		watch.GetModuleInstalledWatches([]string{
-			istio.ComponentName,
 			nginx.ComponentName,
 			cmconstants.CertManagerComponentName,
 			mysql.ComponentName,

--- a/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/mysql_component.go
@@ -19,7 +19,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
@@ -66,7 +65,7 @@ func NewComponent() spi.Component {
 			ImagePullSecretKeyname:    secret.DefaultImagePullSecretKeyName,
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "mysql-values.yaml"),
 			AppendOverridesFunc:       appendMySQLOverrides,
-			Dependencies:              []string{networkpolicies.ComponentName, istio.ComponentName, MySQLOperatorComponentName, fluentoperator.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, MySQLOperatorComponentName, fluentoperator.ComponentName},
 			GetInstallOverridesFunc:   GetOverrides,
 			AvailabilityObjects: &ready.AvailabilityObjects{
 				StatefulsetNames: []types.NamespacedName{

--- a/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/mysqloperator/mysqloperator_component.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -70,7 +69,7 @@ func NewComponent() spi.Component {
 			MinVerrazzanoVersion:      vpocons.VerrazzanoVersion1_4_0,
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "mysql-operator-values.yaml"),
 			AppendOverridesFunc:       AppendOverrides,
-			Dependencies:              []string{networkpolicies.ComponentName, istio.ComponentName, fluentoperator.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, fluentoperator.ComponentName},
 			GetInstallOverridesFunc:   getOverrides,
 			InstallBeforeUpgrade:      true,
 			AvailabilityObjects: &ready.AvailabilityObjects{

--- a/platform-operator/controllers/verrazzano/component/networkpolicies/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/networkpolicies/module_integration.go
@@ -5,9 +5,10 @@ package networkpolicies
 
 import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 )
 
 // GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
 func (c networkPoliciesComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
-	return nil
+	return watch.GetVerrazzanoSpecWatch()
 }

--- a/platform-operator/controllers/verrazzano/component/thanos/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/module_integration.go
@@ -9,6 +9,7 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	promoperator "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/prometheus/operator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -57,5 +58,5 @@ func (c ThanosComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazza
 
 // GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
 func (c ThanosComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
-	return watch.GetModuleInstalledWatches([]string{nginx.ComponentName, promoperator.ComponentName, fluentoperator.ComponentName})
+	return watch.GetModuleInstalledWatches([]string{istio.ComponentName, nginx.ComponentName, promoperator.ComponentName, fluentoperator.ComponentName})
 }

--- a/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
+++ b/platform-operator/controllers/verrazzano/component/thanos/thanos_component.go
@@ -5,6 +5,7 @@ package thanos
 
 import (
 	"fmt"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -57,7 +58,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorUninstall: true,
 			ImagePullSecretKeyname:    "image.pullSecrets[0]",
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), "thanos-values.yaml"),
-			Dependencies:              []string{networkpolicies.ComponentName, nginx.ComponentName, promoperator.ComponentName, fluentoperator.ComponentName},
+			Dependencies:              []string{istio.ComponentName, networkpolicies.ComponentName, nginx.ComponentName, promoperator.ComponentName, fluentoperator.ComponentName},
 			AppendOverridesFunc:       AppendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
 			AvailabilityObjects: &ready.AvailabilityObjects{

--- a/platform-operator/experimental/controllers/verrazzano/custom/namespace.go
+++ b/platform-operator/experimental/controllers/verrazzano/custom/namespace.go
@@ -40,12 +40,6 @@ var sharedNamespaces = []string{
 	monitoringNamespace,
 }
 
-// systemNamespaceLabels the verrazzano-system namespace labels required
-var systemNamespaceLabels = map[string]string{
-	"istio-injection":         "enabled",
-	"verrazzano.io/namespace": vzconst.VerrazzanoSystemNamespace,
-}
-
 // DeleteNamespace deletes a namespace
 func DeleteNamespace(cli client.Client, log vzlog.VerrazzanoLogger, namespace string) error {
 	ns := corev1.Namespace{

--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -21,7 +21,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/reconcile/restart"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/transform"
 	"github.com/verrazzano/verrazzano/platform-operator/experimental/controllers/verrazzano/custom"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -204,11 +203,6 @@ func (r Reconciler) postUpgrade(log vzlog.VerrazzanoLogger, actualCR *vzv1alpha1
 
 	if err := argocd.ConfigureKeycloakOIDC(componentCtx); err != nil {
 		log.ErrorfThrottled("Failed Verrazzano post-upgrade ArgoCD configure OIDC: %v", err)
-		return result.NewResultShortRequeueDelayWithError(err)
-	}
-
-	if err := restart.RestartComponents(log, config.GetInjectedSystemNamespaces(), componentCtx.ActualCR().Generation, &restart.OutdatedSidecarPodMatcher{}); err != nil {
-		log.ErrorfThrottled("Failed Verrazzano post-upgrade restart components: %v", err)
 		return result.NewResultShortRequeueDelayWithError(err)
 	}
 

--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/reconcile/restart"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/transform"
 	"github.com/verrazzano/verrazzano/platform-operator/experimental/controllers/verrazzano/custom"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/namespace"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -104,7 +105,8 @@ func (r Reconciler) Reconcile(controllerCtx controllerspi.ReconcileContext, u *u
 func (r Reconciler) preWork(log vzlog.VerrazzanoLogger, actualCR *vzv1alpha1.Verrazzano, effectiveCR *vzv1alpha1.Verrazzano) result.Result {
 	// Pre-create the Verrazzano System namespace if it doesn't already exist, before kicking off the install job,
 	// since it is needed for the subsequent step to syncLocalRegistration secret.
-	if err := custom.CreateVerrazzanoSystemNamespace(r.Client, effectiveCR, log); err != nil {
+	istio := effectiveCR.Spec.Components.Istio
+	if err := namespace.CreateVerrazzanoSystemNamespace(r.Client, istio != nil && istio.IsInjectionEnabled()); err != nil {
 		return result.NewResultShortRequeueDelayWithError(err)
 	}
 


### PR DESCRIPTION
Fix a-la-cart for VPO-modules

1. Istio post-install and post-upgrade must call RestartComponents
2. Istio post-install and post-upgrade must add istio inject label to certain namespaces.
3. Use common CreateNamespace function