### PR TITLE
VZ-11142: Uptake Prometheus Node Exporter v1.6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Component version updates:
 - Kube State Metrics v2.10.0
 - NGINX Prometheus Exporter v0.11.0
 - Prometheus Pushgateway v1.6.2
+- Prometheus Node Exporter v1.6.1
 
 
 Features:

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
@@ -119,6 +119,7 @@ func (c prometheusNodeExporterComponent) MonitorOverrides(ctx spi.ComponentConte
 func (c prometheusNodeExporterComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	// The new Helm chart fails to upgrade because of a label selector immutable field, so we need
 	// to delete the daemonset before upgrading
+	// Added in Verrazzano v1.7.0
 	ctx.Log().Infof("PreUpgrade deleting daemonset %s/%s", ComponentNamespace, daemonsetName)
 	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: ComponentNamespace, Name: daemonsetName}}
 	if err := ctx.Client().Delete(context.TODO(), ds); err != nil && !errors.IsNotFound(err) {

--- a/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
+++ b/platform-operator/controllers/verrazzano/component/prometheus/nodeexporter/nodeexporter_component.go
@@ -115,7 +115,7 @@ func (c prometheusNodeExporterComponent) MonitorOverrides(ctx spi.ComponentConte
 	return true
 }
 
-// PostInstall creates/updates associated resources after this component is installed
+// PreUpgrade performs pre-upgrade processing for this component
 func (c prometheusNodeExporterComponent) PreUpgrade(ctx spi.ComponentContext) error {
 	// The new Helm chart fails to upgrade because of a label selector immutable field, so we need
 	// to delete the daemonset before upgrading

--- a/platform-operator/helm_config/overrides/prometheus-node-exporter-values.yaml
+++ b/platform-operator/helm_config/overrides/prometheus-node-exporter-values.yaml
@@ -8,6 +8,8 @@ fullName: prometheus-node-exporter
 # Prometheus ServiceMonitor settings
 prometheus:
   monitor:
+    additionalLabels:
+      release: prometheus-node-exporter
     relabelings:
       - action: replace
         targetLabel: verrazzano_cluster

--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -61,7 +61,7 @@ modules:
   - name: prometheus-pushgateway
     version: 1.6.2
   - name: prometheus-node-exporter
-    version: 1.3.1
+    version: 1.6.1
   - name: jaeger-operator
     version: 1.42.0
   - name: velero

--- a/platform-operator/thirdparty/charts/README.md
+++ b/platform-operator/thirdparty/charts/README.md
@@ -222,11 +222,11 @@ helm fetch argocd/argo-cd --untar=true --version=${ARGOCD_CHART_VERSION}
 The `prometheus-community/prometheus-node-exporter` folder was created by running the following commands:
 
 ```shell
-export PROMETHEUS_NODE_EXPORTER_CHART_VERSION=3.1.0
+export PROMETHEUS_NODE_EXPORTER_CHART_VERSION=4.23.1
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 rm -rf prometheus-community/prometheus-node-exporter 
-helm fetch prometheus-community/prometheus-node-exporter --untar=true --untardir=prometheus-community/prometheus-node-exporter --version=${PROMETHEUS_NODE_EXPORTER_CHART_VERSION}
+helm fetch prometheus-community/prometheus-node-exporter --untar=true --untardir=prometheus-community --version=${PROMETHEUS_NODE_EXPORTER_CHART_VERSION}
 ```
 
 ### Prometheus Pushgateway
@@ -238,7 +238,7 @@ export PROMETHEUS_PUSHGATEWAY_CHART_VERSION=2.4.1
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 rm -rf prometheus-community/prometheus-pushgateway
-helm fetch prometheus-community/prometheus-pushgateway --untar=true --untardir=prometheus-community/prometheus-pushgateway --version=${PROMETHEUS_PUSHGATEWAY_CHART_VERSION}
+helm fetch prometheus-community/prometheus-pushgateway --untar=true --untardir=prometheus-community --version=${PROMETHEUS_PUSHGATEWAY_CHART_VERSION}
 ```
 
 ### OpenSearch Operator

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/Chart.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/Chart.yaml
@@ -1,19 +1,25 @@
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Chart Source
+      url: https://github.com/prometheus-community/helm-charts
 apiVersion: v2
-name: prometheus-node-exporter
+appVersion: 1.6.1
 description: A Helm chart for prometheus node-exporter
-keywords:
-  - node-exporter
-  - prometheus
-  - exporter
-type: application
-version: 3.1.0
-appVersion: 1.3.1
 home: https://github.com/prometheus/node_exporter/
-sources:
-  - https://github.com/prometheus/node_exporter/
+keywords:
+- node-exporter
+- prometheus
+- exporter
 maintainers:
-  - email: gianrubio@gmail.com
-    name: gianrubio
-  - name: bismarck
-  - email: zanhsieh@gmail.com
-    name: zanhsieh
+- email: gianrubio@gmail.com
+  name: gianrubio
+- email: zanhsieh@gmail.com
+  name: zanhsieh
+- email: rootsandtrees@posteo.de
+  name: zeritti
+name: prometheus-node-exporter
+sources:
+- https://github.com/prometheus/node_exporter/
+type: application
+version: 4.23.1

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/README.md
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/README.md
@@ -1,17 +1,17 @@
-# Prometheus Node Exporter
+# Prometheus `Node Exporter`
 
 Prometheus exporter for hardware and OS metrics exposed by *NIX kernels, written in Go with pluggable metric collectors.
 
-This chart bootstraps a prometheus [Node Exporter](http://github.com/prometheus/node_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a prometheus [`Node Exporter`](http://github.com/prometheus/node_exporter) daemonset on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-## Get Repo Info
+## Get Repository Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
 ## Install Chart
 
@@ -19,7 +19,7 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 helm install [RELEASE_NAME] prometheus-community/prometheus-node-exporter
 ```
 
-_See [configuration](#configuration) below._
+_See [configuration](#configuring) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
@@ -40,6 +40,21 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### 4.16 to 4.17+
+
+`containerSecurityContext.readOnlyRootFilesystem` is set to `true` by default.
+
+### 3.x to 4.x
+
+Starting from version 4.0.0, the `node exporter` chart is using the [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/). Therefore you have to delete the daemonset before you upgrade.
+
+```console
+kubectl delete daemonset -l app=prometheus-node-exporter
+helm upgrade -i prometheus-node-exporter prometheus-community/prometheus-node-exporter
+```
+
+If you use your own custom [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor) or [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmonitor), please ensure to upgrade their `selector` fields accordingly to the new labels.
 
 ### From 2.x to 3.x
 
@@ -64,3 +79,22 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 ```console
 helm show values prometheus-community/prometheus-node-exporter
 ```
+
+### kube-rbac-proxy
+
+You can enable `prometheus-node-exporter` endpoint protection using `kube-rbac-proxy`. By setting `kubeRBACProxy.enabled: true`, this chart will deploy a RBAC proxy container protecting the node-exporter endpoint.
+To authorize access, authenticate your requests (via a `ServiceAccount` for example) with a `ClusterRole` attached such as:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-node-exporter-read
+rules:
+  - apiGroups: [ "" ]
+    resources: ["services/node-exporter-prometheus-node-exporter"]
+    verbs:
+      - get
+```
+
+See [kube-rbac-proxy examples](https://github.com/brancz/kube-rbac-proxy/tree/master/examples/resource-attributes) for more details.

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/NOTES.txt
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/NOTES.txt
@@ -9,7 +9,21 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ template "prometheus-node-exporter.namespace" . }} {{ template "prometheus-node-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ template "prometheus-node-exporter.namespace" . }} -l "app={{ template "prometheus-node-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ template "prometheus-node-exporter.namespace" . }} -l "app.kubernetes.io/name={{ template "prometheus-node-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:9100 to use your application"
   kubectl port-forward --namespace {{ template "prometheus-node-exporter.namespace" . }} $POD_NAME 9100
+{{- end }}
+
+{{- if .Values.kubeRBACProxy.enabled}}
+
+kube-rbac-proxy endpoint protections is enabled:
+- Metrics endpoints is now HTTPS
+- Ensure that the client authenticates the requests (e.g. via service account) with the following role permissions:
+```
+rules:
+  - apiGroups: [ "" ]
+    resources: ["services/{{ template "prometheus-node-exporter.fullname" . }}"]
+    verbs:
+      - get
+```
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/_helpers.tpl
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/_helpers.tpl
@@ -3,8 +3,8 @@
 Expand the name of the chart.
 */}}
 {{- define "prometheus-node-exporter.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -12,26 +12,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "prometheus-node-exporter.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/* Generate basic labels */}}
-{{- define "prometheus-node-exporter.labels" }}
-app: {{ template "prometheus-node-exporter.name" . }}
-heritage: {{.Release.Service }}
-release: {{.Release.Name }}
-chart: {{ template "prometheus-node-exporter.chart" . }}
-{{- if .Values.podLabels}}
-{{ toYaml .Values.podLabels }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -39,50 +28,158 @@ chart: {{ template "prometheus-node-exporter.chart" . }}
 Create chart name and version as used by the chart label.
 */}}
 {{- define "prometheus-node-exporter.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prometheus-node-exporter.labels" -}}
+helm.sh/chart: {{ include "prometheus-node-exporter.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: metrics
+app.kubernetes.io/part-of: {{ include "prometheus-node-exporter.name" . }}
+{{ include "prometheus-node-exporter.selectorLabels" . }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+{{- with .Values.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- if .Values.releaseLabel }}
+release: {{ .Release.Name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prometheus-node-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-node-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 
 
 {{/*
 Create the name of the service account to use
 */}}
 {{- define "prometheus-node-exporter.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "prometheus-node-exporter.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prometheus-node-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
 
 {{/*
 The image to use
 */}}
 {{- define "prometheus-node-exporter.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- if .Values.image.sha }}
+{{- fail "image.sha forbidden. Use image.digest instead" }}
+{{- else if .Values.image.digest }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.digest }}
+{{- else }}
+{{- printf "%s/%s:%s@%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) .Values.image.digest }}
+{{- end }}
+{{- else }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- else }}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*
 Allow the release namespace to be overridden for multi-namespace deployments in combined charts
 */}}
 {{- define "prometheus-node-exporter.namespace" -}}
-  {{- if .Values.namespaceOverride -}}
-    {{- .Values.namespaceOverride -}}
-  {{- else -}}
-    {{- .Release.Namespace -}}
-  {{- end -}}
-{{- end -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create the namespace name of the service monitor
 */}}
 {{- define "prometheus-node-exporter.monitor-namespace" -}}
-  {{- if .Values.namespaceOverride -}}
-    {{- .Values.namespaceOverride -}}
-  {{- else -}}
-    {{- if .Values.prometheus.monitor.namespace -}}
-      {{- .Values.prometheus.monitor.namespace -}}
-    {{- else -}}
-      {{- .Release.Namespace -}}
-    {{- end -}}
-  {{- end -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- if .Values.prometheus.monitor.namespace }}
+{{- .Values.prometheus.monitor.namespace }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Sets default scrape limits for servicemonitor */}}
+{{- define "servicemonitor.scrapeLimits" -}}
+{{- with .sampleLimit }}
+sampleLimit: {{ . }}
+{{- end }}
+{{- with .targetLimit }}
+targetLimit: {{ . }}
+{{- end }}
+{{- with .labelLimit }}
+labelLimit: {{ . }}
+{{- end }}
+{{- with .labelNameLengthLimit }}
+labelNameLengthLimit: {{ . }}
+{{- end }}
+{{- with .labelValueLengthLimit }}
+labelValueLengthLimit: {{ . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Formats imagePullSecrets. Input is (dict "Values" .Values "imagePullSecrets" .{specific imagePullSecrets})
+*/}}
+{{- define "prometheus-node-exporter.imagePullSecrets" -}}
+{{- range (concat .Values.global.imagePullSecrets .imagePullSecrets) }}
+  {{- if eq (typeOf .) "map[string]interface {}" }}
+- {{ toYaml . | trim }}
+  {{- else }}
+- name: {{ . }}
+  {{- end }}
+{{- end }}
 {{- end -}}
+
+{{/*
+Create the namespace name of the pod monitor
+*/}}
+{{- define "prometheus-node-exporter.podmonitor-namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- if .Values.prometheus.podMonitor.namespace }}
+{{- .Values.prometheus.podMonitor.namespace }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Sets default scrape limits for podmonitor */}}
+{{- define "podmonitor.scrapeLimits" -}}
+{{- with .sampleLimit }}
+sampleLimit: {{ . }}
+{{- end }}
+{{- with .targetLimit }}
+targetLimit: {{ . }}
+{{- end }}
+{{- with .labelLimit }}
+labelLimit: {{ . }}
+{{- end }}
+{{- with .labelNameLengthLimit }}
+labelNameLengthLimit: {{ . }}
+{{- end }}
+{{- with .labelValueLengthLimit }}
+labelValueLengthLimit: {{ . }}
+{{- end }}
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/clusterrole.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if and (eq .Values.rbac.create true) (eq .Values.kubeRBACProxy.enabled true) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "prometheus-node-exporter.fullname" . }}
+  namespace: {{ include "prometheus-node-exporter.namespace" . }}
+  labels:
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
+rules:
+  {{-  if $.Values.kubeRBACProxy.enabled  }}
+  - apiGroups: [ "authentication.k8s.io" ]
+    resources:
+      - tokenreviews
+    verbs: [ "create" ]
+  - apiGroups: [ "authorization.k8s.io" ]
+    resources:
+      - subjectaccessreviews
+    verbs: [ "create" ]
+  {{- end }}
+{{- end -}}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/clusterrolebinding.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if and (eq .Values.rbac.create true) (eq .Values.kubeRBACProxy.enabled true) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
+  name: {{ template "prometheus-node-exporter.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+{{- if .Values.rbac.useExistingRole }}
+  name: {{ .Values.rbac.useExistingRole }}
+{{- else }}
+  name: {{ template "prometheus-node-exporter.fullname" . }}
+{{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-node-exporter.serviceAccountName" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+{{- end -}}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/daemonset.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/daemonset.yaml
@@ -1,40 +1,47 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ template "prometheus-node-exporter.fullname" . }}
-  namespace: {{ template "prometheus-node-exporter.namespace" . }}
-  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
+  name: {{ include "prometheus-node-exporter.fullname" . }}
+  namespace: {{ include "prometheus-node-exporter.namespace" . }}
+  labels:
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
+  {{- with .Values.daemonsetAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "prometheus-node-exporter.name" . }}
-      release: {{ .Release.Name }}
-  {{- if .Values.updateStrategy }}
+      {{- include "prometheus-node-exporter.selectorLabels" . | nindent 6 }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- with .Values.updateStrategy }}
   updateStrategy:
-{{ toYaml .Values.updateStrategy | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   template:
     metadata:
-      labels: {{ include "prometheus-node-exporter.labels" . | indent 8 }}
-      {{- if .Values.podAnnotations }}
+      {{- with .Values.podAnnotations }}
       annotations:
-      {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
+      labels:
+        {{- include "prometheus-node-exporter.labels" . | nindent 8 }}
     spec:
-      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
-      serviceAccountName: {{ template "prometheus-node-exporter.serviceAccountName" . }}
-{{- if .Values.securityContext }}
+      automountServiceAccountToken: {{ ternary true false (or .Values.serviceAccount.automountServiceAccountToken .Values.kubeRBACProxy.enabled) }}
+      {{- with .Values.securityContext }}
       securityContext:
-{{ toYaml .Values.securityContext | indent 8 }}
-{{- end }}
-{{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
-{{- end }}
-      {{- if .Values.extraInitContainers }}
-      initContainers:
-      {{ toYaml .Values.extraInitContainers | nindent 6 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "prometheus-node-exporter.serviceAccountName" . }}
       containers:
+        {{- $servicePort := ternary 8100 .Values.service.port .Values.kubeRBACProxy.enabled }}
         - name: node-exporter
           image: {{ include "prometheus-node-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -43,42 +50,80 @@ spec:
             - --path.sysfs=/host/sys
             {{- if .Values.hostRootFsMount.enabled }}
             - --path.rootfs=/host/root
+            {{- if semverCompare ">=1.4.0" (default .Chart.AppVersion .Values.image.tag) }}
+            - --path.udev.data=/host/root/run/udev/data
             {{- end }}
-            - --web.listen-address=[$(HOST_IP)]:{{ .Values.service.port }}
-{{- if .Values.extraArgs }}
-{{ toYaml .Values.extraArgs | indent 12 }}
-{{- end }}
+            {{- end }}
+            - --web.listen-address=[$(HOST_IP)]:{{ $servicePort }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.containerSecurityContext }}
-          securityContext: {{ toYaml . | nindent 12 }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-          - name: HOST_IP
-            {{- if .Values.service.listenOnAllInterfaces }}
-            value: 0.0.0.0
-            {{- else }}
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.hostIP
+            - name: HOST_IP
+              {{- if .Values.kubeRBACProxy.enabled }}
+              value: 127.0.0.1
+              {{- else if .Values.service.listenOnAllInterfaces }}
+              value: 0.0.0.0
+              {{- else }}
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+              {{- end }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
             {{- end }}
-          {{- range $key, $value := .Values.env }}
-          - name: {{ $key }}
-            value: {{ $value | quote }}
-          {{- end }}
+          {{- if eq .Values.kubeRBACProxy.enabled false }}
           ports:
             - name: {{ .Values.service.portName }}
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- end }}
           livenessProbe:
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             httpGet:
+              {{- if .Values.kubeRBACProxy.enabled }}
+              host: 127.0.0.1
+              {{- end }}
+              httpHeaders:
+              {{- range $_, $header := .Values.livenessProbe.httpGet.httpHeaders }}
+              - name: {{ $header.name }}
+                value: {{ $header.value }}
+              {{- end }}
               path: /
-              port: {{ .Values.service.port }}
+              port: {{ $servicePort }}
+              scheme: {{ upper .Values.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             httpGet:
+              {{- if .Values.kubeRBACProxy.enabled }}
+              host: 127.0.0.1
+              {{- end }}
+              httpHeaders:
+              {{- range $_, $header := .Values.readinessProbe.httpGet.httpHeaders }}
+              - name: {{ $header.name }}
+                value: {{ $header.value }}
+              {{- end }}
               path: /
-              port: {{ .Values.service.port }}
+              port: {{ $servicePort }}
+              scheme: {{ upper .Values.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          {{- with .Values.resources }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: proc
               mountPath: /host/proc
@@ -94,8 +139,37 @@ spec:
               {{- end }}
               readOnly: true
             {{- end }}
-            {{- if .Values.extraHostVolumeMounts }}
             {{- range $_, $mount := .Values.extraHostVolumeMounts }}
+            - name: {{ $mount.name }}
+              mountPath: {{ $mount.mountPath }}
+              readOnly: {{ $mount.readOnly }}
+              {{- with $mount.mountPropagation }}
+              mountPropagation: {{ . }}
+              {{- end }}
+            {{- end }}
+            {{- range $_, $mount := .Values.sidecarVolumeMount }}
+            - name: {{ $mount.name }}
+              mountPath: {{ $mount.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- range $_, $mount := .Values.configmaps }}
+            - name: {{ $mount.name }}
+              mountPath: {{ $mount.mountPath }}
+            {{- end }}
+            {{- range $_, $mount := .Values.secrets }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+        {{- with .Values.sidecars }}
+        {{- toYaml . | nindent 8 }}
+          {{- if or $.Values.sidecarVolumeMount $.Values.sidecarHostVolumeMounts }}
+          volumeMounts:
+            {{- range $_, $mount := $.Values.sidecarVolumeMount }}
+            - name: {{ $mount.name }}
+              mountPath: {{ $mount.mountPath }}
+              readOnly: {{ $mount.readOnly }}
+            {{- end }}
+            {{- range $_, $mount := $.Values.sidecarHostVolumeMounts }}
             - name: {{ $mount.name }}
               mountPath: {{ $mount.mountPath }}
               readOnly: {{ $mount.readOnly }}
@@ -103,55 +177,70 @@ spec:
               mountPropagation: {{ $mount.mountPropagation }}
             {{- end }}
             {{- end }}
-            {{- end }}
-            {{- if .Values.sidecarVolumeMount }}
-            {{- range $_, $mount := .Values.sidecarVolumeMount }}
-            - name: {{ $mount.name }}
-              mountPath: {{ $mount.mountPath }}
-              readOnly: true
-            {{- end }}
-            {{- end }}
-            {{- if .Values.configmaps }}
-            {{- range $_, $mount := .Values.configmaps }}
-            - name: {{ $mount.name }}
-              mountPath: {{ $mount.mountPath }}
-            {{- end }}
-            {{- if .Values.secrets }}
-            {{- range $_, $mount := .Values.secrets }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
-{{- if .Values.sidecars }}
-{{ toYaml .Values.sidecars | indent 8 }}
-          {{- if .Values.sidecarVolumeMount }}
-          volumeMounts:
-            {{- range $_, $mount := .Values.sidecarVolumeMount }}
-            - name: {{ $mount.name }}
-              mountPath: {{ $mount.mountPath }}
-              readOnly: {{ $mount.readOnly }}
-            {{- end }}
           {{- end }}
-{{- end }}
+        {{- end }}
+        {{-  if .Values.kubeRBACProxy.enabled  }}
+        - name: kube-rbac-proxy
+          args:
+            {{-  if .Values.kubeRBACProxy.extraArgs  }}
+            {{- .Values.kubeRBACProxy.extraArgs | toYaml | nindent 12 }}
+            {{-  end  }}
+            - --secure-listen-address=:{{ .Values.service.port}}
+            - --upstream=http://127.0.0.1:{{ $servicePort }}/
+            - --proxy-endpoints-port=8888
+            - --config-file=/etc/kube-rbac-proxy-config/config-file.yaml
+          volumeMounts:
+            - name: kube-rbac-proxy-config
+              mountPath: /etc/kube-rbac-proxy-config
+          imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
+          {{- if .Values.kubeRBACProxy.image.sha }}
+          image: "{{ .Values.global.imageRegistry | default .Values.kubeRBACProxy.image.registry}}/{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}@sha256:{{ .Values.kubeRBACProxy.image.sha }}"
+          {{- else }}
+          image: "{{ .Values.global.imageRegistry | default .Values.kubeRBACProxy.image.registry}}/{{ .Values.kubeRBACProxy.image.repository }}:{{ .Values.kubeRBACProxy.image.tag }}"
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.port}}
+              name: "http"
+            - containerPort: 8888
+              name: "http-healthz"
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8888
+              path: healthz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          {{- if .Values.kubeRBACProxy.resources }}
+          resources:
+          {{ toYaml .Values.kubeRBACProxy.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.kubeRBACProxy.containerSecurityContext }}
+          securityContext:
+          {{ toYaml .Values.kubeRBACProxy.containerSecurityContext | nindent 12 }}
+        {{- end }}
+        {{- end }}
+      {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- include "prometheus-node-exporter.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.imagePullSecrets) | indent 8 }}
+      {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       hostPID: {{ .Values.hostPID }}
-{{- if .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-{{- end }}
-{{- with .Values.dnsConfig }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
       dnsConfig:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- if .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-{{- end }}
-    {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: proc
           hostPath:
@@ -164,31 +253,33 @@ spec:
           hostPath:
             path: /
         {{- end }}
-        {{- if .Values.extraHostVolumeMounts }}
         {{- range $_, $mount := .Values.extraHostVolumeMounts }}
         - name: {{ $mount.name }}
           hostPath:
             path: {{ $mount.hostPath }}
         {{- end }}
-        {{- end }}
-        {{- if .Values.sidecarVolumeMount }}
         {{- range $_, $mount := .Values.sidecarVolumeMount }}
         - name: {{ $mount.name }}
           emptyDir:
             medium: Memory
         {{- end }}
+        {{- range $_, $mount := .Values.sidecarHostVolumeMounts }}
+        - name: {{ $mount.name }}
+          hostPath:
+            path: {{ $mount.hostPath }}
         {{- end }}
-        {{- if .Values.configmaps }}
         {{- range $_, $mount := .Values.configmaps }}
         - name: {{ $mount.name }}
           configMap:
             name: {{ $mount.name }}
         {{- end }}
-        {{- end }}
-        {{- if .Values.secrets }}
         {{- range $_, $mount := .Values.secrets }}
         - name: {{ $mount.name }}
           secret:
             secretName: {{ $mount.name }}
         {{- end }}
+        {{- if .Values.kubeRBACProxy.enabled }}
+        - name: kube-rbac-proxy-config
+          configMap:
+            name: {{ template "prometheus-node-exporter.fullname" . }}-rbac-config
         {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/endpoints.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/endpoints.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: {{ template "prometheus-node-exporter.fullname" . }}
-  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+  name: {{ include "prometheus-node-exporter.fullname" . }}
+  namespace: {{ include "prometheus-node-exporter.namespace" . }}
   labels:
-{{ include "prometheus-node-exporter.labels" . | indent 4 }}
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
 subsets:
   - addresses:
       {{- range .Values.endpoints }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/extra-manifests.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl . $ }}
+{{ end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/networkpolicy.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "prometheus-node-exporter.fullname" . }}
+  namespace: {{ include "prometheus-node-exporter.namespace" . }}
+  labels:
+    {{- include "prometheus-node-exporter.labels" $ | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingress:
+    - ports:
+      - port: {{ .Values.service.port }}
+  policyTypes:
+    - Egress
+    - Ingress
+  podSelector:
+    matchLabels:
+      {{- include "prometheus-node-exporter.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/podmonitor.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/podmonitor.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.prometheus.podMonitor.enabled }}
+apiVersion: {{ .Values.prometheus.podMonitor.apiVersion | default "monitoring.coreos.com/v1" }}
+kind: PodMonitor
+metadata:
+  name: {{ include "prometheus-node-exporter.fullname" . }}
+  namespace: {{ include "prometheus-node-exporter.podmonitor-namespace" . }}
+  labels:
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
+    {{- with .Values.prometheus.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.podMonitor.jobLabel }}
+  {{- include "podmonitor.scrapeLimits" .Values.prometheus.podMonitor | nindent 2 }}
+  selector:
+    matchLabels:
+    {{- with .Values.prometheus.podMonitor.selectorOverride }}
+      {{- toYaml . | nindent 6 }}
+    {{- else }}
+      {{- include "prometheus-node-exporter.selectorLabels" . | nindent 6 }}
+    {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "prometheus-node-exporter.namespace" . }}
+  {{- with .Values.prometheus.podMonitor.attachMetadata }}
+  attachMetadata:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.prometheus.podMonitor.podTargetLabels }}
+  podTargetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  podMetricsEndpoints:
+    - port: {{ .Values.service.portName }}
+      {{- with .Values.prometheus.podMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.path }}
+      path: {{ . }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.basicAuth }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.bearerTokenSecret }}
+      bearerTokenSecret:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.authorization }}
+      authorization:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.oauth2 }}
+      oauth2:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.proxyUrl }}
+      proxyUrl: {{ . }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.honorTimestamps }}
+      honorTimestamps: {{ . }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      enableHttp2: {{ default false .Values.prometheus.podMonitor.enableHttp2 }}
+      filterRunning: {{ default true .Values.prometheus.podMonitor.filterRunning }}
+      followRedirects: {{ default false .Values.prometheus.podMonitor.followRedirects }}
+      {{- with .Values.prometheus.podMonitor.params }}
+      params:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/psp-clusterrole.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/psp-clusterrole.yaml
@@ -1,15 +1,14 @@
-{{- if .Values.rbac.create }}
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: psp-{{ template "prometheus-node-exporter.fullname" . }}
-  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
+  name: psp-{{ include "prometheus-node-exporter.fullname" . }}
+  labels: 
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
 rules:
 - apiGroups: ['extensions']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
-  - {{ template "prometheus-node-exporter.fullname" . }}
-{{- end }}
+    - {{ include "prometheus-node-exporter.fullname" . }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
@@ -1,17 +1,16 @@
-{{- if .Values.rbac.create }}
-{{- if .Values.rbac.pspEnabled }}
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: psp-{{ template "prometheus-node-exporter.fullname" . }}
-  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
+  name: psp-{{ include "prometheus-node-exporter.fullname" . }}
+  labels:
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: psp-{{ template "prometheus-node-exporter.fullname" . }}
+  name: psp-{{ include "prometheus-node-exporter.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "prometheus-node-exporter.fullname" . }}
-    namespace: {{ template "prometheus-node-exporter.namespace" . }}
-{{- end }}
+    name: {{ include "prometheus-node-exporter.fullname" . }}
+    namespace: {{ include "prometheus-node-exporter.namespace" . }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/psp.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/psp.yaml
@@ -1,16 +1,15 @@
-{{- if .Values.rbac.create }}
-{{- if .Values.rbac.pspEnabled }}
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "prometheus-node-exporter.fullname" . }}
-  namespace: {{ template "prometheus-node-exporter.namespace" . }}
-  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
-{{- if .Values.rbac.pspAnnotations }}
+  name: {{ include "prometheus-node-exporter.fullname" . }}
+  namespace: {{ include "prometheus-node-exporter.namespace" . }}
+  labels:
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
+  {{- with .Values.rbac.pspAnnotations }}
   annotations:
-{{ toYaml .Values.rbac.pspAnnotations | indent 4 }}
-{{- end}}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   privileged: false
   # Allow core volume types.
@@ -47,6 +46,4 @@ spec:
       - min: 0
         max: 65535
   readOnlyRootFilesystem: false
-{{- end }}
-{{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/rbac-configmap.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/rbac-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.kubeRBACProxy.enabled}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "prometheus-node-exporter.fullname" . }}-rbac-config
+  namespace: {{ include "prometheus-node-exporter.namespace" . }}
+data:
+  config-file.yaml: |+
+    authorization:
+      resourceAttributes:
+        namespace: {{ template "prometheus-node-exporter.namespace" . }}
+        apiVersion: v1
+        resource: services
+        subresource: {{ template "prometheus-node-exporter.fullname" . }}
+        name: {{ template "prometheus-node-exporter.fullname" . }}
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/service.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/service.yaml
@@ -1,23 +1,29 @@
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "prometheus-node-exporter.fullname" . }}
-  namespace: {{ template "prometheus-node-exporter.namespace" . }}
-{{- if .Values.service.annotations }}
+  name: {{ include "prometheus-node-exporter.fullname" . }}
+  namespace: {{ include "prometheus-node-exporter.namespace" . }}
+  labels:
+    {{- include "prometheus-node-exporter.labels" $ | nindent 4 }}
+  {{- with .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
-  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+{{- if .Values.service.ipDualStack.enabled }}
+  ipFamilies: {{ toYaml .Values.service.ipDualStack.ipFamilies | nindent 4 }}
+  ipFamilyPolicy: {{ .Values.service.ipDualStack.ipFamilyPolicy }}
+{{- end }}
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-    {{- if ( and (eq .Values.service.type "NodePort" ) (not (empty .Values.service.nodePort)) ) }}
+      {{- if ( and (eq .Values.service.type "NodePort" ) (not (empty .Values.service.nodePort)) ) }}
       nodePort: {{ .Values.service.nodePort }}
-    {{- end }}
+      {{- end }}
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: {{ .Values.service.portName }}
   selector:
-    app: {{ template "prometheus-node-exporter.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus-node-exporter.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/serviceaccount.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/serviceaccount.yaml
@@ -1,18 +1,17 @@
-{{- if .Values.rbac.create -}}
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.rbac.create .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "prometheus-node-exporter.serviceAccountName" . }}
-  namespace: {{ template "prometheus-node-exporter.namespace" . }}
-  labels:
-    app: {{ template "prometheus-node-exporter.name" . }}
-    chart: {{ template "prometheus-node-exporter.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+  name: {{ include "prometheus-node-exporter.serviceAccountName" . }}
+  namespace: {{ include "prometheus-node-exporter.namespace" . }}
+  labels: 
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if or .Values.serviceAccount.imagePullSecrets .Values.global.imagePullSecrets }}
 imagePullSecrets:
-{{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
-{{- end -}}
+  {{- include "prometheus-node-exporter.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.serviceAccount.imagePullSecrets) | indent 2 }}
+{{- end }}
 {{- end -}}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/servicemonitor.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/servicemonitor.yaml
@@ -1,48 +1,61 @@
 {{- if .Values.prometheus.monitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ .Values.prometheus.monitor.apiVersion | default "monitoring.coreos.com/v1" }}
 kind: ServiceMonitor
 metadata:
-  name: {{ template "prometheus-node-exporter.fullname" . }}
-  namespace: {{ template "prometheus-node-exporter.monitor-namespace" . }}
-  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
-  {{- if .Values.prometheus.monitor.additionalLabels }}
-    {{- toYaml .Values.prometheus.monitor.additionalLabels | nindent 4 }}
-  {{- end }}
+  name: {{ include "prometheus-node-exporter.fullname" . }}
+  namespace: {{ include "prometheus-node-exporter.monitor-namespace" . }}
+  labels:
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
+    {{- with .Values.prometheus.monitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   jobLabel: {{ default "app.kubernetes.io/name" .Values.prometheus.monitor.jobLabel }}
+  {{- include "servicemonitor.scrapeLimits" .Values.prometheus.monitor | nindent 2 }}
+  {{- with .Values.prometheus.monitor.podTargetLabels }}
+  podTargetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
-    {{- if .Values.prometheus.monitor.selectorOverride }}
-      {{ toYaml .Values.prometheus.monitor.selectorOverride | indent 6 }}
-    {{ else }}
-      app: {{ template "prometheus-node-exporter.name" . }}
-      release: {{ .Release.Name }}
+    {{- with .Values.prometheus.monitor.selectorOverride }}
+      {{- toYaml . | nindent 6 }}
+    {{- else }}
+      {{- include "prometheus-node-exporter.selectorLabels" . | nindent 6 }}
     {{- end }}
+  {{- with .Values.prometheus.monitor.attachMetadata }}
+  attachMetadata:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   endpoints:
     - port: {{ .Values.service.portName }}
       scheme: {{ .Values.prometheus.monitor.scheme }}
-    {{- with .Values.prometheus.monitor.bearerTokenFile }}
+      {{- with .Values.prometheus.monitor.basicAuth }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prometheus.monitor.bearerTokenFile }}
       bearerTokenFile: {{ . }}
-    {{- end }}
-    {{- with .Values.prometheus.monitor.tlsConfig }}
+      {{- end }}
+      {{- with .Values.prometheus.monitor.tlsConfig }}
       tlsConfig:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.prometheus.monitor.proxyUrl }}
+      {{- end }}
+      {{- with .Values.prometheus.monitor.proxyUrl }}
       proxyUrl: {{ . }}
-    {{- end }}
-    {{- with .Values.prometheus.monitor.interval }}
+      {{- end }}
+      {{- with .Values.prometheus.monitor.interval }}
       interval: {{ . }}
-    {{- end }}
-    {{- with .Values.prometheus.monitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.prometheus.monitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
-    {{- end }}
-    {{- with .Values.prometheus.monitor.relabelings }}
+      {{- end }}
+      {{- with .Values.prometheus.monitor.relabelings }}
       relabelings:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.prometheus.monitor.metricRelabelings }}
+      {{- end }}
+      {{- with .Values.prometheus.monitor.metricRelabelings }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
 {{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/verticalpodautoscaler.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,40 @@
+{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.verticalPodAutoscaler.enabled) }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "prometheus-node-exporter.fullname" . }}
+  namespace: {{ include "prometheus-node-exporter.namespace" . }}
+  labels:
+    {{- include "prometheus-node-exporter.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.verticalPodAutoscaler.recommenders }}
+  recommenders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: node-exporter
+      {{- with .Values.verticalPodAutoscaler.controlledResources }}
+      controlledResources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.verticalPodAutoscaler.controlledValues }}
+      controlledValues: {{ . }}
+      {{- end }}
+      {{- with .Values.verticalPodAutoscaler.maxAllowed }}
+      maxAllowed:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.verticalPodAutoscaler.minAllowed }}
+      minAllowed:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: {{ include "prometheus-node-exporter.fullname" . }}
+  {{- with .Values.verticalPodAutoscaler.updatePolicy }}
+  updatePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/values.yaml
+++ b/platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter/values.yaml
@@ -2,12 +2,74 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: quay.io/prometheus/node-exporter
+  registry: quay.io
+  repository: prometheus/node-exporter
   # Overrides the image tag whose default is {{ printf "v%s" .Chart.AppVersion }}
   tag: ""
   pullPolicy: IfNotPresent
+  digest: ""
+
+imagePullSecrets: []
+# - name: "image-pull-secret"
+nameOverride: ""
+fullnameOverride: ""
+
+# Number of old history to retain to allow rollback
+# Default Kubernetes value is set to 10
+revisionHistoryLimit: 10
+
+global:
+  # To help compatibility with other charts which use global.imagePullSecrets.
+  # Allow either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).
+  # global:
+  #   imagePullSecrets:
+  #   - name: pullSecret1
+  #   - name: pullSecret2
+  # or
+  # global:
+  #   imagePullSecrets:
+  #   - pullSecret1
+  #   - pullSecret2
+  imagePullSecrets: []
+  #
+  # Allow parent charts to override registry hostname
+  imageRegistry: ""
+
+# Configure kube-rbac-proxy. When enabled, creates a kube-rbac-proxy to protect the node-exporter http endpoint.
+# The requests are served through the same service but requests are HTTPS.
+kubeRBACProxy:
+  enabled: false
+  image:
+    registry: quay.io
+    repository: brancz/kube-rbac-proxy
+    tag: v0.14.0
+    sha: ""
+    pullPolicy: IfNotPresent
+
+  # List of additional cli arguments to configure kube-rbac-prxy
+  # for example: --tls-cipher-suites, --log-file, etc.
+  # all the possible args can be found here: https://github.com/brancz/kube-rbac-proxy#usage
+  extraArgs: []
+
+  ## Specify security settings for a Container
+  ## Allows overrides and additional options compared to (Pod) securityContext
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  containerSecurityContext: {}
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 64Mi
+  # requests:
+  #  cpu: 10m
+  #  memory: 32Mi
 
 service:
+  enabled: true
   type: ClusterIP
   port: 9100
   targetPort: 9100
@@ -16,6 +78,16 @@ service:
   listenOnAllInterfaces: true
   annotations:
     prometheus.io/scrape: "true"
+  ipDualStack:
+    enabled: false
+    ipFamilies: ["IPv6", "IPv4"]
+    ipFamilyPolicy: "PreferDualStack"
+
+# Set a NetworkPolicy with:
+# ingress only on service.port
+# no egress permitted
+networkPolicy:
+  enabled: false
 
 # Additional environment variables that will be passed to the daemonset
 env: {}
@@ -30,7 +102,12 @@ prometheus:
 
     jobLabel: ""
 
+    # List of pod labels to add to node exporter metrics
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+    podTargetLabels: []
+
     scheme: http
+    basicAuth: {}
     bearerTokenFile:
     tlsConfig: {}
 
@@ -42,10 +119,127 @@ prometheus:
     ##
     selectorOverride: {}
 
+    ## Attach node metadata to discovered targets. Requires Prometheus v2.35.0 and above.
+    ##
+    attachMetadata:
+      node: false
+
     relabelings: []
     metricRelabelings: []
     interval: ""
     scrapeTimeout: 10s
+    ## prometheus.monitor.apiVersion ApiVersion for the serviceMonitor Resource(defaults to "monitoring.coreos.com/v1")
+    apiVersion: ""
+
+    ## SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: 0
+
+    ## TargetLimit defines a limit on the number of scraped targets that will be accepted.
+    ##
+    targetLimit: 0
+
+    ## Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelLimit: 0
+
+    ## Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelNameLengthLimit: 0
+
+    ## Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+    ##
+    labelValueLengthLimit: 0
+
+  # PodMonitor defines monitoring for a set of pods.
+  # ref. https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PodMonitor
+  # Using a PodMonitor may be preferred in some environments where there is very large number
+  # of Node Exporter endpoints (1000+) behind a single service.
+  # The PodMonitor is disabled by default. When switching from ServiceMonitor to PodMonitor,
+  # the time series resulting from the configuration through PodMonitor may have different labels.
+  # For instance, there will not be the service label any longer which might
+  # affect PromQL queries selecting that label.
+  podMonitor:
+    enabled: false
+    # Namespace in which to deploy the pod monitor. Defaults to the release namespace.
+    namespace: ""
+    # Additional labels, e.g. setting a label for pod monitor selector as set in prometheus
+    additionalLabels: {}
+    #  release: kube-prometheus-stack
+    # PodTargetLabels transfers labels of the Kubernetes Pod onto the target.
+    podTargetLabels: []
+    # apiVersion defaults to monitoring.coreos.com/v1.
+    apiVersion: ""
+    # Override pod selector to select pod objects.
+    selectorOverride: {}
+    # Attach node metadata to discovered targets. Requires Prometheus v2.35.0 and above.
+    attachMetadata:
+      node: false
+    # The label to use to retrieve the job name from. Defaults to label app.kubernetes.io/name.
+    jobLabel: ""
+
+    # Scheme/protocol to use for scraping.
+    scheme: "http"
+    # Path to scrape metrics at.
+    path: "/metrics"
+
+    # BasicAuth allow an endpoint to authenticate over basic authentication.
+    # More info: https://prometheus.io/docs/operating/configuration/#endpoint
+    basicAuth: {}
+    # Secret to mount to read bearer token for scraping targets.
+    # The secret needs to be in the same namespace as the pod monitor and accessible by the Prometheus Operator.
+    # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#secretkeyselector-v1-core
+    bearerTokenSecret: {}
+    # TLS configuration to use when scraping the endpoint.
+    tlsConfig: {}
+    # Authorization section for this endpoint.
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.SafeAuthorization
+    authorization: {}
+    # OAuth2 for the URL. Only valid in Prometheus versions 2.27.0 and newer.
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.OAuth2
+    oauth2: {}
+
+    # ProxyURL eg http://proxyserver:2195. Directs scrapes through proxy to this endpoint.
+    proxyUrl: ""
+    # Interval at which endpoints should be scraped. If not specified Prometheus’ global scrape interval is used.
+    interval: ""
+    # Timeout after which the scrape is ended. If not specified, the Prometheus global scrape interval is used.
+    scrapeTimeout: ""
+    # HonorTimestamps controls whether Prometheus respects the timestamps present in scraped data.
+    honorTimestamps: true
+    # HonorLabels chooses the metric’s labels on collisions with target labels.
+    honorLabels: true
+    # Whether to enable HTTP2. Default false.
+    enableHttp2: ""
+    # Drop pods that are not running. (Failed, Succeeded).
+    # Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+    filterRunning: ""
+    # FollowRedirects configures whether scrape requests follow HTTP 3xx redirects. Default false.
+    followRedirects: ""
+    # Optional HTTP URL parameters
+    params: {}
+
+    # RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds
+    # relabelings for a few standard Kubernetes fields. The original scrape job’s name
+    # is available via the __tmp_prometheus_job_name label.
+    # More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    relabelings: []
+    # MetricRelabelConfigs to apply to samples before ingestion.
+    metricRelabelings: []
+
+    # SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+    sampleLimit: 0
+    # TargetLimit defines a limit on the number of scraped targets that will be accepted.
+    targetLimit: 0
+    # Per-scrape limit on number of labels that will be accepted for a sample.
+    # Only valid in Prometheus versions 2.27.0 and newer.
+    labelLimit: 0
+    # Per-scrape limit on length of labels name that will be accepted for a sample.
+    # Only valid in Prometheus versions 2.27.0 and newer.
+    labelNameLengthLimit: 0
+    # Per-scrape limit on length of labels value that will be accepted for a sample.
+    # Only valid in Prometheus versions 2.27.0 and newer.
+    labelValueLengthLimit: 0
 
 ## Customize the updateStrategy if set
 updateStrategy:
@@ -81,7 +275,8 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 65534
 
-containerSecurityContext: {}
+containerSecurityContext:
+  readOnlyRootFilesystem: true
   # capabilities:
   #   add:
   #   - SYS_TIME
@@ -92,7 +287,7 @@ rbac:
   create: true
   ## If true, create & use Pod Security Policy resources
   ## https://kubernetes.io/docs/concepts/policy/pod-security-policy/
-  pspEnabled: false
+  pspEnabled: true
   pspAnnotations: {}
 
 # for deployments that have node_exporter deployed outside of the cluster, list
@@ -135,6 +330,12 @@ podAnnotations:
 # Extra labels to be added to node exporter pods
 podLabels: {}
 
+# Annotations to be added to node exporter daemonset
+daemonsetAnnotations: {}
+
+## set to true to add the release label so scraping of the servicemonitor with kube-prometheus-stack works out of the box
+releaseLabel: false
+
 # Custom DNS configuration to be added to prometheus-node-exporter pods
 dnsConfig: {}
 # nameservers:
@@ -149,9 +350,9 @@ dnsConfig: {}
 
 ## Assign a nodeSelector if operating a hybrid cluster
 ##
-nodeSelector: {}
-#   beta.kubernetes.io/arch: amd64
-#   beta.kubernetes.io/os: linux
+nodeSelector:
+  kubernetes.io/os: linux
+  #  kubernetes.io/arch: amd64
 
 tolerations:
   - effect: NoSchedule
@@ -166,7 +367,7 @@ extraArgs: []
 #   - --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v)d[a-z]|nvme\\d+n\\d+p)\\d+$
 #   - --collector.textfile.directory=/run/prometheus
 
-## Additional mounts from the host
+## Additional mounts from the host to node-exporter container
 ##
 extraHostVolumeMounts: []
 #  - name: <mountName>
@@ -200,6 +401,80 @@ sidecarVolumeMount: []
 ##    mountPath: /run/prometheus
 ##    readOnly: false
 
+## Additional mounts from the host to sidecar containers
+##
+sidecarHostVolumeMounts: []
+#  - name: <mountName>
+#    hostPath: <hostPath>
+#    mountPath: <mountPath>
+#    readOnly: true|false
+#    mountPropagation: None|HostToContainer|Bidirectional
+
 ## Additional InitContainers to initialize the pod
 ##
 extraInitContainers: []
+
+## Liveness probe
+##
+livenessProbe:
+  failureThreshold: 3
+  httpGet:
+    httpHeaders: []
+    scheme: http
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+
+## Readiness probe
+##
+readinessProbe:
+  failureThreshold: 3
+  httpGet:
+    httpHeaders: []
+    scheme: http
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+
+# Enable vertical pod autoscaler support for prometheus-node-exporter
+verticalPodAutoscaler:
+  enabled: false
+
+  # Recommender responsible for generating recommendation for the object.
+  # List should be empty (then the default recommender will generate the recommendation)
+  # or contain exactly one recommender.
+  # recommenders:
+  # - name: custom-recommender-performance
+
+  # List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory
+  controlledResources: []
+  # Specifies which resource values should be controlled: RequestsOnly or RequestsAndLimits.
+  # controlledValues: RequestsAndLimits
+
+  # Define the max allowed resources for the pod
+  maxAllowed: {}
+  # cpu: 200m
+  # memory: 100Mi
+  # Define the min allowed resources for the pod
+  minAllowed: {}
+  # cpu: 200m
+  # memory: 100Mi
+
+  # updatePolicy:
+    # Specifies minimal number of replicas which need to be alive for VPA Updater to attempt pod eviction
+    # minReplicas: 1
+    # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
+    # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
+    # updateMode: Auto
+
+# Extra manifests to deploy as an array
+extraManifests: []
+  # - |
+  #   apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: prometheus-extra
+  #   data:
+  #     extra-data: "value"

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -757,7 +757,7 @@
     },
     {
       "name": "prometheus-node-exporter",
-      "version": "1.3.1",
+      "version": "1.6.1",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -765,7 +765,8 @@
           "images": [
             {
               "image": "node-exporter",
-              "tag": "v1.3.1-20230925070337-b7f69924",
+              "tag": "v1.6.1-20230925193620-d2d52786",
+              "helmRegKey": "image.registry",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/tests/e2e/security/netpol/network_policy_test.go
+++ b/tests/e2e/security/netpol/network_policy_test.go
@@ -6,10 +6,10 @@ package netpol
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	"strings"
 	"time"
 
+	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
 	"github.com/verrazzano/verrazzano/pkg/vzcr"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/certmanager"
 
@@ -234,7 +234,7 @@ var _ = t.Describe("Test Network Policies", Label("f:security.netpol"), func() {
 			},
 			func() {
 				t.Logs.Info("Test verrazzano-platform-operator-webhook ingress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": nodeExporter}}, vzconst.PrometheusOperatorNamespace, metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-platform-operator-webhook"}}, "verrazzano-install", 9443, false, true)
+				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{kubernetesAppLabel: nodeExporter}}, vzconst.PrometheusOperatorNamespace, metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-platform-operator-webhook"}}, "verrazzano-install", 9443, false, true)
 				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test verrazzano-platform-operator ingress rules failed: reason = %s", err))
 			},
 			func() {
@@ -250,7 +250,7 @@ var _ = t.Describe("Test Network Policies", Label("f:security.netpol"), func() {
 				t.Logs.Info("Test verrazzano-application-operator-webhook ingress rules")
 				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": "netpol-test"}}, "netpol-test", metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-application-operator-webhook"}}, vzconst.VerrazzanoSystemNamespace, 9443, false, true)
 				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test verrazzano-application-operator-webhook ingress rules failed: reason = %s", err))
-				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{"app": nodeExporter}}, vzconst.PrometheusOperatorNamespace, metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-application-operator-webhook"}}, vzconst.VerrazzanoSystemNamespace, 9443, false, true)
+				err = testAccess(metav1.LabelSelector{MatchLabels: map[string]string{kubernetesAppLabel: nodeExporter}}, vzconst.PrometheusOperatorNamespace, metav1.LabelSelector{MatchLabels: map[string]string{"app": "verrazzano-application-operator-webhook"}}, vzconst.VerrazzanoSystemNamespace, 9443, false, true)
 				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test verrazzano-application-operator-webhook ingress rules failed: reason = %s", err))
 			},
 			func() {
@@ -271,7 +271,7 @@ var _ = t.Describe("Test Network Policies", Label("f:security.netpol"), func() {
 			},
 			func() {
 				t.Logs.Info("Test prometheus-node-exporter ingress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{kubernetesAppLabel: "prometheus"}}, vzconst.PrometheusOperatorNamespace, metav1.LabelSelector{MatchLabels: map[string]string{"app": nodeExporter}}, vzconst.PrometheusOperatorNamespace, nodeExporterMetricsPort, false, true)
+				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{kubernetesAppLabel: "prometheus"}}, vzconst.PrometheusOperatorNamespace, metav1.LabelSelector{MatchLabels: map[string]string{kubernetesAppLabel: nodeExporter}}, vzconst.PrometheusOperatorNamespace, nodeExporterMetricsPort, false, true)
 				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test prometheus-node-exporter ingress rules failed: reason = %s", err))
 			},
 			func() {
@@ -351,7 +351,7 @@ var _ = t.Describe("Test Network Policies", Label("f:security.netpol"), func() {
 			},
 			func() {
 				t.Logs.Info("Test prometheus-node-exporter ingress rules")
-				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{kubernetesAppLabel: "prometheus"}}, vzconst.PrometheusOperatorNamespace, metav1.LabelSelector{MatchLabels: map[string]string{"app": nodeExporter}}, vzconst.PrometheusOperatorNamespace, 9100, false, true)
+				err := testAccess(metav1.LabelSelector{MatchLabels: map[string]string{kubernetesAppLabel: "prometheus"}}, vzconst.PrometheusOperatorNamespace, metav1.LabelSelector{MatchLabels: map[string]string{kubernetesAppLabel: nodeExporter}}, vzconst.PrometheusOperatorNamespace, 9100, false, true)
 				Expect(err).To(BeNil(), fmt.Sprintf("FAIL: Test prometheus-node-exporter ingress rules failed: reason = %s", err))
 			},
 			func() {


### PR DESCRIPTION
This PR includes the following:
1. Upgrades the Prometheus Node Exporter image to v1.6.1. Both the BOM and modules catalog have been updated.
2. Upgrades the Promethues Node Exporter Helm chart to v4.32.1.
3. A component implementation of PreUpgrade for Node Exporter that removes the previously installed daemonset. The new Helm chart is incompatible with previous versions and requires the daemonset to be removed, otherwise the upgrade fails because it tries to patch an immutable field in the daemonset.

I tested in a local cluster, both install and an upgrade from 1.6.7 and verified that Node Exporter metrics are scraped correctly.