### PR TITLE
VZ-10706 VPO-modules fix 1.4 upgrade

### DIFF
--- a/platform-operator/experimental/controllers/module/component-handler/upgrade/upgrade_handler.go
+++ b/platform-operator/experimental/controllers/module/component-handler/upgrade/upgrade_handler.go
@@ -31,17 +31,9 @@ func (h ComponentHandler) GetWorkName() string {
 
 // IsWorkNeeded returns true if upgrade is needed
 func (h ComponentHandler) IsWorkNeeded(ctx handlerspi.HandlerContext) (bool, result.Result) {
-	compCtx, comp, err := common.GetComponentAndContext(ctx, constants.UpgradeOperation)
-	if err != nil {
-		return false, result.NewResultShortRequeueDelayWithError(err)
-	}
-
-	installed, err := comp.IsInstalled(compCtx)
-	if err != nil {
-		ctx.Log.ErrorfThrottled("Error checking if Helm release installed for %s/%s", ctx.HelmRelease.Namespace, ctx.HelmRelease.Name)
-		return true, result.NewResult()
-	}
-	return installed, result.NewResult()
+	module := ctx.CR.(*moduleapi.Module)
+	needUpgrade := module.Spec.Version != "" && (module.Spec.Version != module.Status.LastSuccessfulVersion)
+	return needUpgrade, result.NewResult()
 }
 
 // CheckDependencies checks if the dependencies are ready


### PR DESCRIPTION
Fix module shim "IsWorkNeeded" method for upgrade.  Compare the spec version to the status version.  This bug was causing the VZ to never reach upgrade complete 

