### PR TITLE
VZ-10568, VZ-10275: Update ArgoCD, Redis, Keycloak and Rancher additional images in release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -155,15 +155,15 @@
             },
             {
               "image": "rancher-fleet-agent",
-              "tag": "v0.6.0-20230503174321-22d5a53"
+              "tag": "v0.6.0-20230919045803-22d5a53"
             },
             {
               "image": "rancher-fleet",
-              "tag": "v0.6.0-20230503174321-22d5a53"
+              "tag": "v0.6.0-20230919045803-22d5a53"
             },
             {
               "image": "rancher-gitjob",
-              "tag": "v0.1.30-20230505115129-1dd0ea0"
+              "tag": "v0.1.30-20230919050310-1dd0ea0"
             },
             {
               "image": "rancher-cleanup",
@@ -449,7 +449,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "v20.0.1-20230529051244-228d40b314",
+              "tag": "v20.0.1-20230919161553-c397f447f5",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -758,7 +758,7 @@
           "images": [
             {
               "image": "argocd",
-              "tag": "v2.7.2-20230523142723-fc41216e",
+              "tag": "v2.7.2-20230919043605-fc41216e",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -770,7 +770,7 @@
           "images": [
             {
               "image": "redis",
-              "tag": "v6.2.7-20230516204818-26c8b963",
+              "tag": "v6.2.7-20230919040640-26c8b963",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
This change -
1. Refreshes rancher-fleet, rancher-fleet-agent and rancher-gitjob images in release-1.6
2. Backports https://github.com/verrazzano/verrazzano/pull/7077 and https://github.com/verrazzano/verrazzano/pull/7072 to release-1.6
