### PR TITLE
VZ-10903: update console image and fix imagePullSecrets

### DIFF
--- a/platform-operator/controllers/verrazzano/component/console/console_component.go
+++ b/platform-operator/controllers/verrazzano/component/console/console_component.go
@@ -18,7 +18,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/authproxy"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/secret"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -50,7 +49,7 @@ func NewComponent() spi.Component {
 			Dependencies:              []string{networkpolicies.ComponentName, authproxy.ComponentName},
 			AppendOverridesFunc:       AppendOverrides,
 			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_4_0,
-			ImagePullSecretKeyname:    secret.DefaultImagePullSecretKeyName,
+			ImagePullSecretKeyname:    "global.imagePullSecrets[0]",
 			GetInstallOverridesFunc:   GetOverrides,
 			AvailabilityObjects: &ready.AvailabilityObjects{
 				DeploymentNames: []types.NamespacedName{

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -271,7 +271,7 @@
             },
             {
               "image": "console",
-              "tag": "v2.0.0-20230828163609-10891b3",
+              "tag": "v2.0.0-20230912070053-2d1883d",
               "helmFullImageKey": "console.imageName",
               "helmTagKey": "console.imageVersion"
             },


### PR DESCRIPTION
update image from  https://github.com/verrazzano/console/pull/285, also fixes `ImagePullSecretKeyname` to use the default. global pull secret as the template does not have `imagePullSecrets` of its own