### PR TITLE
VZ-9535: Merge config.yml and internal_users.yml from the secret and the helm config.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -655,7 +655,7 @@ github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNG
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
-github.com/verrazzano/crossplane-runtime v0.17.0-1 h1:VIwLgGss561pwHDbN0fk9gAsgfKrq9sb+j/GHcz1FFo=
+github.com/verrazzano/crossplane-runtime v0.17.0-1 h1:juTCAYMWDWITX9vFTdNnF97+Sl/b5/HtZGjmqwy6Ib4=
 github.com/verrazzano/crossplane-runtime v0.17.0-1/go.mod h1:fA8Dp1vT5JjpBCE3KlellJ0Z/Xo1aekngOXmuDsryz0=
 github.com/verrazzano/fluent-operator/v2 v2.2.0 h1:rsKzccy5Di5SdbIJW31AdbWqET7cHRW+p0XY10+XXZ0=
 github.com/verrazzano/fluent-operator/v2 v2.2.0/go.mod h1:v/q0zLEOWP6MKHP7xvrhtASZTwlrk4LcCne/kgPQ7J0=

--- a/go.sum
+++ b/go.sum
@@ -655,7 +655,7 @@ github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNG
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
-github.com/verrazzano/crossplane-runtime v0.17.0-1 h1:juTCAYMWDWITX9vFTdNnF97+Sl/b5/HtZGjmqwy6Ib4=
+github.com/verrazzano/crossplane-runtime v0.17.0-1 h1:VIwLgGss561pwHDbN0fk9gAsgfKrq9sb+j/GHcz1FFo=
 github.com/verrazzano/crossplane-runtime v0.17.0-1/go.mod h1:fA8Dp1vT5JjpBCE3KlellJ0Z/Xo1aekngOXmuDsryz0=
 github.com/verrazzano/fluent-operator/v2 v2.2.0 h1:rsKzccy5Di5SdbIJW31AdbWqET7cHRW+p0XY10+XXZ0=
 github.com/verrazzano/fluent-operator/v2 v2.2.0/go.mod h1:v/q0zLEOWP6MKHP7xvrhtASZTwlrk4LcCne/kgPQ7J0=

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	secretName         = "securityconfig-secret"
-	secretNamespace    = "verrazzano-logging"
+	configName         = "securityconfig-secret"
+	configNamespace    = "verrazzano-logging"
 	securityConfigYaml = "/verrazzano/platform-operator/thirdparty/manifests/opensearch-securityconfig.yaml"
 )
 
@@ -32,7 +32,7 @@ func MergeSecretData(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	secret, err := clientset.CoreV1().Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	secret, err := clientset.CoreV1().Secrets(configNamespace).Get(context.TODO(), configName, metav1.GetOptions{})
 	if err != nil {
 		fmt.Println("Error")
 		return err
@@ -90,7 +90,7 @@ func MergeSecretData(ctx spi.ComponentContext) error {
 	if err != nil {
 		return err
 	}
-	adminSecret, err := clientset.CoreV1().Secrets(secretNamespace).Get(context.TODO(), "admin-credentials-secret", metav1.GetOptions{})
+	adminSecret, err := clientset.CoreV1().Secrets(configNamespace).Get(context.TODO(), "admin-credentials-secret", metav1.GetOptions{})
 	if err != nil {
 		fmt.Println("Error")
 		return err
@@ -111,7 +111,7 @@ func MergeSecretData(ctx spi.ComponentContext) error {
 	// Assign the YAML byte slice to the secret data
 	secret.Data["config.yml"] = mergedUsersYAML
 
-	clientset.CoreV1().Secrets(secretNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+	clientset.CoreV1().Secrets(configNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -24,7 +24,7 @@ const (
 	securityConfigYaml = "opensearch-operator/opensearch-securityconfig.yaml"
 	configYaml         = "config.yml"
 	usersYaml          = "internal_users.yml"
-	adminSecretName    = "admin-credentials-secret"
+	hashSecretName     = "admin-credentials-secret"
 )
 
 // getClient returns a controller runtime client for the Verrazzano resource
@@ -105,7 +105,7 @@ func MergeSecretData(ctx spi.ComponentContext, helmManifestsDir string) error {
 		return err
 	}
 	var adminSecret corev1.Secret
-	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: securityNamespace, Name: adminSecretName}, &adminSecret); err != nil {
+	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecretName}, &adminSecret); err != nil {
 		return err
 	}
 

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -93,7 +93,6 @@ func MergeSecretData(ctx spi.ComponentContext, helmManifestsDir string) error {
 
 	// Update the secret with the merged config data
 	scr.Data[configYaml] = mergedConfigYAML
-
 	usersYamlFile, err := getYamlData(securityYamlData, usersYaml)
 	if err != nil {
 		return err
@@ -115,7 +114,6 @@ func MergeSecretData(ctx spi.ComponentContext, helmManifestsDir string) error {
 	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecName}, &adminSecret); err != nil {
 		return err
 	}
-
 	adminHash, err := getAdminHash(&adminSecret)
 	if err != nil {
 		return err
@@ -131,7 +129,6 @@ func MergeSecretData(ctx spi.ComponentContext, helmManifestsDir string) error {
 	}
 	// Assign the YAML byte slice to the secret data
 	scr.Data[usersYaml] = mergedUsersYAML
-
 	// Update the secret
 	if err := client.Update(context.TODO(), &scr); err != nil {
 		return err
@@ -155,7 +152,6 @@ func getSecretYamlData(secret *corev1.Secret, yamlName string) ([]byte, error) {
 	for key, val := range secret.Data {
 		if key == yamlName {
 			byteYaml = val
-
 		}
 	}
 	return byteYaml, nil
@@ -227,25 +223,25 @@ func mergeConfigYamlData(dataSecret, dataFile map[string]interface{}) (map[strin
 }
 
 // mergeUserYamlData merges the internal_users.yml data from the secret and the helm config
-func mergeUserYamlData(data1, data2 map[string]interface{}, hashFromSecret string) (map[string]interface{}, error) {
+func mergeUserYamlData(dataFile, dataSecret map[string]interface{}, hashFromSecret string) (map[string]interface{}, error) {
 	mergedData := make(map[string]interface{})
-	adminData, ok := data1["admin"].(map[string]interface{})
+	adminData, ok := dataFile["admin"].(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("user not found")
 	}
 	adminData["hash"] = hashFromSecret
-	for key1, val1 := range data1 {
-		if key1 == "admin" {
-			mergedData[key1] = adminData
+	for keyFile, valFile := range dataFile {
+		if keyFile == "admin" {
+			mergedData[keyFile] = adminData
 		} else {
-			mergedData[key1] = val1
+			mergedData[keyFile] = valFile
 		}
 	}
-	for key2, val2 := range data2 {
-		if _, exists := mergedData[key2]; exists {
+	for keySecret, valSecret := range dataSecret {
+		if _, exists := mergedData[keySecret]; exists {
 			continue
 		} else {
-			mergedData[key2] = val2
+			mergedData[keySecret] = valSecret
 		}
 	}
 	return mergedData, nil

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"os"
+	"path"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 	"strings"
@@ -18,7 +20,7 @@ import (
 const (
 	securitySecretName = "securityconfig-secret"
 	securityNamespace  = "verrazzano-logging"
-	securityConfigYaml = "../../../../thirdparty/manifests/opensearch-operator/opensearch-securityconfig.yaml"
+	securityConfigYaml = "opensearch-operator/opensearch-securityconfig.yaml"
 	configYaml         = "config.yml"
 	usersYaml          = "internal_users.yml"
 	adminName          = "admin-credentials-secret"
@@ -31,7 +33,8 @@ func getClient(ctx spi.ComponentContext) (client.Client, error) {
 
 // MergeSecretData merges a security config secret
 func MergeSecretData(ctx spi.ComponentContext) error {
-	securityYaml, err := os.ReadFile(securityConfigYaml)
+	filePath := path.Join(config.GetThirdPartyManifestsDir(), securityConfigYaml)
+	securityYaml, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -49,10 +49,14 @@ func MergeSecretData(ctx spi.ComponentContext) error {
 		return err
 	}
 	var scr corev1.Secret
-	if err := client.Get(context.TODO(), types.NamespacedName{Namespace: securityNamespace, Name: securitySecretName}, &scr); err != nil {
+	err = client.Get(context.TODO(), types.NamespacedName{Namespace: securityNamespace, Name: securitySecretName}, &scr)
+	fmt.Println(err)
+	if err.Error() == "secrets \"securityconfig-secret\" not found" {
+		return nil
+	}
+	if err != nil {
 		return err
 	}
-
 	configYamlSecret, err := getSecretData(&scr, configYaml)
 	if err != nil {
 		return err

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"os"
@@ -32,8 +31,8 @@ func getClient(ctx spi.ComponentContext) (client.Client, error) {
 }
 
 // MergeSecretData merges a security config secret
-func MergeSecretData(ctx spi.ComponentContext) error {
-	filePath := path.Join(config.GetThirdPartyManifestsDir(), securityConfigYaml)
+func MergeSecretData(ctx spi.ComponentContext, helmChartsDir string) error {
+	filePath := path.Join(helmChartsDir, securityConfigYaml)
 	securityYaml, err := os.ReadFile(filePath)
 	if err != nil {
 		return err

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 package common
 
 import (

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -24,8 +24,6 @@ const (
 	adminName          = "admin-credentials-secret"
 )
 
-var getClientFunc = getClient
-
 // getClient returns a controller runtime client for the Verrazzano resource
 func getClient(ctx spi.ComponentContext) (client.Client, error) {
 	return ctx.Client(), nil

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	secretName         = "securityconfig-secret"
-	loggingNamespace   = "verrazzano-logging"
+	secretNamespace    = "verrazzano-logging"
 	securityConfigYaml = "/verrazzano/platform-operator/thirdparty/manifests/opensearch-securityconfig.yaml"
 )
 
@@ -32,7 +32,7 @@ func MergeSecretData(ctx spi.ComponentContext) error {
 		return err
 	}
 
-	secret, err := clientset.CoreV1().Secrets(loggingNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	secret, err := clientset.CoreV1().Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
 		fmt.Println("Error")
 		return err
@@ -90,7 +90,7 @@ func MergeSecretData(ctx spi.ComponentContext) error {
 	if err != nil {
 		return err
 	}
-	adminSecret, err := clientset.CoreV1().Secrets(loggingNamespace).Get(context.TODO(), "admin-credentials-secret", metav1.GetOptions{})
+	adminSecret, err := clientset.CoreV1().Secrets(secretNamespace).Get(context.TODO(), "admin-credentials-secret", metav1.GetOptions{})
 	if err != nil {
 		fmt.Println("Error")
 		return err
@@ -111,7 +111,7 @@ func MergeSecretData(ctx spi.ComponentContext) error {
 	// Assign the YAML byte slice to the secret data
 	secret.Data["config.yml"] = mergedUsersYAML
 
-	clientset.CoreV1().Secrets(loggingNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+	clientset.CoreV1().Secrets(secretNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 
 	return nil
 }

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -1,0 +1,192 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"sigs.k8s.io/yaml"
+	"strings"
+)
+
+const (
+	secretName         = "securityconfig-secret"
+	namespace          = "verrazzano-logging"
+	securityConfigYaml = "/verrazzano/platform-operator/thirdparty/manifests/opensearch-securityconfig.yaml"
+)
+
+// MergeSecurityConfigs merges a security config secret yamls and the helm
+// func MergeSecurityConfigs(actualCR *corev1.Secret, helmSecretYaml []byte) ([]byte, error) {
+func MergeSecretData(ctx spi.ComponentContext) error {
+	// Read the contents of the first YAML file into a byte slice.
+	helmYaml, err := os.ReadFile(securityConfigYaml)
+	if err != nil {
+		return err
+	}
+	// Get the kubernetes clientset
+	clientset, err := k8sutil.GetKubernetesClientset()
+	if err != nil {
+		return err
+	}
+
+	secret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Println("Error")
+		return err
+
+	}
+	// Unmarshal the first YAML data into a map[string]interface{}.
+	dataHelmSecret := make(map[string]interface{})
+	err = yaml.Unmarshal(helmYaml, &dataHelmSecret)
+	if err != nil {
+		fmt.Println("Error")
+		return err
+	}
+
+	// Get the YAML data from Helm Secret and Secret
+	configYamlHelm := getYamlData(dataHelmSecret, "config.yml")
+	configYamlSecret := getSecretData(secret, "config.yml")
+
+	// Unmarshal the YAML data into maps
+	dataHelmConfig, err := unmarshalYAML(configYamlHelm)
+	if err != nil {
+		fmt.Println("Error")
+		return err
+	}
+	dataSecretConfig, err := unmarshalYAML(configYamlSecret)
+	if err != nil {
+		fmt.Println("Error")
+		return err
+	}
+	// Merge the config.yml data
+	mergedConfig, err := mergeConfigData(dataSecretConfig, dataHelmConfig)
+	if err != nil {
+		fmt.Println("Error")
+		return err
+	}
+	// Convert the merged data back to YAML format
+	mergedConfigYAML, err := yaml.Marshal(mergedConfig)
+	if err != nil {
+		fmt.Println("Error")
+		return err
+	}
+
+	// Update the secret with the merged config data
+	secret.Data["config.yml"] = mergedConfigYAML
+
+	// Get the YAML data from Helm Secret and Secret
+	usersYamlHelm := getYamlData(dataHelmSecret, "internal_users.yml")
+	usersYamlSecret := getSecretData(secret, "internal_users.yml")
+
+	// Unmarshal the YAML data into maps
+	dataHelmUsers, err := unmarshalYAML(usersYamlHelm)
+	if err != nil {
+		return err
+	}
+	dataSecretUsers, err := unmarshalYAML(usersYamlSecret)
+	if err != nil {
+		return err
+	}
+	adminSecret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), "admin-credentials-secret", metav1.GetOptions{})
+	if err != nil {
+		fmt.Println("Error")
+	}
+	adminHash := getAdminHash(adminSecret)
+	// Merge the config.yml data
+	mergedUsers, err := mergeUserData(dataSecretUsers, dataHelmUsers, adminHash)
+	if err != nil {
+		return err
+	}
+
+	// Convert the merged data back to YAML format
+	mergedUsersYAML, err := yaml.Marshal(mergedUsers)
+	if err != nil {
+		return err
+	}
+
+	// Assign the YAML byte slice to the secret data
+	secret.Data["config.yml"] = mergedUsersYAML
+
+	clientset.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+
+	return nil
+}
+
+func getAdminHash(secret *corev1.Secret) string {
+	hashBytes, ok := secret.Data["hash"]
+	if !ok {
+		// Handle the case where the 'hash' key is not present in the secret
+		return "" // or return an error, depending on your use case
+	}
+	return string(hashBytes)
+}
+
+func getSecretData(secret *corev1.Secret, yamlName string) []byte {
+	var byteYaml []byte
+	for key, val := range secret.Data {
+		if key == yamlName {
+			byteYaml = val
+
+		}
+	}
+	return byteYaml
+}
+func unmarshalYAML(yamlData []byte) (map[interface{}]interface{}, error) {
+	var data map[interface{}]interface{}
+	if err := yaml.Unmarshal(yamlData, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func getYamlData(helmMap map[string]interface{}, yamlName string) []byte {
+	stringData := helmMap["stringData"].(map[interface{}]interface{})[yamlName].(string)
+	return []byte(stringData)
+}
+
+func mergeConfigData(data1, data2 map[interface{}]interface{}) (map[interface{}]interface{}, error) {
+	mergedData := make(map[string]interface{})
+	values1, ok1 := data1["config"].(map[interface{}]interface{})["dynamic"].(map[interface{}]interface{})["authc"].(map[interface{}]interface{})
+	values2, ok2 := data2["config"].(map[interface{}]interface{})["dynamic"].(map[interface{}]interface{})["authc"].(map[interface{}]interface{})
+	if !ok1 || !ok2 {
+		return nil, fmt.Errorf("config data structure mismatch")
+	}
+	for key1, val1 := range values1 {
+		mergedData[key1.(string)] = val1
+	}
+	for key2, val2 := range values2 {
+		if _, ok := mergedData[key2.(string)]; ok && strings.HasPrefix(key2.(string), "vz") {
+			continue
+		}
+		mergedData[key2.(string)] = val2
+	}
+	data1["config"].(map[interface{}]interface{})["dynamic"].(map[interface{}]interface{})["authc"] = mergedData
+	return data1, nil
+}
+func mergeUserData(data1, data2 map[interface{}]interface{}, hashFromSecret string) (map[interface{}]interface{}, error) {
+	mergedData := make(map[interface{}]interface{})
+	// Update the 'hash' field in mergedData1
+	adminData, ok := data1["admin"].(map[interface{}]interface{})
+	if !ok {
+		return nil, fmt.Errorf("user data structure mismatch")
+	}
+	adminData["hash"] = hashFromSecret
+	for key1, val1 := range data1 {
+		if key1 == "admin" {
+			mergedData[key1.(string)] = adminData
+		} else {
+			mergedData[key1.(string)] = val1
+		}
+	}
+	for key2, val2 := range data2 {
+		if _, ok := mergedData[key2.(string)]; ok {
+			continue
+		} else {
+			mergedData[key2.(string)] = val2
+		}
+	}
+	return mergedData, nil
+}

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -190,11 +190,11 @@ func mergeConfigYamlData(dataSecret, dataFile map[string]interface{}) (map[strin
 		return nil, fmt.Errorf("config not found")
 	}
 	authcSecret := make(map[string]interface{})
-	dynamicSecret, ok := dataSecret["config"].(map[string]interface{})
+	configSecret, ok := dataSecret["config"].(map[string]interface{})
 	if ok {
-		dynamicSecret, ok := dynamicSecret["dynamic"].(map[string]interface{})
+		dynamicSecret, ok := configSecret["dynamic"].(map[string]interface{})
 		if ok {
-			authcSecret, ok = dynamicSecret["authc"].(map[string]interface{})
+			authcSecret = dynamicSecret["authc"].(map[string]interface{})
 		}
 	}
 	for key1, val1 := range authcFile {

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -161,11 +161,11 @@ func getYamlData(helmMap map[string]interface{}, yamlName string) ([]byte, error
 
 func mergeConfigYamlData(data1, data2 map[string]interface{}) (map[string]interface{}, error) {
 	mergedData := make(map[string]interface{})
-	values1, ok1 := data1["config"].(map[string]interface{})["dynamic"].(map[string]interface{})["authc"].(map[string]interface{})
-	values2, ok2 := data2["config"].(map[string]interface{})["dynamic"].(map[string]interface{})["authc"].(map[string]interface{})
-	if !ok1 || !ok2 {
-		return nil, fmt.Errorf("config not found")
-	}
+	values1 := data1["config"].(map[string]interface{})["dynamic"].(map[string]interface{})["authc"].(map[string]interface{})
+	values2 := data2["config"].(map[string]interface{})["dynamic"].(map[string]interface{})["authc"].(map[string]interface{})
+	//if !ok1 || !ok2 {
+	//	return nil, fmt.Errorf("config not found")
+	//}
 	for key1, val1 := range values1 {
 		mergedData[key1] = val1
 	}
@@ -180,10 +180,10 @@ func mergeConfigYamlData(data1, data2 map[string]interface{}) (map[string]interf
 }
 func mergeUserYamlData(data1, data2 map[string]interface{}, hashFromSecret string) (map[string]interface{}, error) {
 	mergedData := make(map[string]interface{})
-	adminData, ok := data1["admin"].(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("user not found")
-	}
+	adminData := data1["admin"].(map[string]interface{})
+	//if !ok {
+	//	return nil, fmt.Errorf("user not found")
+	//}
 	adminData["hash"] = hashFromSecret
 	for key1, val1 := range data1 {
 		if key1 == "admin" {

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -50,8 +50,7 @@ func MergeSecretData(ctx spi.ComponentContext) error {
 	}
 	var scr corev1.Secret
 	err = client.Get(context.TODO(), types.NamespacedName{Namespace: securityNamespace, Name: securitySecretName}, &scr)
-	fmt.Println(err)
-	if err.Error() == "secrets \"securityconfig-secret\" not found" {
+	if err != nil && err.Error() == "secrets \"securityconfig-secret\" not found" {
 		return nil
 	}
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator.go
@@ -52,7 +52,7 @@ func MergeSecretData(ctx spi.ComponentContext, helmChartsDir string) error {
 	}
 	var scr corev1.Secret
 	err = client.Get(context.TODO(), types.NamespacedName{Namespace: securityNamespace, Name: securitySecretName}, &scr)
-	if err != nil && err.Error() == "secrets \"securityconfig-secret\" not found" {
+	if err != nil && strings.Contains(err.Error(), "not found") {
 		return nil
 	}
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
@@ -21,16 +21,6 @@ func TestMergeSecurityConfigsError(t *testing.T) {
 	mock := mocks.NewMockClient(mocker)
 	const secretName = "securityconfig-secret"
 	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
-	//// fake client needed to get secret
-	//getClientFunc = func(ctx spi.ComponentContext) (client.Client, error) {
-	//	return fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
-	//		&corev1.Secret{
-	//			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "verrazzano-logging"},
-	//		},
-	//	).Build(), nil
-	//}
-	//defer func() { getClientFunc = getClient }()
-
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
 		secret.Name = secretName

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
@@ -41,8 +41,8 @@ func TestMergeSecurityConfigs(t *testing.T) {
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: adminSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = adminSecretName
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = hashSecretName
 		secret.Namespace = securityNamespace
 		secret.Data = map[string][]byte{"hash": []byte("abcdef")}
 		return nil
@@ -85,7 +85,7 @@ func TestMergeSecurityConfigsGetAdminError(t *testing.T) {
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: adminSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
 	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.Error(err)
 }
@@ -107,8 +107,8 @@ func TestMergeSecurityConfigsUpdateError(t *testing.T) {
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: adminSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = adminSecretName
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = hashSecretName
 		secret.Namespace = securityNamespace
 		secret.Data = map[string][]byte{"hash": []byte("test")}
 		return nil
@@ -136,8 +136,8 @@ func TestMergeSecurityConfigsHashError(t *testing.T) {
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: adminSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = adminSecretName
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = hashSecretName
 		secret.Namespace = securityNamespace
 		secret.Data = map[string][]byte{"hash1": []byte("test")}
 		return nil

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package common
+
+import (
+	"context"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/mocks"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8scheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestMergeSecurityConfigsError(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	const secretName = "securityconfig-secret"
+	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
+	// fake client needed to get secret
+	getClientFunc = func(ctx spi.ComponentContext) (client.Client, error) {
+		return fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "verrazzano-logging"},
+			},
+		).Build(), nil
+	}
+	defer func() { getClientFunc = getClient }()
+
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = secretName
+		secret.Namespace = "verrazzano-logging"
+		secret.Data = map[string][]byte{"config.yml": []byte("config:\n      dynamic:\n        kibana:\n          multitenancy_enabled: false\n        http:\n          anonymous_auth_enabled: false\n          xff:\n            enabled: true\n            internalProxies: '.*'\n            remoteIpHeader: 'x-forwarded-for'\n        authc:\n          vz_proxy_auth_domain:\n            description: \"Authenticate via Verrazzano proxy\"\n            http_enabled: true\n            transport_enabled: true\n            order: 0\n            http_authenticator:\n              type: proxy\n              challenge: false\n              config:\n                user_header: \"X-WEBAUTH-USER\"\n                roles_header: \"x-proxy-roles\"\n            authentication_backend:\n              type: noop\n          vz_basic_internal_auth_domain:\n            description: \"Authenticate via HTTP Basic against internal users database\"\n            http_enabled: true\n            transport_enabled: true\n            order: 1\n            http_authenticator:\n              type: basic\n              challenge: false\n            authentication_backend:\n              type: intern\n          vz_clientcert_auth_domain:\n             description: \"Authenticate via SSL client certificates\"\n             http_enabled: true\n             transport_enabled: true\n             order: 2\n             http_authenticator:\n               type: clientcert\n               config:\n                 enforce_hostname_verification: false\n                 username_attribute: cn\n               challenge: false\n             authentication_backend:\n                 type: noop"), "internal_users.yml": []byte("admin:\n    hash: \n    reserved: true\n    backend_roles:\n    - \"admin\"\n    description: \"Admin user\"")}
+		return nil
+	})
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: "admin-credentials-secret"}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = "admin-credentials-secret"
+		secret.Namespace = "verrazzano-logging"
+		secret.Data = map[string][]byte{"hash": []byte("abcdef")}
+		return nil
+	})
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+
+	err := MergeSecretData(fakeCtx)
+	asserts.NoError(err)
+}

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
@@ -41,8 +41,8 @@ func TestMergeSecurityConfigs(t *testing.T) {
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = hashSecretName
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = hashSecName
 		secret.Namespace = securityNamespace
 		secret.Data = map[string][]byte{"hash": []byte("abcdef")}
 		return nil
@@ -85,7 +85,7 @@ func TestMergeSecurityConfigsGetAdminError(t *testing.T) {
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecName}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
 	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.Error(err)
 }
@@ -107,8 +107,8 @@ func TestMergeSecurityConfigsUpdateError(t *testing.T) {
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = hashSecretName
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = hashSecName
 		secret.Namespace = securityNamespace
 		secret.Data = map[string][]byte{"hash": []byte("test")}
 		return nil
@@ -136,8 +136,8 @@ func TestMergeSecurityConfigsHashError(t *testing.T) {
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = hashSecretName
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: hashSecName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = hashSecName
 		secret.Namespace = securityNamespace
 		secret.Data = map[string][]byte{"hash1": []byte("test")}
 		return nil

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -15,7 +16,7 @@ import (
 	"testing"
 )
 
-func TestMergeSecurityConfigsError(t *testing.T) {
+func TestMergeSecurityConfigs(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -39,4 +40,58 @@ func TestMergeSecurityConfigsError(t *testing.T) {
 
 	err := MergeSecretData(fakeCtx)
 	asserts.NoError(err)
+}
+func TestMergeSecurityConfigsError(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	const secretName = "securityconfig-secret"
+	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
+	err := MergeSecretData(fakeCtx)
+	asserts.Error(err)
+}
+func TestMergeSecurityConfigsError2(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	const secretName = "securityconfig-secret"
+	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = secretName
+		secret.Namespace = "verrazzano-logging"
+		secret.Data = map[string][]byte{"config.yml": []byte("config:\n      dynamic:\n        kibana:\n          multitenancy_enabled: false\n        http:\n          anonymous_auth_enabled: false\n          xff:\n            enabled: true\n            internalProxies: '.*'\n            remoteIpHeader: 'x-forwarded-for'\n        authc:\n          vz_proxy_auth_domain:\n            description: \"Authenticate via Verrazzano proxy\"\n            http_enabled: true\n            transport_enabled: true\n            order: 0\n            http_authenticator:\n              type: proxy\n              challenge: false\n              config:\n                user_header: \"X-WEBAUTH-USER\"\n                roles_header: \"x-proxy-roles\"\n            authentication_backend:\n              type: noop\n          vz_basic_internal_auth_domain:\n            description: \"Authenticate via HTTP Basic against internal users database\"\n            http_enabled: true\n            transport_enabled: true\n            order: 1\n            http_authenticator:\n              type: basic\n              challenge: false\n            authentication_backend:\n              type: intern\n          vz_clientcert_auth_domain:\n             description: \"Authenticate via SSL client certificates\"\n             http_enabled: true\n             transport_enabled: true\n             order: 2\n             http_authenticator:\n               type: clientcert\n               config:\n                 enforce_hostname_verification: false\n                 username_attribute: cn\n               challenge: false\n             authentication_backend:\n                 type: noop"), "internal_users.yml": []byte("admin:\n    hash: \n    reserved: true\n    backend_roles:\n    - \"admin\"\n    description: \"Admin user\"")}
+		return nil
+	})
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: "admin-credentials-secret"}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
+	err := MergeSecretData(fakeCtx)
+	asserts.Error(err)
+}
+func TestMergeSecurityConfigsError3(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	const secretName = "securityconfig-secret"
+	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = secretName
+		secret.Namespace = "verrazzano-logging"
+		secret.Data = map[string][]byte{"config.yml": []byte("config:\n      dynamic:\n        kibana:\n          multitenancy_enabled: false\n        http:\n          anonymous_auth_enabled: false\n          xff:\n            enabled: true\n            internalProxies: '.*'\n            remoteIpHeader: 'x-forwarded-for'\n        authc:\n          vz_proxy_auth_domain:\n            description: \"Authenticate via Verrazzano proxy\"\n            http_enabled: true\n            transport_enabled: true\n            order: 0\n            http_authenticator:\n              type: proxy\n              challenge: false\n              config:\n                user_header: \"X-WEBAUTH-USER\"\n                roles_header: \"x-proxy-roles\"\n            authentication_backend:\n              type: noop\n          vz_basic_internal_auth_domain:\n            description: \"Authenticate via HTTP Basic against internal users database\"\n            http_enabled: true\n            transport_enabled: true\n            order: 1\n            http_authenticator:\n              type: basic\n              challenge: false\n            authentication_backend:\n              type: intern\n          vz_clientcert_auth_domain:\n             description: \"Authenticate via SSL client certificates\"\n             http_enabled: true\n             transport_enabled: true\n             order: 2\n             http_authenticator:\n               type: clientcert\n               config:\n                 enforce_hostname_verification: false\n                 username_attribute: cn\n               challenge: false\n             authentication_backend:\n                 type: noop"), "internal_users.yml": []byte("admin:\n    hash: \n    reserved: true\n    backend_roles:\n    - \"admin\"\n    description: \"Admin user\"")}
+		return nil
+	})
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: "admin-credentials-secret"}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = "admin-credentials-secret"
+		secret.Namespace = "verrazzano-logging"
+		secret.Data = map[string][]byte{"hash": []byte("abcdef")}
+		return nil
+	})
+	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(fmt.Errorf("test-error"))
+
+	err := MergeSecretData(fakeCtx)
+	asserts.Error(err)
 }

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
@@ -6,6 +6,8 @@ package common
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -14,26 +16,34 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 )
 
+const (
+	testConfigData = "config:\n      dynamic:\n        kibana:\n          multitenancy_enabled: false\n        http:\n          anonymous_auth_enabled: false\n          xff:\n            enabled: true\n            internalProxies: '.*'\n            remoteIpHeader: 'x-forwarded-for'\n        authc:\n          vz_proxy_auth_domain:\n            description: \"Authenticate via Verrazzano proxy\"\n            http_enabled: true\n            transport_enabled: true\n            order: 0\n            http_authenticator:\n              type: proxy\n              challenge: false\n              config:\n                user_header: \"X-WEBAUTH-USER\"\n                roles_header: \"x-proxy-roles\"\n            authentication_backend:\n              type: noop\n          vz_basic_internal_auth_domain:\n            description: \"Authenticate via HTTP Basic against internal users database\"\n            http_enabled: true\n            transport_enabled: true\n            order: 1\n            http_authenticator:\n              type: basic\n              challenge: false\n            authentication_backend:\n              type: intern\n          vz_clientcert_auth_domain:\n             description: \"Authenticate via SSL client certificates\"\n             http_enabled: true\n             transport_enabled: true\n             order: 2\n             http_authenticator:\n               type: clientcert\n               config:\n                 enforce_hostname_verification: false\n                 username_attribute: cn\n               challenge: false\n             authentication_backend:\n                 type: noop"
+	testUsersData  = "admin:\n    hash: \n    reserved: true\n    backend_roles:\n    - \"admin\"\n    description: \"Admin user\""
+)
+
+// TestMergeSecurityConfigs tests the MergeSecretData function
+// GIVEN a call to MergeSecretData
+// WHEN OpenSearchOperator is pre-installed
+// THEN no error is returned
 func TestMergeSecurityConfigs(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	const secretName = "securityconfig-secret"
+
 	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = secretName
-		secret.Namespace = "verrazzano-logging"
-		secret.Data = map[string][]byte{"config.yml": []byte("config:\n      dynamic:\n        kibana:\n          multitenancy_enabled: false\n        http:\n          anonymous_auth_enabled: false\n          xff:\n            enabled: true\n            internalProxies: '.*'\n            remoteIpHeader: 'x-forwarded-for'\n        authc:\n          vz_proxy_auth_domain:\n            description: \"Authenticate via Verrazzano proxy\"\n            http_enabled: true\n            transport_enabled: true\n            order: 0\n            http_authenticator:\n              type: proxy\n              challenge: false\n              config:\n                user_header: \"X-WEBAUTH-USER\"\n                roles_header: \"x-proxy-roles\"\n            authentication_backend:\n              type: noop\n          vz_basic_internal_auth_domain:\n            description: \"Authenticate via HTTP Basic against internal users database\"\n            http_enabled: true\n            transport_enabled: true\n            order: 1\n            http_authenticator:\n              type: basic\n              challenge: false\n            authentication_backend:\n              type: intern\n          vz_clientcert_auth_domain:\n             description: \"Authenticate via SSL client certificates\"\n             http_enabled: true\n             transport_enabled: true\n             order: 2\n             http_authenticator:\n               type: clientcert\n               config:\n                 enforce_hostname_verification: false\n                 username_attribute: cn\n               challenge: false\n             authentication_backend:\n                 type: noop"), "internal_users.yml": []byte("admin:\n    hash: \n    reserved: true\n    backend_roles:\n    - \"admin\"\n    description: \"Admin user\"")}
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: securitySecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = securitySecretName
+		secret.Namespace = securityNamespace
+		secret.Data = map[string][]byte{configYaml: []byte(testConfigData), usersYaml: []byte(testUsersData)}
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: "admin-credentials-secret"}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = "admin-credentials-secret"
-		secret.Namespace = "verrazzano-logging"
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: adminSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = adminSecretName
+		secret.Namespace = securityNamespace
 		secret.Data = map[string][]byte{"hash": []byte("abcdef")}
 		return nil
 	})
@@ -42,53 +52,65 @@ func TestMergeSecurityConfigs(t *testing.T) {
 	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.NoError(err)
 }
+
+// TestMergeSecurityConfigsGetConfigError tests the MergeSecretData function
+// GIVEN a call to MergeSecretData
+// WHEN get security config secret fails
+// THEN error is returned
 func TestMergeSecurityConfigsGetConfigError(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	const secretName = "securityconfig-secret"
 	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: securitySecretName}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
 	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.Error(err)
 }
+
+// TestMergeSecurityConfigsGetAdminError tests the MergeSecretData function
+// GIVEN a call to MergeSecretData
+// WHEN get admin secret fails
+// THEN error is returned
 func TestMergeSecurityConfigsGetAdminError(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	const secretName = "securityconfig-secret"
 	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = secretName
-		secret.Namespace = "verrazzano-logging"
-		secret.Data = map[string][]byte{"config.yml": []byte("config:\n      dynamic:\n        kibana:\n          multitenancy_enabled: false\n        http:\n          anonymous_auth_enabled: false\n          xff:\n            enabled: true\n            internalProxies: '.*'\n            remoteIpHeader: 'x-forwarded-for'\n        authc:\n          vz_proxy_auth_domain:\n            description: \"Authenticate via Verrazzano proxy\"\n            http_enabled: true\n            transport_enabled: true\n            order: 0\n            http_authenticator:\n              type: proxy\n              challenge: false\n              config:\n                user_header: \"X-WEBAUTH-USER\"\n                roles_header: \"x-proxy-roles\"\n            authentication_backend:\n              type: noop\n          vz_basic_internal_auth_domain:\n            description: \"Authenticate via HTTP Basic against internal users database\"\n            http_enabled: true\n            transport_enabled: true\n            order: 1\n            http_authenticator:\n              type: basic\n              challenge: false\n            authentication_backend:\n              type: intern\n          vz_clientcert_auth_domain:\n             description: \"Authenticate via SSL client certificates\"\n             http_enabled: true\n             transport_enabled: true\n             order: 2\n             http_authenticator:\n               type: clientcert\n               config:\n                 enforce_hostname_verification: false\n                 username_attribute: cn\n               challenge: false\n             authentication_backend:\n                 type: noop"), "internal_users.yml": []byte("admin:\n    hash: \n    reserved: true\n    backend_roles:\n    - \"admin\"\n    description: \"Admin user\"")}
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: securitySecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = securitySecretName
+		secret.Namespace = securityNamespace
+		secret.Data = map[string][]byte{configYaml: []byte(testConfigData), usersYaml: []byte(testUsersData)}
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: "admin-credentials-secret"}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: adminSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
 	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.Error(err)
 }
+
+// TestMergeSecurityConfigsUpdateError tests the MergeSecretData function
+// GIVEN a call to MergeSecretData
+// WHEN secret update fails
+// THEN error is returned
 func TestMergeSecurityConfigsUpdateError(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	const secretName = "securityconfig-secret"
 	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = secretName
-		secret.Namespace = "verrazzano-logging"
-		secret.Data = map[string][]byte{"config.yml": []byte("config:\n      dynamic:\n        kibana:\n          multitenancy_enabled: false\n        http:\n          anonymous_auth_enabled: false\n          xff:\n            enabled: true\n            internalProxies: '.*'\n            remoteIpHeader: 'x-forwarded-for'\n        authc:\n          vz_proxy_auth_domain:\n            description: \"Authenticate via Verrazzano proxy\"\n            http_enabled: true\n            transport_enabled: true\n            order: 0\n            http_authenticator:\n              type: proxy\n              challenge: false\n              config:\n                user_header: \"X-WEBAUTH-USER\"\n                roles_header: \"x-proxy-roles\"\n            authentication_backend:\n              type: noop\n          vz_basic_internal_auth_domain:\n            description: \"Authenticate via HTTP Basic against internal users database\"\n            http_enabled: true\n            transport_enabled: true\n            order: 1\n            http_authenticator:\n              type: basic\n              challenge: false\n            authentication_backend:\n              type: intern\n          vz_clientcert_auth_domain:\n             description: \"Authenticate via SSL client certificates\"\n             http_enabled: true\n             transport_enabled: true\n             order: 2\n             http_authenticator:\n               type: clientcert\n               config:\n                 enforce_hostname_verification: false\n                 username_attribute: cn\n               challenge: false\n             authentication_backend:\n                 type: noop"), "internal_users.yml": []byte("admin:\n    hash: \n    reserved: true\n    backend_roles:\n    - \"admin\"\n    description: \"Admin user\"")}
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: securitySecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = securitySecretName
+		secret.Namespace = securityNamespace
+		secret.Data = map[string][]byte{configYaml: []byte(testConfigData), usersYaml: []byte(testUsersData)}
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: "admin-credentials-secret"}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = "admin-credentials-secret"
-		secret.Namespace = "verrazzano-logging"
-		secret.Data = map[string][]byte{"hash": []byte("abcdef")}
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: adminSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = adminSecretName
+		secret.Namespace = securityNamespace
+		secret.Data = map[string][]byte{"hash": []byte("test")}
 		return nil
 	})
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(fmt.Errorf("test-error"))
@@ -96,24 +118,28 @@ func TestMergeSecurityConfigsUpdateError(t *testing.T) {
 	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.Error(err)
 }
+
+// TestMergeSecurityConfigsHashError tests the MergeSecretData function
+// GIVEN a call to MergeSecretData
+// WHEN hash key is not found
+// THEN error is returned
 func TestMergeSecurityConfigsHashError(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
-	const secretName = "securityconfig-secret"
 	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = secretName
-		secret.Namespace = "verrazzano-logging"
-		secret.Data = map[string][]byte{"config.yml": []byte("config:\n      dynamic:\n        kibana:\n          multitenancy_enabled: false\n        http:\n          anonymous_auth_enabled: false\n          xff:\n            enabled: true\n            internalProxies: '.*'\n            remoteIpHeader: 'x-forwarded-for'\n        authc:\n          vz_proxy_auth_domain:\n            description: \"Authenticate via Verrazzano proxy\"\n            http_enabled: true\n            transport_enabled: true\n            order: 0\n            http_authenticator:\n              type: proxy\n              challenge: false\n              config:\n                user_header: \"X-WEBAUTH-USER\"\n                roles_header: \"x-proxy-roles\"\n            authentication_backend:\n              type: noop\n          vz_basic_internal_auth_domain:\n            description: \"Authenticate via HTTP Basic against internal users database\"\n            http_enabled: true\n            transport_enabled: true\n            order: 1\n            http_authenticator:\n              type: basic\n              challenge: false\n            authentication_backend:\n              type: intern\n          vz_clientcert_auth_domain:\n             description: \"Authenticate via SSL client certificates\"\n             http_enabled: true\n             transport_enabled: true\n             order: 2\n             http_authenticator:\n               type: clientcert\n               config:\n                 enforce_hostname_verification: false\n                 username_attribute: cn\n               challenge: false\n             authentication_backend:\n                 type: noop")}
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: securitySecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = securitySecretName
+		secret.Namespace = securityNamespace
+		secret.Data = map[string][]byte{configYaml: []byte(testConfigData), usersYaml: []byte(testUsersData)}
 		return nil
 	})
 	mock.EXPECT().
-		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: "admin-credentials-secret"}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
-		secret.Name = "admin-credentials-secret"
-		secret.Namespace = "verrazzano-logging"
-		secret.Data = map[string][]byte{"hash1": []byte("abcdef")}
+		Get(gomock.Any(), types.NamespacedName{Namespace: securityNamespace, Name: adminSecretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = adminSecretName
+		secret.Namespace = securityNamespace
+		secret.Data = map[string][]byte{"hash1": []byte("test")}
 		return nil
 	})
 

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,11 +38,11 @@ func TestMergeSecurityConfigs(t *testing.T) {
 		return nil
 	})
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
-
-	err := MergeSecretData(fakeCtx)
+	config.TestThirdPartyManifestDir = "../../../../thirdparty/manifests"
+	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.NoError(err)
 }
-func TestMergeSecurityConfigsError(t *testing.T) {
+func TestMergeSecurityConfigsGetConfigError(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -49,10 +50,10 @@ func TestMergeSecurityConfigsError(t *testing.T) {
 	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
-	err := MergeSecretData(fakeCtx)
+	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.Error(err)
 }
-func TestMergeSecurityConfigsError2(t *testing.T) {
+func TestMergeSecurityConfigsGetAdminError(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -67,10 +68,10 @@ func TestMergeSecurityConfigsError2(t *testing.T) {
 	})
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: "admin-credentials-secret"}, gomock.Not(gomock.Nil()), gomock.Any()).Return(fmt.Errorf("test-error"))
-	err := MergeSecretData(fakeCtx)
+	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.Error(err)
 }
-func TestMergeSecurityConfigsError3(t *testing.T) {
+func TestMergeSecurityConfigsUpdateError(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -92,10 +93,10 @@ func TestMergeSecurityConfigsError3(t *testing.T) {
 	})
 	mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(fmt.Errorf("test-error"))
 
-	err := MergeSecretData(fakeCtx)
+	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.Error(err)
 }
-func TestMergeSecurityConfigsError4(t *testing.T) {
+func TestMergeSecurityConfigsHashError(t *testing.T) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)
 	mock := mocks.NewMockClient(mocker)
@@ -115,8 +116,7 @@ func TestMergeSecurityConfigsError4(t *testing.T) {
 		secret.Data = map[string][]byte{"hash1": []byte("abcdef")}
 		return nil
 	})
-	//mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(fmt.Errorf("test-error"))
 
-	err := MergeSecretData(fakeCtx)
+	err := MergeSecretData(fakeCtx, config.GetThirdPartyManifestsDir())
 	asserts.Error(err)
 }

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
@@ -10,11 +10,8 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/mocks"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	k8scheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 )
 
@@ -24,15 +21,15 @@ func TestMergeSecurityConfigsError(t *testing.T) {
 	mock := mocks.NewMockClient(mocker)
 	const secretName = "securityconfig-secret"
 	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
-	// fake client needed to get secret
-	getClientFunc = func(ctx spi.ComponentContext) (client.Client, error) {
-		return fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
-			&corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "verrazzano-logging"},
-			},
-		).Build(), nil
-	}
-	defer func() { getClientFunc = getClient }()
+	//// fake client needed to get secret
+	//getClientFunc = func(ctx spi.ComponentContext) (client.Client, error) {
+	//	return fake.NewClientBuilder().WithScheme(k8scheme.Scheme).WithObjects(
+	//		&corev1.Secret{
+	//			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: "verrazzano-logging"},
+	//		},
+	//	).Build(), nil
+	//}
+	//defer func() { getClientFunc = getClient }()
 
 	mock.EXPECT().
 		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {

--- a/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
+++ b/platform-operator/controllers/verrazzano/component/common/opensearch_operator_test.go
@@ -95,3 +95,28 @@ func TestMergeSecurityConfigsError3(t *testing.T) {
 	err := MergeSecretData(fakeCtx)
 	asserts.Error(err)
 }
+func TestMergeSecurityConfigsError4(t *testing.T) {
+	asserts := assert.New(t)
+	mocker := gomock.NewController(t)
+	mock := mocks.NewMockClient(mocker)
+	const secretName = "securityconfig-secret"
+	fakeCtx := spi.NewFakeContext(mock, nil, nil, false)
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: secretName}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = secretName
+		secret.Namespace = "verrazzano-logging"
+		secret.Data = map[string][]byte{"config.yml": []byte("config:\n      dynamic:\n        kibana:\n          multitenancy_enabled: false\n        http:\n          anonymous_auth_enabled: false\n          xff:\n            enabled: true\n            internalProxies: '.*'\n            remoteIpHeader: 'x-forwarded-for'\n        authc:\n          vz_proxy_auth_domain:\n            description: \"Authenticate via Verrazzano proxy\"\n            http_enabled: true\n            transport_enabled: true\n            order: 0\n            http_authenticator:\n              type: proxy\n              challenge: false\n              config:\n                user_header: \"X-WEBAUTH-USER\"\n                roles_header: \"x-proxy-roles\"\n            authentication_backend:\n              type: noop\n          vz_basic_internal_auth_domain:\n            description: \"Authenticate via HTTP Basic against internal users database\"\n            http_enabled: true\n            transport_enabled: true\n            order: 1\n            http_authenticator:\n              type: basic\n              challenge: false\n            authentication_backend:\n              type: intern\n          vz_clientcert_auth_domain:\n             description: \"Authenticate via SSL client certificates\"\n             http_enabled: true\n             transport_enabled: true\n             order: 2\n             http_authenticator:\n               type: clientcert\n               config:\n                 enforce_hostname_verification: false\n                 username_attribute: cn\n               challenge: false\n             authentication_backend:\n                 type: noop")}
+		return nil
+	})
+	mock.EXPECT().
+		Get(gomock.Any(), types.NamespacedName{Namespace: "verrazzano-logging", Name: "admin-credentials-secret"}, gomock.Not(gomock.Nil()), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, secret *corev1.Secret, opts ...client.GetOption) error {
+		secret.Name = "admin-credentials-secret"
+		secret.Namespace = "verrazzano-logging"
+		secret.Data = map[string][]byte{"hash1": []byte("abcdef")}
+		return nil
+	})
+	//mock.EXPECT().Update(gomock.Any(), gomock.Any()).Return(fmt.Errorf("test-error"))
+
+	err := MergeSecretData(fakeCtx)
+	asserts.Error(err)
+}

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
@@ -116,7 +116,6 @@ func (o opensearchOperatorComponent) PreInstall(ctx spi.ComponentContext) error 
 	if err := common.MergeSecretData(ctx, config.GetThirdPartyManifestsDir()); err != nil {
 		return err
 	}
-
 	return o.HelmComponent.PreInstall(ctx)
 }
 

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
@@ -112,7 +112,8 @@ func (o opensearchOperatorComponent) PreInstall(ctx spi.ComponentContext) error 
 	if err := handleLegacyOpenSearch(ctx); err != nil {
 		return err
 	}
-	if err := common.MergeSecretData(ctx); err != nil {
+	log.Debugf("Merging security configs")
+	if err := common.MergeSecretData(ctx, config.GetThirdPartyManifestsDir()); err != nil {
 		return err
 	}
 

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
@@ -119,6 +119,19 @@ func (o opensearchOperatorComponent) PreInstall(ctx spi.ComponentContext) error 
 	return o.HelmComponent.PreInstall(ctx)
 }
 
+// PreUpgrade
+/* Runs pre-upgrade steps
+- Scales down Rancher pods and deletes the ClusterRepo resources to work around Rancher upgrade issues (VZ-7053)
+*/
+func (o opensearchOperatorComponent) PreUpgrade(ctx spi.ComponentContext) error {
+	log := ctx.Log()
+	log.Debugf("Merging security configs")
+	if err := common.MergeSecretData(ctx, config.GetThirdPartyManifestsDir()); err != nil {
+		return err
+	}
+	return o.HelmComponent.PreUpgrade(ctx)
+}
+
 func (o opensearchOperatorComponent) Install(ctx spi.ComponentContext) error {
 	if err := o.HelmComponent.Install(ctx); err != nil {
 		return err

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
@@ -119,10 +119,6 @@ func (o opensearchOperatorComponent) PreInstall(ctx spi.ComponentContext) error 
 	return o.HelmComponent.PreInstall(ctx)
 }
 
-// PreUpgrade
-/* Runs pre-upgrade steps
-- Scales down Rancher pods and deletes the ClusterRepo resources to work around Rancher upgrade issues (VZ-7053)
-*/
 func (o opensearchOperatorComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	log := ctx.Log()
 	log.Debugf("Merging security configs")

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
@@ -112,6 +112,9 @@ func (o opensearchOperatorComponent) PreInstall(ctx spi.ComponentContext) error 
 	if err := handleLegacyOpenSearch(ctx); err != nil {
 		return err
 	}
+	if err := common.MergeSecretData(ctx); err != nil {
+		return err
+	}
 
 	return o.HelmComponent.PreInstall(ctx)
 }

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component_test.go
@@ -259,7 +259,6 @@ func TestPreInstall(t *testing.T) {
 	GetControllerRuntimeClient = func() (client.Client, error) {
 		return fakeClient, nil
 	}
-
 	err := NewComponent().PreInstall(fakeCtx)
 	assert.NoError(t, err)
 }

--- a/platform-operator/thirdparty/charts/opensearch-operator/templates/verrazzano/opensearch-securityconfig-secret.yaml
+++ b/platform-operator/thirdparty/charts/opensearch-operator/templates/verrazzano/opensearch-securityconfig-secret.yaml
@@ -8,7 +8,7 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "admin-credentials-secret") | default dict }}
 {{- $secretData := (get $secretObj "data") | default dict }}
 {{- $password := (get $secretData "password" | b64dec) | default (randAlphaNum 15) }}
-{{- $hash :=  (splitList ":" (htpasswd "" $password)) | last | quote }}
+{{- $hash :=  (get $secretData "hash" | b64dec) | default (splitList ":" (htpasswd "" $password)) | last | quote) }}
 
 apiVersion: v1
 kind: Secret

--- a/platform-operator/thirdparty/charts/opensearch-operator/templates/verrazzano/opensearch-securityconfig-secret.yaml
+++ b/platform-operator/thirdparty/charts/opensearch-operator/templates/verrazzano/opensearch-securityconfig-secret.yaml
@@ -8,6 +8,7 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "admin-credentials-secret") | default dict }}
 {{- $secretData := (get $secretObj "data") | default dict }}
 {{- $password := (get $secretData "password" | b64dec) | default (randAlphaNum 15) }}
+{{- $hash :=  (splitList ":" (htpasswd "" $password)) | last | quote }}
 
 apiVersion: v1
 kind: Secret
@@ -18,6 +19,7 @@ type: Opaque
 data:
   password: {{ $password | b64enc }}
   username: {{ "admin" | b64enc }}
+  hash: {{ $hash | b64enc }}
 ---
 {{- $securityConfigSecret := (lookup "v1" "Secret" .Release.Namespace "securityconfig-secret") }}
 {{- $securityConfigSecretData := (get $securityConfigSecret "data") }}

--- a/platform-operator/thirdparty/charts/opensearch-operator/templates/verrazzano/opensearch-securityconfig-secret.yaml
+++ b/platform-operator/thirdparty/charts/opensearch-operator/templates/verrazzano/opensearch-securityconfig-secret.yaml
@@ -46,7 +46,7 @@ stringData:
       type: "internalusers"
       config_version: 2
     admin:
-      hash: {{ (splitList ":" (htpasswd "" $password)) | last | quote }}
+      hash: {{ $hash }}
       reserved: true
       backend_roles:
       - "admin"

--- a/platform-operator/thirdparty/manifests/opensearch-operator/opensearch-securityconfig.yaml
+++ b/platform-operator/thirdparty/manifests/opensearch-operator/opensearch-securityconfig.yaml
@@ -1,0 +1,137 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: securityconfig-secret
+  namespace: verrazzano-logging
+type: Opaque
+stringData:
+  action_groups.yml: |-
+    _meta:
+      type: "actiongroups"
+      config_version: 2
+  internal_users.yml: |-
+    _meta:
+      type: "internalusers"
+      config_version: 2
+    admin:
+      hash: 
+      reserved: true
+      backend_roles:
+      - "admin"
+      description: "Admin user"
+  nodes_dn.yml: |-
+    _meta:
+      type: "nodesdn"
+      config_version: 2
+  whitelist.yml: |-
+    _meta:
+      type: "whitelist"
+      config_version: 2
+  tenants.yml: |-
+    _meta:
+      type: "tenants"
+      config_version: 2
+  roles_mapping.yml: |-
+    _meta:
+      type: "rolesmapping"
+      config_version: 2
+    all_access:
+      reserved: false
+      backend_roles:
+      - "admin"
+      description: "Maps admin to all_access"
+    vz_log_pusher:
+      reserved: false
+      backend_roles:
+      - "vz_log_pusher"
+      description: "Role for fluentd to push logs"
+    own_index:
+      reserved: false
+      users:
+      - "*"
+      description: "Allow full access to an index named like the username"
+    readall:
+      reserved: false
+      backend_roles:
+      - "readall"
+    manage_snapshots:
+      reserved: false
+      backend_roles:
+      - "snapshotrestore"
+    dashboard_server:
+      reserved: true
+      users:
+      - "dashboarduser"
+  roles.yml: |-
+    _meta:
+      type: "roles"
+      config_version: 2
+    vz_log_pusher:
+      reserved: false
+      hidden: false
+      cluster_permissions:
+        - "cluster:monitor/main"
+        - "cluster:monitor/state"
+        - "cluster:monitor/health"
+        - "cluster_manage_index_templates"
+        - "indices:admin/index_template/get"
+        - "indices:admin/index_template/put"
+        - "indices:admin/mapping/put"
+        - "indices:admin/mapping/get"
+        - "indices:admin/create"
+      index_permissions:
+        - index_patterns:
+            - "*verrazzano*"
+          allowed_actions:
+            - indices_all
+  config.yml: |-
+    _meta:
+      type: "config"
+      config_version: "2"
+    config:
+      dynamic:
+        kibana:
+          multitenancy_enabled: false
+        http:
+          anonymous_auth_enabled: false
+          xff:
+            enabled: true
+            internalProxies: '.*'
+            remoteIpHeader: 'x-forwarded-for'
+        authc:
+          vz_proxy_auth_domain:
+            description: "Authenticate via Verrazzano proxy"
+            http_enabled: true
+            transport_enabled: true
+            order: 0
+            http_authenticator:
+              type: proxy
+              challenge: false
+              config:
+                user_header: "X-WEBAUTH-USER"
+                roles_header: "x-proxy-roles"
+            authentication_backend:
+              type: noop
+          vz_basic_internal_auth_domain:
+            description: "Authenticate via HTTP Basic against internal users database"
+            http_enabled: true
+            transport_enabled: true
+            order: 1
+            http_authenticator:
+              type: basic
+              challenge: false
+            authentication_backend:
+              type: intern
+          vz_clientcert_auth_domain:
+             description: "Authenticate via SSL client certificates"
+             http_enabled: true
+             transport_enabled: true
+             order: 2
+             http_authenticator:
+               type: clientcert
+               config:
+                 enforce_hostname_verification: false
+                 username_attribute: cn
+               challenge: false
+             authentication_backend:
+                 type: noop


### PR DESCRIPTION
Config.yml and internal_users.yml need to be strategically merged during the upgrade and pre-install. We need this kind of strategic merge because helm merge doesn't take care of our use case and will simply override the changes done by the user.
