### PR TITLE
OKE no longer supports 1.24. Turning off OKE only tests, setting ones…

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -183,20 +183,8 @@ pipeline {
             parallel {
                 stage('OCI DNS tests with instance principal') {
                     steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-new-oci-dns-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'OCI_DNS_AUTH', value: 'instance_principal'),
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
-                                        string(name: 'TEST_ENV', value: 'kind'),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                    ], wait: true
-                            }
+                        script {
+                            echo "OKE no longer supports 1.24, no longer running these tests on 1.5"
                         }
                     }
                }
@@ -404,20 +392,8 @@ pipeline {
                 }
                 stage('OCI DNS/ACME-Staging Tests') {
                     steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "verrazzano-new-oci-dns-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'CERT_ISSUER', value: "acme"),
-                                        string(name: 'ACME_ENVIRONMENT', value: "staging"),
-                                        booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: false),
-                                        string(name: 'TEST_ENV', value: 'kind'),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)
-                                    ], wait: true
-                            }
+                        script {
+                            echo "OKE no longer supports 1.24, no longer running these tests on 1.5"
                         }
                     }
                     post {

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -191,7 +191,7 @@ pipeline {
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
-                                        string(name: 'TEST_ENV', 'kind'),
+                                        string(name: 'TEST_ENV', value: 'kind'),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
@@ -412,7 +412,7 @@ pipeline {
                                         string(name: 'CERT_ISSUER', value: "acme"),
                                         string(name: 'ACME_ENVIRONMENT', value: "staging"),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: false),
-                                        string(name: 'TEST_ENV', 'kind'),
+                                        string(name: 'TEST_ENV', value: 'kind'),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)

--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -191,6 +191,7 @@ pipeline {
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
+                                        string(name: 'TEST_ENV', 'kind'),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
@@ -218,17 +219,8 @@ pipeline {
                 }
                stage('Backup and Restore Tests') {
                    steps {
-                       retry(count: JOB_PROMOTION_RETRIES) {
-                           script {
-                               build job: "/verrazzano-backup-all-test-oke/${CLEAN_BRANCH_NAME}",
-                                   parameters: [
-                                       string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                       string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: 'NONE'),
-                                       string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                       string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                       string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                   ], wait: true
-                           }
+                       script {
+                           echo "OKE no longer supports 1.24, no longer running these tests on 1.5"
                        }
                    }
                }
@@ -333,13 +325,7 @@ pipeline {
                 stage('Uninstall Resiliency tests') {
                     steps {
                         script {
-                            build job: "/verrazzano-uninstall-resiliency-suite/${CLEAN_BRANCH_NAME}",
-                                parameters: [
-                                    string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                    string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                    string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                    string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                ], wait: true
+                            echo "OKE no longer supports 1.24, no longer running these tests on 1.5"
                         }
                     }
                 }
@@ -426,6 +412,7 @@ pipeline {
                                         string(name: 'CERT_ISSUER', value: "acme"),
                                         string(name: 'ACME_ENVIRONMENT', value: "staging"),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: false),
+                                        string(name: 'TEST_ENV', 'kind'),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)
@@ -443,16 +430,8 @@ pipeline {
                 }
                 stage('OCI Service Integration Tests') {
                     steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-oci-integration-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)
-                                    ], wait: true
-                            }
+                        script {
+                            echo "OKE no longer supports 1.24, no longer running these tests on 1.5"
                         }
                     }
                     post {

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -205,19 +205,8 @@ pipeline {
                 }
                 stage('OCI DNS tests') {
                     steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-new-oci-dns-acceptance-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
-                                        string(name: 'TEST_ENV', value: 'kind'),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                    ], wait: true
-                            }
+                        script {
+                            echo "OKE no longer supports 1.24, no longer running these tests on 1.5"
                         }
                     }
                 }

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -198,19 +198,8 @@ pipeline {
                 }
                 stage('Uninstall Tests') {
                     steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-uninstall-test/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
-                                        string(name: 'WILDCARD_DNS_DOMAIN', value: params.WILDCARD_DNS_DOMAIN),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
-                                    ], wait: true
-                            }
+                        script {
+                            echo "OKE no longer supports 1.24, no longer running these tests on 1.5"
                         }
                     }
                 }
@@ -223,6 +212,7 @@ pipeline {
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
+                                        string(name: 'TEST_ENV', 'kind'),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),

--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -212,7 +212,7 @@ pipeline {
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'VERRAZZANO_OPERATOR_IMAGE', value: params.VERRAZZANO_OPERATOR_IMAGE),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: true),
-                                        string(name: 'TEST_ENV', 'kind'),
+                                        string(name: 'TEST_ENV', value: 'kind'),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),


### PR DESCRIPTION
OKE no longer supports 1.24. Turning off OKE only tests, setting ones that can also run on Kind to use Kind
