### PR TITLE
VZ-11196 Remove the narrow fields fromt the Opensearch index pattern

### DIFF
--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -618,14 +618,14 @@ pipeline {
                         runGinkgoEx('examples/helidonconfig')
                     }
                 }
-                /*stage('examples bobs books') {
+                stage('examples bobs books') {
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/examples-bobs"
                     }
                     steps {
                         runGinkgoEx('examples/bobsbooks')
                     }
-                }*/
+                }
                 stage('examples weblogic cluster') {
                     environment {
                         DUMP_DIRECTORY="${TEST_DUMP_ROOT}/weblogic-cluster"

--- a/tests/e2e/examples/bobsbooks/bobs_books_test.go
+++ b/tests/e2e/examples/bobsbooks/bobs_books_test.go
@@ -491,10 +491,9 @@ var _ = t.Describe("Bobs Books test", Label("f:app-lcm.oam",
 								{Key: "kubernetes.container_name.keyword", Value: fluentdStdoutSidecar},
 								{Key: k8sLabelDomainUID, Value: bobbysFrontEnd},
 								{Key: k8sLabelWLServerName, Value: managedServer1},
-								{Key: "messageID", Value: "BEA-"},         //matches BEA-*
-								{Key: "message", Value: "Tunneling Ping"}, //"Tunneling Ping" in last line
+								{Key: "messageID", Value: "BEA-"}, //matches BEA-*
 								{Key: "serverName", Value: "bobbys-front-end-managed-server1"},
-								{Key: "subSystem.keyword", Value: "RJVM"}},
+							},
 							[]pkg.Match{})
 					}, longWaitTimeout, longPollingInterval).Should(BeTrue(), "Expected to find a recent log record")
 				})


### PR DESCRIPTION
Bob's book test has been failing to get this logging index intermittently. The log fields are too narrow and only match with one specific log if it happens to appear. Widening the index pattern should provide the same check without failing intermittently.