### PR TITLE
VZ-9709.  Fix ArgoCD private CA integration

### DIFF
--- a/platform-operator/controllers/verrazzano/component/argocd/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/module_integration.go
@@ -5,6 +5,7 @@ package argocd
 
 import (
 	"github.com/verrazzano/verrazzano-modules/pkg/controller/spi/controllerspi"
+	"github.com/verrazzano/verrazzano/pkg/constants"
 	cmconstants "github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/certmanager/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common/watch"
@@ -21,9 +22,9 @@ func (c argoCDComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 			cmconstants.ClusterIssuerComponentName,
 			keycloak.ComponentName,
 		}),
-		watch.GetModuleUpdatedWatches([]string{
-			nginx.ComponentName,
-			cmconstants.ClusterIssuerComponentName,
-		}),
+		watch.GetUpdateSecretWatch(
+			constants.PrivateCABundle,
+			constants.VerrazzanoSystemNamespace,
+		),
 	)
 }

--- a/platform-operator/controllers/verrazzano/component/argocd/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/module_integration.go
@@ -23,6 +23,7 @@ func (c argoCDComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 		}),
 		watch.GetModuleUpdatedWatches([]string{
 			nginx.ComponentName,
+			cmconstants.ClusterIssuerComponentName,
 		}),
 	)
 }


### PR DESCRIPTION
Fixes ArgoCD to work with Let's Encrypt Staging certs. 

Also verified (manually)
- Switching back and forth between self-signed and LE staging configurations
- Renewing the self-signed CA cert is picked up by Argo and other services
- Let's encrypt production works with Argo
