### PR TITLE
Change ServiceMonitor release label

### DIFF
--- a/platform-operator/helm_config/overrides/prometheus-pushgateway-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-pushgateway-values.yaml
@@ -4,7 +4,7 @@
 serviceMonitor:
   namespace: verrazzano-monitoring
   additionalLabels:
-    release: prometheus-operator
+    release: prometheus-pushgateway
 persistentVolume:
   enabled: false
 podLabels:


### PR DESCRIPTION
In the previous version of the Prometheus Pushgateway Helm chart, the default behavior was to add a release label to all resources. In this latest version of the chart, that behavior changed and the release label is no longer added. In order to get the Prometheus Operator to pick up the ServiceMonitor, I had added a `release: prometheus-operator` label to the ServiceMonitor (using overrides).

This PR changes the label to `release: prometheus-pushgateway` to replicate the previous behavior. The selector in the Prometheus CR is configured to pick up ServiceMonitors with that release label value as well.