### PR TITLE
VZ-11003: Uptake Kiali image with original logic of IsIstioAPI restored

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -81,7 +81,7 @@ modules:
     version: 2.0.11
     chart: platform-operator/helm_config/charts/fluentbit-opensearch-output
   - name: kiali-server
-    version: 1.73.0
+    version: 1.73.0-1
     chart: platform-operator/thirdparty/charts/kiali-server
     valuesFiles:
       - platform-operator/helm_config/overrides/kiali-server-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -561,8 +561,8 @@
           "name": "kiali-server",
           "images": [
             {
-              "image": "kiali-jenkins",
-              "tag": "v1.73.0-20231003191318-6f003675",
+              "image": "kiali",
+              "tag": "v1.73.0-20231005093008-ad59bc25",
               "helmFullImageKey": "deployment.image_name",
               "helmTagKey": "deployment.image_version"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -554,15 +554,15 @@
     },
     {
       "name": "kiali-server",
-      "version": "1.73.0",
+      "version": "1.73.0-1",
       "subcomponents": [
         {
           "repository": "verrazzano",
           "name": "kiali-server",
           "images": [
             {
-              "image": "kiali",
-              "tag": "v1.73.0-20231003191318-6f003675",
+              "image": "kiali-jenkins",
+              "tag": "v1.73.0-20231003202013-6fbf4c37",
               "helmFullImageKey": "deployment.image_name",
               "helmTagKey": "deployment.image_version"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -562,7 +562,7 @@
           "images": [
             {
               "image": "kiali-jenkins",
-              "tag": "v1.73.0-20231003202013-6fbf4c37",
+              "tag": "v1.73.0-20231003191318-6f003675",
               "helmFullImageKey": "deployment.image_name",
               "helmTagKey": "deployment.image_version"
             }


### PR DESCRIPTION
Removed temporary work around that was always returning "true" for IsIstioAPI.  The fix required for this function to work was to add an annotation in the Kiali deployment.  That annotation is already in master, release-1.6 and release-1.7 branches.