### PR TITLE
Update rancher and cert-manage catalog versions

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -5,7 +5,7 @@ modules:
   - name: ingress-controller
     version: 1.7.1
   - name: cert-manager
-    version: 1.9.1
+    version: 1.9.1-1
   - name: cert-manager-webhook-oci
     version: 0.1.0
   - name: cluster-issuer
@@ -17,7 +17,7 @@ modules:
   - name: istio
     version: 1.17.2
   - name: rancher
-    version: 2.7.5
+    version: 2.7.5-1
   - name: cluster-api
     version: 1.4.6
   - name: verrazzano


### PR DESCRIPTION
Increment rancher and cert-manager catalog versions to reflect image changes from https://github.com/verrazzano/verrazzano/pull/7142 and https://github.com/verrazzano/verrazzano/pull/7146.