### PR TITLE
VZ-8815: Migrate vz jenkins and private-registry jenkins jobs  to JAO

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ def VZ_BASE_IMAGE = ""
 def tarfilePrefix=""
 def storeLocation=""
 
-def agentLabel = env.JOB_NAME.contains('master') ? "phx-large" : "large"
+def agentLabel = env.JOB_NAME.contains('master') ? "2.0-large-phx" : "2.0-large"
 
 pipeline {
     options {

--- a/ci/private-registry/Jenkinsfile
+++ b/ci/private-registry/Jenkinsfile
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
-def agentLabel = params.DISTRIBUTION_VARIANT == "Lite" ? "phx-large" : "blocked-large"
+def agentLabel = params.DISTRIBUTION_VARIANT == "Lite" ? "2.0-large-phx" : "airgap-2.0-large"
 def ocirRegion = params.DISTRIBUTION_VARIANT == "Lite" ? "phx" : "fra"
 def ociRegionFull = params.DISTRIBUTION_VARIANT == "Lite" ? "us-phoenix-1" : "eu-frankfurt-1"
 def ocirRegistry = "${ocirRegion}.ocir.io"


### PR DESCRIPTION
This PR contains the changes to main verrazzano jenkinsfile and private-registry Jenkinsfile to upgrade the jenkins label to use the label for JAO
