### PR TITLE
VZ-11204: VZ-11304: uptake Coherence 3.3.1 and run coherence workload tests by default

### DIFF
--- a/ci/JenkinsfileTestTrigger
+++ b/ci/JenkinsfileTestTrigger
@@ -242,7 +242,7 @@ pipeline {
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),
                                         string(name: 'EXCLUDED_TESTS', value: params.EXCLUDED_TESTS),
-                                        booleanParam(name: 'RUN_COHERENCE_TESTS', value: false),
+                                        booleanParam(name: 'RUN_COHERENCE_TESTS', value: true),
                                         string(name: 'CONSOLE_REPO_BRANCH', value: params.CONSOLE_REPO_BRANCH)
                                     ], wait: true
                             }

--- a/platform-operator/helm_config/overrides/coherence-values.yaml
+++ b/platform-operator/helm_config/overrides/coherence-values.yaml
@@ -3,7 +3,7 @@
 
 # The coherence-operator image now comes from the bill of materials file (verrazzano-bom.json).
 # This file only specifies the defaultCoherenceImage
-defaultCoherenceImage: ghcr.io/oracle/coherence-ce:22.06.4
+defaultCoherenceImage: ghcr.io/oracle/coherence-ce:22.06.6
 
 replicas: 1
 

--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -68,7 +68,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/weblogic-values.yaml
   - name: coherence-operator
-    version: 3.2.11
+    version: 3.3.1
     chart: platform-operator/thirdparty/charts/coherence-operator
     valuesFiles:
       - platform-operator/helm_config/overrides/coherence-values.yaml

--- a/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
@@ -5,8 +5,8 @@
 name: coherence-operator
 description: A Kubernetes Operator for Coherence
 apiVersion: v1
-version: 3.2.11
-appVersion: 3.2.11
+version: 3.3.1
+appVersion: 3.3.1
 home: https://github.com/oracle/coherence-operator
 sources:
 - https://github.com/oracle/coherence-operator

--- a/platform-operator/thirdparty/charts/coherence-operator/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/templates/deployment.yaml
@@ -16,7 +16,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.11"
+    app.kubernetes.io/version: "3.3.1"
     app.kubernetes.io/component: webhook
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -28,7 +28,7 @@ spec:
   selector:
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.11"
+    app.kubernetes.io/version: "3.3.1"
     app.kubernetes.io/component: manager
 ---
 apiVersion: v1
@@ -40,7 +40,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-rest
-    app.kubernetes.io/version: "3.2.11"
+    app.kubernetes.io/version: "3.3.1"
     app.kubernetes.io/component: rest
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -52,7 +52,7 @@ spec:
   selector:
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.11"
+    app.kubernetes.io/version: "3.3.1"
     app.kubernetes.io/component: manager
 ---
 apiVersion: apps/v1
@@ -64,7 +64,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.11"
+    app.kubernetes.io/version: "3.3.1"
     app.kubernetes.io/component: manager
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -87,7 +87,7 @@ spec:
         control-plane: coherence
         app.kubernetes.io/name: coherence-operator
         app.kubernetes.io/instance: coherence-operator-manager
-        app.kubernetes.io/version: "3.2.11"
+        app.kubernetes.io/version: "3.3.1"
         app.kubernetes.io/component: manager
         app.kubernetes.io/part-of: coherence-operator
         app.kubernetes.io/managed-by: helm
@@ -234,7 +234,7 @@ spec:
                     control-plane: coherence
                     app.kubernetes.io/name: coherence-operator
                     app.kubernetes.io/instance: coherence-operator-manager
-                    app.kubernetes.io/version: "3.2.11"
+                    app.kubernetes.io/version: "3.3.1"
               weight: 50
             - podAffinityTerm:
                 topologyKey: "oci.oraclecloud.com/fault-domain"
@@ -243,7 +243,7 @@ spec:
                     control-plane: coherence
                     app.kubernetes.io/name: coherence-operator
                     app.kubernetes.io/instance: coherence-operator-manager
-                    app.kubernetes.io/version: "3.2.11"
+                    app.kubernetes.io/version: "3.3.1"
               weight: 10
             - podAffinityTerm:
                 topologyKey: "kubernetes.io/hostname"
@@ -252,7 +252,7 @@ spec:
                     control-plane: coherence
                     app.kubernetes.io/name: coherence-operator
                     app.kubernetes.io/instance: coherence-operator-manager
-                    app.kubernetes.io/version: "3.2.11"
+                    app.kubernetes.io/version: "3.3.1"
               weight: 1
 {{- end }}
       volumes:

--- a/platform-operator/thirdparty/charts/coherence-operator/templates/rbac.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/templates/rbac.yaml
@@ -173,6 +173,9 @@ rules:
   - coherence
   - coherence/finalizers
   - coherence/status
+  - coherencejob
+  - coherencejob/finalizers
+  - coherencejob/status
   verbs:
   - create
   - delete

--- a/platform-operator/thirdparty/charts/coherence-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/values.yaml
@@ -6,14 +6,14 @@
 image:
   registry: "ghcr.io/oracle"
   name: "coherence-operator"
-  tag: "3.2.11"
+  tag: "3.3.1"
 
 # defaultCoherenceImage is the default application image that will be used if a Coherence
 # resource does not specify an image name.
 defaultCoherenceImage:
   registry: "ghcr.io/oracle"
   name: "coherence-ce"
-  tag: "22.06.4"
+  tag: "22.06.6"
 
 # watchNamespaces is the comma delimited list of namespaces that the operator should
 # manage Coherence resources in. The default is to manage all namespaces.

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -506,7 +506,7 @@
     },
     {
       "name": "coherence-operator",
-      "version": "3.2.11",
+      "version": "3.3.1",
       "subcomponents": [
         {
           "repository": "oracle",
@@ -514,7 +514,7 @@
           "images": [
             {
               "image": "coherence-operator",
-              "tag": "3.2.11",
+              "tag": "3.3.1",
               "helmFullImageKey": "image"
             }
           ]


### PR DESCRIPTION
release-1.7 backports of #7395 and #7406