### PR TITLE
VZ-10571 - VZ CLI should delete existing VPO deployment only after the new one has been successfully located.

### DIFF
--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -160,6 +160,12 @@ func ApplyPlatformOperatorYaml(cmd *cobra.Command, client clipkg.Client, vzHelpe
 		return err
 	}
 
+	// Delete previous verrazzano-platform-operator deployments when we have successfully downloaded new one.
+	// This allows for the verrazzano-platform-operator validatingWebhookConfiguration to be updated with the correct caBundle.
+	if err = DeleteFunc(client); err != nil {
+		return err
+	}
+
 	// Apply the Verrazzano operator.yaml
 	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Applying the file %s\n", userVisibleFilename))
 	yamlApplier := k8sutil.NewYAMLApplier(client, "")

--- a/tools/vz/cmd/helpers/vpo.go
+++ b/tools/vz/cmd/helpers/vpo.go
@@ -56,7 +56,20 @@ func FakeDeleteFunc(client clipkg.Client) error {
 	return nil
 }
 
-// Allow overriding the vpoIsReady function for unit testing
+// applyYAMLSig Allow overriding the applyYAML function for unit testing
+type applyYAMLSig func(filename string, client clipkg.Client, vzHelper helpers.VZHelper) error
+
+var applyYAMLFunc applyYAMLSig = applyYAML
+
+func SetApplyYAMLFunc(f applyYAMLSig) {
+	applyYAMLFunc = f
+}
+
+func SetDefaultApplyYAMLFunc() {
+	applyYAMLFunc = applyYAML
+}
+
+// vpoIsReadySig Allow overriding the vpoIsReady function for unit testing
 type vpoIsReadySig func(client clipkg.Client) (bool, error)
 
 var vpoIsReadyFunc vpoIsReadySig = vpoIsReady
@@ -160,6 +173,10 @@ func ApplyPlatformOperatorYaml(cmd *cobra.Command, client clipkg.Client, vzHelpe
 		return err
 	}
 
+	if _, err := os.Stat(localOperatorFilename); err != nil {
+		return err
+	}
+
 	// Delete previous verrazzano-platform-operator deployments when we have successfully downloaded new one.
 	// This allows for the verrazzano-platform-operator validatingWebhookConfiguration to be updated with the correct caBundle.
 	if err = DeleteFunc(client); err != nil {
@@ -168,10 +185,14 @@ func ApplyPlatformOperatorYaml(cmd *cobra.Command, client clipkg.Client, vzHelpe
 
 	// Apply the Verrazzano operator.yaml
 	fmt.Fprintf(vzHelper.GetOutputStream(), fmt.Sprintf("Applying the file %s\n", userVisibleFilename))
+	return applyYAMLFunc(localOperatorFilename, client, vzHelper)
+}
+
+func applyYAML(filename string, client clipkg.Client, vzHelper helpers.VZHelper) error {
 	yamlApplier := k8sutil.NewYAMLApplier(client, "")
-	err = yamlApplier.ApplyF(localOperatorFilename)
+	err := yamlApplier.ApplyF(filename)
 	if err != nil {
-		return fmt.Errorf(applyErrorMsg, localOperatorFilename, err.Error())
+		return fmt.Errorf(applyErrorMsg, filename, err.Error())
 	}
 
 	// Dump out the object result messages

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -7,6 +7,9 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/verrazzano/verrazzano/pkg/kubectlutil"
 	"github.com/verrazzano/verrazzano/pkg/semver"
@@ -23,9 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kube-openapi/pkg/util/proto/validation"
 	"k8s.io/kubectl/pkg/util/openapi"
-	"os"
 	clipkg "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 const (
@@ -222,13 +223,6 @@ func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper)
 			return err
 		}
 		if continuePlatformOperatorReinstall {
-			// Delete leftover verrazzano-platform-operator deployments after an abort.
-			// This allows for the verrazzano-platform-operator validatingWebhookConfiguration to be updated with the correct caBundle.
-			err = cmdhelpers.DeleteFunc(client)
-			if err != nil {
-				return err
-			}
-
 			// Apply the Verrazzano operator.yaml.
 			err = cmdhelpers.ApplyPlatformOperatorYaml(cmd, client, vzHelper, version)
 			if err != nil {

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -187,12 +187,6 @@ func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 	}
 
 	if vz.Spec.Version == "" || !upgradeVersion.IsEqualTo(vzSpecVersion) {
-		// Delete leftover verrazzano-operator deployment after an abort.
-		// This allows for the verrazzano-operator validatingWebhookConfiguration to be updated with the correct caBundle.
-		err = cmdhelpers.DeleteFunc(client)
-		if err != nil {
-			return err
-		}
 
 		// Apply the Verrazzano operator.yaml
 		err = cmdhelpers.ApplyPlatformOperatorYaml(cmd, client, vzHelper, version)


### PR DESCRIPTION
e.g. of where this is an issue - if you upgrade VZ but specify an invalid version, the upgrade doesn't take place because new operator cannot be downloaded, but the existing VPO and webhook are deleted anyway, which leaves the cluster in a state that is undesirable.