### PR TITLE
Fix to Add Additional Labels To Managed Cluster ArgoCD Secret

### DIFF
--- a/cluster-operator/controllers/vmc/argocd.go
+++ b/cluster-operator/controllers/vmc/argocd.go
@@ -236,8 +236,9 @@ func (r *VerrazzanoManagedClusterReconciler) mutateArgoCDClusterSecret(secret *c
 		secret.StringData = make(map[string]string)
 	}
 	secret.Type = corev1.SecretTypeOpaque
-	secret.ObjectMeta.Labels = map[string]string{"argocd.argoproj.io/secret-type": "cluster"}
-
+	if secret.ObjectMeta.Labels == nil {
+		secret.ObjectMeta.Labels = map[string]string{"argocd.argoproj.io/secret-type": "cluster"}
+	}
 	secret.StringData["name"] = clusterName
 	secret.StringData["server"] = rancherURL
 

--- a/cluster-operator/controllers/vmc/argocd.go
+++ b/cluster-operator/controllers/vmc/argocd.go
@@ -237,14 +237,11 @@ func (r *VerrazzanoManagedClusterReconciler) mutateArgoCDClusterSecret(secret *c
 	}
 	secret.Type = corev1.SecretTypeOpaque
 	if secret.ObjectMeta.Labels == nil {
-		secret.ObjectMeta.Labels = map[string]string{"argocd.argoproj.io/secret-type": "cluster"}
+		secret.ObjectMeta.Labels = map[string]string{}
 	}
 	secret.StringData["name"] = clusterName
 	secret.StringData["server"] = rancherURL
-	valueToIndicateIfClusterIsRegistered, ok := secret.ObjectMeta.Labels["argocd.argoproj.io/secret-type"]
-	if !ok || valueToIndicateIfClusterIsRegistered != "cluster" {
-		secret.ObjectMeta.Labels["argocd.argoproj.io/secret-type"] = "cluster"
-	}
+	secret.ObjectMeta.Labels["argocd.argoproj.io/secret-type"] = "cluster"
 
 	rancherConfig := &ArgoCDRancherConfig{
 		BearerToken: token,

--- a/cluster-operator/controllers/vmc/argocd.go
+++ b/cluster-operator/controllers/vmc/argocd.go
@@ -241,6 +241,10 @@ func (r *VerrazzanoManagedClusterReconciler) mutateArgoCDClusterSecret(secret *c
 	}
 	secret.StringData["name"] = clusterName
 	secret.StringData["server"] = rancherURL
+	valueToIndicateIfClusterIsRegistered, ok := secret.ObjectMeta.Labels["argocd.argoproj.io/secret-type"]
+	if !ok || valueToIndicateIfClusterIsRegistered != "cluster" {
+		secret.ObjectMeta.Labels["argocd.argoproj.io/secret-type"] = "cluster"
+	}
 
 	rancherConfig := &ArgoCDRancherConfig{
 		BearerToken: token,

--- a/cluster-operator/controllers/vmc/argocd_test.go
+++ b/cluster-operator/controllers/vmc/argocd_test.go
@@ -483,3 +483,68 @@ func TestUpdateArgoCDClusterRoleBindingTemplate(t *testing.T) {
 		})
 	}
 }
+func TestMutateArgoCDSecretLabelDoesNotChange(t *testing.T) {
+	// clear any cached user auth tokens when the test completes
+	defer rancherutil.DeleteStoredTokens()
+
+	cli := generateClientObject()
+	log := vzlog.DefaultLogger()
+
+	savedRancherHTTPClient := rancherutil.RancherHTTPClient
+	defer func() {
+		rancherutil.RancherHTTPClient = savedRancherHTTPClient
+	}()
+
+	savedRetry := rancherutil.DefaultRetry
+	defer func() {
+		rancherutil.DefaultRetry = savedRetry
+	}()
+	rancherutil.DefaultRetry = wait.Backoff{
+		Steps:    1,
+		Duration: 1 * time.Millisecond,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
+
+	vmc := &v1alpha1.VerrazzanoManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+			Name:      "cluster",
+		},
+		Status: v1alpha1.VerrazzanoManagedClusterStatus{
+			RancherRegistration: v1alpha1.RancherRegistration{
+				ClusterID: clusterID,
+			},
+		},
+	}
+	r := &VerrazzanoManagedClusterReconciler{
+		Client: cli,
+		log:    vzlog.DefaultLogger(),
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "demo" + "-" + clusterSecretName,
+			Namespace:   constants.ArgoCDNamespace,
+			Annotations: map[string]string{createTimestamp: time.Now().Add(-10 * time.Hour).Format(time.RFC3339), expiresAtTimestamp: time.Now().Format(time.RFC3339)},
+			Labels:      map[string]string{"testlabel": "shouldnotbedeleted"},
+		},
+		Data: map[string][]byte{
+			"password": []byte("foobar"),
+		},
+	}
+
+	mocker := gomock.NewController(t)
+	httpMock := mocks.NewMockRequestSender(mocker)
+	httpMock = expectHTTPRequests(httpMock)
+	rancherutil.RancherHTTPClient = httpMock
+
+	caData := []byte("ca")
+
+	rc, err := rancherutil.NewRancherConfigForUser(cli, constants.ArgoCDClusterRancherUsername, "foobar", rancherutil.RancherIngressServiceHost(), log)
+	assert.NoError(t, err)
+
+	err = r.mutateArgoCDClusterSecret(secret, rc, vmc.Name, clusterID, rancherURL, caData)
+	assert.NoError(t, err)
+	assert.Equal(t, secret.Labels, map[string]string{"testlabel": "shouldnotbedeleted"})
+}

--- a/cluster-operator/controllers/vmc/argocd_test.go
+++ b/cluster-operator/controllers/vmc/argocd_test.go
@@ -483,7 +483,7 @@ func TestUpdateArgoCDClusterRoleBindingTemplate(t *testing.T) {
 		})
 	}
 }
-func TestMutateArgoCDSecretLabelDoesNotChange(t *testing.T) {
+func TestMutateArgoCDSecretLabelDoesNotGetRemovedandCorrectSecretLabelIsAdded(t *testing.T) {
 	// clear any cached user auth tokens when the test completes
 	defer rancherutil.DeleteStoredTokens()
 
@@ -546,5 +546,5 @@ func TestMutateArgoCDSecretLabelDoesNotChange(t *testing.T) {
 
 	err = r.mutateArgoCDClusterSecret(secret, rc, vmc.Name, clusterID, rancherURL, caData)
 	assert.NoError(t, err)
-	assert.Equal(t, secret.Labels, map[string]string{"testlabel": "shouldnotbedeleted"})
+	assert.Equal(t, secret.Labels, map[string]string{"testlabel": "shouldnotbedeleted", "argocd.argoproj.io/secret-type": "cluster"})
 }


### PR DESCRIPTION

In this PR, additional labels to to a managed cluster can be added to an ArgoCD Secret and not be overwritten. A unit test related to this PR is also committed and it has clean runs in the pipeline. 