### PR TITLE
VZ-10679 Cluster API version overrides not working correctly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 **/*test-result.xml
 **/*-cluster-dump
 **/*.log
+**/*.test
 platform-operator/THIRD_PARTY_LICENSES.txt
 cluster-operator/THIRD_PARTY_LICENSES.txt
 application-operator/THIRD_PARTY_LICENSES.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,7 @@ pipeline {
         booleanParam (description: 'Whether to fail build if UT coverage number decreases lower than its release-* coverage from object storage. This defaults to false, meaning Any non release-*/master branch will WARN only if its coverage is lower. This can be enabled so that jobs will FAIL if coverage drops, for example when testing a PR before merging.', name: 'FAIL_IF_COVERAGE_DECREASED', defaultValue: false)
         booleanParam (description: 'Whether to write the UT coverage number to object storage. This always occurs for release-*/master branches. Defaults to true, but it can be disabled to not always upload.', name: 'UPLOAD_UNIT_TEST_COVERAGE', defaultValue: true)
         booleanParam (description: 'Whether to generate the operator.yaml with module integration configured', name: 'MODULE_INTEGRATION', defaultValue: false)
+        booleanParam (description: 'Whether to run clusterAPI override tests', name: 'RUN_CLUSTERAPI_OVERRIDE_TESTS', defaultValue: false)
         choice (name: 'WILDCARD_DNS_DOMAIN',
                 description: 'Wildcard DNS Domain',
                 // 1st choice is the default value
@@ -423,6 +424,7 @@ pipeline {
                                 booleanParam(name: 'RUN_SLOW_TESTS', value: params.RUN_SLOW_TESTS),
                                 booleanParam(name: 'DUMP_K8S_CLUSTER_ON_SUCCESS', value: params.DUMP_K8S_CLUSTER_ON_SUCCESS),
                                 booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: params.CREATE_CLUSTER_USE_CALICO),
+                                booleanParam(name: 'RUN_CLUSTERAPI_OVERRIDE_TESTS', value: params.RUN_CLUSTERAPI_OVERRIDE_TESTS),
                                 string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH),
                             ], wait: true
                     }

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -178,21 +178,8 @@ pipeline {
                     chmod 600 $HOME/.netrc
                 """
 
-                script {
-                    try {
-                    sh """
-                        echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
-                    """
-                    } catch(error) {
-                        echo "docker login failed, retrying after sleep"
-                        retry(4) {
-                            sleep(30)
-                            sh """
-                                echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
-                            """
-                        }
-                    }
-                }
+                performDockerLogin()
+
                 sh """
                     rm -rf ${GO_REPO_PATH}/verrazzano
                     mkdir -p ${GO_REPO_PATH}/verrazzano
@@ -884,4 +871,22 @@ def setDisplayName() {
          }
     }
     echo "End setDisplayName"
+}
+
+def performDockerLogin() {
+    script {
+        try {
+            sh """
+                echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
+            """
+        } catch(error) {
+            echo "docker login failed, retrying after sleep"
+            retry(4) {
+                sleep(30)
+                sh """
+                    echo "${DOCKER_CREDS_PSW}" | docker login ${env.DOCKER_REPO} -u ${DOCKER_CREDS_USR} --password-stdin
+                """
+            }
+        }
+    }
 }

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -636,6 +636,15 @@ pipeline {
                     steps {
                         runGinkgo('clusterapi/capi-overrides')
                     }
+                    post {
+                        failure {
+                            archiveArtifacts artifacts: "**/kind-logs/**", allowEmptyArchive: true
+                            dumpK8sCluster('clusterAPI-override-tests-dump')
+                        }
+                        always {
+                            archiveArtifacts artifacts: "acceptance-test-operator.yaml,downloaded-operator.yaml,$INSTALL_CONFIG_FILE_KIND", allowEmptyArchive: true
+                        }
+                    }
                 }
             }
 

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -228,6 +228,7 @@ pipeline {
                         OCI_OS_LOCATION="ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}"
                         REALM_USER_PASSWORD = credentials('todo-mysql-password')
                         REALM_NAME = "test-realm"
+                        GITHUB_TOKEN = credentials('github-api-token-release-process')
                     }
                     steps {
                         script {

--- a/ci/scripts/prepare_jenkins_at_environment.sh
+++ b/ci/scripts/prepare_jenkins_at_environment.sh
@@ -117,6 +117,11 @@ EOF
     kubectl apply -f $WORKSPACE/tests/testdata/grafana/grafana-mysql.yaml
   fi
 
+  # create verrazzano-github-token secret in verrazzano-install ns
+  if [ -n "${GITHUB_TOKEN}" ]; then
+    ./tests/e2e/config/scripts/create-github-token-secret.sh "verrazzano-github-token" "${GITHUB_TOKEN}" "verrazzano-install"
+  fi
+
   # create secret in verrazzano-install ns
   ./tests/e2e/config/scripts/create-image-pull-secret.sh "${IMAGE_PULL_SECRET}" "${DOCKER_REPO}" "${DOCKER_CREDS_USR}" "${DOCKER_CREDS_PSW}" "verrazzano-install"
 

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -27,22 +27,32 @@ import (
 const rbacGroup = "rbac.authorization.k8s.io"
 
 const clusterctlYamlTemplate = `
+{{- if .IncludeImagesHeader }}
 images:
+  {{- if not .GetClusterAPIOverridesVersion }}
   cluster-api:
     repository: {{.GetClusterAPIRepository}}
     tag: {{.GetClusterAPITag}}
+  {{ end }}
 
+  {{- if not .GetOCIOverridesVersion }}
   infrastructure-oci:
     repository: {{.GetOCIRepository}}
     tag: {{.GetOCITag}}
+  {{ end }}
 
+  {{- if not .GetOCNEBootstrapOverridesVersion }}
   bootstrap-ocne:
     repository: {{.GetOCNEBootstrapRepository}}
     tag: {{.GetOCNEBootstrapTag}}
+  {{ end }}
 
+  {{- if not .GetOCNEControlPlaneOverridesVersion }}
   control-plane-ocne:
     repository: {{.GetOCNEControlPlaneRepository}}
     tag: {{.GetOCNEControlPlaneTag}}
+  {{ end }}
+{{ end }}
 
 providers:
   - name: "cluster-api"
@@ -64,6 +74,7 @@ const (
 	expClusterResourceSet                     = "EXP_CLUSTER_RESOURCE_SET"
 	expMachinePool                            = "EXP_MACHINE_POOL"
 	initOCIClientsOnStartup                   = "INIT_OCI_CLIENTS_ON_STARTUP"
+	goproxy                                   = "GOPROXY"
 	clusterAPIControllerImage                 = "cluster-api-controller"
 	clusterAPIOCIControllerImage              = "cluster-api-oci-controller"
 	clusterAPIOCNEBoostrapControllerImage     = "cluster-api-ocne-bootstrap-controller"
@@ -83,14 +94,6 @@ type PodMatcherClusterAPI struct {
 	controlPlaneProvider   string
 	infrastructureProvider string
 }
-
-type ImageCheckResult int
-
-const (
-	OutOfDate ImageCheckResult = iota
-	UpToDate
-	NotFound
-)
 
 const (
 	defaultClusterAPIDir = "/verrazzano/.cluster-api"
@@ -213,16 +216,16 @@ func (c *PodMatcherClusterAPI) initializeImageVersionsOverrides(log vzlog.Verraz
 	return nil
 }
 
-// isImageOutOfDate returns true if the container image is not as expected (out of date)
-func isImageOutOfDate(log vzlog.VerrazzanoLogger, imageName, actualImage, expectedImage string) ImageCheckResult {
-	if strings.Contains(actualImage, imageName) {
-		if 0 != strings.Compare(actualImage, expectedImage) {
-			log.Infof("Image %v is out of date,  actual image: %v, expected image: %v", imageName, actualImage, expectedImage)
-			return OutOfDate
-		}
-		return UpToDate
+// applyUpgradeVersion returns true and corresponding version if either version overrides or bom version is specified. Otherwise, return false and empty version.
+func applyUpgradeVersion(log vzlog.VerrazzanoLogger, versionOverrides, bomVersion, imageName, actualImage, expectedImage string) (bool, string) {
+	if len(versionOverrides) > 0 {
+		return true, versionOverrides
 	}
-	return NotFound
+	if strings.Contains(actualImage, imageName) && actualImage != expectedImage {
+		log.Infof("Image %v is out of date,  actual image: %v, expected image: %v", imageName, actualImage, expectedImage)
+		return true, bomVersion
+	}
+	return false, ""
 }
 
 // MatchAndPrepareUpgradeOptions when a pod has an outdated cluster api controllers images and prepares upgrade options for outdated images.
@@ -233,23 +236,25 @@ func (c *PodMatcherClusterAPI) matchAndPrepareUpgradeOptions(ctx spi.ComponentCo
 	if err := ctx.Client().List(context.TODO(), podList, &client.ListOptions{Namespace: ComponentNamespace}); err != nil {
 		return applyUpgradeOptions, err
 	}
+
 	const formatString = "%s/%s:%s"
 	for _, pod := range podList.Items {
 		for _, co := range pod.Spec.Containers {
-			if isImageOutOfDate(ctx.Log(), clusterAPIControllerImage, co.Image, c.coreProvider) == OutOfDate {
-				applyUpgradeOptions.CoreProvider = fmt.Sprintf(formatString, ComponentNamespace, clusterAPIProviderName, overrides.GetClusterAPIVersion())
+			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetClusterAPIOverridesVersion(), overrides.GetClusterAPIBomVersion(), clusterAPIControllerImage, co.Image, c.coreProvider); ok {
+				applyUpgradeOptions.CoreProvider = fmt.Sprintf(formatString, ComponentNamespace, clusterAPIProviderName, version)
 			}
-			if isImageOutOfDate(ctx.Log(), clusterAPIOCNEBoostrapControllerImage, co.Image, c.bootstrapProvider) == OutOfDate {
-				applyUpgradeOptions.BootstrapProviders = append(applyUpgradeOptions.BootstrapProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overrides.GetOCNEBootstrapVersion()))
+			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetOCNEBootstrapOverridesVersion(), overrides.GetOCNEBootstrapBomVersion(), clusterAPIOCNEBoostrapControllerImage, co.Image, c.bootstrapProvider); ok {
+				applyUpgradeOptions.BootstrapProviders = append(applyUpgradeOptions.BootstrapProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, version))
 			}
-			if isImageOutOfDate(ctx.Log(), clusterAPIOCNEControlPLaneControllerImage, co.Image, c.controlPlaneProvider) == OutOfDate {
-				applyUpgradeOptions.ControlPlaneProviders = append(applyUpgradeOptions.ControlPlaneProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, overrides.GetOCNEControlPlaneVersion()))
+			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetOCNEControlPlaneOverridesVersion(), overrides.GetOCNEControlPlaneBomVersion(), clusterAPIOCNEControlPLaneControllerImage, co.Image, c.controlPlaneProvider); ok {
+				applyUpgradeOptions.ControlPlaneProviders = append(applyUpgradeOptions.ControlPlaneProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, version))
 			}
-			if isImageOutOfDate(ctx.Log(), clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider) == OutOfDate {
-				applyUpgradeOptions.InfrastructureProviders = append(applyUpgradeOptions.InfrastructureProviders, fmt.Sprintf(formatString, ComponentNamespace, ociProviderName, overrides.GetOCIVersion()))
+			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetOCIOverridesVersion(), overrides.GetOCIBomVersion(), clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider); ok {
+				applyUpgradeOptions.InfrastructureProviders = append(applyUpgradeOptions.InfrastructureProviders, fmt.Sprintf(formatString, ComponentNamespace, ociProviderName, version))
 			}
 		}
 	}
+
 	return applyUpgradeOptions, nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
@@ -5,15 +5,16 @@ package clusterapi
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	vzyaml "github.com/verrazzano/verrazzano/pkg/yaml"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/override"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-	"os"
-	"path"
-	"path/filepath"
 	"sigs.k8s.io/yaml"
 )
 
@@ -57,21 +58,30 @@ type OverridesInterface interface {
 	GetClusterAPITag() string
 	GetClusterAPIURL() string
 	GetClusterAPIVersion() string
+	GetClusterAPIOverridesVersion() string
+	GetClusterAPIBomVersion() string
 	GetOCIRepository() string
 	GetOCIControllerFullImagePath() string
 	GetOCITag() string
 	GetOCIURL() string
 	GetOCIVersion() string
+	GetOCIOverridesVersion() string
+	GetOCIBomVersion() string
 	GetOCNEBootstrapRepository() string
 	GetOCNEBootstrapControllerFullImagePath() string
 	GetOCNEBootstrapTag() string
 	GetOCNEBootstrapURL() string
 	GetOCNEBootstrapVersion() string
+	GetOCNEBootstrapOverridesVersion() string
+	GetOCNEBootstrapBomVersion() string
 	GetOCNEControlPlaneRepository() string
 	GetOCNEControlPlaneControllerFullImagePath() string
 	GetOCNEControlPlaneTag() string
 	GetOCNEControlPlaneURL() string
 	GetOCNEControlPlaneVersion() string
+	GetOCNEControlPlaneOverridesVersion() string
+	GetOCNEControlPlaneBomVersion() string
+	IncludeImagesHeader() bool
 }
 
 func newOverridesContext(overrides *capiOverrides) OverridesInterface {
@@ -98,6 +108,14 @@ func (c capiOverrides) GetClusterAPIVersion() string {
 	return getProviderVersion(c.DefaultProviders.Core)
 }
 
+func (c capiOverrides) GetClusterAPIOverridesVersion() string {
+	return c.DefaultProviders.Core.Version
+}
+
+func (c capiOverrides) GetClusterAPIBomVersion() string {
+	return c.DefaultProviders.Core.Image.BomVersion
+}
+
 func (c capiOverrides) GetOCIRepository() string {
 	return getRepositoryForProvider(c, c.DefaultProviders.OCI)
 }
@@ -112,6 +130,14 @@ func (c capiOverrides) GetOCIURL() string {
 
 func (c capiOverrides) GetOCIVersion() string {
 	return getProviderVersion(c.DefaultProviders.OCI)
+}
+
+func (c capiOverrides) GetOCIOverridesVersion() string {
+	return c.DefaultProviders.OCI.Version
+}
+
+func (c capiOverrides) GetOCIBomVersion() string {
+	return c.DefaultProviders.OCI.Image.BomVersion
 }
 
 func (c capiOverrides) GetOCNEBootstrapRepository() string {
@@ -130,6 +156,14 @@ func (c capiOverrides) GetOCNEBootstrapVersion() string {
 	return getProviderVersion(c.DefaultProviders.OCNEBootstrap)
 }
 
+func (c capiOverrides) GetOCNEBootstrapOverridesVersion() string {
+	return c.DefaultProviders.OCNEBootstrap.Version
+}
+
+func (c capiOverrides) GetOCNEBootstrapBomVersion() string {
+	return c.DefaultProviders.OCNEBootstrap.Image.BomVersion
+}
+
 func (c capiOverrides) GetOCNEControlPlaneRepository() string {
 	return getRepositoryForProvider(c, c.DefaultProviders.OCNEControlPlane)
 }
@@ -144,6 +178,24 @@ func (c capiOverrides) GetOCNEControlPlaneURL() string {
 
 func (c capiOverrides) GetOCNEControlPlaneVersion() string {
 	return getProviderVersion(c.DefaultProviders.OCNEControlPlane)
+}
+
+func (c capiOverrides) GetOCNEControlPlaneOverridesVersion() string {
+	return c.DefaultProviders.OCNEControlPlane.Version
+}
+
+func (c capiOverrides) GetOCNEControlPlaneBomVersion() string {
+	return c.DefaultProviders.OCNEControlPlane.Image.BomVersion
+}
+
+// IncludeImagesHeader returns true if the overrides version for any of the default providers is not specified.
+// Otherwise, returns false.
+func (c capiOverrides) IncludeImagesHeader() bool {
+	if len(c.GetClusterAPIOverridesVersion()) == 0 || len(c.GetOCIOverridesVersion()) == 0 ||
+		len(c.GetOCNEBootstrapOverridesVersion()) == 0 || len(c.GetOCNEControlPlaneOverridesVersion()) == 0 {
+		return true
+	}
+	return false
 }
 
 func (c capiOverrides) GetClusterAPIControllerFullImagePath() string {

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_test.go
@@ -4,13 +4,14 @@
 package clusterapi
 
 import (
+	"os"
+	"testing"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
-	"os"
-	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
@@ -101,7 +102,6 @@ func TestToSkipSettingUpgradeOptions(t *testing.T) {
       }
     },
     "oci": {
-      "version": "v0.8.2",
       "image": {
         "repository": "oci-repo",
         "registry": "myreg2.io",

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
             - name: AUTH_PROXY_IMAGE
               value: {{ .Values.global.authProxyImage }}
             {{- end }}
+            - name: GOPROXY
+              value: direct
           resources:
             requests:
               memory: 72Mi

--- a/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-platform-operator/templates/deployment.yaml
@@ -77,6 +77,12 @@ spec:
             {{- end }}
             - name: GOPROXY
               value: direct
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: verrazzano-github-token
+                  key: GITHUB_TOKEN
+                  optional: true
           resources:
             requests:
               memory: 72Mi

--- a/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
+++ b/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
@@ -234,18 +234,14 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 			Eventually(isStatusReconciling, longWaitTimeout, pollingInterval).Should(BeTrue())
 			Eventually(isStatusReady, longWaitTimeout, pollingInterval).Should(BeTrue())
 
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, ocneComp.Version); err != nil {
-				t.Fail(err.Error())
-			}
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, ocneComp.Version); err != nil {
-				t.Fail(err.Error())
-			}
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, ociComp.Version); err != nil {
-				t.Fail(err.Error())
-			}
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, coreComp.Version); err != nil {
-				t.Fail(err.Error())
-			}
+			_, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, ocneComp.Version)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, ocneComp.Version)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, ociComp.Version)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, coreComp.Version)
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 
@@ -262,18 +258,14 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 			Eventually(isStatusReconciling, longWaitTimeout, pollingInterval).Should(BeTrue())
 			Eventually(isStatusReady, longWaitTimeout, pollingInterval).Should(BeTrue())
 
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, "v1.6.1"); err != nil {
-				t.Fail(err.Error())
-			}
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, "v1.6.1"); err != nil {
-				t.Fail(err.Error())
-			}
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, "v0.11.0"); err != nil {
-				t.Fail(err.Error())
-			}
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, "v1.4.2"); err != nil {
-				t.Fail(err.Error())
-			}
+			_, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, "v1.6.1")
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, "v1.6.1")
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, "v0.11.0")
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, "v1.4.2")
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 
@@ -307,18 +299,14 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 			Eventually(isStatusReconciling, waitTimeout, pollingInterval).Should(BeTrue())
 			Eventually(isStatusReady, waitTimeout, pollingInterval).Should(BeTrue())
 
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, ocneComp.Version); err != nil {
-				t.Fail(err.Error())
-			}
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, ocneComp.Version); err != nil {
-				t.Fail(err.Error())
-			}
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, ociComp.Version); err != nil {
-				t.Fail(err.Error())
-			}
-			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, coreComp.Version); err != nil {
-				t.Fail(err.Error())
-			}
+			_, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, ocneComp.Version)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, ocneComp.Version)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, ociComp.Version)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, coreComp.Version)
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 })

--- a/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
+++ b/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
@@ -30,6 +30,14 @@ const (
 	ocneControlPlaneURLFmt = "https://github.com/verrazzano/cluster-api-provider-ocne/releases/%s/control-plane-components.yaml"
 	ociInfraURLFmt         = "https://github.com/oracle/cluster-api-provider-oci/releases/%s/infrastructure-components.yaml"
 
+	verrazzanoCAPINamespace          = "verrazzano-capi"
+	capiCMDeployment                 = "capi-controller-manager"
+	capiOcneBootstrapCMDeployment    = "capi-ocne-bootstrap-controller-manager"
+	capiOcneControlPlaneCMDeployment = "capi-ocne-control-plane-controller-manager"
+	capiociCMDeployment              = "capoci-controller-manager"
+
+	managerContainerName = "manager"
+
 	// globalRegistryOverride - format string to override the registry to use for all providers
 	globalRegistryOverride = `
 {
@@ -213,7 +221,7 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 		})
 	})
 
-	t.Context("override oci, core, ocneBootstrap and ocneControlPlane versions", func() {
+	t.Context("override oci, core, ocneBootstrap and ocneControlPlane versions from BOM", func() {
 		// GIVEN the CAPI environment is ready
 		// WHEN we override versions
 		// THEN the overrides get successfully applied
@@ -225,6 +233,31 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 			Eventually(isStatusReconciling, longWaitTimeout, pollingInterval).Should(BeTrue())
 			Eventually(isStatusReady, longWaitTimeout, pollingInterval).Should(BeTrue())
+
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, ocneComp.Version)
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, ocneComp.Version)
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, ociComp.Version)
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, coreComp.Version)
+		})
+	})
+
+	t.Context("adhoc override oci, core, ocneBootstrap and ocneControlPlane versions", func() {
+		// GIVEN the CAPI environment is ready
+		// WHEN we override versions
+		// THEN the overrides get successfully applied
+		capipkg.WhenClusterAPIInstalledIt(t, "and wait for reconcile to complete", func() {
+			// Using the current actual versions from the BOM, these are expected to work but download
+			// from the internet instead of from the container image.
+			Eventually(func() bool {
+				return updateClusterAPIOverrides(fmt.Sprintf(versionOverrides, "v0.11.0", "v1.6.1", "v1.6.1", "v1.4.2")) == nil
+			}, waitTimeout, pollingInterval).Should(BeTrue())
+			Eventually(isStatusReconciling, longWaitTimeout, pollingInterval).Should(BeTrue())
+			Eventually(isStatusReady, longWaitTimeout, pollingInterval).Should(BeTrue())
+
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, "v1.6.1")
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, "v1.6.1")
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, "v0.11.0")
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, "v1.4.2")
 		})
 	})
 
@@ -257,6 +290,11 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 			Eventually(isStatusReconciling, waitTimeout, pollingInterval).Should(BeTrue())
 			Eventually(isStatusReady, waitTimeout, pollingInterval).Should(BeTrue())
+
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, ocneComp.Version)
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, ocneComp.Version)
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, ociComp.Version)
+			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, coreComp.Version)
 		})
 	})
 })

--- a/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
+++ b/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
@@ -234,10 +234,18 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 			Eventually(isStatusReconciling, longWaitTimeout, pollingInterval).Should(BeTrue())
 			Eventually(isStatusReady, longWaitTimeout, pollingInterval).Should(BeTrue())
 
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, ocneComp.Version)
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, ocneComp.Version)
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, ociComp.Version)
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, coreComp.Version)
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, ocneComp.Version); err != nil {
+				t.Fail(err.Error())
+			}
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, ocneComp.Version); err != nil {
+				t.Fail(err.Error())
+			}
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, ociComp.Version); err != nil {
+				t.Fail(err.Error())
+			}
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, coreComp.Version); err != nil {
+				t.Fail(err.Error())
+			}
 		})
 	})
 
@@ -254,10 +262,18 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 			Eventually(isStatusReconciling, longWaitTimeout, pollingInterval).Should(BeTrue())
 			Eventually(isStatusReady, longWaitTimeout, pollingInterval).Should(BeTrue())
 
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, "v1.6.1")
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, "v1.6.1")
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, "v0.11.0")
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, "v1.4.2")
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, "v1.6.1"); err != nil {
+				t.Fail(err.Error())
+			}
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, "v1.6.1"); err != nil {
+				t.Fail(err.Error())
+			}
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, "v0.11.0"); err != nil {
+				t.Fail(err.Error())
+			}
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, "v1.4.2"); err != nil {
+				t.Fail(err.Error())
+			}
 		})
 	})
 
@@ -291,10 +307,18 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 			Eventually(isStatusReconciling, waitTimeout, pollingInterval).Should(BeTrue())
 			Eventually(isStatusReady, waitTimeout, pollingInterval).Should(BeTrue())
 
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, ocneComp.Version)
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, ocneComp.Version)
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, ociComp.Version)
-			pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, coreComp.Version)
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, ocneComp.Version); err != nil {
+				t.Fail(err.Error())
+			}
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, ocneComp.Version); err != nil {
+				t.Fail(err.Error())
+			}
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, ociComp.Version); err != nil {
+				t.Fail(err.Error())
+			}
+			if _, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, coreComp.Version); err != nil {
+				t.Fail(err.Error())
+			}
 		})
 	})
 })

--- a/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
+++ b/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
@@ -25,10 +25,10 @@ const (
 	waitTimeout            = 5 * time.Minute
 	pollingInterval        = 10 * time.Second
 	longWaitTimeout        = 20 * time.Minute
-	coreURLFmt             = "https://github.com/verrazzano/cluster-api/releases/download/%s/core-components.yaml"
-	ocneBootstrapURLFmt    = "https://github.com/verrazzano/cluster-api-provider-ocne/releases/download/%s/bootstrap-components.yaml"
-	ocneControlPlaneURLFmt = "https://github.com/verrazzano/cluster-api-provider-ocne/releases/download/%s/control-plane-components.yaml"
-	ociInfraURLFmt         = "https://github.com/oracle/cluster-api-provider-oci/releases/download/%s/infrastructure-components.yaml"
+	coreURLFmt             = "https://github.com/verrazzano/cluster-api/releases/%s/core-components.yaml"
+	ocneBootstrapURLFmt    = "https://github.com/verrazzano/cluster-api-provider-ocne/releases/%s/bootstrap-components.yaml"
+	ocneControlPlaneURLFmt = "https://github.com/verrazzano/cluster-api-provider-ocne/releases/%s/control-plane-components.yaml"
+	ociInfraURLFmt         = "https://github.com/oracle/cluster-api-provider-oci/releases/%s/infrastructure-components.yaml"
 
 	// globalRegistryOverride - format string to override the registry to use for all providers
 	globalRegistryOverride = `

--- a/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
+++ b/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
@@ -24,6 +24,7 @@ import (
 const (
 	waitTimeout            = 5 * time.Minute
 	pollingInterval        = 10 * time.Second
+	longWaitTimeout        = 20 * time.Minute
 	coreURLFmt             = "https://github.com/verrazzano/cluster-api/releases/download/%s/core-components.yaml"
 	ocneBootstrapURLFmt    = "https://github.com/verrazzano/cluster-api-provider-ocne/releases/download/%s/bootstrap-components.yaml"
 	ocneControlPlaneURLFmt = "https://github.com/verrazzano/cluster-api-provider-ocne/releases/download/%s/control-plane-components.yaml"
@@ -222,8 +223,8 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 			Eventually(func() bool {
 				return updateClusterAPIOverrides(fmt.Sprintf(versionOverrides, ociComp.Version, ocneComp.Version, ocneComp.Version, coreComp.Version)) == nil
 			}, waitTimeout, pollingInterval).Should(BeTrue())
-			Eventually(isStatusReconciling, waitTimeout, pollingInterval).Should(BeTrue())
-			Eventually(isStatusReady, waitTimeout, pollingInterval).Should(BeTrue())
+			Eventually(isStatusReconciling, longWaitTimeout, pollingInterval).Should(BeTrue())
+			Eventually(isStatusReady, longWaitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
 

--- a/tests/e2e/config/scripts/create-github-token-secret.sh
+++ b/tests/e2e/config/scripts/create-github-token-secret.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+set -u
+
+NAME=$1
+GITHUB_TOKEN=$2
+NAMESPACE=${3:-"verrazzano-install"}
+
+if [ -z "${KUBECONFIG}" ] ; then
+    echo "KUBECONFIG env var must be set!"
+    exit 1
+fi
+
+if kubectl get secret -n ${NAMESPACE} ${NAME} 2>&1 > /dev/null; then
+  echo "Secret ${NAME} already exists"
+  exit 0
+fi
+
+set +x # always disable shell debug for this
+kubectl create secret generic ${NAME} \
+                            --GITHUB_TOKEN=${GITHUB_TOKEN} \
+                            -n ${NAMESPACE}

--- a/tests/e2e/config/scripts/create-github-token-secret.sh
+++ b/tests/e2e/config/scripts/create-github-token-secret.sh
@@ -22,5 +22,5 @@ fi
 
 set +x # always disable shell debug for this
 kubectl create secret generic ${NAME} \
-                            --GITHUB_TOKEN=${GITHUB_TOKEN} \
+                            --from-literal=GITHUB_TOKEN="${GITHUB_TOKEN}" \
                             -n ${NAMESPACE}


### PR DESCRIPTION
Fixes:
- VZ-10679 Cluster API version overrides not working correctly. Downgrading and upgrading CAPI providers via version overrides will start working again. (reverting #7011)
- VZ-10753 rate limit for github api when clusterAPI component enabled with version overrides
- VZ-10443 Automated test for OCNE version configurability