### PR TITLE
VZ-10841: Update Keycloak image with bouncy castle libraries from v1.74, release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -449,7 +449,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "v20.0.1-20230919161553-c397f447f5",
+              "tag": "v20.0.1-20230923031034-a5c064d9f2",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Backports https://github.com/verrazzano/verrazzano/pull/7141 to release-1.5