### PR TITLE
VZ-10840 change internal module versions to match Verrazzano version

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -4,14 +4,13 @@
 package catalog
 
 import (
-	"github.com/verrazzano/verrazzano/pkg/semver"
 	"os"
 	"sigs.k8s.io/yaml"
 )
 
 type Catalog struct {
 	Modules    []Module `json:"modules"`
-	versionMap map[string]*semver.SemVersion
+	versionMap map[string]string
 }
 
 type Module struct {
@@ -31,7 +30,7 @@ func NewCatalog(catalogPath string) (Catalog, error) {
 // NewCatalogfromYAML Create a new Catalog instance from a yaml payload
 func NewCatalogfromYAML(yamlCatalog []byte) (Catalog, error) {
 	catalog := Catalog{
-		versionMap: make(map[string]*semver.SemVersion),
+		versionMap: make(map[string]string),
 	}
 	err := catalog.init(string(yamlCatalog))
 	if err != nil {
@@ -49,16 +48,12 @@ func (c *Catalog) init(yamlCatalog string) error {
 
 	// Build a map of modules
 	for _, module := range c.Modules {
-		version, err := semver.NewSemVersion(module.Version)
-		if err != nil {
-			return err
-		}
-		c.versionMap[module.Name] = version
+		c.versionMap[module.Name] = module.Version
 	}
 	return nil
 }
 
 // GetVersion returns the version for the provided module
-func (c *Catalog) GetVersion(module string) *semver.SemVersion {
+func (c *Catalog) GetVersion(module string) string {
 	return c.versionMap[module]
 }

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 )
 
-const catalogPath = "./catalog.yaml"
-const bomPath = "../../verrazzano-bom.json"
+const catalogPath = "../../platform-operator/manifests/catalog/catalog.yaml"
+const bomPath = "../../platform-operator/verrazzano-bom.json"
 
 type bomSubcomponentOverrides struct {
 	subcomponentName string

--- a/platform-operator/Dockerfile
+++ b/platform-operator/Dockerfile
@@ -47,7 +47,7 @@ COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/ver
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/control-plane-ocne ./capi/control-plane-ocne
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/infrastructure-oci ./capi/infrastructure-oci
 COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/capi/cluster-api ./capi/cluster-api
-COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/experimental/catalog/catalog.yaml ./platform-operator/experimental/catalog/catalog.yaml
+COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/verrazzano/platform-operator/out/generated-catalog.yaml ./platform-operator/manifests/catalog/catalog.yaml
 
 COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano/platform-operator/THIRD_PARTY_LICENSES.txt /licenses/
 

--- a/platform-operator/Makefile
+++ b/platform-operator/Makefile
@@ -128,10 +128,10 @@ docker-clean:
 	rm -rf ${DIST_DIR}
 
 .PHONY: docker-build
-docker-build: generate-bom go-build-linux docker-build-common
+docker-build: generate-bom generate-catalog go-build-linux docker-build-common
 
 .PHONY: docker-build-debug
-docker-build-debug: generate-bom go-build-linux-debug docker-build-common
+docker-build-debug: generate-bom generate-catalog go-build-linux-debug docker-build-common
 
 .PHONY: docker-build-common
 docker-build-common:
@@ -225,3 +225,8 @@ generate-bom:
 	mkdir out || true
 	../tools/scripts/generate_bom.sh verrazzano-bom.json ${VERRAZZANO_VERSION} ${VERRAZZANO_APPLICATION_OPERATOR_IMAGE} ${VERRAZZANO_CLUSTER_OPERATOR_IMAGE} ${VERRAZZANO_AUTHPROXY_IMAGE} ${DOCKER_IMAGE_NAME} ${DOCKER_IMAGE_TAG} out/generated-verrazzano-bom.json
 
+.PHONY: generate-catalog
+generate-catalog:
+	@echo Generating catalog with verrazzano version ${VERRAZZANO_VERSION}
+	mkdir out || true
+	../tools/scripts/generate_catalog.sh manifests/catalog/catalog.yaml ${VERRAZZANO_VERSION} out/generated-catalog.yaml

--- a/platform-operator/experimental/controllers/module/component-handler/common/handler_utils.go
+++ b/platform-operator/experimental/controllers/module/component-handler/common/handler_utils.go
@@ -10,12 +10,12 @@ import (
 	modulestatus "github.com/verrazzano/verrazzano-modules/module-operator/controllers/module/status"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/result"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/handlerspi"
+	modulecatalog "github.com/verrazzano/verrazzano/pkg/catalog"
 	vzconst "github.com/verrazzano/verrazzano/pkg/constants"
 	vzapi "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	"github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	modulecatalog "github.com/verrazzano/verrazzano/platform-operator/experimental/catalog"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -119,11 +119,11 @@ func isDependencyReady(ctx handlerspi.HandlerContext, vz *vzapi.Verrazzano, modu
 		return result.NewResultShortRequeueDelayWithError(err)
 	}
 	version := catalog.GetVersion(comp.Name())
-	if version == nil {
+	if version == "" {
 		err = ctx.Log.ErrorfThrottledNewErr("Failed to find version for module %s in the module catalog", comp.Name())
 		return result.NewResultShortRequeueDelayWithError(err)
 	}
-	if version.ToString() != module.Status.LastSuccessfulVersion {
+	if version != module.Status.LastSuccessfulVersion {
 		return result.NewResultShortRequeueDelay()
 	}
 

--- a/platform-operator/experimental/controllers/verrazzano/module.go
+++ b/platform-operator/experimental/controllers/verrazzano/module.go
@@ -7,13 +7,12 @@ import (
 	"context"
 	moduleapi "github.com/verrazzano/verrazzano-modules/module-operator/apis/platform/v1alpha1"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/result"
+	moduleCatalog "github.com/verrazzano/verrazzano/pkg/catalog"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
-	"github.com/verrazzano/verrazzano/pkg/semver"
 	vzv1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
 	componentspi "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
-	moduleCatalog "github.com/verrazzano/verrazzano/platform-operator/experimental/catalog"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -55,7 +54,7 @@ func (r Reconciler) createOrUpdateModules(log vzlog.VerrazzanoLogger, actualCR *
 
 		// Get the module version from the catalog
 		version := catalog.GetVersion(comp.Name())
-		if version == nil {
+		if version == "" {
 			err = log.ErrorfThrottledNewErr("Failed to find version for module %s in the module catalog", comp.Name())
 			return result.NewResultShortRequeueDelayWithError(err)
 		}
@@ -66,7 +65,7 @@ func (r Reconciler) createOrUpdateModules(log vzlog.VerrazzanoLogger, actualCR *
 	return result.NewResult()
 }
 
-func (r Reconciler) createOrUpdateOneModule(log vzlog.VerrazzanoLogger, actualCR *vzv1alpha1.Verrazzano, effectiveCR *vzv1alpha1.Verrazzano, comp componentspi.Component, version *semver.SemVersion) result.Result {
+func (r Reconciler) createOrUpdateOneModule(log vzlog.VerrazzanoLogger, actualCR *vzv1alpha1.Verrazzano, effectiveCR *vzv1alpha1.Verrazzano, comp componentspi.Component, version string) result.Result {
 	// Create or update the module
 	moduleToUpdate := moduleapi.Module{ObjectMeta: metav1.ObjectMeta{Name: comp.Name(), Namespace: vzconst.VerrazzanoInstallNamespace}}
 
@@ -78,7 +77,7 @@ func (r Reconciler) createOrUpdateOneModule(log vzlog.VerrazzanoLogger, actualCR
 
 	// Create/Update the module if necessary
 	opResult, err := controllerutil.CreateOrUpdate(context.TODO(), r.Client, &moduleToUpdate, func() error {
-		return r.mutateModule(log, actualCR, effectiveCR, &moduleToUpdate, comp, version.ToString())
+		return r.mutateModule(log, actualCR, effectiveCR, &moduleToUpdate, comp, version)
 	})
 	if err != nil {
 		if !errors.IsConflict(err) {

--- a/platform-operator/internal/config/config.go
+++ b/platform-operator/internal/config/config.go
@@ -31,7 +31,7 @@ const (
 	helmOamChartsDirSuffix       = "/platform-operator/thirdparty/charts/oam-kubernetes-runtime"
 	helmOverridesDirSuffix       = "/platform-operator/helm_config/overrides"
 	integrationChartsDirSuffix   = "/platform-operator/experimental/manifests/integration-charts"
-	catalogDirSuffix             = "/platform-operator/experimental/catalog"
+	catalogDirSuffix             = "/platform-operator/manifests/catalog"
 )
 
 const defaultBomFilename = "verrazzano-bom.json"

--- a/platform-operator/internal/config/config_test.go
+++ b/platform-operator/internal/config/config_test.go
@@ -49,7 +49,7 @@ func TestConfigDefaults(t *testing.T) {
 	asserts.Equal("/verrazzano/platform-operator/helm_config", GetHelmConfigDir(), "GetHelmConfigDir() is correct")
 	asserts.Equal("/verrazzano/platform-operator/verrazzano-bom.json", GetDefaultBOMFilePath(), "GetDefaultBOMFilePath() is correct")
 	asserts.Equal("/verrazzano/platform-operator/experimental/manifests/integration-charts", GetIntegrationChartsDir(), "GetIntegrationChartsDir() is correct")
-
+	asserts.Equal("/verrazzano/platform-operator/manifests/catalog/catalog.yaml", GetCatalogPath(), "GetCatalogPath() is correct")
 }
 
 // TestSetConfig tests setting config values

--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -9,7 +9,7 @@ modules:
   - name: cert-manager-webhook-oci
     version: 0.1.0
   - name: cluster-issuer
-    version: 2.0.0
+    version: VERRAZZANO_VERSION
   - name: dex
     version: 2.37.0
   - name: external-dns
@@ -21,21 +21,21 @@ modules:
   - name: cluster-api
     version: 1.4.6
   - name: verrazzano
-    version: 2.0.0
+    version: VERRAZZANO_VERSION
   - name: fluentd
     version: 1.14.5
   - name: verrazzano-console
-    version: 2.0.0
+    version: VERRAZZANO_VERSION
   - name: verrazzano-monitoring-operator
-    version: 2.0.0
+    version: VERRAZZANO_VERSION
   - name: oam-kubernetes-runtime
     version: 0.3.3
   - name: verrazzano-cluster-operator
-    version: 2.0.0
+    version: VERRAZZANO_VERSION
   - name: verrazzano-cluster-agent
-    version: 2.0.0
+    version: VERRAZZANO_VERSION
   - name: verrazzano-application-operator
-    version: 2.0.0
+    version: VERRAZZANO_VERSION
   - name: weblogic-operator
     version: 4.1.2
   - name: coherence-operator
@@ -73,7 +73,7 @@ modules:
   - name: thanos
     version: 0.32.2
   - name: verrazzano-network-policies
-    version: 2.0.0
+    version: VERRAZZANO_VERSION
   - name: opensearch
     version: 2.3.0
   - name: opensearch-dashboards
@@ -81,6 +81,6 @@ modules:
   - name: grafana
     version: 7.5.17
   - name: verrazzano-grafana-dashboards
-    version: 2.0.0
+    version: VERRAZZANO_VERSION
   - name: verrazzano-authproxy
-    version: 2.0.0
+    version: VERRAZZANO_VERSION

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -254,7 +254,7 @@
     },
     {
       "name": "verrazzano",
-      "version": "2.0.0",
+      "version": "VERRAZZANO_VERSION",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -300,7 +300,7 @@
     },
     {
       "name": "verrazzano-console",
-      "version": "2.0.0",
+      "version": "VERRAZZANO_VERSION",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -308,7 +308,7 @@
           "images": [
             {
               "image": "console",
-              "tag": "v2.0.0-20230912070053-2d1883d",
+              "tag": "vVERRAZZANO_VERSION-20230912070053-2d1883d",
               "helmFullImageKey": "imageName",
               "helmTagKey": "imageTag"
             }
@@ -318,7 +318,7 @@
     },
     {
       "name": "verrazzano-monitoring-operator",
-      "version": "2.0.0",
+      "version": "VERRAZZANO_VERSION",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -326,7 +326,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "v2.0.0-20230913103358-6033fa2",
+              "tag": "vVERRAZZANO_VERSION-20230913103358-6033fa2",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },
@@ -400,7 +400,7 @@
     },
     {
       "name": "verrazzano-cluster-operator",
-      "version": "2.0.0",
+      "version": "VERRAZZANO_VERSION",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -417,7 +417,7 @@
     },
     {
       "name": "verrazzano-cluster-agent",
-      "version": "2.0.0",
+      "version": "VERRAZZANO_VERSION",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -434,7 +434,7 @@
     },
     {
       "name": "verrazzano-application-operator",
-      "version": "2.0.0",
+      "version": "VERRAZZANO_VERSION",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -451,7 +451,7 @@
     },
     {
       "name": "verrazzano-authproxy",
-      "version": "2.0.0",
+      "version": "VERRAZZANO_VERSION",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -629,7 +629,7 @@
           "images": [
             {
               "image": "keycloak-oracle-theme",
-              "tag": "v2.0.0-20230628190510-b8bc75a"
+              "tag": "vVERRAZZANO_VERSION-20230628190510-b8bc75a"
             }
           ]
         }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -308,7 +308,7 @@
           "images": [
             {
               "image": "console",
-              "tag": "vVERRAZZANO_VERSION-20230912070053-2d1883d",
+              "tag": "v2.0.0-20230912070053-2d1883d",
               "helmFullImageKey": "imageName",
               "helmTagKey": "imageTag"
             }
@@ -326,7 +326,7 @@
           "images": [
             {
               "image": "verrazzano-monitoring-operator",
-              "tag": "vVERRAZZANO_VERSION-20230913103358-6033fa2",
+              "tag": "v2.0.0-20230913103358-6033fa2",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },
@@ -629,7 +629,7 @@
           "images": [
             {
               "image": "keycloak-oracle-theme",
-              "tag": "vVERRAZZANO_VERSION-20230628190510-b8bc75a"
+              "tag": "v2.0.0-20230628190510-b8bc75a"
             }
           ]
         }

--- a/tools/scripts/generate_catalog.sh
+++ b/tools/scripts/generate_catalog.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
+
+if [ ! -f "$1" ]; then
+  echo "You must specify the catalog file as input"
+  exit 1
+fi
+CATALOG_FILE=$1
+
+if [ -z "$2" ]; then
+  echo "You must specify the Version"
+  exit 1
+fi
+VERRAZZANO_VERSION=$2
+
+GENERATED_CATALOG_FILE=$3
+if [ -z "${GENERATED_CATALOG_FILE}" ]; then
+  echo "You must specify the catalog filename as output"
+  exit 1
+fi
+
+cp ${CATALOG_FILE} ${GENERATED_CATALOG_FILE}
+
+# Update the catalog file with the Verrazzano version
+regex=".*:.*"
+sed -i"" -e "s|VERRAZZANO_VERSION|${VERRAZZANO_VERSION}|g" ${GENERATED_CATALOG_FILE}


### PR DESCRIPTION
This change changes the internal modules versions in the catalog to match the Verrazzano version. The catalog is generated  at build time similar to the how the bom is generated. This change also moved the catalog into the manifests directory.