### PR TITLE
VZ-11124: Uptake NGINX Prometheus Exporter v0.11.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Component version updates:
 - WebLogic Kubernetes Operator v4.1.2
 - WebLogic Monitoring Exporter v2.1.5
 - Thanos v0.32.2 (includes support for OKE Workload Identities)
+- NGINX Prometheus Exporter v0.11.0
 
 Features:
 

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -273,7 +273,7 @@
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "v0.10.0-20230922082301-7cf62c11",
+              "tag": "v0.11.0-20230925134800-53d30b7f",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }


### PR DESCRIPTION
Note that this image is part of the Auth Proxy component so there is no separate module catalog entry, and there is no Helm chart (this is part of the Auth Proxy Helm chart).