### PR TITLE
VZ-11022: Fix upgrade-paths pipeline to capture cluster dump on success in release-1.6

### DIFF
--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -3,7 +3,7 @@
 
 def DOCKER_IMAGE_TAG
 def SKIP_ACCEPTANCE_TESTS = false
-def EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
+EFFECTIVE_DUMP_K8S_CLUSTER_ON_SUCCESS = false
 def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "uk-london-1" ]
 def acmeEnvironments = [ "staging", "production" ]
 Collections.shuffle(availableRegions)


### PR DESCRIPTION
Backports https://github.com/verrazzano/verrazzano/pull/7081 to release-1.6