### PR TITLE
VZ-11100: Update Keycloak image built with validation that redirect URI is http(s), release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -449,7 +449,7 @@
           "images": [
             {
               "image": "keycloak",
-              "tag": "v20.0.1-20230923031034-a5c064d9f2",
+              "tag": "v20.0.1-20230928072224-3874ea5092",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Backports https://github.com/verrazzano/verrazzano/pull/7230 to release-1.5
