### PR TITLE
VZ-10861: Back port uptake of Rancher 2.7.6 to release-1.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### v1.6.7
 Component version updates:
 
+- Rancher 2.7.6
 - WebLogic Kubernetes Operator v4.1.2
 - WebLogic Monitoring Exporter v2.1.5
 - Thanos v0.32.2 (includes support for OKE Workload Identities)

--- a/platform-operator/thirdparty/charts/rancher/Chart.yaml
+++ b/platform-operator/thirdparty/charts/rancher/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: rancher
 description: Install Rancher Server to manage Kubernetes clusters across providers.
-version: 2.7.5-2
-appVersion: 2.7.5
+version: 2.7.6
+appVersion: 2.7.6
 kubeVersion: < 1.28.0-0
 home: https://rancher.com
 icon: https://github.com/rancher/ui/blob/master/public/assets/images/logos/welcome-cow.svg

--- a/platform-operator/thirdparty/charts/rancher/values.yaml
+++ b/platform-operator/thirdparty/charts/rancher/values.yaml
@@ -171,7 +171,7 @@ postDelete:
   enabled: false
   image:
     repository: rancher-shell
-    tag: v0.1.18
+    tag: v0.1.20
   namespaceList:
     - cattle-fleet-system
     - cattle-system

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,13 +151,13 @@
               "rancherUI": "v2.7.2-11/release-2.7.2",
               "ocneDriverVersion": "v0.24.0",
               "ocneDriverChecksum": "0d537a9e810ce23f7727b4ad70d884acc9648afa4d600be9036b0c4893d7311a",
-              "tag": "v2.7.6-20230920212002-537165164",
+              "tag": "v2.7.6-20230921193355-4a359105b",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.6-20230920212002-537165164"
+              "tag": "v2.7.6-20230921193355-4a359105b"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,13 +151,13 @@
               "rancherUI": "v2.7.2-11/release-2.7.2",
               "ocneDriverVersion": "v0.24.0",
               "ocneDriverChecksum": "0d537a9e810ce23f7727b4ad70d884acc9648afa4d600be9036b0c4893d7311a",
-              "tag": "v2.7.5-20230831191011-c6f745626",
+              "tag": "v2.7.6-20230920212002-537165164",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.5-20230831191011-c6f745626"
+              "tag": "v2.7.6-20230920212002-537165164"
             }
           ]
         },
@@ -167,7 +167,7 @@
           "images": [
             {
               "image": "rancher-shell",
-              "tag": "v0.1.18-20230403204343-4124528"
+              "tag": "v0.1.20-20230908151457-b1ce5ae"
             },
             {
               "image": "rancher-webhook",
@@ -175,11 +175,11 @@
             },
             {
               "image": "rancher-fleet-agent",
-              "tag": "v0.7.0-20230803175255-e6633a6d"
+              "tag": "v0.7.1-20230913140901-c69add6c"
             },
             {
               "image": "rancher-fleet",
-              "tag": "v0.7.0-20230803175255-e6633a6d"
+              "tag": "v0.7.1-20230913140901-c69add6c"
             },
             {
               "image": "rancher-gitjob",

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -147,7 +147,7 @@
           "images": [
             {
               "image": "rancher",
-              "dashboard": "v2.7.5-20230818161107-07044c506",
+              "dashboard": "v2.7.5-20230921192928-7c49553c6",
               "rancherUI": "v2.7.2-11/release-2.7.2",
               "ocneDriverVersion": "v0.24.0",
               "ocneDriverChecksum": "0d537a9e810ce23f7727b4ad70d884acc9648afa4d600be9036b0c4893d7311a",
@@ -171,7 +171,7 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.3.5-20230803175843-1a77563"
+              "tag": "v0.3.5-20230922100255-1a77563"
             },
             {
               "image": "rancher-fleet-agent",
@@ -183,11 +183,11 @@
             },
             {
               "image": "rancher-gitjob",
-              "tag": "v0.1.32-20230804152729-58582b0"
+              "tag": "v0.1.32-20230922083827-58582b0"
             },
             {
               "image": "rancher-cleanup",
-              "tag": "v1.0.0-20230626123339-15c72a6"
+              "tag": "v1.0.0-20230922083921-15c72a6"
             }
           ]
         }


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
