### PR TITLE
VZ-11269 fix uninstall when VZ CR is deleted during install 

### DIFF
--- a/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1alpha1/verrazzano_webhook.go
@@ -98,6 +98,13 @@ func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
 	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate update")
 
+	if v.ObjectMeta.DeletionTimestamp != nil && !v.ObjectMeta.DeletionTimestamp.IsZero() {
+		// Verrazzano is being deleted, updates don't matter.  This fixes problem
+		// where the version in the CR didn't match the webhook pod after updating VPO
+		// which prevented uninstall from finishing
+		return nil
+	}
+
 	if !config.Get().WebhookValidationEnabled {
 		log.Info("Validation disabled, skipping")
 		return nil

--- a/platform-operator/apis/verrazzano/v1beta1/verrazzano_webhook.go
+++ b/platform-operator/apis/verrazzano/v1beta1/verrazzano_webhook.go
@@ -98,6 +98,13 @@ func (v *Verrazzano) ValidateUpdate(old runtime.Object) error {
 	log := zap.S().With("source", "webhook", "operation", "update", "resource", fmt.Sprintf("%s:%s", v.Namespace, v.Name))
 	log.Info("Validate update")
 
+	if v.ObjectMeta.DeletionTimestamp != nil && !v.ObjectMeta.DeletionTimestamp.IsZero() {
+		// Verrazzano is being deleted, updates don't matter.  This fixes problem
+		// where the version in the CR didn't match the webhook pod after updating VPO
+		// which prevented uninstall from finishing
+		return nil
+	}
+
 	if !config.Get().WebhookValidationEnabled {
 		log.Info("Validation disabled, skipping")
 		return nil

--- a/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
+++ b/platform-operator/controllers/verrazzano/component/clusterapi/clusterapi_component.go
@@ -7,10 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"os/exec"
-
 	"github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/pkg/k8s/ready"
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
@@ -21,9 +17,13 @@ import (
 	vpoconstants "github.com/verrazzano/verrazzano/platform-operator/constants"
 	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/spi"
+	appsv1 "k8s.io/api/apps/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"os/exec"
+	"strings"
 )
 
 // ComponentName is the name of the component
@@ -94,7 +94,9 @@ func runCAPICmd(cmd *exec.Cmd, log vzlog.VerrazzanoLogger) error {
 	log.Progressf("Component %s is executing the command: %s", ComponentName, cmd.String())
 	err := cmd.Run()
 	if err != nil {
-		log.ErrorfThrottled("command failed with error %s; stdout: %s; stderr: %s", err.Error(), stdoutBuffer.String(), stderrBuffer.String())
+		s := fmt.Sprintf("command failed with error %s; stdout: %s; stderr: %s", err.Error(), stdoutBuffer.String(), stderrBuffer.String())
+		log.ErrorfThrottled(s)
+		return fmt.Errorf(s)
 	}
 	return err
 }
@@ -290,7 +292,17 @@ func (c clusterAPIComponent) PreUninstall(_ spi.ComponentContext) error {
 func (c clusterAPIComponent) Uninstall(ctx spi.ComponentContext) error {
 	cmd := exec.Command("clusterctl", "delete", "--all", "--include-namespace")
 
-	return runCAPICmd(cmd, ctx.Log())
+	if err := runCAPICmd(cmd, ctx.Log()); err != nil {
+		// Ignore not found on uninstall.  This can happen if uninstall is started before install is done
+		e := err.Error()
+		ctx.Log().Info(e)
+		if strings.Contains(err.Error(), `"clusters.cluster.x-k8s.io" not found`) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }
 
 func (c clusterAPIComponent) PostUninstall(_ spi.ComponentContext) error {

--- a/platform-operator/controllers/verrazzano/component/common/vmi.go
+++ b/platform-operator/controllers/verrazzano/component/common/vmi.go
@@ -73,6 +73,9 @@ func DeleteVMI(ctx spi.ComponentContext) error {
 	if errors.IsNotFound(err) {
 		return nil
 	}
+	if _, ok := err.(*meta.NoKindMatchError); ok {
+		return nil
+	}
 
 	if err != nil {
 		return ctx.Log().ErrorfNewErr("failed to delete VMI: %v", err)


### PR DESCRIPTION
cherry-pick of https://github.com/verrazzano/verrazzano/commit/8d33093a913f60a2c5dd064293a911d2231bddd2

First pass at fixing uninstall when VZ CR is deleted during install.

    Handle general case of CRD not installed, just ignore that error.
    Ignore CAPI not found error
    Fix webhook to allow update to CR during delete. This was preventing uninstall from continuing.

