### PR TITLE
VZ-11008: Follow-up to cleanup VMC extensions for K8s and VZ versions

### DIFF
--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -113,14 +113,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) doReconcile(ctx context.Context, agentSecret corev1.Secret) error {
 	managedClusterName := string(agentSecret.Data[constants.ClusterNameData])
 
+	// Create the discovery client for the managed cluster
+	localDiscoveryClient, err := getDiscoveryClientFunc()
+	if err != nil {
+		return fmt.Errorf("failed to get discovery client for this workload cluster: %v", err)
+	}
+
 	// Initialize the syncer object
 	s := &Syncer{
-		LocalClient:         r.Client,
-		Log:                 r.Log,
-		Context:             ctx,
-		ProjectNamespaces:   []string{},
-		StatusUpdateChannel: r.AgentChannel,
-		ManagedClusterName:  managedClusterName,
+		LocalClient:          r.Client,
+		LocalDiscoveryClient: localDiscoveryClient,
+		Log:                  r.Log,
+		Context:              ctx,
+		ProjectNamespaces:    []string{},
+		StatusUpdateChannel:  r.AgentChannel,
+		ManagedClusterName:   managedClusterName,
 	}
 
 	// Read current agent state from config map
@@ -140,13 +147,6 @@ func (r *Reconciler) doReconcile(ctx context.Context, agentSecret corev1.Secret)
 		return fmt.Errorf("failed to get the client for cluster %q with error %v", managedClusterName, err)
 	}
 	s.AdminClient = adminClient
-
-	// Create the discovery client for the managed cluster
-	localDiscoveryClient, err := getDiscoveryClientFunc()
-	if err != nil {
-		return fmt.Errorf("failed to get discovery client for this workload cluster: %v", err)
-	}
-	s.LocalDiscoveryClient = localDiscoveryClient
 
 	// Sync cattle-cluster-agent deployment which will set the new cattleAgentHash on the Syncer
 	cattleAgentHashValue, err := s.syncCattleClusterAgent(mcAgentStateConfigMap.Data[cattleAgentHashData], "")

--- a/application-operator/mcagent/mcagent.go
+++ b/application-operator/mcagent/mcagent.go
@@ -141,6 +141,13 @@ func (r *Reconciler) doReconcile(ctx context.Context, agentSecret corev1.Secret)
 	}
 	s.AdminClient = adminClient
 
+	// Create the discovery client for the managed cluster
+	localDiscoveryClient, err := getDiscoveryClientFunc()
+	if err != nil {
+		return fmt.Errorf("failed to get discovery client for this workload cluster: %v", err)
+	}
+	s.LocalDiscoveryClient = localDiscoveryClient
+
 	// Sync cattle-cluster-agent deployment which will set the new cattleAgentHash on the Syncer
 	cattleAgentHashValue, err := s.syncCattleClusterAgent(mcAgentStateConfigMap.Data[cattleAgentHashData], "")
 	if err != nil {

--- a/application-operator/mcagent/mcagent_syncer.go
+++ b/application-operator/mcagent/mcagent_syncer.go
@@ -231,7 +231,7 @@ func (s *Syncer) getWorkloadVZVersion() (string, error) {
 		return "", fmt.Errorf("error listing Verrazzanos: %v", err)
 	}
 	if len(vzList.Items) > 1 {
-		return "", fmt.Errorf("cannot have more than 1 Verrazzano installations, found %d", len(vzList.Items))
+		return "", fmt.Errorf("cannot have more than 1 Verrazzano installation, found %d", len(vzList.Items))
 	}
 	if len(vzList.Items) == 0 {
 		// If there is no Verrazzano installed on this workload cluster, leave version empty but do not error

--- a/application-operator/mcagent/mcagent_syncer.go
+++ b/application-operator/mcagent/mcagent_syncer.go
@@ -31,11 +31,12 @@ import (
 
 // Syncer contains context for synchronize operations
 type Syncer struct {
-	AdminClient        client.Client
-	LocalClient        client.Client
-	Log                *zap.SugaredLogger
-	ManagedClusterName string
-	Context            context.Context
+	AdminClient          client.Client
+	LocalClient          client.Client
+	LocalDiscoveryClient discovery.DiscoveryInterface
+	Log                  *zap.SugaredLogger
+	ManagedClusterName   string
+	Context              context.Context
 
 	// List of namespaces to watch for multi-cluster objects.
 	ProjectNamespaces   []string
@@ -215,12 +216,7 @@ func (s *Syncer) updateVMCStatus() error {
 
 // getWorkloadK8sVersion retrieves the current Kubernetes version on this managed cluster
 func (s *Syncer) getWorkloadK8sVersion() (string, error) {
-	discoveryClient, err := getDiscoveryClientFunc()
-	if err != nil {
-		return "", fmt.Errorf("failed to get discovery client for this workload cluster: %v", err)
-	}
-
-	k8sVersion, err := discoveryClient.ServerVersion()
+	k8sVersion, err := s.LocalDiscoveryClient.ServerVersion()
 	if err != nil {
 		return "", fmt.Errorf("failed to get Kubernetes version on this workload cluster: %v", err)
 	}

--- a/application-operator/mcagent/mcagent_syncer.go
+++ b/application-operator/mcagent/mcagent_syncer.go
@@ -234,9 +234,14 @@ func (s *Syncer) getWorkloadVZVersion() (string, error) {
 	if err := s.LocalClient.List(s.Context, vzList, &client.ListOptions{}); err != nil {
 		return "", fmt.Errorf("error listing Verrazzanos: %v", err)
 	}
-	if len(vzList.Items) != 1 {
-		return "", fmt.Errorf("number of Verrazzano installations should be 1, but was %d", len(vzList.Items))
+	if len(vzList.Items) > 1 {
+		return "", fmt.Errorf("number of Verrazzano installations should be 0 or 1, but was %d", len(vzList.Items))
 	}
+	if len(vzList.Items) == 0 {
+		// If there is no Verrazzano installed on this workload cluster, leave version empty but do not error
+		return "", nil
+	}
+	// Verrazzano is on this cluster, so get the version
 	vzState := string(vzList.Items[0].Status.Version)
 	return vzState, nil
 }

--- a/application-operator/mcagent/mcagent_syncer.go
+++ b/application-operator/mcagent/mcagent_syncer.go
@@ -231,7 +231,7 @@ func (s *Syncer) getWorkloadVZVersion() (string, error) {
 		return "", fmt.Errorf("error listing Verrazzanos: %v", err)
 	}
 	if len(vzList.Items) > 1 {
-		return "", fmt.Errorf("number of Verrazzano installations should be 0 or 1, but was %d", len(vzList.Items))
+		return "", fmt.Errorf("cannot have more than 1 Verrazzano installations, found %d", len(vzList.Items))
 	}
 	if len(vzList.Items) == 0 {
 		// If there is no Verrazzano installed on this workload cluster, leave version empty but do not error

--- a/application-operator/mcagent/mcagent_test.go
+++ b/application-operator/mcagent/mcagent_test.go
@@ -397,16 +397,17 @@ func TestSyncer_updateVMCStatus(t *testing.T) {
 	adminStatusMock := mocks.NewMockStatusWriter(adminMocker)
 	localClientMock := mocks.NewMockClient(adminMocker)
 
+	fakeDiscoveryClient, err := fakeDiscoveryClientFunc()
+	assert.Nil(err)
+
 	s := &Syncer{
-		AdminClient:        adminMock,
-		Log:                log,
-		ManagedClusterName: "my-test-cluster",
-		LocalClient:        localClientMock,
+		AdminClient:          adminMock,
+		Log:                  log,
+		ManagedClusterName:   "my-test-cluster",
+		LocalClient:          localClientMock,
+		LocalDiscoveryClient: fakeDiscoveryClient,
 	}
 	vmcName := types.NamespacedName{Name: s.ManagedClusterName, Namespace: constants.VerrazzanoMultiClusterNamespace}
-
-	defer setDiscoveryClientFunc(getDiscoveryClientFunc)
-	setDiscoveryClientFunc(fakeDiscoveryClientFunc)
 
 	expectGetAPIServerURLCalled(localClientMock)
 	expectGetPrometheusHostCalled(localClientMock)


### PR DESCRIPTION
Follow-up to https://github.com/verrazzano/verrazzano/pull/7116.

Addresses the previous comments made:

- Initialize the `Syncer` to contain a `DiscoveryClient`
- Account for the case that there are 0 `verrazzanos` on the workload cluster