### PR TITLE
VZ-11085.  Remove DNS config mappings from authproxy in favor of Module watches

### DIFF
--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy.go
@@ -67,9 +67,8 @@ func AppendOverrides(ctx spi.ComponentContext, _ string, _ string, _ string, kvs
 
 	// Environment name
 	overrides.Config = &configValues{
-		EnvName:                   vzconfig.GetEnvName(effectiveCR),
-		PrometheusOperatorEnabled: vzcr.IsPrometheusOperatorEnabled(effectiveCR),
-		IngressClassName:          vzconfig.GetIngressClassName(effectiveCR),
+		EnvName:          vzconfig.GetEnvName(effectiveCR),
+		IngressClassName: vzconfig.GetIngressClassName(effectiveCR),
 	}
 
 	// DNS Suffix

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_component.go
@@ -6,6 +6,7 @@ package authproxy
 import (
 	"fmt"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/dex"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"path/filepath"
 
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
@@ -62,7 +63,7 @@ func NewComponent() spi.Component {
 			MinVerrazzanoVersion:      constants.VerrazzanoVersion1_3_0,
 			ImagePullSecretKeyname:    "global.imagePullSecrets[0]",
 			GetInstallOverridesFunc:   GetOverrides,
-			Dependencies:              []string{networkpolicies.ComponentName, nginx.ComponentName, fluentoperator.ComponentName, dex.ComponentName},
+			Dependencies:              []string{networkpolicies.ComponentName, nginx.ComponentName, istio.ComponentName, fluentoperator.ComponentName, dex.ComponentName},
 			AvailabilityObjects: &ready.AvailabilityObjects{
 				DeploymentNames: []types.NamespacedName{
 					{

--- a/platform-operator/controllers/verrazzano/component/authproxy/authproxy_values.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/authproxy_values.go
@@ -42,10 +42,9 @@ type proxyValues struct {
 }
 
 type configValues struct {
-	EnvName                   string `json:"envName,omitempty"`
-	DNSSuffix                 string `json:"dnsSuffix,omitempty"`
-	PrometheusOperatorEnabled bool   `json:"prometheusOperatorEnabled,omitempty"`
-	IngressClassName          string `json:"ingressClassName,omitempty"`
+	EnvName          string `json:"envName,omitempty"`
+	DNSSuffix        string `json:"dnsSuffix,omitempty"`
+	IngressClassName string `json:"ingressClassName,omitempty"`
 }
 
 type dnsValues struct {

--- a/platform-operator/controllers/verrazzano/component/authproxy/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/module_integration.go
@@ -7,7 +7,6 @@ import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
-	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
@@ -39,8 +38,8 @@ func (c authProxyComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Ve
 // GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
 func (c authProxyComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 	return watch.CombineWatchDescriptors(
-		watch.GetModuleInstalledWatches([]string{nginx.ComponentName, fluentoperator.ComponentName, common.PrometheusOperatorComponentName}),
-		watch.GetModuleInstalledWatches([]string{nginx.ComponentName, common.PrometheusOperatorComponentName}),
+		watch.GetModuleInstalledWatches([]string{nginx.ComponentName, fluentoperator.ComponentName}),
+		watch.GetModuleUpdatedWatches([]string{nginx.ComponentName}),
 		watch.GetCreateSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),
 		watch.GetUpdateSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),
 		watch.GetDeleteSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),

--- a/platform-operator/controllers/verrazzano/component/authproxy/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/module_integration.go
@@ -9,6 +9,7 @@ import (
 	vzconst "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/istio"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -38,7 +39,7 @@ func (c authProxyComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Ve
 // GetWatchDescriptors returns the list of WatchDescriptors for objects being watched by the component
 func (c authProxyComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 	return watch.CombineWatchDescriptors(
-		watch.GetModuleInstalledWatches([]string{nginx.ComponentName, fluentoperator.ComponentName}),
+		watch.GetModuleInstalledWatches([]string{nginx.ComponentName, istio.ComponentName, fluentoperator.ComponentName}),
 		watch.GetModuleUpdatedWatches([]string{nginx.ComponentName}),
 		watch.GetCreateSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),
 		watch.GetUpdateSecretWatch(vzconst.MCRegistrationSecret, vzconst.VerrazzanoSystemNamespace),

--- a/platform-operator/controllers/verrazzano/component/authproxy/module_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/module_integration_test.go
@@ -73,34 +73,9 @@ func TestGetModuleSpec(t *testing.T) {
 			  "verrazzano": {
 				"module": {
 				  "spec": {
-					"environmentName": "Myenv",
-					"ingress": {
-					  "enabled": true,
-					  "ingressClassName": "myclass",
-					  "ports": [
-						{
-						  "name": "myport",
-						  "protocol": "tcp",
-						  "port": 8000,
-						  "targetPort": 0,
-						  "nodePort": 80
-						}
-					  ],
-					  "type": "LoadBalancer"
-					},
-					"dns": {
-					  "oci": {
-						"dnsScope": "global",
-						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
-						"dnsZoneOCID": "ocid..zone.myzone",
-						"dnsZoneName": "myzone",
-						"ociConfigSecret": "oci"
-					  }
-					},
 					"kubernetes": {
 					  "replicas": 3
-					},
-					"prometheusOperatorEnabled": true
+					}
 				  }
 				}
 			  }
@@ -164,34 +139,9 @@ func TestGetModuleSpec(t *testing.T) {
 			  "verrazzano": {
 				"module": {
 				  "spec": {
-					"environmentName": "Myenv",
-					"ingress": {
-					  "enabled": true,
-					  "ingressClassName": "myclass",
-					  "ports": [
-						{
-						  "name": "myport",
-						  "protocol": "tcp",
-						  "port": 8000,
-						  "targetPort": 0,
-						  "nodePort": 80
-						}
-					  ],
-					  "type": "LoadBalancer"
-					},
-					"dns": {
-					  "oci": {
-						"dnsScope": "global",
-						"dnsZoneCompartmentOCID": "ocid..compartment.mycomp",
-						"dnsZoneOCID": "ocid..zone.myzone",
-						"dnsZoneName": "myzone",
-						"ociConfigSecret": "oci"
-					  }
-					},
 					"kubernetes": {
 					  "replicas": 3
-					},
-					"prometheusOperatorEnabled": true
+					}
 				  }
 				}
 			  }

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/values.yaml
@@ -34,7 +34,6 @@ affinity:
 config:
   envName:
   dnsSuffix:
-  prometheusOperatorEnabled:
   ingressClassName:
 
 dns:


### PR DESCRIPTION
Remove DNS config mappings from authproxy in favor of Module watches
- refactor Promethes Operator component name/namespace into common package to avoid import cycles
