### PR TITLE
VZ-11196. Disable intermittently failing OCI DNS backend example tests

### DIFF
--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -576,7 +576,7 @@ pipeline {
                         runGinkgoEx('examples/todo')
                     }
                 }
-                stage('examples socks') {
+                /*stage('examples socks') {
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-socks"
                     }
@@ -585,7 +585,7 @@ pipeline {
                         runSocksVariant('micronaut')
                         runSocksVariant('spring')
                     }
-                }
+                }*/
                 stage('examples springboot') {
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-spring"
@@ -618,14 +618,14 @@ pipeline {
                         runGinkgoEx('examples/helidonconfig')
                     }
                 }
-                stage('examples bobs books') {
+                /*stage('examples bobs books') {
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-bobs"
                     }
                     steps {
                         runGinkgoEx('examples/bobsbooks')
                     }
-                }
+                }*/
                 stage('examples weblogic cluster') {
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/weblogic-cluster"


### PR DESCRIPTION
Disable Bob's Books and Socks examples in OCI DNS backend tests due to intermittent failures
