### PR TITLE
Force quickcreate namespaces

### DIFF
--- a/cluster-operator/controllers/quickcreate/controller/controller.go
+++ b/cluster-operator/controllers/quickcreate/controller/controller.go
@@ -74,8 +74,8 @@ func RequeueDelay() ctrl.Result {
 	}
 }
 
-func ApplyTemplates(cli clipkg.Client, props any, templates ...[]byte) error {
-	applier := k8sutil.NewYAMLApplier(cli, "")
+func ApplyTemplates(cli clipkg.Client, props any, ns string, templates ...[]byte) error {
+	applier := k8sutil.NewYAMLApplier(cli, ns)
 	for _, tmpl := range templates {
 		if err := applier.ApplyBT(tmpl, props); err != nil {
 			return err

--- a/cluster-operator/controllers/quickcreate/ociocne/ociocne_controller.go
+++ b/cluster-operator/controllers/quickcreate/ociocne/ociocne_controller.go
@@ -74,7 +74,7 @@ func (r *ClusterReconciler) syncCluster(ctx context.Context, q *vmcv1alpha1.OCNE
 	}
 	// If provisioning has not successfully started, attempt to provisioning the cluster
 	if shouldProvision(q) {
-		if err := controller.ApplyTemplates(r.Client, ocne, clusterTemplate, nodesTemplate, ocneTemplate); err != nil {
+		if err := controller.ApplyTemplates(r.Client, ocne, q.Namespace, clusterTemplate, nodesTemplate, ocneTemplate); err != nil {
 			return controller.RequeueDelay(), err
 		}
 		q.Status = vmcv1alpha1.OCNEOCIQuickCreateStatus{
@@ -85,7 +85,7 @@ func (r *ClusterReconciler) syncCluster(ctx context.Context, q *vmcv1alpha1.OCNE
 	}
 	// If OCI Network is loaded, update the quick create to completed phase
 	if ocne.HasOCINetwork() {
-		if err := controller.ApplyTemplates(r.Client, ocne, addonsTemplate); err != nil {
+		if err := controller.ApplyTemplates(r.Client, ocne, q.Namespace, addonsTemplate); err != nil {
 			return controller.RequeueDelay(), err
 		}
 		// If the cluster only has control plane nodes, set them for scheduling

--- a/cluster-operator/controllers/quickcreate/oke/oke_controller.go
+++ b/cluster-operator/controllers/quickcreate/oke/oke_controller.go
@@ -68,7 +68,7 @@ func (r *ClusterReconciler) syncCluster(ctx context.Context, q *vmcv1alpha1.OKEQ
 	}
 	// If provisioning has not successfully started, attempt to create the OKE control plane
 	if shouldProvision(q) {
-		if err := controller.ApplyTemplates(r.Client, props, clusterTemplate); err != nil {
+		if err := controller.ApplyTemplates(r.Client, props, q.Namespace, clusterTemplate); err != nil {
 			return controller.RequeueDelay(), err
 		}
 		q.Status = vmcv1alpha1.OKEQuickCreateStatus{
@@ -79,7 +79,7 @@ func (r *ClusterReconciler) syncCluster(ctx context.Context, q *vmcv1alpha1.OKEQ
 	}
 	// If OCI Network is loaded, create the nodes and update phase to completed
 	if props.HasOCINetwork() {
-		if err := controller.ApplyTemplates(r.Client, props, nodesTemplate); err != nil {
+		if err := controller.ApplyTemplates(r.Client, props, q.Namespace, nodesTemplate); err != nil {
 			return controller.RequeueDelay(), err
 		}
 		q.Status.Phase = vmcv1alpha1.QuickCreatePhaseComplete


### PR DESCRIPTION
Follow up PR to ensure quickcreate namespaces are always the same as the parent object