### PR TITLE
VZ-11175 update the prometheus operator version

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -53,7 +53,7 @@ modules:
   - name: keycloak
     version: 20.0.1
   - name: prometheus-operator
-    version: 0.64.1
+    version: 0.64.1-1
   - name: prometheus-adapter
     version: 0.10.0
   - name: kube-state-metrics

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -637,7 +637,7 @@
     },
     {
       "name": "prometheus-operator",
-      "version": "0.64.1",
+      "version": "0.64.1-1",
       "subcomponents": [
         {
           "repository": "verrazzano",


### PR DESCRIPTION
This is needed so that the Prometheus Operator component will pick up the change and get upgraded