### PR TITLE
Fix the default Kubernetes version in HA pipeline

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -33,7 +33,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value, use older version as default to ensure cluster will perform upgrade
-                choices: [ "v1.25.4", v1.25.12, "v1.26.2", v1.26.7, "v1.27.2" ])
+                choices: [ "v1.25.4", "v1.25.12", "v1.26.2", "v1.26.7", "v1.27.2" ])
         choice (name: 'OKE_NODE_POOL',
                 description: 'OKE node pool configuration',
                 // 1st choice is the default value

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -33,7 +33,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value, use older version as default to ensure cluster will perform upgrade
-                choices: [ "v1.24.1", "v1.25.4", "v1.26.2", "v1.27.2" ])
+                choices: [ "v1.25.4", v1.25.12, "v1.26.2", v1.26.7, "v1.27.2" ])
         choice (name: 'OKE_NODE_POOL',
                 description: 'OKE node pool configuration',
                 // 1st choice is the default value


### PR DESCRIPTION
Updates the default Kubernetes version in HA pipeline to v1.25.4. The pipeline attempts to upgrade the Kubernetes version, so the default version is not set to the highest supported one.