### PR TITLE
VZ-10807. Fix CAPI overrides tests with modules

### DIFF
--- a/platform-operator/experimental/controllers/module/component-handler/common/vzcomponent_status.go
+++ b/platform-operator/experimental/controllers/module/component-handler/common/vzcomponent_status.go
@@ -89,11 +89,6 @@ func UpdateVerrazzanoComponentStatus(ctx handlerspi.HandlerContext, sd StatusDat
 	}
 	addOrReplaceCondition(compStatus, cond)
 
-	// Change state to reconciling if needed
-	if (vzcr.Status.State == "" || vzcr.Status.State == vzapi.VzStateReady) && sd.CondType == vzapi.CondInstallStarted {
-		vzcr.Status.State = vzapi.VzStateReconciling
-	}
-
 	if err := ctx.Client.Status().Update(context.TODO(), vzcr); err != nil {
 		if !errors.IsConflict(err) {
 			ctx.Log.Progress("Failed to update Verrazzano component status, retrying: %v", err)

--- a/platform-operator/experimental/controllers/verrazzano/module.go
+++ b/platform-operator/experimental/controllers/verrazzano/module.go
@@ -106,12 +106,6 @@ func (r Reconciler) moduleDeepEqual(mod1 *moduleapi.Module, mod2 *moduleapi.Modu
 	//
 	// For now we will use DeepEqual to compare parts of the Module objects we care about directly unless we can
 	// determine why we're getting diffs from the full ObjectCompare
-	/*
-		For debugging DeepEqual
-		if !equality.Semantic.DeepEqual(moduleExisting, module) {
-			log.Debugf("Full object diff for %s failed", client.ObjectKeyFromObject(&module))
-		}
-	*/
 	return equality.Semantic.DeepEqual(mod1.Spec, mod2.Spec) &&
 		equality.Semantic.DeepEqual(mod1.ObjectMeta, mod2.ObjectMeta) &&
 		equality.Semantic.DeepEqual(mod1.Status, mod2.Status)

--- a/platform-operator/experimental/controllers/verrazzano/reconciler.go
+++ b/platform-operator/experimental/controllers/verrazzano/reconciler.go
@@ -87,9 +87,6 @@ func (r Reconciler) Reconcile(controllerCtx controllerspi.ReconcileContext, u *u
 
 	// Do the actual install, update, and or upgrade.
 	if res := r.doWork(log, actualCR, effectiveCR); res.ShouldRequeue() {
-		if res := r.updateStatusIfNeeded(log, actualCR); res.ShouldRequeue() {
-			return res
-		}
 		return res
 	}
 

--- a/platform-operator/experimental/controllers/verrazzano/vzstatus.go
+++ b/platform-operator/experimental/controllers/verrazzano/vzstatus.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"time"
 )
 
@@ -83,7 +84,10 @@ func (r Reconciler) initializeComponentStatus(log vzlog.VerrazzanoLogger, actual
 	return result.NewResult()
 }
 
-func (r Reconciler) updateStatusIfNeeded(log vzlog.VerrazzanoLogger, actualCR *vzv1alpha1.Verrazzano) result.Result {
+func (r Reconciler) updateStatusIfNeeded(log vzlog.VerrazzanoLogger, actualCR *vzv1alpha1.Verrazzano, opResult controllerutil.OperationResult) result.Result {
+	if opResult == controllerutil.OperationResultNone {
+		return result.NewResult()
+	}
 	if !r.isUpgrading(actualCR) {
 		if err := r.updateStatusInstalling(log, actualCR); err != nil {
 			return result.NewResultShortRequeueDelayWithError(err)


### PR DESCRIPTION
Modules reconciler change to fix VZ reconciing status on updates.  Sets the status for the VZ CR to Reconciling/InstallStarted when
* the module Spec changes on `CreateOrUpdate`
* any Secret or Configmap overrides that cause a change to the target copy in `verrazzano-install`
* Remove the code in the module handlers that tweaks the VZ CR State

Reconciling completes when the `postWork` finishes successfully.