### PR TITLE
VZ-11084: Back port uptake of new gitjob image to release-1.6

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -183,7 +183,7 @@
             },
             {
               "image": "rancher-gitjob",
-              "tag": "v0.1.32-20230922083827-58582b0"
+              "tag": "v0.1.32-20230925114322-53ac350"
             },
             {
               "image": "rancher-cleanup",


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
