### PR TITLE
VZ-10125: Uptake Thanos v0.32.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Component version updates:
 
 - WebLogic Kubernetes Operator v4.1.2
 - WebLogic Monitoring Exporter v2.1.5
+- Thanos v0.32.2 (includes support for OKE Workload Identities)
 
 Features:
 

--- a/platform-operator/thirdparty/charts/thanos/Chart.yaml
+++ b/platform-operator/thirdparty/charts/thanos/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Analytics
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: 0.30.2
+appVersion: 0.32.2
 dependencies:
   - name: common
     repository: file://common

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -929,7 +929,7 @@
     },
     {
       "name": "thanos",
-      "version": "v0.30.2",
+      "version": "v0.32.2",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -937,7 +937,7 @@
           "images": [
             {
               "image": "thanos",
-              "tag": "v0.30.2-20230525123422-4b7a94ea",
+              "tag": "v0.32.2-20230911193410-1e27f1f9",
               "helmRegKey": "image.registry",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"


### PR DESCRIPTION
Uptake Thanos v032.2. This new version of Thanos includes support for OKE Workload Identities.

This does not require a newer version of the Thanos Helm chart but we should update the chart in a future PR.