### PR TITLE
VZ-11247: Update VMC status K8s version for CAPI clusters without VZ

### DIFF
--- a/cluster-operator/controllers/vmc/update_status.go
+++ b/cluster-operator/controllers/vmc/update_status.go
@@ -299,8 +299,8 @@ func (r *VerrazzanoManagedClusterReconciler) updateK8sVersionUsingCAPI(vmc *clus
 	if err := r.List(context.TODO(), cpList, clipkg.InNamespace(clusterNamespacedName.Namespace)); err != nil {
 		return fmt.Errorf("error listing control plane objects: %v", err)
 	}
-	if len(cpList.Items) != 1 {
-		return fmt.Errorf("expected to find 1 %s objects, but found %d", cpKind, len(cpList.Items))
+	if len(cpList.Items) < 1 {
+		return fmt.Errorf("failed to find %s objects", cpKind)
 	}
 	k8sVersion, found, err := unstructured.NestedString(cpList.Items[0].Object, "status", "version")
 	if !found {

--- a/cluster-operator/controllers/vmc/update_status.go
+++ b/cluster-operator/controllers/vmc/update_status.go
@@ -267,6 +267,9 @@ func (r *VerrazzanoManagedClusterReconciler) shouldUpdateK8sVersion(vmc *cluster
 	}
 	vzList := &v1beta1.VerrazzanoList{}
 	if err = capiClient.List(context.TODO(), vzList, &clipkg.ListOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
 		return false, fmt.Errorf("error listing verrazzanos in ClusterAPI cluster %s: %v", capiClusterName, err)
 	}
 	if len(vzList.Items) > 0 {

--- a/cluster-operator/controllers/vmc/update_status.go
+++ b/cluster-operator/controllers/vmc/update_status.go
@@ -268,6 +268,8 @@ func (r *VerrazzanoManagedClusterReconciler) shouldUpdateK8sVersion(vmc *cluster
 	}
 	vzList := &v1beta1.VerrazzanoList{}
 	if err = capiClient.List(context.TODO(), vzList, &clipkg.ListOptions{}); err != nil {
+		// If verrazzanos are either not found or if the verrazzano CRD is not defined on this cluster,
+		// then return true
 		vzGroupVersionResource := schema.GroupVersionResource{
 			Group:    v1beta1.SchemeGroupVersion.Group,
 			Version:  v1beta1.SchemeGroupVersion.Version,

--- a/cluster-operator/controllers/vmc/update_status.go
+++ b/cluster-operator/controllers/vmc/update_status.go
@@ -26,6 +26,9 @@ const (
 	okeProviderDisplayName      = "Oracle OKE"
 )
 
+// for unit testing
+var getCAPIClientFunc = capi.GetClusterClient
+
 // updateStatus updates the status of the VMC in the cluster, with all provided conditions, after setting the vmc.Status.State field for the cluster
 func (r *VerrazzanoManagedClusterReconciler) updateStatus(ctx context.Context, vmc *clustersv1alpha1.VerrazzanoManagedCluster) error {
 	// Update the VMC's status.state
@@ -258,7 +261,7 @@ func (r *VerrazzanoManagedClusterReconciler) shouldUpdateK8sVersion(vmc *cluster
 
 	// If Verrazzano is installed on the workload cluster, then let the verrazzano cluster agent handle updating the K8s version.
 	capiClusterName := types.NamespacedName{Name: vmc.Status.ClusterRef.Name, Namespace: vmc.Status.ClusterRef.Namespace}
-	capiClient, err := capi.GetClusterClient(context.TODO(), r.Client, capiClusterName, r.Scheme)
+	capiClient, err := getCAPIClientFunc(context.TODO(), r.Client, capiClusterName, r.Scheme)
 	if err != nil {
 		return false, fmt.Errorf("failed to get client for ClusterAPI cluster %s: %v", capiClusterName, err)
 	}

--- a/cluster-operator/controllers/vmc/update_status.go
+++ b/cluster-operator/controllers/vmc/update_status.go
@@ -266,7 +266,7 @@ func (r *VerrazzanoManagedClusterReconciler) shouldUpdateK8sVersion(vmc *cluster
 		if errors.IsNotFound(err) {
 			return false, nil
 		}
-		return false, err
+		return false, fmt.Errorf("error listing verrazzanos in ClusterAPI cluster %s: %v", capiClusterName, err)
 	}
 	// FIXME: do check for length of vzList?
 	return true, nil

--- a/cluster-operator/controllers/vmc/update_status.go
+++ b/cluster-operator/controllers/vmc/update_status.go
@@ -263,12 +263,11 @@ func (r *VerrazzanoManagedClusterReconciler) shouldUpdateK8sVersion(vmc *cluster
 	}
 	vzList := &v1beta1.VerrazzanoList{}
 	if err = capiClient.List(context.TODO(), vzList, &clipkg.ListOptions{}); err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
 		return false, fmt.Errorf("error listing verrazzanos in ClusterAPI cluster %s: %v", capiClusterName, err)
 	}
-	// FIXME: do check for length of vzList?
+	if len(vzList.Items) > 0 {
+		return false, nil
+	}
 	return true, nil
 }
 

--- a/cluster-operator/controllers/vmc/update_status_test.go
+++ b/cluster-operator/controllers/vmc/update_status_test.go
@@ -131,6 +131,9 @@ func TestUpdateStatusImported(t *testing.T) {
 	_ = v1alpha1.AddToScheme(scheme)
 	_ = v1beta1.AddToScheme(scheme)
 
+	defaultCAPIClientFunc := getCAPIClientFunc
+	defer func() { getCAPIClientFunc = defaultCAPIClientFunc }()
+
 	tests := []struct {
 		testName         string
 		vmc              *v1alpha1.VerrazzanoManagedCluster
@@ -153,6 +156,7 @@ func TestUpdateStatusImported(t *testing.T) {
 			// GIVEN a VMC with either a nil or non-nil ClusterRef
 			// WHEN updateStatus is called
 			// THEN expect the VMC's status imported field to be set
+			getCAPIClientFunc = fakeCAPIClient
 			ctx := context.TODO()
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.vmc).Build()
 			r := &VerrazzanoManagedClusterReconciler{

--- a/cluster-operator/controllers/vmc/update_status_test.go
+++ b/cluster-operator/controllers/vmc/update_status_test.go
@@ -342,6 +342,19 @@ func TestShouldUpdateK8sVersion(t *testing.T) {
 			false,
 			nil,
 		},
+		{
+			// TODO: implement having Verrazzano installed or not
+			"ClusterAPI cluster without Verrazzano",
+			false,
+			false,
+			nil,
+		},
+		{
+			"ClusterAPI cluster with Verrazzano",
+			false,
+			false,
+			nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/clusterrole.yaml
@@ -150,6 +150,13 @@ rules:
       - create
       - update
   - apiGroups:
+      - controlplane.cluster.x-k8s.io
+    resources:
+      - ocimanagedcontrolplanes
+      - ocnecontrolplanes
+    verbs:
+      - list
+  - apiGroups:
       - cluster.x-k8s.io
     resources:
       - clusters


### PR DESCRIPTION
Updates the `status.kubernetes.version` field of the VMC in the case that the VMC represents a ClusterAPI cluster where Verrazzano is not installed.

Before this PR, the verrazzano cluster agent already updates this field of the VMC, but only for workload clusters with Verrazzano installed. This PR is being made since it is possible to retrieve the K8s version from the CAPI CRs even without VZ.