### PR TITLE
VZ-10917: Network policy for Dex

### DIFF
--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -302,9 +302,6 @@ pipeline {
                 }
 
                 stage ('console') {
-                    when {
-                        expression {params.ENABLE_DEX == false}
-                    }
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
                     }

--- a/ci/kind/Jenkinsfile
+++ b/ci/kind/Jenkinsfile
@@ -302,6 +302,9 @@ pipeline {
                 }
 
                 stage ('console') {
+                    when {
+                        expression {params.ENABLE_DEX == false}
+                    }
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/console"
                     }

--- a/ci/scripts/run_console_tests.sh
+++ b/ci/scripts/run_console_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 

--- a/ci/scripts/run_console_tests.sh
+++ b/ci/scripts/run_console_tests.sh
@@ -9,6 +9,11 @@ if [ -z "$GO_REPO_PATH" ]; then
   exit 1
 fi
 
+if [ "${ENABLE_DEX}" == "true" ]; then
+  echo "Skip running console tests, when Dex is enabled"
+  exit 0
+fi
+
 # Temporarily clone the console repo until it is moved to the Verrazzano repo
 cd ${GO_REPO_PATH}
 console_sha=${CONSOLE_REPO_BRANCH}

--- a/platform-operator/controllers/verrazzano/component/common/namespace.go
+++ b/platform-operator/controllers/verrazzano/component/common/namespace.go
@@ -98,7 +98,7 @@ func CreateAndLabelNamespaces(ctx spi.ComponentContext) error {
 	}
 
 	if vzcr.IsDexEnabled(ctx.EffectiveCR()) {
-		if err := namespace.CreateDexNamespace(ctx.Client()); err != nil {
+		if err := namespace.CreateDexNamespace(ctx.Client(), istioInject); err != nil {
 			return ctx.Log().ErrorfNewErr("Failed creating namespace %s: %v", constants.DexNamespace, err)
 		}
 	}

--- a/platform-operator/controllers/verrazzano/component/common/namespace.go
+++ b/platform-operator/controllers/verrazzano/component/common/namespace.go
@@ -97,6 +97,12 @@ func CreateAndLabelNamespaces(ctx spi.ComponentContext) error {
 		}
 	}
 
+	if vzcr.IsDexEnabled(ctx.EffectiveCR()) {
+		if err := namespace.CreateDexNamespace(ctx.Client(), istioInject); err != nil {
+			return ctx.Log().ErrorfNewErr("Failed creating namespace %s: %v", constants.DexNamespace, err)
+		}
+	}
+
 	return nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/common/namespace.go
+++ b/platform-operator/controllers/verrazzano/component/common/namespace.go
@@ -98,7 +98,7 @@ func CreateAndLabelNamespaces(ctx spi.ComponentContext) error {
 	}
 
 	if vzcr.IsDexEnabled(ctx.EffectiveCR()) {
-		if err := namespace.CreateDexNamespace(ctx.Client(), istioInject); err != nil {
+		if err := namespace.CreateDexNamespace(ctx.Client()); err != nil {
 			return ctx.Log().ErrorfNewErr("Failed creating namespace %s: %v", constants.DexNamespace, err)
 		}
 	}

--- a/platform-operator/controllers/verrazzano/component/dex/dex.go
+++ b/platform-operator/controllers/verrazzano/component/dex/dex.go
@@ -232,6 +232,10 @@ func ensureDexNamespace(ctx spi.ComponentContext) error {
 			namespace.Labels = map[string]string{}
 		}
 		namespace.Labels[v8oconst.LabelVerrazzanoNamespace] = constants.DexNamespace
+		istio := ctx.EffectiveCR().Spec.Components.Istio
+		if istio != nil && istio.IsInjectionEnabled() {
+			namespace.Labels["istio-injection"] = "enabled"
+		}
 		return nil
 	})
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/dex/dex.go
+++ b/platform-operator/controllers/verrazzano/component/dex/dex.go
@@ -232,10 +232,6 @@ func ensureDexNamespace(ctx spi.ComponentContext) error {
 			namespace.Labels = map[string]string{}
 		}
 		namespace.Labels[v8oconst.LabelVerrazzanoNamespace] = constants.DexNamespace
-		istio := ctx.EffectiveCR().Spec.Components.Istio
-		if istio != nil && istio.IsInjectionEnabled() {
-			namespace.Labels["istio-injection"] = "enabled"
-		}
 		return nil
 	})
 	if err != nil {

--- a/platform-operator/controllers/verrazzano/component/dex/dex_component.go
+++ b/platform-operator/controllers/verrazzano/component/dex/dex_component.go
@@ -14,6 +14,7 @@ import (
 	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -57,7 +58,7 @@ func NewComponent() spi.Component {
 			ImagePullSecretKeyname:    secret.DefaultImagePullSecretKeyName,
 			MinVerrazzanoVersion:      constants.VerrazzanoVersion2_0_0,
 			ValuesFile:                filepath.Join(config.GetHelmOverridesDir(), helmValuesFile),
-			Dependencies:              []string{networkpolicies.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, istio.ComponentName, nginx.ComponentName, cmconstants.CertManagerComponentName},
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
 			AppendOverridesFunc:       AppendDexOverrides,

--- a/platform-operator/controllers/verrazzano/component/networkpolicies/netpol.go
+++ b/platform-operator/controllers/verrazzano/component/networkpolicies/netpol.go
@@ -70,6 +70,7 @@ var netpolNamespaceNames = []types.NamespacedName{
 	{Namespace: constants.VeleroNameSpace, Name: "velero"},
 	{Namespace: vzconst.ArgoCDNamespace, Name: "argocd"},
 	{Namespace: vzconst.VerrazzanoCAPINamespace, Name: "clusterAPI"},
+	{Namespace: constants.DexNamespace, Name: "dex"},
 }
 
 // List of network policies from which we should remove the Helm release of this component,
@@ -151,6 +152,7 @@ func appendVerrazzanoValues(ctx spi.ComponentContext, overrides *chartValues) er
 	overrides.ArgoCD = &argoCDValues{Enabled: vzcr.IsArgoCDEnabled(effectiveCR)}
 	overrides.ClusterAPI = &clusterAPIValues{Enabled: vzcr.IsClusterAPIEnabled(effectiveCR)}
 	overrides.FluentOperator = &fluentOperatorValues{Enabled: vzcr.IsFluentOperatorEnabled(effectiveCR)}
+	overrides.Dex = &dexValues{Enabled: vzcr.IsDexEnabled(effectiveCR)}
 	return nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_component_test.go
@@ -27,13 +27,16 @@ import (
 )
 
 var enabled = true
-var veleroEnabledCR = &vzapi.Verrazzano{
+var optionalCompsEnabledCR = &vzapi.Verrazzano{
 	Spec: vzapi.VerrazzanoSpec{
 		Components: vzapi.ComponentSpec{
 			Velero: &vzapi.VeleroComponent{
 				Enabled: &enabled,
 			},
 			ArgoCD: &vzapi.ArgoCDComponent{
+				Enabled: &enabled,
+			},
+			Dex: &vzapi.DexComponent{
 				Enabled: &enabled,
 			},
 		},
@@ -55,7 +58,7 @@ func TestIsEnabled(t *testing.T) {
 //	THEN the expected namespaces have been created
 func TestPreInstall(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().Build()
-	ctx := spi.NewFakeContext(fakeClient, veleroEnabledCR, nil, false)
+	ctx := spi.NewFakeContext(fakeClient, optionalCompsEnabledCR, nil, false)
 	comp := NewComponent()
 
 	err := comp.PreInstall(ctx)
@@ -122,7 +125,7 @@ func TestPreUpgrade(t *testing.T) {
 	_, err := common.AssociateHelmObject(fakeClient, obj, vzComponentNSN, netPolNSN, false)
 	assert.NoError(t, err)
 
-	ctx := spi.NewFakeContext(fakeClient, veleroEnabledCR, nil, false)
+	ctx := spi.NewFakeContext(fakeClient, optionalCompsEnabledCR, nil, false)
 	comp := NewComponent()
 
 	err = comp.PreUpgrade(ctx)
@@ -164,7 +167,7 @@ func TestPostUpgrade(t *testing.T) {
 			},
 		},
 	).Build()
-	ctx := spi.NewFakeContext(fakeClient, veleroEnabledCR, nil, false)
+	ctx := spi.NewFakeContext(fakeClient, optionalCompsEnabledCR, nil, false)
 	comp := NewComponent()
 
 	err := comp.PostUpgrade(ctx)
@@ -188,7 +191,7 @@ func TestPostUpgrade(t *testing.T) {
 			},
 		},
 	).Build()
-	ctx = spi.NewFakeContext(fakeClient, veleroEnabledCR, nil, false)
+	ctx = spi.NewFakeContext(fakeClient, optionalCompsEnabledCR, nil, false)
 
 	err = comp.PostUpgrade(ctx)
 	assert.NoError(t, err)

--- a/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_values.go
+++ b/platform-operator/controllers/verrazzano/component/networkpolicies/netpol_values.go
@@ -30,6 +30,7 @@ type chartValues struct {
 	ArgoCD              *argoCDValues            `json:"argoCd,omitempty"`
 	FluentOperator      *fluentOperatorValues    `json:"fluentOperator,omitempty"`
 	ClusterAPI          *clusterAPIValues        `json:"clusterAPI,omitempty"`
+	Dex                 *dexValues               `json:"dex,omitempty"`
 }
 
 type authproxyValues struct {
@@ -115,5 +116,9 @@ type clusterAPIValues struct {
 }
 
 type fluentOperatorValues struct {
+	Enabled bool `json:"enabled"` // Always write
+}
+
+type dexValues struct {
 	Enabled bool `json:"enabled"` // Always write
 }

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
@@ -696,12 +696,6 @@ spec:
             matchLabels:
               app.kubernetes.io/instance: velero
               app.kubernetes.io/name: velero
-        - namespaceSelector:
-            matchLabels:
-              verrazzano.io/namespace: verrazzano-auth
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: dex
     - ports:
         - port: 15017
           protocol: TCP
@@ -926,6 +920,10 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+        - protocol: TCP
+          port: 5558
+        - protocol: TCP
+          port: 5556
     - from:
         - namespaceSelector:
             matchLabels:
@@ -933,15 +931,10 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              verrazzano.io/namespace: verrazzano-auth
-      ports:
         - protocol: TCP
           port: 5558
         - protocol: TCP
-          port: 80
+          port: 5556
     - from:
         - namespaceSelector:
             matchLabels:

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
@@ -912,8 +912,6 @@ spec:
         - protocol: TCP
           port: 8080
         - protocol: TCP
-          port: 5558
-        - protocol: TCP
           port: 5556
     - from:
         - namespaceSelector:
@@ -922,8 +920,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
-        - protocol: TCP
-          port: 5558
         - protocol: TCP
           port: 5556
     - from:

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
@@ -879,21 +879,6 @@ spec:
 {{- end }}
 {{- if .Values.dex.enabled }}
 ---
-# Allow any pod in the dex namespace to have network ingress to any other pod
-# in the dex namespace
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-same-namespace
-  namespace: verrazzano-auth
-spec:
-  podSelector: {}
-  policyTypes:
-    - Ingress
-  ingress:
-    - from:
-        - podSelector: {}
----
   # Network policy for Dex
   # Ingress: allow nginx ingress and ingress from pods in the verrazzano-system namespace
   #          allow connect from Prometheus to scrape Envoy stats on port 15090

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
@@ -696,6 +696,12 @@ spec:
             matchLabels:
               app.kubernetes.io/instance: velero
               app.kubernetes.io/name: velero
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-auth
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: dex
     - ports:
         - port: 15017
           protocol: TCP

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/templates/thirdparty-networkpolicy.yaml
@@ -696,6 +696,12 @@ spec:
             matchLabels:
               app.kubernetes.io/instance: velero
               app.kubernetes.io/name: velero
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-auth
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: dex
     - ports:
         - port: 15017
           protocol: TCP
@@ -877,3 +883,75 @@ spec:
         - port: 9443
           protocol: TCP
 {{- end }}
+{{- if .Values.dex.enabled }}
+---
+# Allow any pod in the dex namespace to have network ingress to any other pod
+# in the dex namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: verrazzano-auth
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+  # Network policy for Dex
+  # Ingress: allow nginx ingress and ingress from pods in the verrazzano-system namespace
+  #          allow connect from Prometheus to scrape Envoy stats on port 15090
+  # Egress: allow all
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dex
+  namespace: verrazzano-auth
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: dex
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: {{ .Values.ingressNGINX.namespace }}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: ingress-controller
+      ports:
+        - protocol: TCP
+          port: 8080
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: {{ .Release.Namespace }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-auth
+      ports:
+        - protocol: TCP
+          port: 5558
+        - protocol: TCP
+          port: 80
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              verrazzano.io/namespace: verrazzano-monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - port: 15090
+          protocol: TCP
+---
+{{- end }}
+

--- a/platform-operator/helm_config/charts/verrazzano-network-policies/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-network-policies/values.yaml
@@ -72,3 +72,6 @@ fluentOperator:
 
 clusterAPI:
   enabled: false
+
+dex:
+  enabled: false

--- a/platform-operator/helm_config/overrides/dex-values.yaml
+++ b/platform-operator/helm_config/overrides/dex-values.yaml
@@ -20,6 +20,9 @@ envVars:
   - name: PASSWORD_DB_USERNAME_PROMPT
     value: "Username"
 
+podAnnotations:
+  traffic.sidecar.istio.io/excludeOutboundPorts: "443"
+
 ingress:
   enabled: true
   annotations:

--- a/platform-operator/internal/k8s/namespace/namespace.go
+++ b/platform-operator/internal/k8s/namespace/namespace.go
@@ -86,8 +86,8 @@ func CreateArgoCDNamespace(client client.Client, istioInjectionEnabled bool) err
 }
 
 // CreateDexNamespace - Create/Update and label the Dex namespace
-func CreateDexNamespace(client client.Client, istioInjectionEnabled bool) error {
-	return CreateAndLabelNamespace(client, constants.DexNamespace, true, istioInjectionEnabled)
+func CreateDexNamespace(client client.Client) error {
+	return CreateAndLabelNamespace(client, constants.DexNamespace, true, false)
 }
 
 // MergeMaps Merge one map into another, creating new one if necessary; returns the updated map and true if it was modified

--- a/platform-operator/internal/k8s/namespace/namespace.go
+++ b/platform-operator/internal/k8s/namespace/namespace.go
@@ -86,8 +86,8 @@ func CreateArgoCDNamespace(client client.Client, istioInjectionEnabled bool) err
 }
 
 // CreateDexNamespace - Create/Update and label the Dex namespace
-func CreateDexNamespace(client client.Client) error {
-	return CreateAndLabelNamespace(client, constants.DexNamespace, true, false)
+func CreateDexNamespace(client client.Client, istioInjectionEnabled bool) error {
+	return CreateAndLabelNamespace(client, constants.DexNamespace, true, istioInjectionEnabled)
 }
 
 // MergeMaps Merge one map into another, creating new one if necessary; returns the updated map and true if it was modified

--- a/platform-operator/internal/k8s/namespace/namespace.go
+++ b/platform-operator/internal/k8s/namespace/namespace.go
@@ -85,6 +85,11 @@ func CreateArgoCDNamespace(client client.Client, istioInjectionEnabled bool) err
 	return CreateAndLabelNamespace(client, constants.ArgoCDNamespace, true, istioInjectionEnabled)
 }
 
+// CreateDexNamespace - Create/Update and label the Dex namespace
+func CreateDexNamespace(client client.Client, istioInjectionEnabled bool) error {
+	return CreateAndLabelNamespace(client, constants.DexNamespace, true, istioInjectionEnabled)
+}
+
 // MergeMaps Merge one map into another, creating new one if necessary; returns the updated map and true if it was modified
 func MergeMaps(to map[string]string, from map[string]string) (map[string]string, bool) {
 	mergedMap := to

--- a/platform-operator/internal/k8s/namespace/namespace_test.go
+++ b/platform-operator/internal/k8s/namespace/namespace_test.go
@@ -207,8 +207,8 @@ func TestCreateVerrazzanoMultiClusterNamespace(t *testing.T) {
 // WHEN no error occurs
 // THEN no error is returned, the namespace is created, and the proper labels have been added
 func TestCreateDexNamespace(t *testing.T) {
-	runNamespaceTestWithIstioFlag(t, constants.DexNamespace,
-		createVZAndIstioLabels(constants.DexNamespace),
+	runNamespaceTest(t, constants.DexNamespace,
+		createVzLabels(constants.DexNamespace),
 		CreateDexNamespace)
 }
 

--- a/platform-operator/internal/k8s/namespace/namespace_test.go
+++ b/platform-operator/internal/k8s/namespace/namespace_test.go
@@ -202,6 +202,16 @@ func TestCreateVerrazzanoMultiClusterNamespace(t *testing.T) {
 		CreateVerrazzanoMultiClusterNamespace)
 }
 
+// TestCreateDexNamespace tests the CreateDexNamespace function
+// GIVEN a call to CreateDexNamespace
+// WHEN no error occurs
+// THEN no error is returned, the namespace is created, and the proper labels have been added
+func TestCreateDexNamespace(t *testing.T) {
+	runNamespaceTestWithIstioFlag(t, constants.DexNamespace,
+		createVZAndIstioLabels(constants.DexNamespace),
+		CreateDexNamespace)
+}
+
 func runNamespaceTest(t *testing.T, namespace string, expectedLabels map[string]string, namespaceFunc func(client client.Client) error) {
 	asserts := assert.New(t)
 	mocker := gomock.NewController(t)

--- a/platform-operator/internal/k8s/namespace/namespace_test.go
+++ b/platform-operator/internal/k8s/namespace/namespace_test.go
@@ -207,8 +207,8 @@ func TestCreateVerrazzanoMultiClusterNamespace(t *testing.T) {
 // WHEN no error occurs
 // THEN no error is returned, the namespace is created, and the proper labels have been added
 func TestCreateDexNamespace(t *testing.T) {
-	runNamespaceTest(t, constants.DexNamespace,
-		createVzLabels(constants.DexNamespace),
+	runNamespaceTestWithIstioFlag(t, constants.DexNamespace,
+		createVZAndIstioLabels(constants.DexNamespace),
 		CreateDexNamespace)
 }
 

--- a/tests/e2e/verify-install/security/pod_security_test.go
+++ b/tests/e2e/verify-install/security/pod_security_test.go
@@ -161,6 +161,7 @@ var _ = t.Describe("Ensure pod security", Label("f:security.podsecurity"), func(
 		Entry("Checking pod security in keycloak", "keycloak"),
 		Entry("Checking pod security in argocd", "argocd"),
 		Entry("Checking pod security in istio-system", "istio-system"),
+		Entry("Checking pod security in verrazzano-auth", "verrazzano-auth"),
 	)
 })
 


### PR DESCRIPTION
This change enables istio pod injection in verrazzano-auth namespace where Dex is installed. It defines the network policy for Dex, adds required tests. 

There are few additional changes done for pipeline and e2e tests.
1. The console tests, which are written with Keycloak as the ODIC provider is disabled from Kind AT when Dex is enabled. Otherwise, console tests fail after long time and the job aborts with timeout.This change will be removed once the tests are fixed. The intention is to run other tests in Kind AT without the job being aborted as the console tests run forever 
2. This change enables pod security test for namespace verrazzano-auth.