### PR TITLE
Have Rancher wait for webhook to be updated

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -308,9 +308,9 @@ func (c clusterAPIComponent) Upgrade(ctx spi.ComponentContext) error {
 		}
 
 		// delete the RBAC resources that Rancher puts finalizers on and keep requeuing until they're gone
-		if err = deleteRBACComponents(ctx, components); err != nil {
-			return err
-		}
+		//if err = deleteRBACComponents(ctx, components); err != nil {
+		//	return err
+		//}
 
 		// then apply the upgrade
 		return capiClient.ApplyUpgrade(applyUpgradeOptions)

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -301,11 +301,11 @@ func (c clusterAPIComponent) Upgrade(ctx spi.ComponentContext) error {
 	}
 	if isUpgradeOptionsNotEmpty(applyUpgradeOptions) {
 		// get all the resource that will be deleted and recreated
-		components, err := getComponentsToUpgrade(capiClient, applyUpgradeOptions)
-		if err != nil {
-			ctx.Log().ErrorfThrottled("Error generating cluster-api provider components to be upgraded")
-			return err
-		}
+		//components, err := getComponentsToUpgrade(capiClient, applyUpgradeOptions)
+		//if err != nil {
+		//	ctx.Log().ErrorfThrottled("Error generating cluster-api provider components to be upgraded")
+		//	return err
+		//}
 
 		// delete the RBAC resources that Rancher puts finalizers on and keep requeuing until they're gone
 		//if err = deleteRBACComponents(ctx, components); err != nil {

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -13,6 +13,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	vpoconstants "github.com/verrazzano/verrazzano/platform-operator/constants"
 	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/rancher"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
@@ -109,7 +110,7 @@ func (c clusterAPIComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.V
 
 // GetDependencies returns the dependencies of this component.
 func (c clusterAPIComponent) GetDependencies() []string {
-	return []string{cmconstants.CertManagerComponentName, cmconstants.ClusterIssuerComponentName}
+	return []string{cmconstants.CertManagerComponentName, cmconstants.ClusterIssuerComponentName, rancher.ComponentName}
 }
 
 // IsReady indicates whether a component is Ready for dependency components.

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -823,7 +823,7 @@ func isRancherWebhookImageUpToDate(ctx spi.ComponentContext) bool {
 		return false
 	}
 
-	var deployment *appsv1.Deployment
+	deployment := &appsv1.Deployment{}
 	err = ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: ComponentNamespace, Name: rancherWebhookDeployment}, deployment)
 	if err != nil {
 		ctx.Log().ErrorfThrottled("Failed to get the rancher-webhook deployment: %v", err)

--- a/platform-operator/controllers/verrazzano/component/rancher/rancher.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/rancher.go
@@ -9,6 +9,8 @@ import (
 	"encoding/base32"
 	"encoding/base64"
 	"fmt"
+	"github.com/verrazzano/verrazzano/pkg/bom"
+	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"reflect"
 	"strings"
 	"time"
@@ -305,7 +307,8 @@ func (r rancherComponent) isRancherReady(ctx spi.ComponentContext) bool {
 	log := ctx.Log()
 	c := ctx.Client()
 	prefix := fmt.Sprintf("Component %s", ctx.GetComponent())
-	return ready.DeploymentsAreReady(log, c, r.AvailabilityObjects.DeploymentNames, 1, prefix)
+	return ready.DeploymentsAreReady(log, c, r.AvailabilityObjects.DeploymentNames, 1, prefix) &&
+		isRancherWebhookImageUpToDate(ctx)
 }
 
 // chartsNotUpdatedWorkaround - workaround for VZ-7053, where some of the Helm charts are not
@@ -794,4 +797,38 @@ func getRancherLogoContentWithRetry(log vzlog.VerrazzanoLogger, cli kubernetes.I
 	})
 
 	return logoContent, err
+}
+
+func isRancherWebhookImageUpToDate(ctx spi.ComponentContext) bool {
+	bomFile, err := bom.NewBom(config.GetDefaultBOMFilePath())
+	if err != nil {
+		ctx.Log().Errorf("Failed to get the bom file for the Rancher webhook image: %v", err)
+		return false
+	}
+
+	subcomponent, err := bomFile.GetSubcomponent(rancherImageSubcomponent)
+	if err != nil {
+		ctx.Log().Errorf("Failed to get the subcomponent %s from the bom: %v", rancherImageSubcomponent, err)
+		return false
+	}
+
+	var webhookImageTag string
+	for _, image := range subcomponent.Images {
+		if strings.Contains(image.ImageName, "rancher-webhook") {
+			webhookImageTag = image.ImageTag
+		}
+	}
+	if webhookImageTag == "" {
+		ctx.Log().Errorf("Failed to find rancher webhook image tag in the bom")
+		return false
+	}
+
+	var deployment *appsv1.Deployment
+	err = ctx.Client().Get(context.TODO(), types.NamespacedName{Namespace: ComponentNamespace, Name: rancherWebhookDeployment}, deployment)
+	if err != nil {
+		ctx.Log().ErrorfThrottled("Failed to get the rancher-webhook deployment: %v", err)
+		return false
+	}
+
+	return strings.Contains(deployment.Spec.Template.Spec.Containers[0].Image, webhookImageTag)
 }


### PR DESCRIPTION
This change makes isRancherReady wait for the Rancher webhook deployment to be updated with the latest image. This means that Rancher will now be fully ready when it finished upgrading and it fixes the CAPI upgrade issue that's caused by the Rancher finalizer. As part of this change I rolled back the previous CAPI fix I added to Rancher.