### PR TITLE
Turn off OCI Integration test, OKE version no longer supported

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -483,17 +483,9 @@ pipeline {
                 }
                 stage('OCI Service Integration Tests') {
                     steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-oci-integration-tests/${CLEAN_BRANCH_NAME}",
-                                    parameters: [
-                                        string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
-                                        string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
-                                        string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS)
-                                    ], wait: true
-                            }
-                        }
+                       script {
+                           echo "OKE no longer supports 1.24, no longer running these tests on 1.4"
+                       }
                     }
                     post {
                         failure {


### PR DESCRIPTION
Turn off OCI Integration test, OKE version no longer supported
