### PR TITLE
VZ-10825.  Opensearch operator dynamic config fixes

### DIFF
--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/module_integration.go
@@ -15,7 +15,6 @@ func (o opensearchOperatorComponent) GetWatchDescriptors() []controllerspi.Watch
 	return watch.CombineWatchDescriptors(
 		watch.GetModuleInstalledWatches([]string{
 			nginx.ComponentName,
-			cmconstants.CertManagerComponentName,
 			cmconstants.ClusterIssuerComponentName,
 		}),
 		watch.GetModuleUpdatedWatches([]string{

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/module_integration.go
@@ -16,9 +16,11 @@ func (o opensearchOperatorComponent) GetWatchDescriptors() []controllerspi.Watch
 		watch.GetModuleInstalledWatches([]string{
 			nginx.ComponentName,
 			cmconstants.CertManagerComponentName,
+			cmconstants.ClusterIssuerComponentName,
 		}),
 		watch.GetModuleUpdatedWatches([]string{
 			nginx.ComponentName,
+			cmconstants.ClusterIssuerComponentName,
 		}),
 	)
 }

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
@@ -5,20 +5,19 @@ package opensearchoperator
 
 import (
 	"context"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/certmanager"
+	cmconst "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -53,7 +52,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
 			ImagePullSecretKeyname:    "manager.imagePullSecrets[0]",
-			Dependencies:              []string{networkpolicies.ComponentName, certmanager.ComponentName, nginx.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, cmconst.ClusterIssuerComponentName, nginx.ComponentName},
 			AppendOverridesFunc:       appendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
 		},

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
@@ -12,7 +12,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/certmanager"
+	cmconst "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/certmanager"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
@@ -53,7 +53,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
 			ImagePullSecretKeyname:    "manager.imagePullSecrets[0]",
-			Dependencies:              []string{networkpolicies.ComponentName, certmanager.ComponentName, nginx.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, cmconst.ClusterIssuerComponentName, nginx.ComponentName},
 			AppendOverridesFunc:       appendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
 		},

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component.go
@@ -12,7 +12,7 @@ import (
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
-	cmconst "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/certmanager"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/certmanager"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/helm"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
@@ -53,7 +53,7 @@ func NewComponent() spi.Component {
 			SupportsOperatorInstall:   true,
 			SupportsOperatorUninstall: true,
 			ImagePullSecretKeyname:    "manager.imagePullSecrets[0]",
-			Dependencies:              []string{networkpolicies.ComponentName, cmconst.ClusterIssuerComponentName, nginx.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, certmanager.ComponentName, nginx.ComponentName},
 			AppendOverridesFunc:       appendOverrides,
 			GetInstallOverridesFunc:   GetOverrides,
 		},

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component_test.go
@@ -7,15 +7,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/certmanager"
+	cmconst "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
-
-	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -117,7 +116,7 @@ func TestGetDependencies(t *testing.T) {
 	dependencies := NewComponent().GetDependencies()
 	assert.Len(t, dependencies, 3)
 	assert.Equal(t, networkpolicies.ComponentName, dependencies[0])
-	assert.Equal(t, certmanager.ComponentName, dependencies[1])
+	assert.Equal(t, cmconst.ClusterIssuerComponentName, dependencies[1])
 	assert.Equal(t, nginx.ComponentName, dependencies[2])
 }
 

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component_test.go
@@ -5,11 +5,11 @@ package opensearchoperator
 
 import (
 	"fmt"
+	cmconst "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"testing"
 
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/certmanager"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -117,7 +117,7 @@ func TestGetDependencies(t *testing.T) {
 	dependencies := NewComponent().GetDependencies()
 	assert.Len(t, dependencies, 3)
 	assert.Equal(t, networkpolicies.ComponentName, dependencies[0])
-	assert.Equal(t, certmanager.ComponentName, dependencies[1])
+	assert.Equal(t, cmconst.ClusterIssuerComponentName, dependencies[1])
 	assert.Equal(t, nginx.ComponentName, dependencies[2])
 }
 

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component_test.go
@@ -5,11 +5,11 @@ package opensearchoperator
 
 import (
 	"fmt"
-	cmconst "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"testing"
 
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/certmanager"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/networkpolicies"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
@@ -117,7 +117,7 @@ func TestGetDependencies(t *testing.T) {
 	dependencies := NewComponent().GetDependencies()
 	assert.Len(t, dependencies, 3)
 	assert.Equal(t, networkpolicies.ComponentName, dependencies[0])
-	assert.Equal(t, cmconst.CertManagerComponentName, dependencies[1])
+	assert.Equal(t, certmanager.ComponentName, dependencies[1])
 	assert.Equal(t, nginx.ComponentName, dependencies[2])
 }
 

--- a/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component_test.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchoperator/opensearchoperator_component_test.go
@@ -117,7 +117,7 @@ func TestGetDependencies(t *testing.T) {
 	dependencies := NewComponent().GetDependencies()
 	assert.Len(t, dependencies, 3)
 	assert.Equal(t, networkpolicies.ComponentName, dependencies[0])
-	assert.Equal(t, cmconst.ClusterIssuerComponentName, dependencies[1])
+	assert.Equal(t, cmconst.CertManagerComponentName, dependencies[1])
 	assert.Equal(t, nginx.ComponentName, dependencies[2])
 }
 

--- a/tests/e2e/update/env-dns-cm/env_dns_cert_update_test.go
+++ b/tests/e2e/update/env-dns-cm/env_dns_cert_update_test.go
@@ -282,7 +282,7 @@ func ItvalidateCertManagerResourcesCleanup() {
 			}
 			// Verify that the certificate is issued by the right cluster issuer
 			for _, issuer := range issuerList.Items {
-				if issuer.Name != currentCertIssuerName {
+				if issuer.Name == currentCertIssuerName {
 					return fmt.Errorf("issuer %s should NOT exist in the namespace %s", currentCertIssuerName, currentCertIssuerNamespace)
 				}
 			}


### PR DESCRIPTION
Updates the opensearchOperator component to address dynamic changes to DNS
- change CertManager dependencies to ClusterIssuer (which transitively depends on CertManager)
- Change watches for opensearchOperator to trigger on ClusterIssuer install/update, in case we are using a customer-managed Cert-Manager
- Fix e2e test to check for the VZ self-signed issuer to be cleaned up