### PR TITLE
Update the LRE Jenkisfile to regenerate the Kubeconfig

### DIFF
--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -62,6 +62,7 @@ pipeline {
         DEV_LRE_SUSPECT_LIST = credentials('dev_lre_suspect_list')
         PIPELINE_OWNERS = credentials('lretests-owners')
         DEV_LRE_KUBECONFIG = credentials('dev-lre-kubeconfig')
+        DEV_LRE_RANCHER_ADMIN_PSW = credentials('dev-lre-rancher-admin-password')
         KUBECONFIG = "${WORKSPACE}/.kube/config"
         VZ_CLI_TARGZ="vz-linux-amd64.tar.gz"
         TEST_ENV = "LRE"
@@ -125,7 +126,7 @@ pipeline {
                         RANCHER_TOKEN=$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H 'Content-Type: application/json' \
                         "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3-public/localProviders/local?action=login" \
-                        -d "{\"username\":\"admin\", \"password\":\"Placeholder\"}" | jq -r ".token")
+                        -d "{\"username\":\"admin\", \"password\":\"$DEV_LRE_RANCHER_ADMIN_PSW\"}" | jq -r ".token")
 
                         curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H "Authorization: Bearer $RANCHER_TOKEN" \

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
                         RANCHER_TOKEN=\$(curl -vvv -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H 'Content-Type: application/json' \
                         "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3-public/localProviders/local?action=login" \
-                        -d "{\"username\":\"admin\", \"password\":\"${DEV_LRE_RANCHER_ADMIN_PSW}\"}")
+                        -d '{"username":"admin", "password":"${DEV_LRE_RANCHER_ADMIN_PSW}"}')
 
                         curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H "Authorization: Bearer \${RANCHER_TOKEN}" \

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -123,10 +123,10 @@ pipeline {
                         mkdir -p ${WORKSPACE}/.kube
                         rm -rf ${KUBECONFIG}
 
-                        RANCHER_TOKEN=\$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
+                        RANCHER_TOKEN=\$(curl -vvv -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H 'Content-Type: application/json' \
                         "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3-public/localProviders/local?action=login" \
-                        -d "{\"username\":\"admin\", \"password\":\"${DEV_LRE_RANCHER_ADMIN_PSW}\"}" | jq -r ".token")
+                        -d "{\"username\":\"admin\", \"password\":\"${DEV_LRE_RANCHER_ADMIN_PSW}\"}")
 
                         curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H "Authorization: Bearer \${RANCHER_TOKEN}" \

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
                         mkdir -p ${WORKSPACE}/.kube
                         rm -rf ${KUBECONFIG}
 
-                        RANCHER_TOKEN=$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
+                        RANCHER_TOKEN=\$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H 'Content-Type: application/json' \
                         "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3-public/localProviders/local?action=login" \
                         -d "{\"username\":\"admin\", \"password\":\"${DEV_LRE_RANCHER_ADMIN_PSW}\"}" | jq -r ".token")

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -123,10 +123,10 @@ pipeline {
                         mkdir -p ${WORKSPACE}/.kube
                         rm -rf ${KUBECONFIG}
 
-                        RANCHER_TOKEN=\$(curl -vvv -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
+                        RANCHER_TOKEN=\$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H 'Content-Type: application/json' \
                         "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3-public/localProviders/local?action=login" \
-                        -d '{"username":"admin", "password":"${DEV_LRE_RANCHER_ADMIN_PSW}"}')
+                        -d '{"username":"admin", "password":"${DEV_LRE_RANCHER_ADMIN_PSW}"}' | jq -r ".token")
 
                         curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H "Authorization: Bearer \${RANCHER_TOKEN}" \

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -121,7 +121,18 @@ pipeline {
                     sh """
                         mkdir -p ${WORKSPACE}/.kube
                         rm -rf ${KUBECONFIG}
-                        cp ${DEV_LRE_KUBECONFIG} ${KUBECONFIG}
+
+                        RANCHER_TOKEN=$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
+                        -H 'Content-Type: application/json' \
+                        "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3-public/localProviders/local?action=login" \
+                        -d "{\"username\":\"admin\", \"password\":\"Placeholder\"}" | jq -r ".token")
+
+                        curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
+                        -H "Authorization: Bearer $RANCHER_TOKEN" \
+                        -H 'Content-Type: application/json' \
+                        "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3/clusters/local?action=generateKubeconfig" \
+                        | jq -r ".config" > ${KUBECONFIG}
+
                         cat ${KUBECONFIG}
                     """
                 }

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -123,13 +123,13 @@ pipeline {
                         mkdir -p ${WORKSPACE}/.kube
                         rm -rf ${KUBECONFIG}
 
-                        export RANCHER_TOKEN=\$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
+                        RANCHER_TOKEN=\$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H 'Content-Type: application/json' \
                         "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3-public/localProviders/local?action=login" \
                         -d "{\"username\":\"admin\", \"password\":\"${DEV_LRE_RANCHER_ADMIN_PSW}\"}" | jq -r ".token")
 
                         curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
-                        -H "Authorization: Bearer ${RANCHER_TOKEN}" \
+                        -H "Authorization: Bearer \${RANCHER_TOKEN}" \
                         -H 'Content-Type: application/json' \
                         "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3/clusters/local?action=generateKubeconfig" \
                         | jq -r ".config" > ${KUBECONFIG}

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -126,10 +126,10 @@ pipeline {
                         RANCHER_TOKEN=$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H 'Content-Type: application/json' \
                         "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3-public/localProviders/local?action=login" \
-                        -d "{\"username\":\"admin\", \"password\":\"$DEV_LRE_RANCHER_ADMIN_PSW\"}" | jq -r ".token")
+                        -d "{\"username\":\"admin\", \"password\":\"${DEV_LRE_RANCHER_ADMIN_PSW}\"}" | jq -r ".token")
 
                         curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
-                        -H "Authorization: Bearer $RANCHER_TOKEN" \
+                        -H "Authorization: Bearer ${RANCHER_TOKEN}" \
                         -H 'Content-Type: application/json' \
                         "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3/clusters/local?action=generateKubeconfig" \
                         | jq -r ".config" > ${KUBECONFIG}

--- a/ci/lre/Jenkinsfile
+++ b/ci/lre/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
                         mkdir -p ${WORKSPACE}/.kube
                         rm -rf ${KUBECONFIG}
 
-                        RANCHER_TOKEN=\$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
+                        export RANCHER_TOKEN=\$(curl -s -k --noproxy rancher.lre.dev.v8odev01iad.oraclevcn.com -X POST \
                         -H 'Content-Type: application/json' \
                         "https://rancher.lre.dev.v8odev01iad.oraclevcn.com/v3-public/localProviders/local?action=login" \
                         -d "{\"username\":\"admin\", \"password\":\"${DEV_LRE_RANCHER_ADMIN_PSW}\"}" | jq -r ".token")


### PR DESCRIPTION
These commands use the Rancher proxy to generate a new kubeconfig for each run. This avoids having a stale kubeconfig.
