### PR TITLE
First pass of adding metrics to Verrazzano controller

### DIFF
--- a/pkg/controller/errors/errors.go
+++ b/pkg/controller/errors/errors.go
@@ -67,7 +67,7 @@ func ShouldLogKubernetesAPIError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if IsUpdateConflict(err) {
+	if IsUpdateConflict(err) || IsRetryableError(err) {
 		return false
 	}
 	return true

--- a/platform-operator/controllers/verrazzano/controller/reconciler.go
+++ b/platform-operator/controllers/verrazzano/controller/reconciler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/result"
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
+	"github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	"github.com/verrazzano/verrazzano/pkg/semver"
 	vzstring "github.com/verrazzano/verrazzano/pkg/string"
@@ -24,6 +25,7 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/transform"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/config"
 	"github.com/verrazzano/verrazzano/platform-operator/internal/k8s/namespace"
+	"github.com/verrazzano/verrazzano/platform-operator/metricsexporter"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,10 +34,34 @@ import (
 // Reconcile reconciles the Verrazzano CR.  This includes new installations, updates, upgrades, and partial uninstalls.
 // NOTE: full uninstalls are done by the finalizer.go code
 func (r Reconciler) Reconcile(controllerCtx controllerspi.ReconcileContext, u *unstructured.Unstructured) result.Result {
+	// Initialize metrics
+	zapLogForMetrics := zap.S().With(log.FieldController, "verrazzano")
+	counterMetricObject, err := metricsexporter.GetSimpleCounterMetric(metricsexporter.ReconcileCounter)
+	if err != nil {
+		zapLogForMetrics.Error(err)
+		return result.NewResult()
+	}
+	counterMetricObject.Inc()
+	errorCounterMetricObject, err := metricsexporter.GetSimpleCounterMetric(metricsexporter.ReconcileError)
+	if err != nil {
+		zapLogForMetrics.Error(err)
+		return result.NewResult()
+	}
+
+	reconcileDurationMetricObject, err := metricsexporter.GetDurationMetric(metricsexporter.ReconcileDuration)
+	if err != nil {
+		zapLogForMetrics.Error(err)
+		return result.NewResult()
+	}
+	reconcileDurationMetricObject.TimerStart()
+	defer reconcileDurationMetricObject.TimerStop()
 	// Convert the unstructured to a Verrazzano CR
 	actualCR := &vzv1alpha1.Verrazzano{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, actualCR); err != nil {
 		controllerCtx.Log.ErrorfThrottled(err.Error())
+		if metricsexporter.IsMetricError(err) {
+			errorCounterMetricObject.Inc()
+		}
 		// This is a fatal error which should never happen, don't requeue
 		return result.NewResult()
 	}
@@ -49,6 +75,9 @@ func (r Reconciler) Reconcile(controllerCtx controllerspi.ReconcileContext, u *u
 		ControllerName: "verrazzano",
 	})
 	if err != nil {
+		if metricsexporter.IsMetricError(err) {
+			errorCounterMetricObject.Inc()
+		}
 		zap.S().Errorf("Failed to create controller logger for Verrazzano controller: %v", err)
 	}
 
@@ -60,6 +89,9 @@ func (r Reconciler) Reconcile(controllerCtx controllerspi.ReconcileContext, u *u
 	// If an upgrade is pending, do not reconcile; an upgrade is pending if the VPO has been upgraded, but the user
 	// has not modified the version in the Verrazzano CR to match the BOM.
 	if upgradePending, err := r.isUpgradeRequired(actualCR); upgradePending || err != nil {
+		if metricsexporter.IsMetricError(err) {
+			errorCounterMetricObject.Inc()
+		}
 		controllerCtx.Log.Oncef("Upgrade required before reconciling modules")
 		return result.NewResultShortRequeueDelayIfError(err)
 	}
@@ -68,6 +100,9 @@ func (r Reconciler) Reconcile(controllerCtx controllerspi.ReconcileContext, u *u
 	// Always use actualCR when updating status
 	effectiveCR, err := transform.GetEffectiveCR(actualCR)
 	if err != nil {
+		if metricsexporter.IsMetricError(err) {
+			errorCounterMetricObject.Inc()
+		}
 		return result.NewResultShortRequeueDelayWithError(err)
 	}
 	effectiveCR.Status = actualCR.Status
@@ -78,6 +113,9 @@ func (r Reconciler) Reconcile(controllerCtx controllerspi.ReconcileContext, u *u
 	// where the status is updated in those cases.
 	if r.isUpgrading(actualCR) {
 		if err := r.updateStatusUpgrading(log, actualCR); err != nil {
+			if metricsexporter.IsMetricError(err) {
+				errorCounterMetricObject.Inc()
+			}
 			return result.NewResultShortRequeueDelayWithError(err)
 		}
 	}
@@ -100,6 +138,9 @@ func (r Reconciler) Reconcile(controllerCtx controllerspi.ReconcileContext, u *u
 
 	// All done reconciling.  Add the completed condition to the status and set the state back to Ready.
 	if err := r.updateStatusInstallUpgradeComplete(actualCR); err != nil {
+		if metricsexporter.IsMetricError(err) {
+			errorCounterMetricObject.Inc()
+		}
 		return result.NewResultShortRequeueDelayWithError(err)
 	}
 	controllerCtx.Log.Oncef("Successfully reconciled Verrazzano for generation %v", actualCR.Generation)

--- a/platform-operator/metricsexporter/metricsexporter.go
+++ b/platform-operator/metricsexporter/metricsexporter.go
@@ -5,6 +5,7 @@ package metricsexporter
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	spi "github.com/verrazzano/verrazzano/pkg/controller/errors"
 )
 
 type MetricsExporter struct {
@@ -118,4 +119,10 @@ func (c *ComponentHealth) SetComponentHealth(JSONname string, availability bool,
 	}
 	metric.Set(float64(setting))
 	return metric, nil
+}
+func IsMetricError(err error) bool {
+	if spi.IsUpdateConflict(err) || spi.IsRetryableError(err) {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
This PR wires in metrics to the Verrazzano controller. These are the same metric/name/titles used in the legacy controller. There are also changes related to logging of some errors. 
