### PR TITLE
Cron for backend tests only should be firing off weekly

### DIFF
--- a/ci/cron/JenkinsfileBackend
+++ b/ci/cron/JenkinsfileBackend
@@ -216,11 +216,8 @@ def runPipeline() {
 }
 
 def getCronSchedule() {
-    if (env.BRANCH_NAME.equals("master")) {
-        // scheduled for every 6 hours
-        return "H */6 * * *"
-    } else if (env.BRANCH_NAME.startsWith("release-")) {
-        return "@daily"
+    if (env.BRANCH_NAME.equals("master") || env.BRANCH_NAME.startsWith("release-")) {
+        return "@weekly"
     }
     return ""
 }


### PR DESCRIPTION
The backend tests are supposed to run once a week.

The cron is supposed to be a fallback in case the URL trigger misses triggering there weekly, and should also only be weekly
