### PR TITLE
VZ-10800: Avoid restart of OAM application pods while adding metrics labels/annotations

### DIFF
--- a/application-operator/controllers/metricstrait/metricstrait_controller_test.go
+++ b/application-operator/controllers/metricstrait/metricstrait_controller_test.go
@@ -467,7 +467,7 @@ func TestDeploymentUpdateError(t *testing.T) {
 	// Expect a call to get the Pod to update
 	mock.EXPECT().
 		Get(gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, name types.NamespacedName, pod *k8score.Pod, opts ...client.GetOption) error {
+		DoAndReturn(func(ctx context.Context, name types.NamespacedName, pod *k8score.Pod) error {
 			pod.ObjectMeta = k8smeta.ObjectMeta{OwnerReferences: []k8smeta.OwnerReference{{APIVersion: "v1", Kind: "ReplicSet", Name: "test-rs"}}}
 			pod.CreationTimestamp = k8smeta.Now()
 			return nil

--- a/application-operator/controllers/metricstrait/workloads.go
+++ b/application-operator/controllers/metricstrait/workloads.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package metricstrait
@@ -10,7 +10,6 @@ import (
 	vzapi "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	vznav "github.com/verrazzano/verrazzano/application-operator/controllers/navigation"
 	"github.com/verrazzano/verrazzano/application-operator/controllers/reconcileresults"
-	vzlog2 "github.com/verrazzano/verrazzano/pkg/log"
 	"github.com/verrazzano/verrazzano/pkg/log/vzlog"
 	k8sapps "k8s.io/api/apps/v1"
 	k8score "k8s.io/api/core/v1"
@@ -18,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -56,26 +56,49 @@ func (r *Reconciler) createOrUpdateRelatedWorkloads(ctx context.Context, trait *
 // updateRelatedDeployment updates the labels and annotations of a related workload deployment.
 // For example containerized workloads produce related deployments.
 func (r *Reconciler) updateRelatedDeployment(ctx context.Context, trait *vzapi.MetricsTrait, workload *unstructured.Unstructured, traitDefaults *vzapi.MetricsTraitSpec, child *unstructured.Unstructured, log vzlog.VerrazzanoLogger) (vzapi.QualifiedResourceRelation, controllerutil.OperationResult, error) {
-	log.Debugf("Update workload deployment %s", vznav.GetNamespacedNameFromUnstructured(child))
-	ref := vzapi.QualifiedResourceRelation{APIVersion: child.GetAPIVersion(), Kind: child.GetKind(), Namespace: child.GetNamespace(), Name: child.GetName(), Role: sourceRole}
 	deployment := &k8sapps.Deployment{
 		TypeMeta:   metav1.TypeMeta{APIVersion: child.GetAPIVersion(), Kind: child.GetKind()},
 		ObjectMeta: metav1.ObjectMeta{Namespace: child.GetNamespace(), Name: child.GetName()},
 	}
-	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, func() error {
-		// If the deployment was not found don't attempt to create or update it.
-		if deployment.CreationTimestamp.IsZero() {
-			log.Debug("Workload child deployment not found")
-			return apierrors.NewNotFound(schema.GroupResource{Group: deployment.APIVersion, Resource: deployment.Kind}, deployment.Name)
-		}
-		deployment.Spec.Template.ObjectMeta.Annotations = MutateAnnotations(trait, traitDefaults, deployment.Spec.Template.ObjectMeta.Annotations)
-		deployment.Spec.Template.ObjectMeta.Labels = MutateLabels(trait, workload, deployment.Spec.Template.ObjectMeta.Labels)
-		return nil
-	})
+	ref := vzapi.QualifiedResourceRelation{APIVersion: child.GetAPIVersion(), Kind: child.GetKind(), Namespace: child.GetNamespace(), Name: child.GetName(), Role: sourceRole}
+
+	err := r.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
+
 	if err != nil && !apierrors.IsNotFound(err) {
-		_, err = vzlog2.IgnoreConflictWithLog(fmt.Sprintf("Failed to update workload child deployment %s: %v", vznav.GetNamespacedNameFromObjectMeta(deployment.ObjectMeta).Name, err), err, log.GetZapLogger())
+		return ref, controllerutil.OperationResultNone, fmt.Errorf("failed to getworkload child deployment %s: %v", vznav.GetNamespacedNameFromObjectMeta(deployment.ObjectMeta).Name, err)
 	}
-	return ref, res, err
+
+	if apierrors.IsNotFound(err) || deployment.CreationTimestamp.IsZero() {
+		log.Debug("Workload child deployment not found")
+		return ref, controllerutil.OperationResultNone, apierrors.NewNotFound(schema.GroupResource{Group: deployment.APIVersion, Resource: deployment.Kind}, deployment.Name)
+	}
+
+	replicaSets := &k8sapps.ReplicaSetList{}
+	err = r.List(ctx, replicaSets, client.InNamespace(deployment.Namespace))
+	if err != nil && !apierrors.IsNotFound(err) {
+		return ref, controllerutil.OperationResultNone, fmt.Errorf("failed to get replicasets of workload child deployment %s: %v", vznav.GetNamespacedNameFromObjectMeta(deployment.ObjectMeta).Name, err)
+	}
+
+	if apierrors.IsNotFound(err) || len(replicaSets.Items) == 0 {
+		log.Debug("Replicasets of Workload child deployment not found")
+		return ref, controllerutil.OperationResultNone, apierrors.NewNotFound(schema.GroupResource{Group: replicaSets.APIVersion, Resource: replicaSets.Kind}, deployment.Name)
+	}
+
+	for _, replicaSet := range replicaSets.Items {
+		for _, replicaSetOwnerRef := range replicaSet.GetOwnerReferences() {
+			if replicaSetOwnerRef.APIVersion == deployment.APIVersion && replicaSetOwnerRef.Kind == deployment.Kind && replicaSetOwnerRef.Name == deployment.Name {
+				res, err := r.updateRelatedPods(ctx, trait, workload, traitDefaults, log, ref.Namespace, replicaSet.Kind, replicaSet.Name, replicaSet.APIVersion)
+				if err != nil {
+					return ref, res, err
+				}
+			}
+
+		}
+
+	}
+
+	return ref, controllerutil.OperationResultUpdated, nil
+
 }
 
 // updateRelatedStatefulSet updates the labels and annotations of a related workload stateful set.
@@ -87,19 +110,19 @@ func (r *Reconciler) updateRelatedStatefulSet(ctx context.Context, trait *vzapi.
 		TypeMeta:   metav1.TypeMeta{APIVersion: child.GetAPIVersion(), Kind: child.GetKind()},
 		ObjectMeta: metav1.ObjectMeta{Namespace: child.GetNamespace(), Name: child.GetName()},
 	}
-	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, statefulSet, func() error {
-		// If the statefulset was not found don't attempt to create or update it.
-		if statefulSet.CreationTimestamp.IsZero() {
-			log.Debug("Workload child statefulset not found")
-			return apierrors.NewNotFound(schema.GroupResource{Group: statefulSet.APIVersion, Resource: statefulSet.Kind}, statefulSet.Name)
-		}
-		statefulSet.Spec.Template.ObjectMeta.Annotations = MutateAnnotations(trait, traitDefaults, statefulSet.Spec.Template.ObjectMeta.Annotations)
-		statefulSet.Spec.Template.ObjectMeta.Labels = MutateLabels(trait, workload, statefulSet.Spec.Template.ObjectMeta.Labels)
-		return nil
-	})
+
+	err := r.Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet)
+
 	if err != nil && !apierrors.IsNotFound(err) {
-		log.Errorf("Failed to update workload child statefulset %s: %v", vznav.GetNamespacedNameFromObjectMeta(statefulSet.ObjectMeta), err)
+		return ref, controllerutil.OperationResultNone, fmt.Errorf("unable to fetch workload child statefulset %s: %v", vznav.GetNamespacedNameFromObjectMeta(statefulSet.ObjectMeta).Name, err)
 	}
+
+	if apierrors.IsNotFound(err) || statefulSet.CreationTimestamp.IsZero() {
+		log.Debug("Workload child statefulset not found")
+		return ref, controllerutil.OperationResultNone, apierrors.NewNotFound(schema.GroupResource{Group: statefulSet.APIVersion, Resource: statefulSet.Kind}, statefulSet.Name)
+	}
+
+	res, err := r.updateRelatedPods(ctx, trait, workload, traitDefaults, log, ref.Namespace, statefulSet.Kind, statefulSet.Name, statefulSet.APIVersion)
 	return ref, res, err
 }
 
@@ -107,25 +130,11 @@ func (r *Reconciler) updateRelatedStatefulSet(ctx context.Context, trait *vzapi.
 // For example WLS workloads produce related pods.
 func (r *Reconciler) updateRelatedPod(ctx context.Context, trait *vzapi.MetricsTrait, workload *unstructured.Unstructured, traitDefaults *vzapi.MetricsTraitSpec, child *unstructured.Unstructured, log vzlog.VerrazzanoLogger) (vzapi.QualifiedResourceRelation, controllerutil.OperationResult, error) {
 	log.Debug("Update workload pod %s", vznav.GetNamespacedNameFromUnstructured(child))
-	rel := vzapi.QualifiedResourceRelation{APIVersion: child.GetAPIVersion(), Kind: child.GetKind(), Namespace: child.GetNamespace(), Name: child.GetName(), Role: sourceRole}
 	pod := &k8score.Pod{
 		TypeMeta:   metav1.TypeMeta{APIVersion: child.GetAPIVersion(), Kind: child.GetKind()},
 		ObjectMeta: metav1.ObjectMeta{Namespace: child.GetNamespace(), Name: child.GetName()},
 	}
-	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, pod, func() error {
-		// If the pod was not found don't attempt to create or update it.
-		if pod.CreationTimestamp.IsZero() {
-			log.Debug("Workload child pod not found")
-			return apierrors.NewNotFound(schema.GroupResource{Group: pod.APIVersion, Resource: pod.Kind}, pod.Name)
-		}
-		pod.ObjectMeta.Annotations = MutateAnnotations(trait, traitDefaults, pod.ObjectMeta.Annotations)
-		pod.ObjectMeta.Labels = MutateLabels(trait, workload, pod.ObjectMeta.Labels)
-		return nil
-	})
-	if err != nil && !apierrors.IsNotFound(err) {
-		log.Errorf("Failed to update workload child pod %s: %v", vznav.GetNamespacedNameFromObjectMeta(pod.ObjectMeta), err)
-	}
-	return rel, res, err
+	return r.updatePod(ctx, trait, workload, traitDefaults, log, *pod)
 }
 
 // NewTraitDefaultsForWLSDomainWorkload creates metrics trait default values for a WLS domain workload.
@@ -242,4 +251,53 @@ func (r *Reconciler) fetchWLSDomainCredentialsSecretName(ctx context.Context, wo
 		return nil, nil
 	}
 	return &secretName, nil
+}
+
+func (r *Reconciler) updateRelatedPods(ctx context.Context, trait *vzapi.MetricsTrait, workload *unstructured.Unstructured, traitDefaults *vzapi.MetricsTraitSpec, log vzlog.VerrazzanoLogger, namespace string, ownerKind string, ownerName string, ownerAPIVersion string) (controllerutil.OperationResult, error) {
+	pods := &k8score.PodList{}
+	err := r.List(ctx, pods, client.InNamespace(namespace))
+	if err != nil && !apierrors.IsNotFound(err) {
+		return controllerutil.OperationResultNone, fmt.Errorf("unable to fetch pods from namespace %s: %v", namespace, err)
+	}
+
+	if apierrors.IsNotFound(err) || len(pods.Items) == 0 {
+		log.Debugf("pods of %s %s not found", ownerKind, ownerName)
+		return controllerutil.OperationResultNone, apierrors.NewNotFound(schema.GroupResource{Group: pods.APIVersion, Resource: pods.Kind}, ownerName)
+	}
+
+	for _, pod := range pods.Items {
+		for _, podOwnerRef := range pod.GetOwnerReferences() {
+			if podOwnerRef.APIVersion == ownerAPIVersion && podOwnerRef.Kind == ownerKind && podOwnerRef.Name == ownerName {
+				_, _, err := r.updatePod(ctx, trait, workload, traitDefaults, log, pod)
+				if err != nil && !apierrors.IsNotFound(err) {
+					return controllerutil.OperationResultNone, fmt.Errorf("failed to update labels for pod %s of %s %s: %v", vznav.GetNamespacedNameFromObjectMeta(pod.ObjectMeta).Name, ownerKind, ownerName, err)
+				}
+			}
+
+		}
+	}
+
+	return controllerutil.OperationResultUpdated, nil
+
+}
+
+// updatePod updates the labels and annotations of a workload pod.
+func (r *Reconciler) updatePod(ctx context.Context, trait *vzapi.MetricsTrait, workload *unstructured.Unstructured, traitDefaults *vzapi.MetricsTraitSpec, log vzlog.VerrazzanoLogger, pod k8score.Pod) (vzapi.QualifiedResourceRelation, controllerutil.OperationResult, error) {
+	rel := vzapi.QualifiedResourceRelation{APIVersion: pod.APIVersion, Kind: pod.Kind, Namespace: pod.GetNamespace(), Name: pod.GetName(), Role: sourceRole}
+	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, &pod, func() error {
+		// If the statefulset was not found don't attempt to create or update it.
+		if pod.CreationTimestamp.IsZero() {
+			log.Debug("Workload child pod not found")
+			return apierrors.NewNotFound(schema.GroupResource{Group: pod.APIVersion, Resource: pod.Kind}, pod.Name)
+		}
+		pod.ObjectMeta.Annotations = MutateAnnotations(trait, traitDefaults, pod.ObjectMeta.Annotations)
+		pod.ObjectMeta.Labels = MutateLabels(trait, workload, pod.ObjectMeta.Labels)
+		return nil
+	})
+
+	if err != nil && !apierrors.IsNotFound(err) {
+		return rel, res, log.ErrorfThrottledNewErr("Failed to update workload child pod %s: %v", vznav.GetNamespacedNameFromObjectMeta(pod.ObjectMeta), err)
+	}
+
+	return rel, controllerutil.OperationResultUpdated, nil
 }


### PR DESCRIPTION
port of #7295
