### PR TITLE
OKE no longer supports 1.24. Turning off OKE only tests, setting ones…

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -212,7 +212,7 @@ pipeline {
                                     parameters: [
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
-                                        string(name: 'TEST_ENV', 'kind'),
+                                        string(name: 'TEST_ENV', value: 'kind'),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)
@@ -230,7 +230,7 @@ pipeline {
                                         string(name: 'OCI_DNS_AUTH', value: 'instance_principal'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'TEST_ENV', 'kind'),
+                                        string(name: 'TEST_ENV', value: 'kind'),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -206,39 +206,16 @@ pipeline {
                 // OKE no longer supports K8S 1.24, so all OCI DNS testing is now using Kind only
                 stage('OCI DNS tests') {
                     steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-new-oci-dns-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
-                                        string(name: 'TEST_ENV', value: 'kind'),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)
-                                    ], wait: true
-                            }
-                        }
+                       script {
+                           echo "OKE no longer supports 1.24, no longer running these tests on 1.4"
+                       }
                     }
                 }
                 stage('OCI DNS tests with instance principal') {
                     steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-new-oci-dns-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'OCI_DNS_AUTH', value: 'instance_principal'),
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'TEST_ENV', value: 'kind'),
-                                        booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
-                                    ], wait: true
-                            }
-                        }
+                       script {
+                           echo "OKE no longer supports 1.24, no longer running these tests on 1.4"
+                       }
                     }
                }
                 stage('Verrazzano in OCNE environment') {
@@ -492,20 +469,9 @@ pipeline {
                 }
                 stage('OCI DNS/ACME-Staging Tests') {
                     steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "verrazzano-new-oci-dns-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'CERT_ISSUER', value: "acme"),
-                                        string(name: 'ACME_ENVIRONMENT', value: "staging"),
-                                        booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: false),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)
-                                    ], wait: true
-                            }
-                        }
+                       script {
+                           echo "OKE no longer supports 1.24, no longer running these tests on 1.4"
+                       }
                     }
                     post {
                         failure {

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -197,20 +197,13 @@ pipeline {
                     }
                 }
                 stage('Uninstall Tests') {
-                    steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-uninstall-test/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)
-                                    ], wait: true
-                            }
-                        }
-                    }
+                   steps {
+                       script {
+                           echo "OKE no longer supports 1.24, no longer running these tests on 1.4"
+                       }
+                   }
                 }
+                // OKE no longer supports K8S 1.24, so all OCI DNS testing is now using Kind only
                 stage('OCI DNS tests') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
@@ -219,6 +212,7 @@ pipeline {
                                     parameters: [
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
+                                        string(name: 'TEST_ENV', 'kind'),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)
@@ -236,6 +230,7 @@ pipeline {
                                         string(name: 'OCI_DNS_AUTH', value: 'instance_principal'),
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                        string(name: 'TEST_ENV', 'kind'),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
@@ -266,18 +261,8 @@ pipeline {
                 }
                stage('Backup and Restore Tests') {
                    steps {
-                       retry(count: JOB_PROMOTION_RETRIES) {
-                           script {
-                               build job: "/verrazzano-backup-all-test-oke/${CLEAN_BRANCH_NAME}",
-                                   parameters: [
-                                       string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                       string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: 'NONE'),
-                                       string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                       string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                       string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                       booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
-                                   ], wait: true
-                           }
+                       script {
+                           echo "OKE no longer supports 1.24, no longer running these tests on 1.4"
                        }
                    }
                }

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -216,7 +216,7 @@ pipeline {
                                     parameters: [
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'TEST_ENV', 'kind'),
+                                        string(name: 'TEST_ENV', value: 'kind'),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -207,24 +207,11 @@ pipeline {
                        }
                    }
                 }
-                // OKE no longer supports K8S 1.24, so all OCI DNS testing is now using Kind only
                 stage('OCI DNS tests') {
                     steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-new-oci-dns-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'TEST_ENV', value: 'kind'),
-                                        booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS)
-                                    ], wait: true
-                            }
-                        }
+                       script {
+                           echo "OKE no longer supports 1.24, no longer running these tests on 1.4"
+                       }
                     }
                 }
                 stage('Kind Acceptance Tests on 1.24') {

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -201,24 +201,13 @@ pipeline {
                     }
                 }
                 stage('Uninstall Tests') {
-                    steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-uninstall-test/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        booleanParam(name: 'EMIT_METRICS', value: params.EMIT_METRICS),
-                                        string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
-                                    ], wait: true
-                            }
-                        }
-                    }
+                   steps {
+                       script {
+                           echo "OKE no longer supports 1.24, no longer running these tests on 1.4"
+                       }
+                   }
                 }
+                // OKE no longer supports K8S 1.24, so all OCI DNS testing is now using Kind only
                 stage('OCI DNS tests') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
@@ -227,6 +216,7 @@ pipeline {
                                     parameters: [
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
+                                        string(name: 'TEST_ENV', 'kind'),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),


### PR DESCRIPTION
OKE no longer supports 1.24. Turning off OKE only tests, setting ones that can also run on Kind to use Kind