### PR TITLE
Auth Proxy v2 enhancements

### DIFF
--- a/authproxy/internal/httputil/httputil.go
+++ b/authproxy/internal/httputil/httputil.go
@@ -8,22 +8,34 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
+	"net/url"
+	"os"
 
 	"github.com/hashicorp/go-retryablehttp"
 	vzpassword "github.com/verrazzano/verrazzano/pkg/security/password"
 )
 
 // GetHTTPClientWithCABundle returns a retryable HTTP client with the given cert pool
-func GetHTTPClientWithCABundle(rootCA *x509.CertPool) *retryablehttp.Client {
+func GetHTTPClientWithCABundle(rootCA *x509.CertPool) (*retryablehttp.Client, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tls.Config{
 		RootCAs:    rootCA,
 		MinVersion: tls.VersionTLS12,
 	}
 
+	proxyURL := getProxyURL()
+	if proxyURL != "" {
+		u := url.URL{}
+		proxy, err := u.Parse(proxyURL)
+		if err != nil {
+			return nil, err
+		}
+		transport.Proxy = http.ProxyURL(proxy)
+	}
+
 	client := retryablehttp.NewClient()
 	client.HTTPClient.Transport = transport
-	return client
+	return client, nil
 }
 
 // ObfuscateRequestData removes the Authorization header data from the request before logging
@@ -34,4 +46,15 @@ func ObfuscateRequestData(req *http.Request) *http.Request {
 		hiddenReq.Header[authKey][i] = vzpassword.MaskFunction("")(hiddenReq.Header[authKey][i])
 	}
 	return hiddenReq
+}
+
+// getProxyURL returns an HTTP proxy from the environment if one is set, otherwise an empty string
+func getProxyURL() string {
+	if proxyURL := os.Getenv("https_proxy"); proxyURL != "" {
+		return proxyURL
+	}
+	if proxyURL := os.Getenv("HTTPS_PROXY"); proxyURL != "" {
+		return proxyURL
+	}
+	return ""
 }

--- a/authproxy/internal/httputil/httputil_test.go
+++ b/authproxy/internal/httputil/httputil_test.go
@@ -17,7 +17,8 @@ import (
 // WHEN the cert pool is given
 // THEN the client returned is not nil
 func TestGetHTTPClientWithCABundle(t *testing.T) {
-	cli := GetHTTPClientWithCABundle(&x509.CertPool{})
+	cli, err := GetHTTPClientWithCABundle(&x509.CertPool{})
+	assert.NoError(t, err)
 	assert.NotNil(t, cli)
 }
 

--- a/authproxy/internal/testutil/testauth/authenticator.go
+++ b/authproxy/internal/testutil/testauth/authenticator.go
@@ -41,7 +41,7 @@ func (f *FakeAuthenticator) SetRequestFunc(fun func() (bool, error)) {
 	f.authenticateRequestFunc = fun
 }
 
-func (a *FakeAuthenticator) ExchangeCodeForToken(req *http.Request, rw http.ResponseWriter, codeVerifier string) (string, error) {
+func (a *FakeAuthenticator) ExchangeCodeForToken(req *http.Request, codeVerifier string) (string, error) {
 	return "", nil
 }
 

--- a/authproxy/internal/testutil/testauth/authenticator.go
+++ b/authproxy/internal/testutil/testauth/authenticator.go
@@ -7,24 +7,25 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/verrazzano/verrazzano/authproxy/src/auth"
 )
 
 // FakeAuthenticator returns a fake implementation of the Authenticator interface
 type FakeAuthenticator struct {
-	authenticateTokenFunc   func() (bool, error)
+	authenticateTokenFunc   func() (*oidc.IDToken, error)
 	authenticateRequestFunc func() (bool, error)
 }
 
 // NewFakeAuthenticator returns a new FakeAuthenticator object with authentication set to true
 func NewFakeAuthenticator() *FakeAuthenticator {
 	return &FakeAuthenticator{
-		authenticateTokenFunc:   AuthenticateTrue,
+		authenticateTokenFunc:   AuthenticateWithToken,
 		authenticateRequestFunc: AuthenticateTrue,
 	}
 }
 
-func (f *FakeAuthenticator) AuthenticateToken(_ context.Context, _ string) (bool, error) {
+func (f *FakeAuthenticator) AuthenticateToken(_ context.Context, _ string) (*oidc.IDToken, error) {
 	return f.authenticateTokenFunc()
 }
 func (f *FakeAuthenticator) AuthenticateRequest(_ *http.Request, _ http.ResponseWriter) (bool, error) {
@@ -32,12 +33,16 @@ func (f *FakeAuthenticator) AuthenticateRequest(_ *http.Request, _ http.Response
 }
 func (f *FakeAuthenticator) SetCallbackURL(_ string) {}
 
-func (f *FakeAuthenticator) SetTokenFunc(fun func() (bool, error)) {
+func (f *FakeAuthenticator) SetTokenFunc(fun func() (*oidc.IDToken, error)) {
 	f.authenticateTokenFunc = fun
 }
 
 func (f *FakeAuthenticator) SetRequestFunc(fun func() (bool, error)) {
 	f.authenticateRequestFunc = fun
+}
+
+func (a *FakeAuthenticator) ExchangeCodeForToken(req *http.Request, rw http.ResponseWriter, codeVerifier string) (string, error) {
+	return "", nil
 }
 
 func AuthenticateTrue() (bool, error) {
@@ -46,6 +51,10 @@ func AuthenticateTrue() (bool, error) {
 
 func AuthenticateFalse() (bool, error) {
 	return false, nil
+}
+
+func AuthenticateWithToken() (*oidc.IDToken, error) {
+	return &oidc.IDToken{}, nil
 }
 
 var _ auth.Authenticator = &FakeAuthenticator{}

--- a/authproxy/internal/testutil/testauth/authenticator.go
+++ b/authproxy/internal/testutil/testauth/authenticator.go
@@ -41,7 +41,7 @@ func (f *FakeAuthenticator) SetRequestFunc(fun func() (bool, error)) {
 	f.authenticateRequestFunc = fun
 }
 
-func (a *FakeAuthenticator) ExchangeCodeForToken(req *http.Request, codeVerifier string) (string, error) {
+func (f *FakeAuthenticator) ExchangeCodeForToken(req *http.Request, codeVerifier string) (string, error) {
 	return "", nil
 }
 

--- a/authproxy/src/apiserver/apiserver.go
+++ b/authproxy/src/apiserver/apiserver.go
@@ -72,7 +72,7 @@ func (a *APIRequest) preprocessAPIRequest() (*retryablehttp.Request, error) {
 		return nil, err
 	}
 
-	a.Authenticator.SetCallbackURL(fmt.Sprintf("https://%s%s", ingressHost, a.CallbackPath))
+	a.Authenticator.SetCallbackURL(fmt.Sprintf("https://%s/clusters/local%s", ingressHost, a.CallbackPath))
 	continueProcessing, err := a.Authenticator.AuthenticateRequest(req, rw)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusUnauthorized)

--- a/authproxy/src/auth/auth.go
+++ b/authproxy/src/auth/auth.go
@@ -71,7 +71,8 @@ func (a *OIDCAuthenticator) AuthenticateRequest(req *http.Request, rw http.Respo
 		return false, fmt.Errorf("failed to get token from authorization header: %v", err)
 	}
 
-	return a.AuthenticateToken(req.Context(), token)
+	_, err = a.AuthenticateToken(req.Context(), token)
+	return err == nil, err
 }
 
 // SetCallbackURL sets the OIDC Callback URL for redirects

--- a/authproxy/src/auth/auth.go
+++ b/authproxy/src/auth/auth.go
@@ -5,12 +5,10 @@ package auth
 
 import (
 	"context"
-	"crypto/x509"
 	"fmt"
 	"net/http"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/verrazzano/verrazzano/authproxy/internal/httputil"
 	"go.uber.org/zap"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -30,9 +28,13 @@ type verifier interface {
 func NewAuthenticator(oidcConfig *OIDCConfiguration, log *zap.SugaredLogger, client k8sclient.Client) (*OIDCAuthenticator, error) {
 	authenticator := &OIDCAuthenticator{
 		Log:        log,
-		client:     httputil.GetHTTPClientWithCABundle(&x509.CertPool{}),
 		oidcConfig: oidcConfig,
 		k8sClient:  client,
+	}
+
+	var err error
+	if authenticator.ctx, err = authenticator.createContextWithHTTPClient(); err != nil {
+		return nil, err
 	}
 
 	if err := authenticator.initExternalOIDCProvider(); err != nil {

--- a/authproxy/src/auth/auth_test.go
+++ b/authproxy/src/auth/auth_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -28,6 +29,10 @@ type mockVerifier struct {
 var _ verifier = &mockVerifier{}
 
 func TestNewAuthenticator(t *testing.T) {
+	// unset these otherwise the test fails due to not being able to connect to the proxy
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("https_proxy")
+
 	server := testserver.FakeOIDCProviderServer(t)
 
 	config := &OIDCConfiguration{
@@ -41,7 +46,7 @@ func TestNewAuthenticator(t *testing.T) {
 	assert.NotNil(t, authenticator)
 	assert.Equal(t, config, authenticator.oidcConfig)
 	assert.Equal(t, client, authenticator.k8sClient)
-	assert.NotNil(t, authenticator.client)
+	assert.NotNil(t, authenticator.ctx)
 	assert.Implements(t, (*verifier)(nil), authenticator.verifier.Load())
 }
 

--- a/authproxy/src/auth/login.go
+++ b/authproxy/src/auth/login.go
@@ -22,11 +22,7 @@ import (
 
 // initExternalOIDCProvider initializes the external URL based OIDC Provider in the given Authenticator
 func (a *OIDCAuthenticator) initExternalOIDCProvider() error {
-	ctx, err := a.createContextWithHTTPClient()
-	if err != nil {
-		return err
-	}
-	provider, err := oidc.NewProvider(ctx, a.oidcConfig.ExternalURL)
+	provider, err := oidc.NewProvider(a.ctx, a.oidcConfig.ExternalURL)
 	if err != nil {
 		return err
 	}
@@ -48,9 +44,11 @@ func (a *OIDCAuthenticator) createContextWithHTTPClient() (context.Context, erro
 		}
 	}
 
-	httpClient := httputil.GetHTTPClientWithCABundle(certPool)
-	ctx := context.Background()
-	return context.WithValue(ctx, oauth2.HTTPClient, httpClient.HTTPClient), nil
+	httpClient, err := httputil.GetHTTPClientWithCABundle(certPool)
+	if err != nil {
+		return nil, err
+	}
+	return context.WithValue(context.Background(), oauth2.HTTPClient, httpClient.StandardClient()), nil
 }
 
 // performLoginRedirect redirects the incoming request to the OIDC provider

--- a/authproxy/src/auth/login_test.go
+++ b/authproxy/src/auth/login_test.go
@@ -4,6 +4,7 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -42,7 +43,6 @@ func TestPerformLoginRedirect(t *testing.T) {
 
 // TestCreateContextWithHTTPClient tests that the context client can be created
 func TestCreateContextWithHTTPClient(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		objects []k8sclient.Object
@@ -110,6 +110,7 @@ func TestInitExternalOIDCProvider(t *testing.T) {
 		oidcConfig: &OIDCConfiguration{
 			ExternalURL: server.URL,
 		},
+		ctx: context.WithValue(context.Background(), oauth2.HTTPClient, server.Client()),
 	}
 
 	err := authenticator.initExternalOIDCProvider()

--- a/authproxy/src/auth/token.go
+++ b/authproxy/src/auth/token.go
@@ -40,8 +40,9 @@ func (a *OIDCAuthenticator) AuthenticateToken(ctx context.Context, token string)
 	return idToken, nil
 }
 
+// ExchangeCodeForToken calls the identity provider to exchange the code in the HTTP request for a JWT token. On successful exchange this
+// function returns the identity token as a string.
 func (a *OIDCAuthenticator) ExchangeCodeForToken(req *http.Request, codeVerifier string) (string, error) {
-	// TODO Create this once?
 	oauthConfig := oauth2.Config{
 		ClientID:    a.oidcConfig.ClientID,
 		Endpoint:    a.ExternalProvider.Endpoint(),

--- a/authproxy/src/auth/token_test.go
+++ b/authproxy/src/auth/token_test.go
@@ -50,14 +50,14 @@ func TestAuthenticateToken(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			validated, err := authenticator.AuthenticateToken(context.TODO(), tt.token)
+			idToken, err := authenticator.AuthenticateToken(context.TODO(), tt.token)
 			if tt.expectValidation {
 				assert.NoError(t, err)
-				assert.True(t, validated)
+				assert.NotNil(t, idToken)
 				return
 			}
 			assert.Error(t, err)
-			assert.False(t, validated)
+			assert.Nil(t, idToken)
 		})
 	}
 }

--- a/authproxy/src/auth/types.go
+++ b/authproxy/src/auth/types.go
@@ -16,9 +16,10 @@ import (
 
 // Authenticator is the interface implemented by OIDCAuthenticator
 type Authenticator interface {
-	AuthenticateToken(ctx context.Context, token string) (bool, error)
+	AuthenticateToken(ctx context.Context, token string) (*oidc.IDToken, error)
 	AuthenticateRequest(req *http.Request, rw http.ResponseWriter) (bool, error)
 	SetCallbackURL(url string)
+	ExchangeCodeForToken(req *http.Request, rw http.ResponseWriter, codeVerifier string) (string, error)
 }
 
 // OIDCAuthenticator authenticates incoming requests against the Identity Provider

--- a/authproxy/src/auth/types.go
+++ b/authproxy/src/auth/types.go
@@ -9,7 +9,6 @@ import (
 	"sync/atomic"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/hashicorp/go-retryablehttp"
 	"go.uber.org/zap"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -19,14 +18,14 @@ type Authenticator interface {
 	AuthenticateToken(ctx context.Context, token string) (*oidc.IDToken, error)
 	AuthenticateRequest(req *http.Request, rw http.ResponseWriter) (bool, error)
 	SetCallbackURL(url string)
-	ExchangeCodeForToken(req *http.Request, rw http.ResponseWriter, codeVerifier string) (string, error)
+	ExchangeCodeForToken(req *http.Request, codeVerifier string) (string, error)
 }
 
 // OIDCAuthenticator authenticates incoming requests against the Identity Provider
 type OIDCAuthenticator struct {
 	k8sClient        k8sclient.Client
 	oidcConfig       *OIDCConfiguration
-	client           *retryablehttp.Client
+	ctx              context.Context
 	ExternalProvider *oidc.Provider
 	verifier         atomic.Value
 	Log              *zap.SugaredLogger

--- a/authproxy/src/cookie/cookie.go
+++ b/authproxy/src/cookie/cookie.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package cookie
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+)
+
+const stateCookie = "vz_state"
+
+type VZState struct {
+	State        string
+	Nonce        string
+	CodeVerifier string
+	RedirectURI  string
+}
+
+var encryptor cipher.AEAD
+var encryptorMutex sync.Mutex
+
+// var allows overriding in unit tests
+var encryptionKeyFile = "/etc/config/cookie-encryption-key"
+
+func init() {
+	gob.Register(&VZState{})
+}
+
+func SetEncryptionKeyFile(filename string) {
+	encryptionKeyFile = filename
+}
+
+func GetEncryptionKeyFile() string {
+	return encryptionKeyFile
+}
+
+// SetStateCookie encrypts the state and stores it in a cookie in the response
+func SetStateCookie(rw http.ResponseWriter, state *VZState) error {
+	cookie, err := CreateStateCookie(state)
+	if err != nil {
+		return err
+	}
+	http.SetCookie(rw, cookie)
+	return nil
+}
+
+// CreateStateCookie encrypts a VZState and returns it in a cookie
+func CreateStateCookie(state *VZState) (*http.Cookie, error) {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(state); err != nil {
+		return nil, err
+	}
+	return encryptCookie(stateCookie, base64.RawURLEncoding.EncodeToString(buf.Bytes()))
+}
+
+// GetStateCookie fetches the state from a cookie and decrypts it
+func GetStateCookie(req *http.Request) (*VZState, error) {
+	c, err := req.Cookie(stateCookie)
+	if err != nil {
+		return nil, err
+	}
+
+	val, err := decryptCookie(c)
+	if err != nil {
+		return nil, err
+	}
+
+	var state VZState
+	b, err := base64.RawURLEncoding.DecodeString(val)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := gob.NewDecoder(bytes.NewReader(b)).Decode(&state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+// initEncryptor initializes the cookie encryptor
+func initEncryptor() error {
+	encryptorMutex.Lock()
+	defer encryptorMutex.Unlock()
+
+	if encryptor != nil {
+		return nil
+	}
+
+	b, err := os.ReadFile(encryptionKeyFile)
+	if err != nil {
+		return err
+	}
+
+	block, err := aes.NewCipher(b[:32])
+	if err != nil {
+		return err
+	}
+
+	encryptor, err = cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// encryptCookie encrypts the provided value and returns a cookie with the name and encrypted value
+func encryptCookie(name, value string) (*http.Cookie, error) {
+	// lazy initialize the cookie encryptor
+	if encryptor == nil {
+		if err := initEncryptor(); err != nil {
+			return nil, err
+		}
+	}
+
+	nonce := make([]byte, encryptor.NonceSize())
+	_, err := io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return nil, err
+	}
+	plainText := fmt.Sprintf("%s:%s", name, value)
+	encryptedValue := encryptor.Seal(nonce, nonce, []byte(plainText), nil)
+
+	c := &http.Cookie{Name: name, Value: base64.RawURLEncoding.EncodeToString(encryptedValue)}
+	return c, nil
+}
+
+// decryptCookie decrypts the value in the cookie
+func decryptCookie(cookie *http.Cookie) (string, error) {
+	// lazy initialize the cookie encryptor
+	if encryptor == nil {
+		if err := initEncryptor(); err != nil {
+			return "", err
+		}
+	}
+
+	encryptedValue, err := base64.RawURLEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		return "", err
+	}
+
+	nonceSize := encryptor.NonceSize()
+	if len(encryptedValue) < nonceSize {
+		return "", fmt.Errorf("Invalid state cookie value")
+	}
+
+	nonce := encryptedValue[:nonceSize]
+	val := encryptedValue[nonceSize:]
+	plainText, err := encryptor.Open(nil, []byte(nonce), []byte(val), nil)
+	if err != nil {
+		return "", err
+	}
+	expectedName, value, ok := strings.Cut(string(plainText), ":")
+	if !ok {
+		return "", fmt.Errorf("Invalid state cookie value")
+	}
+	if expectedName != cookie.Name {
+		return "", fmt.Errorf("Invalid state cookie value")
+	}
+
+	return value, nil
+}

--- a/authproxy/src/cookie/cookie_test.go
+++ b/authproxy/src/cookie/cookie_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package cookie
+
+import (
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStateCookie tests the state cookie encryption and decryption functionality
+func TestStateCookie(t *testing.T) {
+	// create a temporary file with a generated cookie encryption key
+	filename, err := writeEncryptionKeyFile()
+	assert.NoError(t, err)
+	defer os.Remove(filename)
+	prevEncryptionKeyFile := GetEncryptionKeyFile()
+	defer SetEncryptionKeyFile(prevEncryptionKeyFile)
+	SetEncryptionKeyFile(filename)
+
+	// GIVEN a VZState struct
+	// WHEN the struct is encrypted and stored in a cookie and then read back and decrypted into a new struct
+	// THEN the two structs have exactly the same data
+
+	// populate a VZState, encrypt it, and store it in a cookie
+	vzState := &VZState{
+		State:        "test-state",
+		Nonce:        "test-nonce",
+		CodeVerifier: "test-verifier",
+		RedirectURI:  "https://example.com/redirect",
+	}
+
+	rw := httptest.NewRecorder()
+	SetStateCookie(rw, vzState)
+
+	req := httptest.NewRequest("", "https://example.com", nil)
+	for _, c := range rw.Result().Cookies() {
+		req.AddCookie(c)
+	}
+
+	// read the cookie back (decrypted) and validate that it matches the input state
+	newVZState, err := GetStateCookie(req)
+	assert.NoError(t, err)
+	assert.Equal(t, vzState, newVZState)
+}
+
+// writeEncryptionKeyFile creates a temporary file and writes an encryption key. The function returns the file name.
+func writeEncryptionKeyFile() (string, error) {
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	f.Write([]byte("abcdefghijklmnopqrstuvwxyz1234567890"))
+	f.Close()
+	return f.Name(), nil
+}

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -131,8 +131,6 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 // handleAuthCallback is the http handler for authentication callback
 func (h *Handler) handleAuthCallback(rw http.ResponseWriter, req *http.Request) {
-	h.Log.Debugf("Handling oauth callback, request: %+v", req)
-
 	// the state field in the VZ cookie must match the state query param value
 	state, err := cookie.GetStateCookie(req)
 	if err != nil {
@@ -140,7 +138,6 @@ func (h *Handler) handleAuthCallback(rw http.ResponseWriter, req *http.Request) 
 		http.Error(rw, "Failed to read state cookie", http.StatusUnauthorized)
 		return
 	}
-	h.Log.Debugf("State struct: %+v", state)
 
 	stateQueryParam := req.URL.Query().Get("state")
 	if stateQueryParam == "" {
@@ -163,8 +160,6 @@ func (h *Handler) handleAuthCallback(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	h.Log.Debugf("Got token: %s", token)
-
 	// validate the token and get the ID token
 	idToken, err := h.Authenticator.AuthenticateToken(context.TODO(), token)
 	if err != nil {
@@ -173,14 +168,11 @@ func (h *Handler) handleAuthCallback(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	h.Log.Debugf("ID token: %+v", *idToken)
-
 	if idToken.Nonce != state.Nonce {
 		http.Error(rw, "nonce does not match", http.StatusUnauthorized)
 		return
 	}
 
-	h.Log.Debug("Successfully validated callback")
 	http.Redirect(rw, req, state.RedirectURI, http.StatusFound)
 }
 

--- a/authproxy/src/proxy/proxy.go
+++ b/authproxy/src/proxy/proxy.go
@@ -4,10 +4,12 @@
 package proxy
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,6 +19,7 @@ import (
 	"github.com/verrazzano/verrazzano/authproxy/src/apiserver"
 	"github.com/verrazzano/verrazzano/authproxy/src/auth"
 	"github.com/verrazzano/verrazzano/authproxy/src/config"
+	"github.com/verrazzano/verrazzano/authproxy/src/cookie"
 	"github.com/verrazzano/verrazzano/pkg/k8sutil"
 	"go.uber.org/zap"
 	"k8s.io/client-go/rest"
@@ -99,19 +102,18 @@ func ConfigureKubernetesAPIProxy(authproxy *AuthProxy, k8sClient client.Client, 
 
 // findPathHandler returns the path handler function given the request path
 func (h *Handler) findPathHandler(req *http.Request) handlerFuncType {
-	switch req.URL.Path {
-	case callbackPath:
+	if strings.HasSuffix(req.URL.Path, callbackPath) {
 		return h.handleAuthCallback
-	case logoutPath:
-		return h.handleLogout
-	default:
-		return h.handleAPIRequest
 	}
+	if strings.HasSuffix(req.URL.Path, logoutPath) {
+		return h.handleLogout
+	}
+	return h.handleAPIRequest
 }
 
 // ServeHTTP accepts an incoming server request and forwards it to the Kubernetes API server
 func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	h.Log.Debug("Incoming request: %+v", httputil.ObfuscateRequestData(req))
+	h.Log.Debugf("Incoming request: %+v", httputil.ObfuscateRequestData(req))
 
 	err := h.initializeAuthenticator()
 	if err != nil {
@@ -126,7 +128,54 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 // handleAuthCallback is the http handler for authentication callback
 func (h *Handler) handleAuthCallback(rw http.ResponseWriter, req *http.Request) {
+	h.Log.Debugf("Handling oauth callback, request: %+v", req)
 
+	state, err := cookie.GetStateCookie(req)
+	if err != nil {
+		h.Log.Errorf("Failed to read state cookie: %v", err)
+		http.Error(rw, "Failed to read state cookie", http.StatusInternalServerError)
+		return
+	}
+	h.Log.Debugf("State struct: %+v", state)
+
+	stateQueryParam := req.URL.Query().Get("state")
+	if stateQueryParam == "" {
+		h.Log.Errorf("Missing state")
+		http.Error(rw, "Missing state", http.StatusUnauthorized)
+		return
+	}
+
+	if state.State != stateQueryParam {
+		h.Log.Errorf("State does not match")
+		http.Error(rw, "State does not match", http.StatusUnauthorized)
+		return
+	}
+
+	token, err := h.Authenticator.ExchangeCodeForToken(req, rw, state.CodeVerifier)
+	if err != nil {
+		h.Log.Errorf("Failed to exchange code for token: %v", err)
+		http.Error(rw, "Failed to exchange code for token", http.StatusInternalServerError)
+		return
+	}
+
+	h.Log.Debugf("Got token: %s", token)
+
+	idToken, err := h.Authenticator.AuthenticateToken(context.TODO(), token)
+	if err != nil {
+		h.Log.Errorf("Failed authenticating token: %v", err)
+		http.Error(rw, "Failed authenticating token", http.StatusUnauthorized)
+		return
+	}
+
+	h.Log.Debugf("ID token: %+v", *idToken)
+
+	if idToken.Nonce != state.Nonce {
+		http.Error(rw, "nonce does not match", http.StatusUnauthorized)
+		return
+	}
+
+	h.Log.Debug("Successfully validated callback")
+	http.Redirect(rw, req, state.RedirectURI, http.StatusFound)
 }
 
 // handleLogout is the http handler for logout

--- a/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-authproxy/templates/verrazzano-authproxy.yaml
@@ -103,9 +103,13 @@ spec:
                   - key: reload.sh
                     path: reload.sh
                     mode: 0755
-       - name: oidc-config-secret
-         secret:
-           secretName: {{ .Values.v2.oidcConfigSecret }}
+       - name: v2-config
+         projected:
+           sources:
+           - secret:
+               name: verrazzano-authproxy-secret
+           - secret:
+               name: {{ .Values.v2.oidcConfigSecret }}
       {{- with .Values.affinity }}
       affinity:
         {{- tpl . $ | nindent 8 }}
@@ -217,7 +221,7 @@ spec:
             drop:
               - ALL
         volumeMounts:
-        - name: oidc-config-secret
+        - name: v2-config
           mountPath: /etc/config
       {{- end }}
       serviceAccountName: {{ .Values.name }}


### PR DESCRIPTION
This PR includes the following changes to Auth Proxy v2:
- Implement oauth callback handler
  - Validates state
  - Exchanges the oauth one-time use code for a token and validates the token
- Add HTTP client support for proxies (facilitates local debugging)
- Improved HTTP client management
  - We were creating a retryable client but it wasn't actually being used
  - Also consolidated creation of HTTP clients to eliminate recreating them unnecessarily
- Lots more unit tests