### PR TITLE
VZ-11250: Cluster API URL overrides not working

### DIFF
--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi.go
@@ -27,25 +27,25 @@ import (
 const clusterctlYamlTemplate = `
 {{- if .IncludeImagesHeader }}
 images:
-  {{- if not .GetClusterAPIOverridesVersion }}
+  {{- if not .ClusterAPIOverridesExists }}
   cluster-api:
     repository: {{.GetClusterAPIRepository}}
     tag: {{.GetClusterAPITag}}
   {{ end }}
 
-  {{- if not .GetOCIOverridesVersion }}
+  {{- if not .OCIOverridesExists }}
   infrastructure-oci:
     repository: {{.GetOCIRepository}}
     tag: {{.GetOCITag}}
   {{ end }}
 
-  {{- if not .GetOCNEBootstrapOverridesVersion }}
+  {{- if not .OCNEBootstrapOverridesExists }}
   bootstrap-ocne:
     repository: {{.GetOCNEBootstrapRepository}}
     tag: {{.GetOCNEBootstrapTag}}
   {{ end }}
 
-  {{- if not .GetOCNEControlPlaneOverridesVersion }}
+  {{- if not .OCNEControlPlaneOverridesExists }}
   control-plane-ocne:
     repository: {{.GetOCNEControlPlaneRepository}}
     tag: {{.GetOCNEControlPlaneTag}}
@@ -180,7 +180,7 @@ func createClusterctlYaml(ctx spi.ComponentContext) error {
 	}
 
 	// Apply the image overrides and versions to generate clusterctl.yaml
-	result, err := applyTemplate(clusterctlYamlTemplate, newOverridesContext(overrides))
+	result, err := applyTemplate(ctx, clusterctlYamlTemplate, newOverridesContext(overrides))
 	if err != nil {
 		ctx.Log().ErrorfThrottled("Failed to apply template for creating clusterctl.yaml: %v", err)
 		return err
@@ -204,10 +204,11 @@ func createClusterctlYaml(ctx spi.ComponentContext) error {
 }
 
 // applyTemplate applies the CAPI provider image overrides and versions to the clusterctl.yaml template
-func applyTemplate(templateContent string, params interface{}) (bytes.Buffer, error) {
+func applyTemplate(ctx spi.ComponentContext, templateContent string, params interface{}) (bytes.Buffer, error) {
 	// Parse the template file
 	capiYaml, err := template.New("capi").Parse(templateContent)
 	if err != nil {
+		ctx.Log().ErrorfThrottled("template error: %v", err)
 		return bytes.Buffer{}, err
 	}
 
@@ -215,6 +216,7 @@ func applyTemplate(templateContent string, params interface{}) (bytes.Buffer, er
 	var buf bytes.Buffer
 	err = capiYaml.Execute(&buf, &params)
 	if err != nil {
+		ctx.Log().ErrorfThrottled("template execution error: %v", err)
 		return bytes.Buffer{}, err
 	}
 
@@ -231,13 +233,20 @@ func (c *PodMatcherClusterAPI) initializeImageVersionsOverrides(log vzlog.Verraz
 	return nil
 }
 
-// applyUpgradeVersion returns true and corresponding version if either version overrides or bom version is specified. Otherwise, return false and empty version.
-func applyUpgradeVersion(log vzlog.VerrazzanoLogger, versionOverrides, bomVersion, imageName, actualImage, expectedImage string) (bool, string) {
+// applyUpgradeVersion returns true and corresponding version if either URL overrides, version overrides or bom version is specified. Otherwise, return false and empty version.
+func applyUpgradeVersion(log vzlog.VerrazzanoLogger, URLOverrides, versionOverrides, bomVersion, imageName, actualImage, expectedImage string) (bool, string) {
+	if len(URLOverrides) > 0 {
+		// Version is expected as the penultimate component of the overrides URL
+		splitURL := strings.Split(URLOverrides, "/")
+		version := splitURL[len(splitURL)-2]
+		log.Infof("URL Overrides version \"%v\" extracted from URL Overriddes %v", version, URLOverrides)
+		return true, version
+	}
 	if len(versionOverrides) > 0 {
 		return true, versionOverrides
 	}
 	if strings.Contains(actualImage, imageName) && actualImage != expectedImage {
-		log.Infof("Image %v is out of date,  actual image: %v, expected image: %v", imageName, actualImage, expectedImage)
+		log.Infof("Image %v is out of date, actual image: %v, expected image: %v", imageName, actualImage, expectedImage)
 		return true, bomVersion
 	}
 	return false, ""
@@ -255,16 +264,16 @@ func (c *PodMatcherClusterAPI) matchAndPrepareUpgradeOptions(ctx spi.ComponentCo
 	const formatString = "%s/%s:%s"
 	for _, pod := range podList.Items {
 		for _, co := range pod.Spec.Containers {
-			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetClusterAPIOverridesVersion(), overrides.GetClusterAPIBomVersion(), clusterAPIControllerImage, co.Image, c.coreProvider); ok {
+			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetClusterAPIOverridesURL(), overrides.GetClusterAPIOverridesVersion(), overrides.GetClusterAPIBomVersion(), clusterAPIControllerImage, co.Image, c.coreProvider); ok {
 				applyUpgradeOptions.CoreProvider = fmt.Sprintf(formatString, ComponentNamespace, clusterAPIProviderName, version)
 			}
-			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetOCNEBootstrapOverridesVersion(), overrides.GetOCNEBootstrapBomVersion(), clusterAPIOCNEBoostrapControllerImage, co.Image, c.bootstrapProvider); ok {
+			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetOCNEBootstrapOverridesURL(), overrides.GetOCNEBootstrapOverridesVersion(), overrides.GetOCNEBootstrapBomVersion(), clusterAPIOCNEBoostrapControllerImage, co.Image, c.bootstrapProvider); ok {
 				applyUpgradeOptions.BootstrapProviders = append(applyUpgradeOptions.BootstrapProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, version))
 			}
-			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetOCNEControlPlaneOverridesVersion(), overrides.GetOCNEControlPlaneBomVersion(), clusterAPIOCNEControlPLaneControllerImage, co.Image, c.controlPlaneProvider); ok {
+			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetOCNEControlPlaneOverridesURL(), overrides.GetOCNEControlPlaneOverridesVersion(), overrides.GetOCNEControlPlaneBomVersion(), clusterAPIOCNEControlPLaneControllerImage, co.Image, c.controlPlaneProvider); ok {
 				applyUpgradeOptions.ControlPlaneProviders = append(applyUpgradeOptions.ControlPlaneProviders, fmt.Sprintf(formatString, ComponentNamespace, ocneProviderName, version))
 			}
-			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetOCIOverridesVersion(), overrides.GetOCIBomVersion(), clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider); ok {
+			if ok, version := applyUpgradeVersion(ctx.Log(), overrides.GetOCIOverridesURL(), overrides.GetOCIOverridesVersion(), overrides.GetOCIBomVersion(), clusterAPIOCIControllerImage, co.Image, c.infrastructureProvider); ok {
 				applyUpgradeOptions.InfrastructureProviders = append(applyUpgradeOptions.InfrastructureProviders, fmt.Sprintf(formatString, ComponentNamespace, ociProviderName, version))
 			}
 		}

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_overrides.go
@@ -57,30 +57,38 @@ type OverridesInterface interface {
 	GetClusterAPIControllerFullImagePath() string
 	GetClusterAPITag() string
 	GetClusterAPIURL() string
+	GetClusterAPIOverridesURL() string
 	GetClusterAPIVersion() string
 	GetClusterAPIOverridesVersion() string
 	GetClusterAPIBomVersion() string
+	ClusterAPIOverridesExists() bool
 	GetOCIRepository() string
 	GetOCIControllerFullImagePath() string
 	GetOCITag() string
 	GetOCIURL() string
+	GetOCIOverridesURL() string
 	GetOCIVersion() string
 	GetOCIOverridesVersion() string
 	GetOCIBomVersion() string
+	OCIOverridesExists() bool
 	GetOCNEBootstrapRepository() string
 	GetOCNEBootstrapControllerFullImagePath() string
 	GetOCNEBootstrapTag() string
 	GetOCNEBootstrapURL() string
+	GetOCNEBootstrapOverridesURL() string
 	GetOCNEBootstrapVersion() string
 	GetOCNEBootstrapOverridesVersion() string
 	GetOCNEBootstrapBomVersion() string
+	OCNEBootstrapOverridesExists() bool
 	GetOCNEControlPlaneRepository() string
 	GetOCNEControlPlaneControllerFullImagePath() string
 	GetOCNEControlPlaneTag() string
 	GetOCNEControlPlaneURL() string
+	GetOCNEControlPlaneOverridesURL() string
 	GetOCNEControlPlaneVersion() string
 	GetOCNEControlPlaneOverridesVersion() string
 	GetOCNEControlPlaneBomVersion() string
+	OCNEControlPlaneOverridesExists() bool
 	IncludeImagesHeader() bool
 }
 
@@ -104,6 +112,10 @@ func (c capiOverrides) GetClusterAPIURL() string {
 	return getURLForProvider(c.DefaultProviders.Core, "cluster-api")
 }
 
+func (c capiOverrides) GetClusterAPIOverridesURL() string {
+	return c.DefaultProviders.Core.URL
+}
+
 func (c capiOverrides) GetClusterAPIVersion() string {
 	return getProviderVersion(c.DefaultProviders.Core)
 }
@@ -114,6 +126,10 @@ func (c capiOverrides) GetClusterAPIOverridesVersion() string {
 
 func (c capiOverrides) GetClusterAPIBomVersion() string {
 	return c.DefaultProviders.Core.Image.BomVersion
+}
+
+func (c capiOverrides) ClusterAPIOverridesExists() bool {
+	return len(c.GetClusterAPIOverridesVersion()) > 0 || len(c.GetClusterAPIOverridesURL()) > 0
 }
 
 func (c capiOverrides) GetOCIRepository() string {
@@ -128,6 +144,10 @@ func (c capiOverrides) GetOCIURL() string {
 	return getURLForProvider(c.DefaultProviders.OCI, "cluster-api-provider-oci")
 }
 
+func (c capiOverrides) GetOCIOverridesURL() string {
+	return c.DefaultProviders.OCI.URL
+}
+
 func (c capiOverrides) GetOCIVersion() string {
 	return getProviderVersion(c.DefaultProviders.OCI)
 }
@@ -138,6 +158,10 @@ func (c capiOverrides) GetOCIOverridesVersion() string {
 
 func (c capiOverrides) GetOCIBomVersion() string {
 	return c.DefaultProviders.OCI.Image.BomVersion
+}
+
+func (c capiOverrides) OCIOverridesExists() bool {
+	return len(c.GetOCIOverridesVersion()) > 0 || len(c.GetOCIOverridesURL()) > 0
 }
 
 func (c capiOverrides) GetOCNEBootstrapRepository() string {
@@ -152,6 +176,10 @@ func (c capiOverrides) GetOCNEBootstrapURL() string {
 	return getURLForProvider(c.DefaultProviders.OCNEBootstrap, "cluster-api-provider-ocne")
 }
 
+func (c capiOverrides) GetOCNEBootstrapOverridesURL() string {
+	return c.DefaultProviders.OCNEBootstrap.URL
+}
+
 func (c capiOverrides) GetOCNEBootstrapVersion() string {
 	return getProviderVersion(c.DefaultProviders.OCNEBootstrap)
 }
@@ -162,6 +190,10 @@ func (c capiOverrides) GetOCNEBootstrapOverridesVersion() string {
 
 func (c capiOverrides) GetOCNEBootstrapBomVersion() string {
 	return c.DefaultProviders.OCNEBootstrap.Image.BomVersion
+}
+
+func (c capiOverrides) OCNEBootstrapOverridesExists() bool {
+	return len(c.GetOCNEBootstrapOverridesVersion()) > 0 || len(c.GetOCNEBootstrapOverridesURL()) > 0
 }
 
 func (c capiOverrides) GetOCNEControlPlaneRepository() string {
@@ -176,6 +208,10 @@ func (c capiOverrides) GetOCNEControlPlaneURL() string {
 	return getURLForProvider(c.DefaultProviders.OCNEControlPlane, "cluster-api-provider-ocne")
 }
 
+func (c capiOverrides) GetOCNEControlPlaneOverridesURL() string {
+	return c.DefaultProviders.OCNEControlPlane.URL
+}
+
 func (c capiOverrides) GetOCNEControlPlaneVersion() string {
 	return getProviderVersion(c.DefaultProviders.OCNEControlPlane)
 }
@@ -188,11 +224,14 @@ func (c capiOverrides) GetOCNEControlPlaneBomVersion() string {
 	return c.DefaultProviders.OCNEControlPlane.Image.BomVersion
 }
 
-// IncludeImagesHeader returns true if the overrides version for any of the default providers is not specified.
+func (c capiOverrides) OCNEControlPlaneOverridesExists() bool {
+	return len(c.GetOCNEControlPlaneOverridesVersion()) > 0 || len(c.GetOCNEControlPlaneOverridesURL()) > 0
+}
+
+// IncludeImagesHeader returns true if the overrides for any of the default providers is not specified.
 // Otherwise, returns false.
 func (c capiOverrides) IncludeImagesHeader() bool {
-	if len(c.GetClusterAPIOverridesVersion()) == 0 || len(c.GetOCIOverridesVersion()) == 0 ||
-		len(c.GetOCNEBootstrapOverridesVersion()) == 0 || len(c.GetOCNEControlPlaneOverridesVersion()) == 0 {
+	if !c.ClusterAPIOverridesExists() || !c.OCIOverridesExists() || !c.OCNEControlPlaneOverridesExists() || !c.OCNEBootstrapOverridesExists() {
 		return true
 	}
 	return false

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_test.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_test.go
@@ -50,7 +50,7 @@ func TestApplyTemplate(t *testing.T) {
 	overrides, err := createOverrides(compContext)
 	assert.NoError(t, err)
 	assert.NotNil(t, overrides)
-	clusterctl, err := applyTemplate(clusterctlYamlTemplate, overrides)
+	clusterctl, err := applyTemplate(compContext, clusterctlYamlTemplate, overrides)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, clusterctl)
 	assert.NotContains(t, clusterctl.String(), "{{.")
@@ -88,7 +88,6 @@ func TestToSkipSettingUpgradeOptions(t *testing.T) {
   },
   "defaultProviders": {
     "ocneBootstrap": {
-      "url": "/test/bootstrap.yaml",
       "image": {
         "registry": "myreg.io",
         "tag": "v1.0"

--- a/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
+++ b/tests/e2e/clusterapi/capi-overrides/capi_overrides_test.go
@@ -280,13 +280,22 @@ var _ = t.Describe("Cluster API", Label("f:platform-lcm.install"), func() {
 			// from the internet instead of from the container image.
 			Eventually(func() error {
 				return updateClusterAPIOverrides(fmt.Sprintf(urlOverrides,
-					fmt.Sprintf(ociInfraURLFmt, ociComp.Version),
-					fmt.Sprintf(ocneBootstrapURLFmt, ocneComp.Version),
-					fmt.Sprintf(ocneControlPlaneURLFmt, ocneComp.Version),
-					fmt.Sprintf(coreURLFmt, coreComp.Version)))
+					fmt.Sprintf(ociInfraURLFmt, "v0.11.0"),
+					fmt.Sprintf(ocneBootstrapURLFmt, "v1.6.1"),
+					fmt.Sprintf(ocneControlPlaneURLFmt, "v1.6.1"),
+					fmt.Sprintf(coreURLFmt, "v1.4.2")))
 			}, waitTimeout, pollingInterval).Should(BeNil())
 			Eventually(isGenerationMet, waitTimeout, pollingInterval).Should(BeTrue(), "%s lastReconciledGeneration did not meet %v", capiComponentName)
 			Eventually(isStatusReady, waitTimeout, pollingInterval).Should(BeTrue(), "Did not reach Ready status")
+
+			_, err := pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneControlPlaneCMDeployment, managerContainerName, "v1.6.1")
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiOcneBootstrapCMDeployment, managerContainerName, "v1.6.1")
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiociCMDeployment, managerContainerName, "v0.11.0")
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = pkg.ValidateDeploymentContainerImage(verrazzanoCAPINamespace, capiCMDeployment, managerContainerName, "v1.4.2")
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
On applying a VZ CR with clusterAPI URL overrides, this will correctly update:
- the clusterctl yaml in VPO pod
- the k8s deployments in `verrazzano-capi` namespace to run the correct images

```
apiVersion: install.verrazzano.io/v1beta1
kind: Verrazzano
metadata:
  name: my-verrazzano
spec:
  profile: dev
  components:
    clusterAPI:
      enabled: true
      overrides:
      - values:
          defaultProviders:
            ocneControlPlane:
              url: https://github.com/verrazzano/cluster-api-provider-ocne/releases/v1.6.1/control-plane-components.yaml
            ocneBootstrap:
              url: https://github.com/verrazzano/cluster-api-provider-ocne/releases/v1.6.1/bootstrap-components.yaml
            core:
              url: https://github.com/verrazzano/cluster-api/releases/v1.4.2/core-components.yaml
            oci:
              url: https://github.com/oracle/cluster-api-provider-oci/releases/v0.11.1/infrastructure-components.yaml
```
