### PR TITLE
VZ-11085.  Clean up module integration

### DIFF
--- a/platform-operator/controllers/verrazzano/component/authproxy/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/authproxy/module_integration.go
@@ -13,12 +13,15 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
 // valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
 type valuesConfig struct {
 	Kubernetes *v1alpha1.AuthProxyKubernetesSection `json:"kubernetes,omitempty"`
 }
+
+var emptyConfig = valuesConfig{}
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
 func (c authProxyComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
@@ -31,6 +34,10 @@ func (c authProxyComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Ve
 	authProxy := effectiveCR.Spec.Components.AuthProxy
 	if authProxy.Kubernetes != nil {
 		configSnippet.Kubernetes = authProxy.Kubernetes.DeepCopy()
+	}
+
+	if reflect.DeepEqual(emptyConfig, configSnippet) {
+		return nil, nil
 	}
 
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)

--- a/platform-operator/controllers/verrazzano/component/certmanager/certmanager/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/certmanager/module_integration.go
@@ -11,31 +11,36 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
-// certManagerModuleConfig Internal component configuration used to communicate Verrazzano CR config for CertManager to
+// valuesConfig Internal component configuration used to communicate Verrazzano CR config for CertManager to
 // this component through the Module interface as Helm values
-type certManagerModuleConfig struct {
+type valuesConfig struct {
 	ClusterResourceNamespace string `json:"clusterResourceNamespace,omitempty"`
 }
+
+var emptyConfig = valuesConfig{}
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
 func (c certManagerComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
 	// Convert the CertManager Verrazzano CR config to internal well-known Helm values
-	compConfig := effectiveCR.Spec.Components.CertManager
-	if compConfig == nil {
+	configSnippet := effectiveCR.Spec.Components.CertManager
+	if configSnippet == nil {
 		return nil, nil
 	}
-	// TODO: Review this, the CM component only uses the ClusterIssuerComponent.ClusterResourceNamespace for configuration
-	//  beyond the basic enable/disable and overrides capability.  Because we handle the InstallOverrides separately
-	//  this may be all we need to trigger reconciles of the CM install
-	clusterResourceNamespace := compConfig.Certificate.CA.ClusterResourceNamespace
+	clusterResourceNamespace := configSnippet.Certificate.CA.ClusterResourceNamespace
 	issuerConfig := effectiveCR.Spec.Components.ClusterIssuer
 	if issuerConfig != nil {
 		clusterResourceNamespace = issuerConfig.ClusterResourceNamespace
 	}
+
+	if reflect.DeepEqual(emptyConfig, configSnippet) {
+		return nil, nil
+	}
+
 	return spi.NewModuleConfigHelmValuesWrapper(
-		certManagerModuleConfig{
+		valuesConfig{
 			ClusterResourceNamespace: clusterResourceNamespace,
 		},
 	)

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/module_integration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
 // issuerValuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
@@ -18,6 +19,8 @@ type issuerValuesConfig struct {
 	IssuerConfig             v1alpha1.IssuerConfig  `json:"issuerConfig"`
 	ClusterResourceNamespace string                 `json:"clusterResourceNamespace,omitempty"`
 }
+
+var emptyConfig = issuerValuesConfig{}
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON issuerValuesConfig representing the portion of the Verrazzano CR that corresponds to the module
 func (c clusterIssuerComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
@@ -43,6 +46,11 @@ func (c clusterIssuerComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha
 		ClusterResourceNamespace: clusterIssuer.ClusterResourceNamespace,
 		IssuerConfig:             clusterIssuer.IssuerConfig,
 	}
+
+	if reflect.DeepEqual(emptyConfig, configSnippet) {
+		return nil, nil
+	}
+
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
 }
 

--- a/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/webhookoci/module_integration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
 // webhookOCIValuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
@@ -19,6 +20,8 @@ type webhookOCIValuesConfig struct {
 	ClusterResourceNamespace string                `json:"clusterResourceNamespace,omitempty"`
 	IssuerConfig             v1alpha1.IssuerConfig `json:"issuerConfig"`
 }
+
+var emptyConfig = webhookOCIValuesConfig{}
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON webhookOCIValuesConfig representing the portion of the Verrazzano CR that corresponds to the module
 func (c certManagerWebhookOCIComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
@@ -43,6 +46,10 @@ func (c certManagerWebhookOCIComponent) GetModuleConfigAsHelmValues(effectiveCR 
 		OCIConfigSecret:          ociConfigSecret,
 		ClusterResourceNamespace: clusterResourceNamespace,
 		IssuerConfig:             clusterIssuer.IssuerConfig,
+	}
+
+	if reflect.DeepEqual(emptyConfig, configSnippet) {
+		return nil, nil
 	}
 
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)

--- a/platform-operator/controllers/verrazzano/component/fluentd/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/module_integration.go
@@ -35,6 +35,11 @@ func (c fluentdComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verr
 			ExtraVolumeMounts:   fluentd.ExtraVolumeMounts,
 		}
 	}
+
+	if configSnippet == nil {
+		return nil, nil
+	}
+
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
 }
 

--- a/platform-operator/controllers/verrazzano/component/fluentd/module_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/fluentd/module_integration_test.go
@@ -87,6 +87,11 @@ func TestGetModuleSpec(t *testing.T) {
 			}
 			`,
 		},
+		{
+			name:        "EmptyConfig",
+			effectiveCR: &vzapi.Verrazzano{},
+			wantErr:     assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -95,7 +100,11 @@ func TestGetModuleSpec(t *testing.T) {
 			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
 				return
 			}
-			assert.JSONEq(t, tt.want, string(got.Raw))
+			if len(tt.want) == 0 {
+				assert.Nil(t, got)
+			} else {
+				assert.JSONEq(t, tt.want, string(got.Raw))
+			}
 		})
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/grafana/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/module_integration.go
@@ -53,7 +53,7 @@ func (g grafanaComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazz
 	if reflect.DeepEqual(configSnippet, emptyConfig) {
 		return nil, nil
 	}
-	
+
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
 }
 

--- a/platform-operator/controllers/verrazzano/component/grafana/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/grafana/module_integration.go
@@ -18,6 +18,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
 // valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
@@ -48,6 +49,11 @@ func (g grafanaComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazz
 		configSnippet.Replicas = grafana.Replicas
 	}
 
+	emptyConfig := valuesConfig{}
+	if reflect.DeepEqual(configSnippet, emptyConfig) {
+		return nil, nil
+	}
+	
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
 }
 

--- a/platform-operator/controllers/verrazzano/component/helm/helm_component.go
+++ b/platform-operator/controllers/verrazzano/component/helm/helm_component.go
@@ -179,7 +179,6 @@ func (h HelmComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON snippet representing the portion of the Verrazzano CR that corresponds to the module
 func (h HelmComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
-
 	return nil, nil
 }
 

--- a/platform-operator/controllers/verrazzano/component/istio/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/istio/module_integration.go
@@ -15,7 +15,7 @@ import (
 
 // issuerValuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
 type valuesConfig struct {
-	InjectionEnabled *bool `json:"injectionEnabled,omitempty"`
+	Istio *v1alpha1.IstioComponent `json:"istio,omitempty"`
 }
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON issuerValuesConfig representing the portion of the Verrazzano CR that corresponds to the module
@@ -24,11 +24,15 @@ func (i istioComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verraz
 		return nil, nil
 	}
 
-	configSnippet := valuesConfig{}
 	istio := effectiveCR.Spec.Components.Istio
-	if istio != nil {
-		configSnippet.InjectionEnabled = istio.InjectionEnabled
+	if istio == nil {
+		return nil, nil
 	}
+	configSnippet := valuesConfig{
+		Istio: istio.DeepCopy(),
+	}
+	configSnippet.Istio.InstallOverrides = v1alpha1.InstallOverrides{}
+
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
 }
 

--- a/platform-operator/controllers/verrazzano/component/istio/module_integration_test.go
+++ b/platform-operator/controllers/verrazzano/component/istio/module_integration_test.go
@@ -48,12 +48,20 @@ func TestGetModuleSpec(t *testing.T) {
 				  "verrazzano": {
 					"module": {
 					  "spec": {
-						"injectionEnabled": true
+						"istio": {
+      					  "enabled": true,
+						  "injectionEnabled": true
+						}
 					  }
 					}
 				  }
 				}
 				`,
+		},
+		{
+			name:        "EmptyConfig",
+			effectiveCR: &vzapi.Verrazzano{},
+			wantErr:     assert.NoError,
 		},
 	}
 	for _, tt := range tests {
@@ -63,7 +71,11 @@ func TestGetModuleSpec(t *testing.T) {
 			if !tt.wantErr(t, err, fmt.Sprintf("GetModuleConfigAsHelmValues(%v)", tt.effectiveCR)) {
 				return
 			}
-			assert.JSONEq(t, tt.want, string(got.Raw))
+			if len(tt.want) == 0 {
+				assert.Nil(t, got)
+			} else {
+				assert.JSONEq(t, tt.want, string(got.Raw))
+			}
 		})
 	}
 }

--- a/platform-operator/controllers/verrazzano/component/jaeger/operator/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/jaeger/operator/module_integration.go
@@ -17,6 +17,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
 // valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
@@ -24,6 +25,8 @@ type valuesConfig struct {
 	DefaultVolumeSource      *corev1.VolumeSource            `json:"defaultVolumeSource,omitempty" patchStrategy:"replace"`
 	VolumeClaimSpecTemplates []vzapi.VolumeClaimSpecTemplate `json:"volumeClaimSpecTemplates,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
 }
+
+var emptyConfig = valuesConfig{}
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
 func (c jaegerOperatorComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
@@ -34,6 +37,10 @@ func (c jaegerOperatorComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.
 	configSnippet := valuesConfig{
 		DefaultVolumeSource:      effectiveCR.Spec.DefaultVolumeSource,
 		VolumeClaimSpecTemplates: effectiveCR.Spec.VolumeClaimSpecTemplates,
+	}
+
+	if reflect.DeepEqual(emptyConfig, configSnippet) {
+		return nil, nil
 	}
 
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)

--- a/platform-operator/controllers/verrazzano/component/mysql/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/mysql/module_integration.go
@@ -12,14 +12,18 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
 // valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
 type valuesConfig struct {
 	VolumeSource             *corev1.VolumeSource            `json:"volumeSource,omitempty"`
+	MySQLInstallArgs         []vzapi.InstallArgs             `json:"mysqlInstallArgs,omitempty"`
 	DefaultVolumeSource      *corev1.VolumeSource            `json:"defaultVolumeSource,omitempty"`
 	VolumeClaimSpecTemplates []vzapi.VolumeClaimSpecTemplate `json:"volumeClaimSpecTemplates,omitempty"`
 }
+
+var emptyConfig = valuesConfig{}
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
 func (c mysqlComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
@@ -35,6 +39,11 @@ func (c mysqlComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzan
 	keycloak := effectiveCR.Spec.Components.Keycloak
 	if keycloak != nil {
 		configSnippet.VolumeSource = keycloak.MySQL.VolumeSource.DeepCopy()
+		configSnippet.MySQLInstallArgs = keycloak.MySQL.MySQLInstallArgs
+	}
+
+	if reflect.DeepEqual(emptyConfig, configSnippet) {
+		return nil, nil
 	}
 
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)

--- a/platform-operator/controllers/verrazzano/component/nginx/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/nginx/module_integration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/fluentoperator"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
 // valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
@@ -19,6 +20,8 @@ type valuesConfig struct {
 	DNS             *v1alpha1.DNSComponent          `json:"dns,omitempty"`
 	EnvironmentName string                          `json:"environmentName,omitempty"`
 }
+
+var emptyConfig = valuesConfig{}
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
 func (c nginxComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verrazzano) (*apiextensionsv1.JSON, error) {
@@ -48,6 +51,9 @@ func (c nginxComponent) GetModuleConfigAsHelmValues(effectiveCR *v1alpha1.Verraz
 		configSnippet.EnvironmentName = effectiveCR.Spec.EnvironmentName
 	}
 
+	if reflect.DeepEqual(emptyConfig, configSnippet) {
+		return nil, nil
+	}
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)
 }
 

--- a/platform-operator/controllers/verrazzano/component/opensearch/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/opensearch/module_integration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
 // valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
@@ -27,6 +28,8 @@ type valuesConfig struct {
 	DefaultVolumeSource      *corev1.VolumeSource            `json:"defaultVolumeSource,omitempty" patchStrategy:"replace"`
 	VolumeClaimSpecTemplates []vzapi.VolumeClaimSpecTemplate `json:"volumeClaimSpecTemplates,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
 }
+
+var emptyConfig = valuesConfig{}
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
 func (o opensearchComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
@@ -46,6 +49,10 @@ func (o opensearchComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verr
 		configSnippet.Plugins = opensearch.Plugins
 		configSnippet.DisableDefaultPolicy = opensearch.DisableDefaultPolicy
 		configSnippet.ESInstallArgs = opensearch.ESInstallArgs
+	}
+
+	if reflect.DeepEqual(emptyConfig, configSnippet) {
+		return nil, nil
 	}
 
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)

--- a/platform-operator/controllers/verrazzano/component/opensearchdashboards/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/opensearchdashboards/module_integration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
 // valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
@@ -24,6 +25,8 @@ type valuesConfig struct {
 	DefaultVolumeSource      *corev1.VolumeSource            `json:"defaultVolumeSource,omitempty" patchStrategy:"replace"`
 	VolumeClaimSpecTemplates []vzapi.VolumeClaimSpecTemplate `json:"volumeClaimSpecTemplates,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
 }
+
+var emptyConfig = valuesConfig{}
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
 func (d opensearchDashboardsComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
@@ -40,6 +43,10 @@ func (d opensearchDashboardsComponent) GetModuleConfigAsHelmValues(effectiveCR *
 	if osd != nil {
 		configSnippet.Replicas = osd.Replicas
 		configSnippet.Plugins = osd.Plugins
+	}
+
+	if reflect.DeepEqual(emptyConfig, configSnippet) {
+		return nil, nil
 	}
 
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)

--- a/platform-operator/controllers/verrazzano/component/rancher/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/rancher/module_integration.go
@@ -12,12 +12,15 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/nginx"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"reflect"
 )
 
 // valuesConfig Structure for the translated effective Verrazzano CR values to Module CR Helm values
 type valuesConfig struct {
 	KeycloakAuthEnabled *bool `json:"keycloakAuthEnabled,omitempty"`
 }
+
+var emptyConfig = valuesConfig{}
 
 // GetModuleConfigAsHelmValues returns an unstructured JSON valuesConfig representing the portion of the Verrazzano CR that corresponds to the module
 func (r rancherComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazzano) (*apiextensionsv1.JSON, error) {
@@ -31,6 +34,10 @@ func (r rancherComponent) GetModuleConfigAsHelmValues(effectiveCR *vzapi.Verrazz
 	if rancher != nil {
 		// The prometheus operator digs into the Thanos overrides for the Thanos ruler settings, so we need to trigger on that
 		configSnippet.KeycloakAuthEnabled = rancher.KeycloakAuthEnabled
+	}
+
+	if reflect.DeepEqual(emptyConfig, configSnippet) {
+		return nil, nil
 	}
 
 	return spi.NewModuleConfigHelmValuesWrapper(configSnippet)


### PR DESCRIPTION
Some general cleanup of modules config mappings
- Return nil from `GetModuleConfigAsHelmValues` from components if derived config is empty
- Map Istio, MySQL config more directly to v1alpha1 API
- add more unit tests/cases around the modules integration code where needed
