### PR TITLE
VZ-11376: Update NGINX, external-dns and oam-kubernetes-runtime images built with Go v1.20.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,7 @@ replace (
 	github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.2.0
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.18
 	github.com/crossplane/crossplane-runtime => github.com/verrazzano/crossplane-runtime v0.17.0-1
-	github.com/crossplane/oam-kubernetes-runtime => github.com/verrazzano/oam-kubernetes-runtime v0.3.3-3
+	github.com/crossplane/oam-kubernetes-runtime => github.com/verrazzano/oam-kubernetes-runtime v0.3.3-4
 	github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/docker/distribution => github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/docker => github.com/docker/docker v20.10.24+incompatible

--- a/go.sum
+++ b/go.sum
@@ -844,8 +844,8 @@ github.com/verrazzano/crossplane-runtime v0.17.0-1 h1:juTCAYMWDWITX9vFTdNnF97+Sl
 github.com/verrazzano/crossplane-runtime v0.17.0-1/go.mod h1:fA8Dp1vT5JjpBCE3KlellJ0Z/Xo1aekngOXmuDsryz0=
 github.com/verrazzano/fluent-operator/v2 v2.2.0 h1:rsKzccy5Di5SdbIJW31AdbWqET7cHRW+p0XY10+XXZ0=
 github.com/verrazzano/fluent-operator/v2 v2.2.0/go.mod h1:v/q0zLEOWP6MKHP7xvrhtASZTwlrk4LcCne/kgPQ7J0=
-github.com/verrazzano/oam-kubernetes-runtime v0.3.3-3 h1:bxHzLJ7CtPOQ8RKVEGbxb3q1Zoq7wMH60AF6vSEXdEo=
-github.com/verrazzano/oam-kubernetes-runtime v0.3.3-3/go.mod h1:yw2g1lpW2qcQPPVI/0pcgmnRQL2KU9CucT06laPlG24=
+github.com/verrazzano/oam-kubernetes-runtime v0.3.3-4 h1:32vLP4nf/Z4A3yto7O9O+439leZDB5128EMYecoVuhs=
+github.com/verrazzano/oam-kubernetes-runtime v0.3.3-4/go.mod h1:1p/NurfVWx9Xi5uLuXF9Ojx+XUmIF+z9TPkljcZcd5E=
 github.com/verrazzano/pkg v0.0.2 h1:Q80lpGaAswNPXkZZL/0THIa9PXvewi+c6xSSzWQyhG8=
 github.com/verrazzano/pkg v0.0.2/go.mod h1:l9utTv9KBQZlJI/HYnw2NQwisYTeHeHl82XOlCiZygM=
 github.com/verrazzano/verrazzano-modules v0.0.0-20230915154150-1fe7062cbccd h1:+YEpt1F5UUr20PSeyvy4knsEO//a3SnmjJj1AvAxRqk=

--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -3,7 +3,7 @@
 
 modules:
   - name: ingress-controller
-    version: 1.7.1
+    version: 1.7.1-1
     chart: platform-operator/thirdparty/charts/ingress-nginx
     valuesFiles:
       - platform-operator/helm_config/overrides/ingress-nginx-values.yaml
@@ -23,7 +23,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/dex-values.yaml
   - name: external-dns
-    version: 0.12.2-1
+    version: 0.12.2-2
     chart: platform-operator/thirdparty/charts/external-dns
     valuesFiles:
       - platform-operator/helm_config/overrides/external-dns-values.yaml
@@ -49,7 +49,7 @@ modules:
     version: VERRAZZANO_VERSION
     chart: platform-operator/helm_config/charts/verrazzano-monitoring-operator
   - name: oam-kubernetes-runtime
-    version: 0.3.3-1
+    version: 0.3.3-2
     chart: platform-operator/thirdparty/charts/oam-kubernetes-runtime
     valuesFiles:
       - platform-operator/helm_config/overrides/oam-kubernetes-runtime-values.yaml

--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -101,7 +101,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/keycloak-values.yaml
   - name: prometheus-operator
-    version: 0.64.1-2
+    version: 0.64.1-3
     chart: platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack
     valuesFiles:
       - platform-operator/helm_config/overrides/prometheus-operator-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "ingress-controller",
-      "version": "1.7.1",
+      "version": "1.7.1-1",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -28,13 +28,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20230817215350-c8315d559",
+              "tag": "v1.7.1-20231107025443-ae3a45db1",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "v1.7.1-20230817215350-c8315d559",
+              "tag": "v1.7.1-20231107025443-ae3a45db1",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -103,7 +103,7 @@
     },
     {
       "name": "external-dns",
-      "version": "0.12.2-1",
+      "version": "0.12.2-2",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -111,7 +111,7 @@
           "images": [
             {
               "image": "external-dns",
-              "tag": "v0.12.2-20230922083811-49b4f66e",
+              "tag": "v0.12.2-20231107025450-8480e5c7",
               "helmFullImageKey": "image.repository",
               "helmRegKey": "image.registry",
               "helmTagKey": "image.tag"
@@ -283,7 +283,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20230817215350-c8315d559",
+              "tag": "v1.7.1-20231107025443-ae3a45db1",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
@@ -373,7 +373,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20230817215350-c8315d559",
+              "tag": "v1.7.1-20231107025443-ae3a45db1",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]
@@ -406,7 +406,7 @@
           "images": [
             {
               "image": "oam-kubernetes-runtime",
-              "tag": "v0.3.3-20230922080726-c8b5d4a",
+              "tag": "v0.3.3-20231107030837-d2005b2",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -668,7 +668,7 @@
             },
             {
               "image": "kube-webhook-certgen",
-              "tag": "v1.7.1-20230817215350-c8315d559",
+              "tag": "v1.7.1-20231107025443-ae3a45db1",
               "helmRegKey": "prometheusOperator.admissionWebhooks.patch.image.registry",
               "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
               "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -398,7 +398,7 @@
     },
     {
       "name": "oam-kubernetes-runtime",
-      "version": "0.3.3-1",
+      "version": "0.3.3-2",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -653,7 +653,7 @@
     },
     {
       "name": "prometheus-operator",
-      "version": "0.64.1-2",
+      "version": "0.64.1-3",
       "subcomponents": [
         {
           "repository": "verrazzano",


### PR DESCRIPTION
Updates NGINX, external-dns and oam-kubernetes-runtime images built with Go v1.20.10, by the following PRs
1. https://github.com/verrazzano/ingress-nginx/pull/13
2. https://github.com/verrazzano/external-dns/pull/3
3. https://github.com/verrazzano/oam-kubernetes-runtime/pull/6
