### PR TITLE
vz-11038 Some Trivy JSON not handled correctly when converting to CSV

### DIFF
--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -16,6 +16,12 @@ pipeline {
         }
     }
 
+    parameters {
+        booleanParam (name: 'TEST_RUN',
+            description: 'Indicate whether this is a TEST run, which will do some stuff but will not try uploading anything, ignored for master/release-* runs',
+            defaultValue: true)
+    }
+
     triggers { cron("@daily") }
 
     environment {
@@ -96,10 +102,12 @@ pipeline {
     post {
         success {
             script {
-                build job: '/upload-scan-report', parameters: [
-                    string(name: 'UPSTREAM_JOB', value: "${env.JOB_NAME}"),
-                    string(name: 'UPSTREAM_BUILD', value: "${env.BUILD_NUMBER}")
-                ], propagate: false, wait: false
+                if (env.BRANCH_NAME == "master" || env.BRANCH_NAME ==~ "release-.*" || params.TEST_RUN == false) {
+                    build job: '/upload-scan-report', parameters: [
+                        string(name: 'UPSTREAM_JOB', value: "${env.JOB_NAME}"),
+                        string(name: 'UPSTREAM_BUILD', value: "${env.BUILD_NUMBER}")
+                    ], propagate: false, wait: false
+                }
             }
         }
     }

--- a/release/scripts/scan_bom_images.sh
+++ b/release/scripts/scan_bom_images.sh
@@ -81,7 +81,7 @@ function scan_images_in_bom() {
 
     echo "performing trivy scan for $SCAN_IMAGE"
     trivy image -f json -o ${RESULT_FILE_PREFIX}-trivy-details.json ${SCAN_IMAGE} 2> ${RESULT_FILE_PREFIX}-trivy.err || echo "trivy scan failed for $SCAN_IMAGE"
-    cat ${RESULT_FILE_PREFIX}-trivy-details.json | jq -r '.Results[].Vulnerabilities[] | { sev: .Severity, cve: ."VulnerabilityID", description: .Description } ' | sed 's/\\[nt]/ /g' | jq -r '[.[]] | @csv' | sort -u > ${RESULT_FILE_PREFIX}-trivy-details.csv
+    cat ${RESULT_FILE_PREFIX}-trivy-details.json | jq -r '.Results[]' | sed 's/null//g' | jq -r '.Vulnerabilities' | sed 's/null//g' | jq -r ' .[] | { sev: .Severity, cve: ."VulnerabilityID", description: .Description } ' | sed 's/\\[nt]/ /g' | jq -r '[.[]] | @csv' | sort -u > ${RESULT_FILE_PREFIX}-trivy-details.csv
 
     echo "performing grype scan for $BOM_IMAGE"
     grype ${SCAN_IMAGE} -o json > ${RESULT_FILE_PREFIX}-grype-details.json 2> ${RESULT_FILE_PREFIX}-grype.err || echo "grype scan failed for $SCAN_IMAGE"

--- a/release/scripts/scan_bom_images.sh
+++ b/release/scripts/scan_bom_images.sh
@@ -81,7 +81,13 @@ function scan_images_in_bom() {
 
     echo "performing trivy scan for $SCAN_IMAGE"
     trivy image -f json -o ${RESULT_FILE_PREFIX}-trivy-details.json ${SCAN_IMAGE} 2> ${RESULT_FILE_PREFIX}-trivy.err || echo "trivy scan failed for $SCAN_IMAGE"
-    cat ${RESULT_FILE_PREFIX}-trivy-details.json | jq -r '.Results[]' | sed 's/null//g' | jq -r '.Vulnerabilities' | sed 's/null//g' | jq -r ' .[] | { sev: .Severity, cve: ."VulnerabilityID", description: .Description } ' | sed 's/\\[nt]/ /g' | jq -r '[.[]] | @csv' | sort -u > ${RESULT_FILE_PREFIX}-trivy-details.csv
+    # Check if any Results section was included or not, only convert to CSV if there are Results there
+    results_size=$(cat ${RESULT_FILE_PREFIX}-trivy-details.json |  jq '.Results' | wc -l)
+    if [[ results_size -gt 1 ]]; then
+      cat ${RESULT_FILE_PREFIX}-trivy-details.json | jq -r '.Results[]' | sed 's/null//g' | jq -r '.Vulnerabilities' | sed 's/null//g' | jq -r ' .[] | { sev: .Severity, cve: ."VulnerabilityID", description: .Description } ' | sed 's/\\[nt]/ /g' | jq -r '[.[]] | @csv' | sort -u > ${RESULT_FILE_PREFIX}-trivy-details.csv
+    else
+      echo "No Results section found in ${RESULT_FILE_PREFIX}-trivy-details.json, so no need to generate CSV for it"
+    fi
 
     echo "performing grype scan for $BOM_IMAGE"
     grype ${SCAN_IMAGE} -o json > ${RESULT_FILE_PREFIX}-grype-details.json 2> ${RESULT_FILE_PREFIX}-grype.err || echo "grype scan failed for $SCAN_IMAGE"


### PR DESCRIPTION
This:

- fixes issue where one or more null result entries are included for Trivy JSON Results, these will not prevent CVE results from being seen (original issue)
- Will skip converting Trivy JSON to csv if there are no Results at all
- Added param to allow user branches to test the scan without uploading it TEST_RUN, defaults to that for user branches, master/release-* ignore that and always upload
