### PR TITLE
VZ-10706 istio restart - revert non-module component restart logic

### DIFF
--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -464,12 +464,6 @@ func (i istioComponent) PostUpgrade(compContext spi.ComponentContext) error {
 	// Make sure namespaces get updated with Istio Enabled
 	callCreateNamespaces(compContext)
 
-	// During upgrade there is a window where the latest Istio envoy sidecar container is not included in a pod.
-	// Restart system components that are missing the sidecar.
-	if err := restart.RestartComponents(compContext.Log(), config.GetInjectedSystemNamespaces(), compContext.ActualCR().Generation, &restart.OutdatedSidecarPodMatcher{}); err != nil {
-		return err
-	}
-
 	err := deleteIstioCoreDNS(compContext)
 	if err != nil {
 		return err

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -461,9 +461,6 @@ func (i istioComponent) PreUpgrade(context spi.ComponentContext) error {
 }
 
 func (i istioComponent) PostUpgrade(compContext spi.ComponentContext) error {
-	// Make sure namespaces get updated with Istio Enabled
-	callCreateNamespaces(compContext)
-
 	err := deleteIstioCoreDNS(compContext)
 	if err != nil {
 		return err

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component.go
@@ -82,9 +82,6 @@ const istioSidecarMutatingWebhook = "istio-sidecar-injector"
 const istioRevisionMutatingWebhook = "istio-revision-tag-default"
 
 // for unit testing
-type funcCreateNamespaces func(ctx spi.ComponentContext) error
-
-var callCreateNamespaces funcCreateNamespaces = common.CreateAndLabelNamespaces
 var istioLabelSelector = clipkg.ListOptions{LabelSelector: labels.Set(map[string]string{"release": "istio"}).AsSelector()}
 
 const (

--- a/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_component_test.go
@@ -336,9 +336,6 @@ func fakeUpgrade(log vzlog.VerrazzanoLogger, imageOverridesString string, overri
 func TestPostUpgrade(t *testing.T) {
 	a := assert.New(t)
 
-	callCreateNamespaces = func(ctx spi.ComponentContext) error {
-		return nil
-	}
 	comp := istioComponent{}
 
 	// Setup fake client to provide workloads for restart platform testing

--- a/platform-operator/controllers/verrazzano/component/istio/istio_install.go
+++ b/platform-operator/controllers/verrazzano/component/istio/istio_install.go
@@ -202,8 +202,10 @@ func (i istioComponent) PreInstall(compContext spi.ComponentContext) error {
 }
 
 func (i istioComponent) PostInstall(compContext spi.ComponentContext) error {
-	// Make sure namespaces get updated with Istio Enabled
-	common.CreateAndLabelNamespaces(compContext)
+	if config.Get().ModuleIntegration {
+		// Make sure namespaces get updated with Istio Enabled
+		common.CreateAndLabelNamespaces(compContext)
+	}
 
 	// During install there is a window where the Istio envoy sidecar container is not included in a pod.
 	// Restart system components that are missing the sidecar.

--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -15,6 +15,7 @@ import (
 	vzv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/validators"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/argocd"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/mysql"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
 	componentspi "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -208,6 +209,9 @@ func (r Reconciler) postUpgrade(log vzlog.VerrazzanoLogger, actualCR *vzv1alpha1
 		log.ErrorfThrottled("Failed Verrazzano post-upgrade ArgoCD configure OIDC: %v", err)
 		return result.NewResultShortRequeueDelayWithError(err)
 	}
+
+	// Make sure namespaces get updated with Istio Enabled
+	common.CreateAndLabelNamespaces(componentCtx)
 
 	if err := restart.RestartComponents(log, config.GetInjectedSystemNamespaces(), componentCtx.ActualCR().Generation, &restart.OutdatedSidecarPodMatcher{}); err != nil {
 		log.ErrorfThrottled("Failed Verrazzano post-upgrade restart components: %v", err)

--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/reconcile/restart"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/transform"
 	"github.com/verrazzano/verrazzano/platform-operator/experimental/controllers/verrazzano/custom"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/namespace"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -205,6 +206,11 @@ func (r Reconciler) postUpgrade(log vzlog.VerrazzanoLogger, actualCR *vzv1alpha1
 
 	if err := argocd.ConfigureKeycloakOIDC(componentCtx); err != nil {
 		log.ErrorfThrottled("Failed Verrazzano post-upgrade ArgoCD configure OIDC: %v", err)
+		return result.NewResultShortRequeueDelayWithError(err)
+	}
+
+	if err := restart.RestartComponents(log, config.GetInjectedSystemNamespaces(), componentCtx.ActualCR().Generation, &restart.OutdatedSidecarPodMatcher{}); err != nil {
+		log.ErrorfThrottled("Failed Verrazzano post-upgrade restart components: %v", err)
 		return result.NewResultShortRequeueDelayWithError(err)
 	}
 


### PR DESCRIPTION
Revert the Istio post-install and post-upgrade component restart logic to what is was before modules were introduced.