### PR TITLE
VZ-11269 fix uninstall when VZ CR is deleted during install

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -95,15 +95,15 @@ func (v *Verrazzano) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
+	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
+	log.Info("Validate update")
+
 	if v.ObjectMeta.DeletionTimestamp == nil || v.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Verrazzano is being deleted, updates don't matter.  This fixes problem
 		// where the version in the CR didn't match the webhook pod after updating VPO
 		// which prevented uninstall from finishing
 		return nil
 	}
-
-	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
-	log.Info("Validate update")
 
 	if !config.Get().WebhookValidationEnabled {
 		log.Info("Validation disabled, skipping")

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -95,6 +95,13 @@ func (v *Verrazzano) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
+	if v.ObjectMeta.DeletionTimestamp == nil {
+		// Verrazzano is being deleted, updates don't matter.  This fixes problem
+		// where the version in the CR didn't match the webhook pod after updating VPO
+		// which prevented uninstall from finishing
+		return nil
+	}
+
 	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate update")
 

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -98,7 +98,7 @@ func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
 	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate update")
 
-	if v.ObjectMeta.DeletionTimestamp == nil || v.ObjectMeta.DeletionTimestamp.IsZero() {
+	if v.ObjectMeta.DeletionTimestamp != nil && !v.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Verrazzano is being deleted, updates don't matter.  This fixes problem
 		// where the version in the CR didn't match the webhook pod after updating VPO
 		// which prevented uninstall from finishing

--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -95,7 +95,7 @@ func (v *Verrazzano) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
-	if v.ObjectMeta.DeletionTimestamp == nil {
+	if v.ObjectMeta.DeletionTimestamp == nil || v.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Verrazzano is being deleted, updates don't matter.  This fixes problem
 		// where the version in the CR didn't match the webhook pod after updating VPO
 		// which prevented uninstall from finishing

--- a/platform-operator/apis/verrazzano/v1beta1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1beta1/verrazzano_webhook.go
@@ -98,6 +98,13 @@ func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
 	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate update")
 
+	if v.ObjectMeta.DeletionTimestamp == nil || v.ObjectMeta.DeletionTimestamp.IsZero() {
+		// Verrazzano is being deleted, updates don't matter.  This fixes problem
+		// where the version in the CR didn't match the webhook pod after updating VPO
+		// which prevented uninstall from finishing
+		return nil
+	}
+
 	if !config.Get().WebhookValidationEnabled {
 		log.Info("Validation disabled, skipping")
 		return nil

--- a/platform-operator/apis/verrazzano/v1beta1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1beta1/verrazzano_webhook.go
@@ -98,7 +98,7 @@ func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
 	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate update")
 
-	if v.ObjectMeta.DeletionTimestamp == nil || v.ObjectMeta.DeletionTimestamp.IsZero() {
+	if v.ObjectMeta.DeletionTimestamp != nil && !v.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Verrazzano is being deleted, updates don't matter.  This fixes problem
 		// where the version in the CR didn't match the webhook pod after updating VPO
 		// which prevented uninstall from finishing

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -293,7 +293,7 @@ func (c clusterAPIComponent) Uninstall(ctx spi.ComponentContext) error {
 	cmd := exec.Command("clusterctl", "delete", "--all", "--include-namespace")
 
 	if err := runCAPICmd(cmd, ctx.Log()); err != nil {
-		// Ignore not found on uninstall.  This can happend if uninstall is started before install is done
+		// Ignore not found on uninstall.  This can happen if uninstall is started before install is done
 		e := err.Error()
 		ctx.Log().Info(e)
 		if strings.Contains(err.Error(), `"clusters.cluster.x-k8s.io" not found`) {

--- a/platform-operator/controllers/verrazzano/component/common/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/common/vmi.go
@@ -73,6 +73,9 @@ func DeleteVMI(ctx spi.ComponentContext) error {
 	if errors.IsNotFound(err) {
 		return nil
 	}
+	if _, ok := err.(*meta.NoKindMatchError); ok {
+		return nil
+	}
 
 	if err != nil {
 		return ctx.Log().ErrorfNewErr("failed to delete VMI: %v", err)


### PR DESCRIPTION
First pass at fixing uninstall when VZ CR is deleted during install.  

1. Handle general case of CRD not installed, just ignore that error.   
2. Ignore CAPI not found error 
3. Fix webhook to allow update to CR during delete.  This was preventing uninstall from continuing.