### PR TITLE
VZ-11395: Remove redundant Jenkins jobs

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -302,19 +302,6 @@ pipeline {
                         }
                     }
                 }
-                stage('Verrazzano a-la-carte') {
-                    steps {
-                        retry(count: JOB_PROMOTION_RETRIES) {
-                            script {
-                                build job: "/verrazzano-a-la-carte/${CLEAN_BRANCH_NAME}",
-                                        parameters: [
-                                                string(name: 'KUBERNETES_CLUSTER_VERSION', value: '1.27'),
-                                                string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
-                                        ], wait: true
-                            }
-                        }
-                    }
-                }
                 stage('HA tests') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -44,7 +44,7 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "1.24", "1.25", "1.26", "1.27" ])
         string (name: 'EXCLUDE_RELEASES',
-                defaultValue: "v1.0, v1.1, v1.2, v1.3", v1.4,
+                defaultValue: "v1.0, v1.1, v1.2, v1.3, v1.4",
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)
         string (name: 'VERRAZZANO_OPERATOR_IMAGE',
                         defaultValue: 'NONE',

--- a/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
+++ b/ci/upgrade-paths/JenkinsfileTestTriggerMinorRelease
@@ -44,7 +44,7 @@ pipeline {
                 // 1st choice is the default value
                 choices: [ "1.24", "1.25", "1.26", "1.27" ])
         string (name: 'EXCLUDE_RELEASES',
-                defaultValue: "v1.0, v1.1, v1.2, v1.3",
+                defaultValue: "v1.0, v1.1, v1.2, v1.3", v1.4,
                 description: 'This is to exclude the specified releases from upgrade tests.', trim: true)
         string (name: 'VERRAZZANO_OPERATOR_IMAGE',
                         defaultValue: 'NONE',


### PR DESCRIPTION
This PR contains changes that remove redundant Jenkins jobs that are not used by Verrazzano customers.