### PR TITLE
VZ-10805.  Fix CM on uninstall with modules enabled

### DIFF
--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager.go
@@ -254,7 +254,7 @@ func cleanupLeaderElectionResources(compContext spi.ComponentContext) error {
 	return nil
 }
 
-// checkOrphanedResources Checks that the leader-election resources in kube-system are successfully deleted; returns
+// verifyLeaderElectionResourcesDeleted Checks that the leader-election resources in kube-system are successfully deleted; returns
 // a retryable error if the resource still exists
 func verifyLeaderElectionResourcesDeleted(ctx spi.ComponentContext) error {
 	for _, resource := range leaderElectionSystemResources {

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager.go
@@ -6,10 +6,16 @@ package certmanager
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
+	spi2 "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"io"
+	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
@@ -41,8 +47,10 @@ const (
 	acmeSolverArg = "--acme-http01-solver-image="
 
 	// Uninstall resources
-	controllerConfigMap = "cert-manager-controller"
-	caInjectorConfigMap = "cert-manager-cainjector-leader-election"
+	controllerConfigMap          = "cert-manager-controller"
+	caInjectorConfigMap          = "cert-manager-cainjector-leader-election"
+	caInjectorLeaderElectionRole = "cert-manager-cainjector:leaderelection"
+	controllerLeaderElectionRole = "cert-manager:leaderelection"
 )
 
 const snippetSubstring = "rfc2136:\n"
@@ -75,6 +83,21 @@ var ociDNSSnippet = strings.Split(`ocidns:
   required:
     - ocizonename
   type: object`, "\n")
+
+// Defines a set of leader election resources that Cert-Manager creates that sometimes gets orphaned on uninstall,
+// possibly due to Rancher finalizers
+var leaderElectionSystemResources = []struct {
+	client.ObjectKey
+	obj client.Object
+}{
+	{types.NamespacedName{Name: controllerConfigMap, Namespace: constants.KubeSystem}, &v1.ConfigMap{}},
+	{types.NamespacedName{Name: caInjectorConfigMap, Namespace: constants.KubeSystem}, &v1.ConfigMap{}},
+	{types.NamespacedName{Name: caInjectorLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.RoleBinding{}},
+	{types.NamespacedName{Name: caInjectorLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.Role{}},
+	{types.NamespacedName{Name: caInjectorLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.RoleBinding{}},
+	{types.NamespacedName{Name: controllerLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.Role{}},
+	{types.NamespacedName{Name: controllerLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.RoleBinding{}},
+}
 
 // CertIssuerType identifies the certificate issuer type
 type CertIssuerType string
@@ -214,33 +237,53 @@ func createSnippetWithPadding(padding string) []byte {
 	return []byte(builder.String())
 }
 
-// uninstallCertManager is the implementation for the cert-manager uninstall step
+// cleanupLeaderElectionResources is the implementation for the cert-manager uninstall step
 // this removes cert-manager ConfigMaps from the cluster and after the helm uninstall, deletes the namespace
-func uninstallCertManager(compContext spi.ComponentContext) error {
-	// Delete the kube-system cert-manager configMaps [controller, caInjector]
-	err := vzresource.Resource{
-		Name:      controllerConfigMap,
-		Namespace: constants.KubeSystem,
-		Client:    compContext.Client(),
-		Object:    &v1.ConfigMap{},
-		Log:       compContext.Log(),
-	}.Delete()
-	if err != nil {
-		return err
+func cleanupLeaderElectionResources(compContext spi.ComponentContext) error {
+	for _, resource := range leaderElectionSystemResources {
+		err := vzresource.Resource{
+			Name:      resource.Name,
+			Namespace: resource.Namespace,
+			Client:    compContext.Client(),
+			Object:    resource.obj,
+			Log:       compContext.Log(),
+		}.RemoveFinalizersAndDelete()
+		if err != nil {
+			return err
+		}
 	}
-
-	err = vzresource.Resource{
-		Name:      caInjectorConfigMap,
-		Namespace: constants.KubeSystem,
-		Client:    compContext.Client(),
-		Object:    &v1.ConfigMap{},
-		Log:       compContext.Log(),
-	}.Delete()
-	if err != nil {
-		return err
-	}
-
 	return nil
+}
+
+// checkOrphanedResources Checks that the leader-election resources in kube-system are successfully deleted; returns
+// a retryable error if the resource still exists
+func verifyLeaderElectionResourcesDeleted(ctx spi.ComponentContext) error {
+	for _, resource := range leaderElectionSystemResources {
+		exists, err := resourceExists(ctx.Client(), resource.ObjectKey, resource.obj)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return spi2.RetryableError{
+				Source: ComponentName,
+			}
+		}
+		ctx.Log().Progressf("Verified that resource %s has been successfully deleted", resource.ObjectKey)
+	}
+	return nil
+}
+
+// resourceExists checks if the specified Object still exists in the cluster; returns true/nil if the object exists,
+// false/nil if not
+func resourceExists(cli client.Client, key client.ObjectKey, obj client.Object) (bool, error) {
+	err := cli.Get(context.TODO(), key, obj)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // GetOverrides gets the install overrides

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager.go
@@ -94,9 +94,8 @@ var leaderElectionSystemResources = []struct {
 	{types.NamespacedName{Name: caInjectorConfigMap, Namespace: constants.KubeSystem}, &v1.ConfigMap{}},
 	{types.NamespacedName{Name: caInjectorLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.RoleBinding{}},
 	{types.NamespacedName{Name: caInjectorLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.Role{}},
-	{types.NamespacedName{Name: caInjectorLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.RoleBinding{}},
-	{types.NamespacedName{Name: controllerLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.Role{}},
 	{types.NamespacedName{Name: controllerLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.RoleBinding{}},
+	{types.NamespacedName{Name: controllerLeaderElectionRole, Namespace: constants.KubeSystem}, &rbac.Role{}},
 }
 
 // CertIssuerType identifies the certificate issuer type

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager.go
@@ -8,18 +8,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	spi2 "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"io"
-	rbac "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
-	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 
 	"github.com/verrazzano/verrazzano/pkg/bom"
 	"github.com/verrazzano/verrazzano/pkg/constants"
+	vzerrors "github.com/verrazzano/verrazzano/pkg/controller/errors"
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	vzresource "github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -29,7 +24,12 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	v1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -264,7 +264,7 @@ func verifyLeaderElectionResourcesDeleted(ctx spi.ComponentContext) error {
 			return err
 		}
 		if exists {
-			return spi2.RetryableError{
+			return vzerrors.RetryableError{
 				Source: ComponentName,
 			}
 		}

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager_component.go
@@ -186,7 +186,10 @@ func (c certManagerComponent) PostUninstall(compContext spi.ComponentContext) er
 		compContext.Log().Debug("cert-manager PostUninstall dry run")
 		return nil
 	}
-	return uninstallCertManager(compContext)
+	if err := cleanupLeaderElectionResources(compContext); err != nil {
+		return err
+	}
+	return verifyLeaderElectionResourcesDeleted(compContext)
 }
 
 // MonitorOverrides checks whether monitoring of install overrides is enabled or not

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager_component.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager_component.go
@@ -6,6 +6,8 @@ package certmanager
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
@@ -25,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager_test.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/certmanager_test.go
@@ -257,7 +257,7 @@ func createClientFunc(caConfig vzapi.CA, cn string, otherObjs ...runtime.Object)
 }
 
 // TestUninstallCertManager tests the cert-manager uninstall process
-// GIVEN a call to uninstallCertManager
+// GIVEN a call to cleanupLeaderElectionResources
 // WHEN the objects exist in the cluster
 // THEN no error is returned and all objects are deleted
 func TestUninstallCertManager(t *testing.T) {
@@ -314,7 +314,7 @@ func TestUninstallCertManager(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(tt.objects...).Build()
 			fakeContext := spi.NewFakeContext(c, vz, nil, false, profileDir)
-			err := uninstallCertManager(fakeContext)
+			err := cleanupLeaderElectionResources(fakeContext)
 			assert.NoError(t, err)
 			// expect the controller ConfigMap to get deleted
 			err = c.Get(context.TODO(), types.NamespacedName{Name: controllerConfigMap, Namespace: constants.KubeSystem}, &v1.ConfigMap{})

--- a/platform-operator/experimental/controllers/module/component-handler/delete/delete_handler.go
+++ b/platform-operator/experimental/controllers/module/component-handler/delete/delete_handler.go
@@ -115,12 +115,12 @@ func (h ComponentHandler) IsWorkDone(ctx handlerspi.HandlerContext) (bool, resul
 		return false, result.NewResultShortRequeueDelayWithError(err)
 	}
 
-	installed, err := comp.IsInstalled(compCtx)
+	exists, err := comp.Exists(compCtx)
 	if err != nil {
-		ctx.Log.ErrorfThrottled("Error checking if Helm release installed for %s/%s", ctx.HelmRelease.Namespace, ctx.HelmRelease.Name)
-		return true, result.NewResult()
+		ctx.Log.ErrorfThrottled("Error checking if Helm release exists for %s/%s", ctx.HelmRelease.Namespace, ctx.HelmRelease.Name)
+		return false, result.NewResultShortRequeueDelayWithError(err)
 	}
-	return !installed, result.NewResult()
+	return !exists, result.NewResult()
 }
 
 // PostWorkUpdateStatus does the post-work status update


### PR DESCRIPTION
- Have Cert-Manager component clean up leader-election resources in kube-system on uninstall and wait for them to be deleted successfully
- Have the new delete handler use Exists() instead of IsInstalled() as trigger to do delete work
