### PR TITLE
VZ-10780 Update to WebLogic Workload Controller to support WKO 4.1 feature initializeDomainOnPV

### DIFF
--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -824,7 +824,7 @@ func (r *Reconciler) GetConfigMapLocation(u *unstructured.Unstructured) ([]strin
 				return specConfigurationDomainOnPVConfigMap, err
 			}
 		} else {
-			return nil, err
+			return specConfigurationWDTConfigMap, err
 		}
 	}
 	return specConfigurationWDTConfigMap, err

--- a/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
+++ b/application-operator/controllers/wlsworkload/weblogicworkload_controller.go
@@ -204,7 +204,9 @@ var specServerPodVolumeMountsFields = append(specServerPodFields, "volumeMounts"
 var specServerServiceLabelsFields = append(specServerServiceFields, "labels")
 var specConfigurationIstioEnabledFields = []string{specField, "configuration", "istio", "enabled"}
 var specConfigurationRuntimeEncryptionSecret = []string{specField, "configuration", "model", "runtimeEncryptionSecret"}
+var specDomainSourceType = []string{specField, "domainHomeSourceType"}
 var specConfigurationWDTConfigMap = []string{specField, "configuration", "model", "configMap"}
+var specConfigurationDomainOnPVConfigMap = []string{specField, "configuration", "initializeDomainOnPV", "domain", "domainCreationConfigMap"}
 var specMonitoringExporterFields = []string{specField, "monitoringExporter"}
 var specRestartVersionFields = []string{specField, "restartVersion"}
 var specServerStartPolicyFields = []string{specField, "serverStartPolicy"}
@@ -808,58 +810,127 @@ func (r *Reconciler) updateStatusReconcileDone(ctx context.Context, wl *vzapi.Ve
 // with WeblogicPluginEnabled setting if not already done.
 func (r *Reconciler) CreateOrUpdateWDTConfigMap(ctx context.Context, log vzlog.VerrazzanoLogger, namespaceName string, u *unstructured.Unstructured, workloadLabels map[string]string) error {
 	// Get the specified WDT config map name in the WebLogic spec
-	configMapName, found, err := unstructured.NestedString(u.Object, specConfigurationWDTConfigMap...)
+	//Find domainHomeSourceType
+	domainHomeSourceType, exists, err := unstructured.NestedString(u.Object, specDomainSourceType...)
 	if err != nil {
-		log.Errorf("Failed to extract WDT configMap from WebLogic spec: %v", err)
+		log.Errorf("Failed to extract Domain Source Type: %v", err)
 		return err
 	}
-	if !found {
-		domainUID, domainUIDFound, err := unstructured.NestedString(u.Object, specDomainUID...)
-		if err != nil {
-			log.Errorf("Failed to extract domainUID from the WebLogic spec: %v", err)
-			return err
-		}
-		if !domainUIDFound {
-			log.Errorf("Failed to find domainUID in WebLogic spec: %v", err)
-			return errors.New("unable to find domainUID in WebLogic spec")
-		}
-		// Create a default WDT config map
-		err = r.createDefaultWDTConfigMap(ctx, log, namespaceName, domainUID, workloadLabels)
-		if err != nil {
-			return err
-		}
-		// Set WDT config map field in WebLogic spec
-		err = unstructured.SetNestedField(u.Object, getWDTConfigMapName(domainUID), specConfigurationWDTConfigMap...)
-		if err != nil {
-			log.Errorf("Failed to set WDT config map in WebLogic spec: %v", err)
-			return err
-		}
-	} else {
-		configMap, err := r.getConfigMap(ctx, u.GetNamespace(), configMapName)
-		if err != nil {
-			return err
-		}
-		if configMap == nil {
-			log.Errorf("Failed to find the specified WDT config map: %v", err)
-			return err
-		}
-		// Update WDT configMap configuration to add default WLS plugin configuration
-		v := configMap.Data[webLogicPluginConfigYamlKey]
-		if v == "" {
-			byt, err := yaml.JSONToYAML([]byte(defaultWDTConfigMapData))
+	if exists {
+		if domainHomeSourceType == "PersistentVolume" {
+			configMapNamePV, fnd, err := unstructured.NestedString(u.Object, specConfigurationDomainOnPVConfigMap...)
 			if err != nil {
+				log.Debugf("Failed to extract WDT configMap from WebLogic spec for Domain on PV: %v", err)
 				return err
 			}
-			if configMap.Data == nil {
-				configMap.Data = map[string]string{}
+			if !fnd {
+				domainUID, domainUIDFound, err := unstructured.NestedString(u.Object, specDomainUID...)
+				if err != nil {
+					log.Errorf("Failed to extract domainUID from the WebLogic spec: %v", err)
+					return err
+				}
+				if !domainUIDFound {
+					log.Errorf("Failed to find domainUID in WebLogic spec: %v", err)
+					return errors.New("unable to find domainUID in WebLogic spec")
+				}
+				// Create a default WDT config map
+				err = r.createDefaultWDTConfigMap(ctx, log, namespaceName, domainUID, workloadLabels)
+				if err != nil {
+					return err
+				}
+				// Set WDT config map field in WebLogic spec
+				err = unstructured.SetNestedField(u.Object, getWDTConfigMapName(domainUID), specConfigurationDomainOnPVConfigMap...)
+				if err != nil {
+					log.Errorf("Failed to set WDT config map in WebLogic spec: %v", err)
+					return err
+				}
+			} else {
+
+				configMap, err := r.getConfigMap(ctx, u.GetNamespace(), configMapNamePV)
+				if err != nil {
+					return err
+				}
+				if configMap == nil {
+					log.Errorf("Failed to find the specified WDT config map: %v", err)
+					return err
+				}
+				// Update WDT configMap configuration to add default WLS plugin configuration
+				v := configMap.Data[webLogicPluginConfigYamlKey]
+				if v == "" {
+					byt, err := yaml.JSONToYAML([]byte(defaultWDTConfigMapData))
+					if err != nil {
+						return err
+					}
+					if configMap.Data == nil {
+						configMap.Data = map[string]string{}
+					}
+					configMap.Data[webLogicPluginConfigYamlKey] = string(byt)
+					err = r.Client.Update(ctx, configMap)
+					if err != nil {
+						return err
+					}
+				}
 			}
-			configMap.Data[webLogicPluginConfigYamlKey] = string(byt)
-			err = r.Client.Update(ctx, configMap)
+		} else if domainHomeSourceType == "FromModel" {
+
+			configMapNameModel, ex, err := unstructured.NestedString(u.Object, specConfigurationWDTConfigMap...)
 			if err != nil {
+				log.Errorf("Failed to extract WDT configMap from WebLogic spec for Model: %v", err)
 				return err
 			}
+			if !ex {
+				domainUID, domainUIDFound, err := unstructured.NestedString(u.Object, specDomainUID...)
+				if err != nil {
+					log.Errorf("Failed to extract domainUID from the WebLogic spec: %v", err)
+					return err
+				}
+				if !domainUIDFound {
+					log.Errorf("Failed to find domainUID in WebLogic spec: %v", err)
+					return errors.New("unable to find domainUID in WebLogic spec")
+				}
+				// Create a default WDT config map
+				err = r.createDefaultWDTConfigMap(ctx, log, namespaceName, domainUID, workloadLabels)
+				if err != nil {
+					return err
+				}
+				// Set WDT config map field in WebLogic spec
+				err = unstructured.SetNestedField(u.Object, getWDTConfigMapName(domainUID), specConfigurationWDTConfigMap...)
+				if err != nil {
+					log.Errorf("Failed to set WDT config map in WebLogic spec: %v", err)
+					return err
+				}
+			} else {
+
+				configMap, err := r.getConfigMap(ctx, u.GetNamespace(), configMapNameModel)
+				if err != nil {
+					return err
+				}
+				if configMap == nil {
+					log.Errorf("Failed to find the specified WDT config map: %v", err)
+					return err
+				}
+				// Update WDT configMap configuration to add default WLS plugin configuration
+				v := configMap.Data[webLogicPluginConfigYamlKey]
+				if v == "" {
+					byt, err := yaml.JSONToYAML([]byte(defaultWDTConfigMapData))
+					if err != nil {
+						return err
+					}
+					if configMap.Data == nil {
+						configMap.Data = map[string]string{}
+					}
+					configMap.Data[webLogicPluginConfigYamlKey] = string(byt)
+					err = r.Client.Update(ctx, configMap)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
 		}
+
 	}
+
 	return nil
 }
 

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/platform-operator/helm_config/charts/verrazzano-application-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-application-operator/templates/clusterrole.yaml
@@ -16,6 +16,8 @@ rules:
       - rolebindings
       - serviceaccounts
       - services
+      - persistentvolumeclaims
+      - persistentvolumes
     verbs:
       - create
       - delete


### PR DESCRIPTION
This PR is to update the WebLogic Workload Controller to support a new feature for WebLogic Kubernetes Operator 4.1 in relation to Domain on PV type WebLogic Domains.
