### PR TITLE
VZ-10925 Register CAPI clusters with Verrazzano when Rancher is not enabled/installed

### DIFF
--- a/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_webhook.go
+++ b/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1alpha1

--- a/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_webhook.go
+++ b/cluster-operator/apis/clusters/v1alpha1/verrazzanomanagedcluster_webhook.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,9 +94,7 @@ func getClient() (client.Client, error) {
 func newScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	AddToScheme(scheme)
-	scheme.AddKnownTypes(schema.GroupVersion{
-		Version: "v1",
-	}, &corev1.Secret{}, &corev1.ConfigMap{})
+	corev1.AddToScheme(scheme)
 	scheme.AddKnownTypes(v1beta1.SchemeGroupVersion, &v1beta1.Verrazzano{}, &v1beta1.VerrazzanoList{})
 	meta_v1.AddToGroupVersion(scheme, v1beta1.SchemeGroupVersion)
 

--- a/cluster-operator/controllers/capi/capi_cluster_controller.go
+++ b/cluster-operator/controllers/capi/capi_cluster_controller.go
@@ -124,11 +124,11 @@ func (r *CAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if r.RancherEnabled {
 		// Is Rancher Deployment ready
-		r.Log.Infof("Attempting cluster regisration with Rancher")
+		r.Log.Debugf("Attempting cluster regisration with Rancher")
 		return r.RancherRegistrar.doReconcile(ctx, cluster)
 	}
 
-	r.Log.Infof("Attempting cluster regisration with Verrazzano")
+	r.Log.Debugf("Attempting cluster regisration with Verrazzano")
 	return r.VerrazzanoRegistrar.doReconcile(ctx, cluster)
 }
 

--- a/cluster-operator/controllers/capi/capi_cluster_controller.go
+++ b/cluster-operator/controllers/capi/capi_cluster_controller.go
@@ -126,12 +126,10 @@ func (r *CAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// Is Rancher Deployment ready
 		r.Log.Infof("Attempting cluster regisration with Rancher")
 		return r.RancherRegistrar.doReconcile(ctx, cluster)
-	} else {
-		r.Log.Infof("Attempting cluster regisration with Verrazzano")
-		return r.VerrazzanoRegistrar.doReconcile(ctx, cluster)
 	}
 
-	return ctrl.Result{}, nil
+	r.Log.Infof("Attempting cluster regisration with Verrazzano")
+	return r.VerrazzanoRegistrar.doReconcile(ctx, cluster)
 }
 
 func (r *CAPIClusterReconciler) unregisterCluster(ctx context.Context, cluster *unstructured.Unstructured) error {

--- a/cluster-operator/controllers/capi/capi_cluster_controller.go
+++ b/cluster-operator/controllers/capi/capi_cluster_controller.go
@@ -124,8 +124,10 @@ func (r *CAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if r.RancherEnabled {
 		// Is Rancher Deployment ready
+		r.Log.Infof("Attempting cluster regisration with Rancher")
 		return r.RancherRegistrar.doReconcile(ctx, cluster)
 	} else {
+		r.Log.Infof("Attempting cluster regisration with Verrazzano")
 		return r.VerrazzanoRegistrar.doReconcile(ctx, cluster)
 	}
 

--- a/cluster-operator/controllers/capi/capi_cluster_controller.go
+++ b/cluster-operator/controllers/capi/capi_cluster_controller.go
@@ -6,15 +6,8 @@ package capi
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/cluster-operator/controllers/vmc"
 	"github.com/verrazzano/verrazzano/pkg/constants"
-	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
-	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
-	"github.com/verrazzano/verrazzano/pkg/k8sutil"
-	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"github.com/verrazzano/verrazzano/pkg/rancherutil"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -38,39 +31,18 @@ const (
 	clusterStatusSuffix          = "-cluster-status"
 	clusterIDKey                 = "clusterId"
 	clusterRegistrationStatusKey = "clusterRegistration"
-	registrationRetrieved        = "started"
-	registrationInitiated        = "completed"
+	registrationRetrieved        = "retrieved"
+	registrationInitiated        = "initiated"
 )
 
 type CAPIClusterReconciler struct {
 	client.Client
-	Scheme             *runtime.Scheme
-	Log                *zap.SugaredLogger
-	RancherIngressHost string
-}
-
-type ClusterRegistrationFnType func(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) (ctrl.Result, error)
-
-var clusterRegistrationFn ClusterRegistrationFnType = ensureRancherRegistration
-
-func SetClusterRegistrationFunction(f ClusterRegistrationFnType) {
-	clusterRegistrationFn = f
-}
-
-func SetDefaultClusterRegistrationFunction() {
-	clusterRegistrationFn = ensureRancherRegistration
-}
-
-type ClusterUnregistrationFnType func(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) error
-
-var clusterUnregistrationFn ClusterUnregistrationFnType = UnregisterRancherCluster
-
-func SetClusterUnregistrationFunction(f ClusterUnregistrationFnType) {
-	clusterUnregistrationFn = f
-}
-
-func SetDefaultClusterUnregistrationFunction() {
-	clusterUnregistrationFn = UnregisterRancherCluster
+	Scheme              *runtime.Scheme
+	Log                 *zap.SugaredLogger
+	RancherRegistrar    *RancherRegistration
+	RancherIngressHost  string
+	RancherEnabled      bool
+	VerrazzanoRegistrar *VerrazzanoRegistration
 }
 
 var gvk = schema.GroupVersionKind{
@@ -96,18 +68,9 @@ func (r *CAPIClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *CAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.Infof("Reconciling CAPI cluster: %v", req.NamespacedName)
 
-	// Is Rancher available
-	err := ready.DeploymentsAreAvailable(r.Client, []types.NamespacedName{{
-		Namespace: common.CattleSystem,
-		Name:      common.RancherName,
-	}})
-	if err != nil {
-		return vzctrl.LongRequeue(), nil
-	}
-
 	cluster := &unstructured.Unstructured{}
 	cluster.SetGroupVersionKind(gvk)
-	err = r.Get(context.TODO(), req.NamespacedName, cluster)
+	err := r.Get(context.TODO(), req.NamespacedName, cluster)
 	if err != nil && !errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -127,7 +90,8 @@ func (r *CAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// if the deletion timestamp is set, unregister the corresponding Rancher cluster
 	if !cluster.GetDeletionTimestamp().IsZero() {
 		if vzstring.SliceContainsString(cluster.GetFinalizers(), finalizerName) {
-			if err := clusterUnregistrationFn(ctx, r, cluster); err != nil {
+			err = r.unregisterCluster(ctx, cluster)
+			if err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -137,9 +101,11 @@ func (r *CAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		// delete the cluster id secret
-		clusterRegistrationStatusSecret, err := r.getClusterRegistrationStatusSecret(ctx, cluster)
-		if err != nil {
-			return ctrl.Result{}, err
+		clusterRegistrationStatusSecret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: constants.VerrazzanoCAPINamespace,
+				Name:      cluster.GetName() + clusterStatusSuffix,
+			},
 		}
 		err = r.Delete(ctx, clusterRegistrationStatusSecret)
 		if err != nil {
@@ -156,14 +122,24 @@ func (r *CAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	if registrationInitiated != r.getClusterRegistrationStatus(ctx, cluster) {
-		// wait for kubeconfig and complete registration on workload cluster
-		if result, err := clusterRegistrationFn(ctx, r, cluster); err != nil {
-			return result, err
-		}
+	if r.RancherEnabled {
+		// Is Rancher Deployment ready
+		return r.RancherRegistrar.doReconcile(ctx, cluster)
+	} else {
+		return r.VerrazzanoRegistrar.doReconcile(ctx, cluster)
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *CAPIClusterReconciler) unregisterCluster(ctx context.Context, cluster *unstructured.Unstructured) error {
+	var err error
+	if r.RancherEnabled {
+		err = clusterRancherUnregistrationFn(ctx, r.RancherRegistrar, cluster)
+	} else {
+		err = UnregisterVerrazzanoCluster(ctx, r.VerrazzanoRegistrar, cluster)
+	}
+	return err
 }
 
 // ensureFinalizer adds a finalizer to the CAPI cluster if the finalizer is not already present
@@ -188,78 +164,8 @@ func (r *CAPIClusterReconciler) removeFinalizer(cluster *unstructured.Unstructur
 	return nil
 }
 
-// ensureRancherRegistration ensures that the CAPI cluster is registered with Rancher.
-func ensureRancherRegistration(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) (ctrl.Result, error) {
-	kubeconfig, err := r.getWorkloadClusterKubeconfig(ctx, cluster)
-	if err != nil {
-		// requeue since we're waiting for cluster
-		return vzctrl.ShortRequeue(), err
-	}
-
-	rc, log, err := r.GetRancherAPIResources(cluster)
-	if err != nil {
-		r.Log.Infof("Failed getting rancher api resources")
-		return ctrl.Result{}, err
-	}
-
-	clusterID := r.getClusterID(ctx, cluster)
-	registryYaml, clusterID, registryErr := vmc.RegisterManagedClusterWithRancher(rc, cluster.GetName(), clusterID, log)
-	// persist the cluster ID, if present, even if the registry yaml was not returned
-	err = r.persistClusterStatus(ctx, cluster, clusterID, registrationRetrieved)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	// handle registry failure error
-	if registryErr != nil {
-		r.Log.Error(err, "failed to obtain registration manifest from Rancher")
-		return ctrl.Result{}, registryErr
-	}
-	// it appears that in some circumstances the registry yaml may be empty so need to re-queue to re-attempt retrieval
-	if len(registryYaml) == 0 {
-		return vzctrl.ShortRequeue(), nil
-	}
-	// create workload cluster client
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
-	if err != nil {
-		r.Log.Warnf("Failed getting rest config from workload kubeconfig")
-		return ctrl.Result{}, err
-	}
-	workloadClient, err := r.getWorkloadClusterClient(restConfig)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// apply registration yaml to managed cluster
-	yamlApplier := k8sutil.NewYAMLApplier(workloadClient, "")
-	err = yamlApplier.ApplyS(registryYaml)
-	if err != nil {
-		r.Log.Infof("Failed applying Rancher registration yaml in workload cluster")
-		return ctrl.Result{}, err
-	}
-
-	// get and label the cattle-system namespace
-	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: common.CattleSystem}}
-	if _, err := ctrl.CreateOrUpdate(context.TODO(), workloadClient, ns, func() error {
-		if ns.Labels == nil {
-			ns.Labels = make(map[string]string)
-		}
-		ns.Labels[constants.LabelVerrazzanoNamespace] = common.CattleSystem
-		return nil
-	}); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	err = r.persistClusterStatus(ctx, cluster, clusterID, registrationInitiated)
-	if err != nil {
-		r.Log.Infof("Failed to perist cluster status")
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
-}
-
-// getWorkloadClusterClient returns a controller runtime client configured for the workload cluster
-func (r *CAPIClusterReconciler) getWorkloadClusterClient(restConfig *rest.Config) (client.Client, error) {
+// getClusterClient returns a controller runtime client configured for the workload cluster
+func getClusterClient(restConfig *rest.Config) (client.Client, error) {
 	scheme := runtime.NewScheme()
 	_ = rbacv1.AddToScheme(scheme)
 	_ = v1.AddToScheme(scheme)
@@ -269,10 +175,10 @@ func (r *CAPIClusterReconciler) getWorkloadClusterClient(restConfig *rest.Config
 }
 
 // getClusterID returns the cluster ID assigned by Rancher for the given cluster
-func (r *CAPIClusterReconciler) getClusterID(ctx context.Context, cluster *unstructured.Unstructured) string {
+func getClusterID(ctx context.Context, client client.Client, cluster *unstructured.Unstructured) string {
 	clusterID := ""
 
-	regStatusSecret, err := r.getClusterRegistrationStatusSecret(ctx, cluster)
+	regStatusSecret, err := getClusterRegistrationStatusSecret(ctx, client, cluster)
 	if err != nil {
 		return clusterID
 	}
@@ -282,10 +188,10 @@ func (r *CAPIClusterReconciler) getClusterID(ctx context.Context, cluster *unstr
 }
 
 // getClusterRegistrationStatus returns the Rancher registration status for the cluster
-func (r *CAPIClusterReconciler) getClusterRegistrationStatus(ctx context.Context, cluster *unstructured.Unstructured) string {
+func getClusterRegistrationStatus(ctx context.Context, c client.Client, cluster *unstructured.Unstructured) string {
 	clusterStatus := registrationRetrieved
 
-	regStatusSecret, err := r.getClusterRegistrationStatusSecret(ctx, cluster)
+	regStatusSecret, err := getClusterRegistrationStatusSecret(ctx, c, cluster)
 	if err != nil {
 		return clusterStatus
 	}
@@ -295,13 +201,13 @@ func (r *CAPIClusterReconciler) getClusterRegistrationStatus(ctx context.Context
 }
 
 // getClusterRegistrationStatusSecret returns the secret that stores cluster status information
-func (r *CAPIClusterReconciler) getClusterRegistrationStatusSecret(ctx context.Context, cluster *unstructured.Unstructured) (*v1.Secret, error) {
+func getClusterRegistrationStatusSecret(ctx context.Context, c client.Client, cluster *unstructured.Unstructured) (*v1.Secret, error) {
 	clusterIDSecret := &v1.Secret{}
 	secretName := types.NamespacedName{
 		Namespace: constants.VerrazzanoCAPINamespace,
 		Name:      cluster.GetName() + clusterStatusSuffix,
 	}
-	err := r.Get(ctx, secretName, clusterIDSecret)
+	err := c.Get(ctx, secretName, clusterIDSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -309,15 +215,15 @@ func (r *CAPIClusterReconciler) getClusterRegistrationStatusSecret(ctx context.C
 }
 
 // persistClusterStatus stores the cluster status in the cluster status secret
-func (r *CAPIClusterReconciler) persistClusterStatus(ctx context.Context, cluster *unstructured.Unstructured, clusterID string, status string) error {
-	r.Log.Debugf("Persisting cluster %s cluster id: %s", cluster.GetName(), clusterID)
+func persistClusterStatus(ctx context.Context, client client.Client, cluster *unstructured.Unstructured, log *zap.SugaredLogger, clusterID string, status string) error {
+	log.Debugf("Persisting cluster %s cluster id: %s", cluster.GetName(), clusterID)
 	clusterRegistrationStatusSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.GetName() + clusterStatusSuffix,
 			Namespace: constants.VerrazzanoCAPINamespace,
 		},
 	}
-	_, err := ctrl.CreateOrUpdate(ctx, r.Client, clusterRegistrationStatusSecret, func() error {
+	_, err := ctrl.CreateOrUpdate(ctx, client, clusterRegistrationStatusSecret, func() error {
 		// Build the secret data
 		if clusterRegistrationStatusSecret.Data == nil {
 			clusterRegistrationStatusSecret.Data = make(map[string][]byte)
@@ -328,7 +234,7 @@ func (r *CAPIClusterReconciler) persistClusterStatus(ctx context.Context, cluste
 		return nil
 	})
 	if err != nil {
-		r.Log.Errorf("Unable to persist status for cluster %s: %v", cluster.GetName(), err)
+		log.Errorf("Unable to persist status for cluster %s: %v", cluster.GetName(), err)
 		return err
 	}
 
@@ -336,63 +242,40 @@ func (r *CAPIClusterReconciler) persistClusterStatus(ctx context.Context, cluste
 }
 
 // getWorkloadClusterKubeconfig returns a kubeconfig for accessing the workload cluster
-func (r *CAPIClusterReconciler) getWorkloadClusterKubeconfig(ctx context.Context, cluster *unstructured.Unstructured) ([]byte, error) {
+func getWorkloadClusterKubeconfig(client client.Client, cluster *unstructured.Unstructured, log *zap.SugaredLogger) ([]byte, error) {
 	// get the cluster kubeconfig
 	kubeconfigSecret := &v1.Secret{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s-kubeconfig", cluster.GetName()), Namespace: cluster.GetNamespace()}, kubeconfigSecret)
+	err := client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s-kubeconfig", cluster.GetName()), Namespace: cluster.GetNamespace()}, kubeconfigSecret)
 	if err != nil {
-		r.Log.Warn(err, "failed to obtain workload cluster kubeconfig resource. Re-queuing...")
+		log.Warn(err, "failed to obtain workload cluster kubeconfig resource. Re-queuing...")
 		return nil, err
 	}
 	kubeconfig, ok := kubeconfigSecret.Data["value"]
 	if !ok {
-		r.Log.Error(err, "failed to read kubeconfig from resource")
+		log.Error(err, "failed to read kubeconfig from resource")
 		return nil, fmt.Errorf("Unable to read kubeconfig from retrieved cluster resource")
 	}
 
 	return kubeconfig, nil
 }
 
-// GetRancherAPIResources returns the set of resources required for interacting with Rancher
-func (r *CAPIClusterReconciler) GetRancherAPIResources(cluster *unstructured.Unstructured) (*rancherutil.RancherConfig, vzlog.VerrazzanoLogger, error) {
-	// Get the resource logger needed to log message using 'progress' and 'once' methods
-	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
-		Name:           cluster.GetName(),
-		Namespace:      cluster.GetNamespace(),
-		ID:             string(cluster.GetUID()),
-		Generation:     cluster.GetGeneration(),
-		ControllerName: "capicluster",
-	})
+func getWorkloadClusterClient(client client.Client, log *zap.SugaredLogger, cluster *unstructured.Unstructured) (client.Client, error) {
+	// identify whether the workload cluster is using "untrusted" certs
+	kubeconfig, err := getWorkloadClusterKubeconfig(client, cluster, log)
 	if err != nil {
-		r.Log.Errorf("Failed to create controller logger for CAPI cluster controller", err)
-		return nil, nil, err
+		// requeue since we're waiting for cluster
+		return nil, err
 	}
-
-	// using direct rancher API to register cluster
-	rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.RancherIngressHost, log)
+	// create a workload cluster client
+	// create workload cluster client
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
 	if err != nil {
-		r.Log.Error(err, "failed to create Rancher API client")
-		return nil, nil, err
+		log.Warnf("Failed getting rest config from workload kubeconfig")
+		return nil, err
 	}
-	return rc, log, nil
-}
-
-// UnregisterRancherCluster performs the operations required to de-register the cluster from Rancher
-func UnregisterRancherCluster(ctx context.Context, r *CAPIClusterReconciler, cluster *unstructured.Unstructured) error {
-	clusterID := r.getClusterID(ctx, cluster)
-	if len(clusterID) == 0 {
-		// no cluster id found
-		return fmt.Errorf("No cluster ID found for cluster %s", cluster.GetName())
-	}
-	rc, log, err := r.GetRancherAPIResources(cluster)
+	workloadClient, err := getClusterClient(restConfig)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = vmc.DeleteClusterFromRancher(rc, clusterID, log)
-	if err != nil {
-		log.Errorf("Unable to unregister cluster %s from Rancher: %v", cluster.GetName(), err)
-		return err
-	}
-
-	return nil
+	return workloadClient, nil
 }

--- a/cluster-operator/controllers/capi/rancher.go
+++ b/cluster-operator/controllers/capi/rancher.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package capi
+
+import (
+	"context"
+	"fmt"
+	"github.com/verrazzano/verrazzano/cluster-operator/controllers/vmc"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
+	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
+	"github.com/verrazzano/verrazzano/pkg/rancherutil"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type RancherRegistration struct {
+	client.Client
+	Log                *zap.SugaredLogger
+	RancherIngressHost string
+}
+
+type ClusterRancherRegistrationFnType func(ctx context.Context, r *RancherRegistration, cluster *unstructured.Unstructured) (ctrl.Result, error)
+
+var clusterRancherRegistrationFn ClusterRancherRegistrationFnType = ensureRancherRegistration
+
+func SetClusterRancherRegistrationFunction(f ClusterRancherRegistrationFnType) {
+	clusterRancherRegistrationFn = f
+}
+
+func SetDefaultClusterRancherRegistrationFunction() {
+	clusterRancherRegistrationFn = ensureRancherRegistration
+}
+
+type ClusterRancherUnregistrationFnType func(ctx context.Context, r *RancherRegistration, cluster *unstructured.Unstructured) error
+
+var clusterRancherUnregistrationFn ClusterRancherUnregistrationFnType = UnregisterRancherCluster
+
+func SetClusterRancherUnregistrationFunction(f ClusterRancherUnregistrationFnType) {
+	clusterRancherUnregistrationFn = f
+}
+
+func SetDefaultClusterRancherUnregistrationFunction() {
+	clusterRancherUnregistrationFn = UnregisterRancherCluster
+}
+
+func (r *RancherRegistration) doReconcile(ctx context.Context, cluster *unstructured.Unstructured) (ctrl.Result, error) {
+	err := ready.DeploymentsAreAvailable(r.Client, []types.NamespacedName{{
+		Namespace: common.CattleSystem,
+		Name:      common.RancherName,
+	}})
+	if err != nil {
+		return vzctrl.LongRequeue(), nil
+	}
+
+	if registrationInitiated != getClusterRegistrationStatus(ctx, r.Client, cluster) {
+		// wait for kubeconfig and complete registration on workload cluster
+		if result, err := clusterRancherRegistrationFn(ctx, r, cluster); err != nil {
+			return result, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// GetRancherAPIResources returns the set of resources required for interacting with Rancher
+func (r *RancherRegistration) GetRancherAPIResources(cluster *unstructured.Unstructured) (*rancherutil.RancherConfig, vzlog.VerrazzanoLogger, error) {
+	// Get the resource logger needed to log message using 'progress' and 'once' methods
+	log, err := vzlog.EnsureResourceLogger(&vzlog.ResourceConfig{
+		Name:           cluster.GetName(),
+		Namespace:      cluster.GetNamespace(),
+		ID:             string(cluster.GetUID()),
+		Generation:     cluster.GetGeneration(),
+		ControllerName: "capicluster",
+	})
+	if err != nil {
+		r.Log.Errorf("Failed to create controller logger for CAPI cluster controller", err)
+		return nil, nil, err
+	}
+
+	// using direct rancher API to register cluster
+	rc, err := rancherutil.NewAdminRancherConfig(r.Client, r.RancherIngressHost, log)
+	if err != nil {
+		r.Log.Error(err, "failed to create Rancher API client")
+		return nil, nil, err
+	}
+	return rc, log, nil
+}
+
+// UnregisterRancherCluster performs the operations required to de-register the cluster from Rancher
+func UnregisterRancherCluster(ctx context.Context, r *RancherRegistration, cluster *unstructured.Unstructured) error {
+	clusterID := getClusterID(ctx, r.Client, cluster)
+	if len(clusterID) == 0 {
+		// no cluster id found
+		return fmt.Errorf("No cluster ID found for cluster %s", cluster.GetName())
+	}
+	rc, log, err := r.GetRancherAPIResources(cluster)
+	if err != nil {
+		return err
+	}
+	_, err = vmc.DeleteClusterFromRancher(rc, clusterID, log)
+	if err != nil {
+		log.Errorf("Unable to unregister cluster %s from Rancher: %v", cluster.GetName(), err)
+		return err
+	}
+
+	return nil
+}
+
+// ensureRancherRegistration ensures that the CAPI cluster is registered with Rancher.
+func ensureRancherRegistration(ctx context.Context, r *RancherRegistration, cluster *unstructured.Unstructured) (ctrl.Result, error) {
+	workloadClient, err := getWorkloadClusterClient(r.Client, r.Log, cluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	rc, log, err := r.GetRancherAPIResources(cluster)
+	if err != nil {
+		r.Log.Infof("Failed getting rancher api resources")
+		return ctrl.Result{}, err
+	}
+
+	clusterID := getClusterID(ctx, r.Client, cluster)
+	registryYaml, clusterID, registryErr := vmc.RegisterManagedClusterWithRancher(rc, cluster.GetName(), clusterID, log)
+	// persist the cluster ID, if present, even if the registry yaml was not returned
+	err = persistClusterStatus(ctx, r.Client, cluster, r.Log, clusterID, registrationRetrieved)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// handle registry failure error
+	if registryErr != nil {
+		r.Log.Error(err, "failed to obtain registration manifest from Rancher")
+		return ctrl.Result{}, registryErr
+	}
+	// it appears that in some circumstances the registry yaml may be empty so need to re-queue to re-attempt retrieval
+	if len(registryYaml) == 0 {
+		return vzctrl.ShortRequeue(), nil
+	}
+
+	// apply registration yaml to managed cluster
+	yamlApplier := k8sutil.NewYAMLApplier(workloadClient, "")
+	err = yamlApplier.ApplyS(registryYaml)
+	if err != nil {
+		r.Log.Infof("Failed applying Rancher registration yaml in workload cluster")
+		return ctrl.Result{}, err
+	}
+
+	// get and label the cattle-system namespace
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: common.CattleSystem}}
+	if _, err := ctrl.CreateOrUpdate(context.TODO(), workloadClient, ns, func() error {
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		ns.Labels[constants.LabelVerrazzanoNamespace] = common.CattleSystem
+		return nil
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	err = persistClusterStatus(ctx, r.Client, cluster, r.Log, clusterID, registrationInitiated)
+	if err != nil {
+		r.Log.Infof("Failed to perist cluster status")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/cluster-operator/controllers/capi/verrazzano.go
+++ b/cluster-operator/controllers/capi/verrazzano.go
@@ -28,7 +28,7 @@ type VerrazzanoRegistration struct {
 
 // doReconcile performs the reconciliation of the CAPI cluster to register it with Verrazzano
 func (v *VerrazzanoRegistration) doReconcile(ctx context.Context, cluster *unstructured.Unstructured) (ctrl.Result, error) {
-	v.Log.Infof("Registering cluster %s with Verrazzano", cluster.GetName())
+	v.Log.Debugf("Registering cluster %s with Verrazzano", cluster.GetName())
 	workloadClient, err := getWorkloadClusterClient(v.Client, v.Log, cluster)
 	if err != nil {
 		v.Log.Errorf("Error getting workload cluster %s client: %v", cluster.GetName(), err)
@@ -38,7 +38,7 @@ func (v *VerrazzanoRegistration) doReconcile(ctx context.Context, cluster *unstr
 	// ensure Verrazzano is installed and ready in workload cluster
 	ready, err := v.isVerrazzanoReady(ctx, workloadClient)
 	if !ready {
-		v.Log.Infof("Verrazzano not installed or not ready in cluster %s", cluster.GetName())
+		v.Log.Debugf("Verrazzano not installed or not ready in cluster %s", cluster.GetName())
 		return vzctrl.LongRequeue(), err
 	}
 
@@ -109,7 +109,7 @@ func (v *VerrazzanoRegistration) doReconcile(ctx context.Context, cluster *unstr
 	yamlApplier := k8sutil.NewYAMLApplier(workloadClient, "")
 	err = yamlApplier.ApplyS(string(manifest))
 	if err != nil {
-		v.Log.Infof("Failed applying cluster manifest to workload cluster %s", cluster.GetName())
+		v.Log.Errorf("Failed applying cluster manifest to workload cluster %s", cluster.GetName())
 		return ctrl.Result{}, err
 	}
 
@@ -238,7 +238,7 @@ func UnregisterVerrazzanoCluster(ctx context.Context, v *VerrazzanoRegistration,
 	yamlApplier := k8sutil.NewYAMLApplier(workloadClient, "")
 	err = yamlApplier.DeleteS(string(manifest))
 	if err != nil {
-		v.Log.Infof("Failed deleting resources of cluster manifest from workload cluster %s", cluster.GetName())
+		v.Log.Errorf("Failed deleting resources of cluster manifest from workload cluster %s", cluster.GetName())
 		return err
 	}
 

--- a/cluster-operator/controllers/capi/verrazzano.go
+++ b/cluster-operator/controllers/capi/verrazzano.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package capi
+
+import (
+	"context"
+	"fmt"
+	clustersv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
+	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzctrl "github.com/verrazzano/verrazzano/pkg/controller"
+	"github.com/verrazzano/verrazzano/pkg/k8sutil"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type VerrazzanoRegistration struct {
+	client.Client
+	Log *zap.SugaredLogger
+}
+
+func (v *VerrazzanoRegistration) doReconcile(ctx context.Context, cluster *unstructured.Unstructured) (ctrl.Result, error) {
+	workloadClient, err := getWorkloadClusterClient(v.Client, v.Log, cluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// ensure Verrazzano is installed and ready in workload cluster
+	ready, err := v.isVerrazzanoReady(ctx, workloadClient)
+	if !ready {
+		return vzctrl.ShortRequeue(), err
+	}
+
+	// if verrazzano-tls-ca exists, the cluster is untrusted
+	err = workloadClient.Get(ctx, types.NamespacedName{Name: constants.PrivateCABundle,
+		Namespace: constants.VerrazzanoSystemNamespace}, &v1.Secret{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// need to create a CA secret in admin cluster
+
+			// get the workload cluster API CA cert
+			caCrt, err := v.getWorkloadClusterCACert(workloadClient)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			// persist the workload API certificate on the admin cluster
+			adminWorkloadCertSecret := &v1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("ca-secret-%s", cluster.GetName()),
+				Namespace: constants.VerrazzanoMultiClusterNamespace}}
+			if _, err := ctrl.CreateOrUpdate(context.TODO(), workloadClient, adminWorkloadCertSecret, func() error {
+				if len(adminWorkloadCertSecret.Data) == 0 {
+					adminWorkloadCertSecret.Data = make(map[string][]byte)
+				}
+				adminWorkloadCertSecret.Data["cacrt"] = caCrt
+
+				return nil
+			}); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return vzctrl.ShortRequeue(), err
+	}
+	// obtain the API endpoint IP address for the admin cluster
+	err = v.createAdminAccessConfigMap(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// create the VMC if it does not exist
+	vmc, err := v.createWorkloadClusterVMC(ctx, cluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// wait for VMC status to indicate the VMC is ready
+	existingVMC := &clustersv1alpha1.VerrazzanoManagedCluster{}
+	err = v.Get(ctx, types.NamespacedName{Namespace: vmc.Namespace, Name: vmc.Name}, existingVMC)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	for _, condition := range existingVMC.Status.Conditions {
+		if condition.Type == clustersv1alpha1.ConditionReady && condition.Status != v1.ConditionTrue {
+			return vzctrl.ShortRequeue(), nil
+		}
+	}
+
+	manifest, err := v.getClusterManifest(workloadClient, cluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// apply the manifest to workload cluster
+	yamlApplier := k8sutil.NewYAMLApplier(workloadClient, "")
+	err = yamlApplier.ApplyS(string(manifest))
+	if err != nil {
+		v.Log.Infof("Failed applying cluster manifest to workload cluster %s", cluster.GetName())
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (v *VerrazzanoRegistration) createWorkloadClusterVMC(ctx context.Context, cluster *unstructured.Unstructured) (*clustersv1alpha1.VerrazzanoManagedCluster, error) {
+	vmc := &clustersv1alpha1.VerrazzanoManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.GetName(),
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+		Spec: clustersv1alpha1.VerrazzanoManagedClusterSpec{
+			CASecret:    fmt.Sprintf("ca-secret-%s", cluster.GetName()),
+			Description: fmt.Sprintf("%s VerrazzanoManagedCluster Resource", cluster.GetName()),
+		},
+	}
+	if err := v.Create(ctx, vmc); err != nil {
+		if !errors.IsAlreadyExists(err) {
+			v.Log.Errorf("Unable to create VMC with name %s: %v", cluster.GetName(), err)
+			return nil, err
+		}
+		v.Log.Debugf("VMC %s already exists", cluster.GetName())
+	} else {
+		v.Log.Infof("Created VMC for cluster %s", cluster.GetName())
+	}
+	return vmc, nil
+}
+
+func (v *VerrazzanoRegistration) createAdminAccessConfigMap(ctx context.Context) error {
+	ep := &v1.Endpoints{}
+	if err := v.Get(ctx, types.NamespacedName{Name: "kubernetes"}, ep); err != nil {
+		return err
+	}
+	apiServerIP := ep.Subsets[0].Addresses[0].IP
+
+	// create the admin server IP config map
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "verrazzano-admin-cluster",
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+	}
+	if _, err := ctrl.CreateOrUpdate(ctx, v.Client, cm, func() error {
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
+		cm.Data["server"] = apiServerIP
+
+		return nil
+	}); err != nil {
+		v.Log.Errorf("Failed to create the Verrazzano admin cluster config map: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (v *VerrazzanoRegistration) getWorkloadClusterCACert(workloadClient client.Client) ([]byte, error) {
+	caCrtSecret := &v1.Secret{}
+	err := workloadClient.Get(context.TODO(), types.NamespacedName{
+		Name:      constants.VerrazzanoIngressTLSSecret,
+		Namespace: constants.VerrazzanoSystemNamespace},
+		caCrtSecret)
+	if err != nil {
+		return nil, err
+	}
+	caCrt, ok := caCrtSecret.Data["ca.crt"]
+	if !ok {
+		return nil, fmt.Errorf("Workload cluster CA certificate not found in verrazzano-tls secret")
+	}
+	return caCrt, nil
+}
+
+func (v *VerrazzanoRegistration) isVerrazzanoReady(ctx context.Context, workloadClient client.Client) (bool, error) {
+	if err := workloadClient.Get(ctx,
+		types.NamespacedName{Name: constants.Verrazzano, Namespace: constants.VerrazzanoSystemNamespace},
+		&v1.Secret{}); err != nil {
+		if !errors.IsNotFound(err) {
+			v.Log.Debugf("Failed to retrieve verrazzano secret: %v", err)
+			return false, err
+		}
+		v.Log.Debugf("Verrazzano secret not found")
+		return false, nil
+	}
+	return true, nil
+}
+
+func (v *VerrazzanoRegistration) getClusterManifest(workloadClient client.Client, cluster *unstructured.Unstructured) ([]byte, error) {
+	// retrieve the manifest for the workload cluster
+	manifestSecret := &v1.Secret{}
+	err := workloadClient.Get(context.TODO(), types.NamespacedName{
+		Name:      fmt.Sprintf("verrazzano-cluster-%s-manifest", cluster.GetName()),
+		Namespace: constants.VerrazzanoMultiClusterNamespace},
+		manifestSecret)
+	if err != nil {
+		return nil, err
+	}
+	manifest, ok := manifestSecret.Data["yaml"]
+	if !ok {
+		return nil, fmt.Errorf("Error retrieving cluster manifest for %s", cluster.GetName())
+	}
+	return manifest, nil
+}
+
+// UnregisterRancherCluster performs the operations required to de-register the cluster from Rancher
+func UnregisterVerrazzanoCluster(ctx context.Context, v *VerrazzanoRegistration, cluster *unstructured.Unstructured) error {
+	workloadClient, err := getWorkloadClusterClient(v.Client, v.Log, cluster)
+	if err != nil {
+		return err
+	}
+	// get the list of cluster related resources
+	manifest, err := v.getClusterManifest(workloadClient, cluster)
+	if err != nil {
+		return err
+	}
+
+	// remove the VMC
+	vmc := &clustersv1alpha1.VerrazzanoManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.GetName(),
+			Namespace: constants.VerrazzanoMultiClusterNamespace,
+		},
+	}
+	err = v.Delete(ctx, vmc)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			v.Log.Infof("VMC for cluster %s not found - nothing to do", cluster.GetName())
+		}
+		return err
+	}
+
+	// remove the resources from workload cluster
+	yamlApplier := k8sutil.NewYAMLApplier(workloadClient, "")
+	err = yamlApplier.DeleteS(string(manifest))
+	if err != nil {
+		v.Log.Infof("Failed deleting resources of cluster manifest from workload cluster %s", cluster.GetName())
+		return err
+	}
+
+	return nil
+}

--- a/cluster-operator/controllers/vmc/sync_registration_secret.go
+++ b/cluster-operator/controllers/vmc/sync_registration_secret.go
@@ -234,7 +234,7 @@ func (r *VerrazzanoManagedClusterReconciler) getAdminCaBundle() ([]byte, error) 
 		// Combine the two CA bundles
 		tlsCABundle := optSecret.Data[constants.RancherTLSCAKey]
 		if len(tlsCABundle) > 0 {
-			r.log.Infof("Adding tls-ca bundle to Admin CA bundle")
+			r.log.Debugf("Adding tls-ca bundle to Admin CA bundle")
 			caBundle = tlsCABundle
 		}
 	}
@@ -250,7 +250,7 @@ func (r *VerrazzanoManagedClusterReconciler) getAdminCaBundle() ([]byte, error) 
 			r.log.Infof("Adding ingress CA cert bundle to Admin CA bundle")
 			caBundle = append(caBundle, tlsIngressCA...)
 		} else {
-			r.log.Infof("ingress CA bundle already present in bundle data, skipping")
+			r.log.Debugf("ingress CA bundle already present in bundle data, skipping")
 		}
 	}
 

--- a/cluster-operator/internal/operatorinit/run_operator.go
+++ b/cluster-operator/internal/operatorinit/run_operator.go
@@ -111,12 +111,24 @@ func StartClusterOperator(log *zap.SugaredLogger, props Properties) error {
 
 	// only start the CAPI cluster controller if the clusters CRD is installed and the controller is enabled
 	if capiCrdInstalled && !props.DisableCAPIRancherRegistration {
-		log.Infof("Starting CAPI Cluster controller")
-		if err = (&capi.CAPIClusterReconciler{
+		rancherRegistration := &capi.RancherRegistration{
 			Client:             mgr.GetClient(),
 			Log:                log,
-			Scheme:             mgr.GetScheme(),
 			RancherIngressHost: props.IngressHost,
+		}
+		vzRegistration := &capi.VerrazzanoRegistration{
+			Client: mgr.GetClient(),
+			Log:    log,
+		}
+		log.Infof("Starting CAPI Cluster controller")
+		if err = (&capi.CAPIClusterReconciler{
+			Client:              mgr.GetClient(),
+			Log:                 log,
+			Scheme:              mgr.GetScheme(),
+			RancherRegistrar:    rancherRegistration,
+			RancherIngressHost:  props.IngressHost,
+			RancherEnabled:      crdInstalled,
+			VerrazzanoRegistrar: vzRegistration,
 		}).SetupWithManager(mgr); err != nil {
 			log.Errorf("Failed to create CAPI cluster controller: %v", err)
 			os.Exit(1)

--- a/pkg/k8sutil/apply_yaml.go
+++ b/pkg/k8sutil/apply_yaml.go
@@ -113,7 +113,7 @@ func (y *YAMLApplier) ApplyF(filePath string) error {
 	return y.doFileAction(filePath, y.applyAction)
 }
 
-// ApplyB applies a spec to Kubernetes via a byte slice
+// ApplyS applies a spec to Kubernetes via a string
 func (y *YAMLApplier) ApplyS(spec string) error {
 	return y.doStringAction(spec, y.applyAction)
 }
@@ -140,6 +140,11 @@ func (y *YAMLApplier) ApplyFTDefaultConfig(filePath string, args any) error {
 // DeleteF deletes a file spec from Kubernetes
 func (y *YAMLApplier) DeleteF(filePath string) error {
 	return y.doFileAction(filePath, y.deleteAction)
+}
+
+// DeleteS deletes resources in a spec from Kubernetes via a string
+func (y *YAMLApplier) DeleteS(spec string) error {
+	return y.doStringAction(spec, y.deleteAction)
 }
 
 // DeleteFWithDependents deletes a file spec from Kubernetes along with other dependent objects in the background

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
@@ -66,6 +66,7 @@ rules:
     resources:
       - serviceaccounts
       - configmaps
+      - endpoints
       - secrets
       - services
       - pods/exec


### PR DESCRIPTION
- Refactored CAPI cluster controller to process either Rancher or VZ registration
- Created VZ registration code
- Some modifications to existing VMC/MC code