### PR TITLE
VZ-11001: Create ClusterIssuer to issue the opensearch self signed certificates

### DIFF
--- a/platform-operator/thirdparty/charts/opensearch-operator/templates/verrazzano/opensearch-certificate.yaml
+++ b/platform-operator/thirdparty/charts/opensearch-operator/templates/verrazzano/opensearch-certificate.yaml
@@ -2,6 +2,40 @@
 # Create certificates to be used by OpenSearch cluster with Verrazzano CA
 # Required for the security plugin in OpenSearch
 
+# Create a selfsigned Issuer in order to create a root CA certificate for
+# signing certificates required for the security plugin in OpenSearch.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.openSearchCluster.name }}-self-signed-issuer
+  namespace: cert-manager
+spec:
+  selfSigned: {}
+---
+# Generate a CA Certificate used to sign certificates required for the security plugin in OpenSearch.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.openSearchCluster.name }}-ca-cert
+  namespace: cert-manager
+spec:
+  secretName: {{ .Values.openSearchCluster.name }}-ca-cert
+  duration: 2160h0m0s
+  renewBefore: 360h0m0s
+  issuerRef:
+    name: {{ .Values.openSearchCluster.name }}-self-signed-issuer
+  commonName: "ca.opensearch"
+  isCA: true
+---
+# Create an ClusterIssuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ .Values.openSearchCluster.name }}-root-issuer
+spec:
+  ca:
+    secretName: {{ .Values.openSearchCluster.name }}-ca-cert
+---
 # Certificate name and secret name are kept same and will be generated based on openSearchCluster.name variable
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -26,7 +60,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: verrazzano-cluster-issuer
+    name: {{ .Values.openSearchCluster.name }}-root-issuer
 status: {}
 ---
 apiVersion: cert-manager.io/v1
@@ -57,7 +91,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: verrazzano-cluster-issuer
+    name: {{ .Values.openSearchCluster.name }}-root-issuer
 status: {}
 ---
 apiVersion: cert-manager.io/v1
@@ -89,7 +123,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: verrazzano-cluster-issuer
+    name: {{ .Values.openSearchCluster.name }}-root-issuer
 status: {}
 ---
 apiVersion: cert-manager.io/v1
@@ -120,7 +154,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: verrazzano-cluster-issuer
+    name: {{ .Values.openSearchCluster.name }}-root-issuer
 status: {}
 ---
 apiVersion: cert-manager.io/v1
@@ -146,5 +180,5 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: verrazzano-cluster-issuer
+    name: {{ .Values.openSearchCluster.name }}-root-issuer
 status: {}


### PR DESCRIPTION
Earlier, we were using `verrazzano-cluster-issuer` to issue the certificates required for the internal communication among Opensearch Nodes. As` verrazzano-cluster-issuer` ClusterIssuer could be CA or ACME depending on the Verrazzano CR, we need a separate Issuer for Opensearch Certificates. The reason being, ClusterIssuer type ACME will not accept the Certificate Request for Opensearch certificates as in those Cert request, k8s service DNS are being mentioned as DNS. So we need an other issuer that will be always CA type to sign the Opensearch certs.

Changes:

- `opensearch-self-signed-issuer` Issuer will be created in cert-manager namespace to bootstrap the CA.
-` opensearch-ca-cert`CA  Certitifcate in  cert-manager namespace that will be used to create CA Issuer.
- `opensearch-root-issuer` CA ClusterIssuer that will sign the Opensearch certificates. ClusterIssuer is being created in this PR instead of Issuer, because it needs to sign the certificates from `verrazzano-logging` and `verrazzano-monitoring` namespace.


Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
