### PR TITLE
VZ-11248.  VZ controller incorrectly updates VZ status version when build/pre-release fields are set

### DIFF
--- a/platform-operator/controllers/verrazzano/controller/reconciler.go
+++ b/platform-operator/controllers/verrazzano/controller/reconciler.go
@@ -336,14 +336,14 @@ func (r Reconciler) isUpgradeRequired(actualCR *vzv1alpha1.Verrazzano) (bool, er
 		if err != nil {
 			return false, err
 		}
-		return specVersion.IsLessThan(bomVersion), nil
+		return bomVersion.IsGreatherThan(specVersion), nil
 	}
 	if len(actualCR.Status.Version) > 0 {
 		statusVersion, err := semver.NewSemVersion(actualCR.Status.Version)
 		if err != nil {
 			return false, err
 		}
-		return statusVersion.IsLessThan(bomVersion), nil
+		return bomVersion.IsGreatherThan(statusVersion), nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
For upgrades within the `master` branch, the `isUpgradeRequired()` check in the new controller is returning a false-negative allowing the controller to reconcile and set the new BOM version in the status field.    This only affects upgrades between VPO versions within the master branch where the `pre-release` and `build` fields are set.

This is happening because the `IsLessThan()` method is checking `CompareTo() < 0`, and when the `m.m.p` versions are equal but the `pre-release` and/or `build` fields are not equal, `CompareTo` always returns a value > 0.

The `CheckUpgradeRequired` code in the webhook validator uses `bomVersion.IsGreatherThan(installedVersion)`, so using that for the status field comparison to the BOM value fixes it.  `IsGreaterThan` will return `true` if the `m.m.p` versions are equal but the `pre-release` or `build` versions are not.

Most likely `CompareTo` should not be comparing things other than the `m.m.p` fields, but since there's existing behavior based on it we will have to be careful if changing that.  I may follow up on that in a separate PR.