### PR TITLE
Add Jaeger images to image tag compliance check

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -829,7 +829,7 @@
           "images": [
             {
               "image": "jaeger-ingester",
-              "tag": "1.42.0-20230925061552-cd357656y",
+              "tag": "1.42.0-20230925061552-cd357656",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -851,7 +851,7 @@
           "images": [
             {
               "image": "jaeger-es-rollover",
-              "tag": "1.42.0-20230925061552-cd357656x",
+              "tag": "1.42.0-20230925061552-cd357656",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -829,7 +829,7 @@
           "images": [
             {
               "image": "jaeger-ingester",
-              "tag": "1.42.0-20230925061552-cd357656",
+              "tag": "1.42.0-20230925061552-cd357656y",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -851,7 +851,7 @@
           "images": [
             {
               "image": "jaeger-es-rollover",
-              "tag": "1.42.0-20230925061552-cd357656",
+              "tag": "1.42.0-20230925061552-cd357656x",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]

--- a/release/scripts/check_image_tags.sh
+++ b/release/scripts/check_image_tags.sh
@@ -39,6 +39,16 @@ if [ -f $BOM_FILE ]; then
     MISMATCH=true
   fi
 
+  echo Checking Jaeger image tags in $BOM_FILE
+  # All Jaeger images (excluding the jaeger-operator image) should have the same tag
+  UNIQUE_JAEGER_IMAGE_TAGS=$(jq -r '.components[] | select(.name == "jaeger-operator") | .subcomponents[] | select(.name != "jaeger-operator") | .images[] | .tag' $BOM_FILE | sort | uniq)
+  UNIQUE_JAEGER_IMAGE_TAGS_COUNT=$(echo "$UNIQUE_JAEGER_IMAGE_TAGS" | wc -l)
+  if [ $UNIQUE_JAEGER_IMAGE_TAGS_COUNT -gt 1 ]; then
+    echo "Expected all Jaeger image tags (excluding jaeger-operator) to match but found these unique tags:"
+    echo "$UNIQUE_JAEGER_IMAGE_TAGS"
+    MISMATCH=true
+  fi
+
   if [ $MISMATCH == true ]; then
     echo FATAL: One or more mismatched image tags found
     exit 1


### PR DESCRIPTION
This PR adds Jaeger image tag checking to the compliance script. All of the Jaeger images (except for the jaeger-operator image) in the BOM should have the same tag. This check will fail the compliance checks if there is a tag mismatch.