### PR TITLE
Fix the default Kubernetes version in HA pipeline, release-1.6

### DIFF
--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -33,7 +33,7 @@ pipeline {
         choice (name: 'KUBERNETES_CLUSTER_VERSION',
                 description: 'Kubernetes Version for OKE Cluster',
                 // 1st choice is the default value, use older version as default to ensure cluster will perform upgrade
-                choices: [ "v1.24.1", "v1.25.4", "v1.26.2", "v1.27.2" ])
+                choices: [ "v1.25.4", "v1.25.12", "v1.26.2", "v1.26.7", "v1.27.2" ])
         choice (name: 'OKE_NODE_POOL',
                 description: 'OKE node pool configuration',
                 // 1st choice is the default value


### PR DESCRIPTION
Backport https://github.com/verrazzano/verrazzano/pull/7204 to release-1.6