### PR TITLE
VZ-9709.  Fix DNS updates for ArgoCD

### DIFF
--- a/platform-operator/controllers/verrazzano/component/argocd/module_integration.go
+++ b/platform-operator/controllers/verrazzano/component/argocd/module_integration.go
@@ -22,6 +22,12 @@ func (c argoCDComponent) GetWatchDescriptors() []controllerspi.WatchDescriptor {
 			cmconstants.ClusterIssuerComponentName,
 			keycloak.ComponentName,
 		}),
+		// For DNS/Cert updates
+		watch.GetModuleUpdatedWatches([]string{
+			nginx.ComponentName,
+			cmconstants.ClusterIssuerComponentName,
+		}),
+		// For private CA rotations, pick up the new CA bundle from the shared secret
 		watch.GetUpdateSecretWatch(
 			constants.PrivateCABundle,
 			constants.VerrazzanoSystemNamespace,


### PR DESCRIPTION
Add module update watches for NGINX, `clusterIssuer` to `argoCD`, fixes dynamic config tests.