### PR TITLE
VZ-11186: Update "verify upgrade required" test

### DIFF
--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -425,11 +425,11 @@ pipeline {
                                 upgradePlatformOperator()
                             }
                         }
-                        /*stage("Verify Upgrade Required") {
+                        stage("Verify Upgrade Required") {
                             steps {
                                 runGinkgoRandomizeSerial('upgrade/pre-upgrade/verify-upgrade-required')
                             }
-                        }*/
+                        }
                     }
                 }
                 stage("upgrade-verrazzano") {

--- a/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
+++ b/tests/e2e/upgrade/pre-upgrade/verify-upgrade-required/verify_upgrade_required_test.go
@@ -65,6 +65,7 @@ var _ = t.Describe("Verify upgrade required when new version is available", Labe
 
 			var vz *vzalpha1.Verrazzano
 			Eventually(func() (*vzalpha1.Verrazzano, error) {
+				var err error
 				vz, err = pkg.GetVerrazzano()
 				return vz, err
 			}).WithPolling(pollingInterval).WithTimeout(waitTimeout).


### PR DESCRIPTION
This PR updates the "verify upgrade required" test in the upgrade paths pipeline to remove an obsolete version check that would fail intermittently. Since we no longer test upgrades from version 1.3.x, the version check is no longer necessary.

I also re-enabled the test in the Jenkinsfile.