### PR TITLE
Ensure module integration is on by default

### DIFF
--- a/platform-operator/internal/config/config_test.go
+++ b/platform-operator/internal/config/config_test.go
@@ -33,6 +33,7 @@ func TestConfigDefaults(t *testing.T) {
 	asserts.True(conf.WebhookValidationEnabled, "WebhookValidationEnabled is incorrect")
 	asserts.False(conf.CloudCredentialWatchEnabled, "CloudCredentialWatchEnabled is incorrect")
 	asserts.Equal(conf.VerrazzanoRootDir, "/verrazzano", "VerrazzanoRootDir is incorrect")
+	asserts.True(conf.ModuleIntegration, "Module integration is enabled by default")
 	asserts.Equal("/verrazzano/platform-operator/helm_config", GetHelmConfigDir(), "GetHelmConfigDir() is incorrect")
 	asserts.Equal("/verrazzano/platform-operator/helm_config/charts", GetHelmChartsDir(), "GetHelmChartsDir() is incorrect")
 	asserts.Equal("/verrazzano/platform-operator/helm_config/charts/verrazzano-monitoring-operator", GetHelmVMOChartsDir(), "GetHelmVmoChartsDir() is incorrect")


### PR DESCRIPTION
This adds a check to the VPO Config unit test to make sure that modules are on by default.