### PR TITLE
VZ-11236 modify retry mechanism to accommodate test timeouts

### DIFF
--- a/tests/e2e/multicluster/verify-cluster-sync/cluster_sync_test.go
+++ b/tests/e2e/multicluster/verify-cluster-sync/cluster_sync_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package cluster_sync_test
@@ -6,6 +6,7 @@ package cluster_sync_test
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"os"
 	"time"
 
@@ -45,6 +46,17 @@ var _ = AfterSuite(afterSuite)
 
 var rancherClusterLabels = map[string]string{"rancher-sync": "enabled"}
 var _ = t.Describe("Multi Cluster Rancher Validation", Label("f:platform-lcm.install"), func() {
+
+	savedRetry := rancherutil.DefaultRetry
+	defer func() {
+		rancherutil.DefaultRetry = savedRetry
+	}()
+	rancherutil.DefaultRetry = wait.Backoff{
+		Steps:    5,
+		Duration: 1 * time.Second,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
 
 	// 1. Create clusters in Rancher with labels that match the selector configured in the Verrazzano resource
 	// 2. Delete the cluster in Rancher
@@ -236,6 +248,17 @@ func testVMCCreation(rc *rancherutil.RancherConfig, client *versioned.Clientset,
 	// GIVEN a VMC is created for a cluster
 	// WHEN the Rancher clusters are prompted to sync with the VMC
 	// THEN a Rancher cluster should be created with the same name
+
+	savedRetry := rancherutil.DefaultRetry
+	defer func() {
+		rancherutil.DefaultRetry = savedRetry
+	}()
+	rancherutil.DefaultRetry = wait.Backoff{
+		Steps:    5,
+		Duration: 1 * time.Second,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
 
 	// Create the VMC resource in the cluster
 	Eventually(func() (*v1alpha1.VerrazzanoManagedCluster, error) {


### PR DESCRIPTION
This is a forward port of the fixes to the release-1.7 branch.  Although less common in the master branch there are some instances where the Rancher HTTP retry mechanism extends the test duration past the configured timeout.