### PR TITLE
VZ-10568, VZ-10275: Update ArgoCD, Redis and Keycloak images in release-1.6

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -569,7 +569,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "v20.0.1-20230529051244-228d40b314",
+              "tag": "v20.0.1-20230919161553-c397f447f5",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -884,7 +884,7 @@
           "images": [
             {
               "image": "argocd",
-              "tag": "v2.7.2-20230601094358-fc41216e",
+              "tag": "v2.7.2-20230919043605-fc41216e",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -896,7 +896,7 @@
           "images": [
             {
               "image": "redis",
-              "tag": "v6.2.7-20230601100836-26c8b963",
+              "tag": "v6.2.7-20230919040640-26c8b963",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
This change backports https://github.com/verrazzano/verrazzano/pull/7072 and https://github.com/verrazzano/verrazzano/pull/7077 to release-1.6