### PR TITLE
VZ-11288: apply fluent-bit crds as part of preUpgrade

### DIFF
--- a/platform-operator/controllers/verrazzano/component/fluentoperator/fluentoperator_component.go
+++ b/platform-operator/controllers/verrazzano/component/fluentoperator/fluentoperator_component.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/verrazzano/verrazzano/pkg/k8s/resource"
+	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"path/filepath"
@@ -166,6 +167,9 @@ func (c fluentOperatorComponent) Install(ctx spi.ComponentContext) error {
 
 // PreUpgrade FluentOperator component pre-upgrade processing
 func (c fluentOperatorComponent) PreUpgrade(ctx spi.ComponentContext) error {
+	if err := common.ApplyCRDYaml(ctx, filepath.Join(config.GetHelmFluentOperatorChartsDir(), "/charts/fluent-bit-crds")); err != nil {
+		return err
+	}
 	return c.HelmComponent.PreUpgrade(ctx)
 }
 

--- a/platform-operator/internal/config/config.go
+++ b/platform-operator/internal/config/config.go
@@ -33,6 +33,7 @@ const (
 	helmOverridesDirSuffix          = "/platform-operator/helm_config/overrides"
 	integrationChartsDirSuffix      = "/platform-operator/experimental/manifests/integration-charts"
 	catalogDirSuffix                = "/platform-operator/manifests/catalog"
+	fluentOperatorDirSuffix         = "/platform-operator/thirdparty/charts/fluent-operator"
 )
 
 const defaultBomFilename = "verrazzano-bom.json"
@@ -165,6 +166,11 @@ func GetHelmVMOChartsDir() string {
 		return filepath.Join(TestHelmConfigDir, "/charts/verrazzano-monitoring-operator")
 	}
 	return filepath.Join(instance.VerrazzanoRootDir, helmVMOChartsDirSuffix)
+}
+
+// GetHelmFluentOperatorChartsDir returns the fluent operator helm charts dir
+func GetHelmFluentOperatorChartsDir() string {
+	return filepath.Join(instance.VerrazzanoRootDir, fluentOperatorDirSuffix)
 }
 
 // GetHelmAppOpChartsDir returns the Verrazzano Application Operator helm charts dir

--- a/tests/e2e/config/scripts/v1alpha1/install-vz-prod-kind-upgrade.yaml
+++ b/tests/e2e/config/scripts/v1alpha1/install-vz-prod-kind-upgrade.yaml
@@ -11,8 +11,6 @@ spec:
     persistentVolumeClaim:
       claimName: vmi     # set storage for the metrics stack
   components:
-    fluentOperator:
-      enabled: true
     keycloak:
       mysql:
         volumeSource:

--- a/tests/e2e/config/scripts/v1alpha1/install-vz-prod-kind-upgrade.yaml
+++ b/tests/e2e/config/scripts/v1alpha1/install-vz-prod-kind-upgrade.yaml
@@ -11,6 +11,8 @@ spec:
     persistentVolumeClaim:
       claimName: vmi     # set storage for the metrics stack
   components:
+    fluentOperator:
+      enabled: true
     keycloak:
       mysql:
         volumeSource:


### PR DESCRIPTION
Apply fluent-bit crds as part of fluent-operator PreUpgrade to fix a bug with operator where helm upgrade fails to update CRDs since v2.2.0.