### PR TITLE
VZ-11376: Update cert-manager and node-exporter images, built with Go v1.20.10

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -8,7 +8,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/ingress-nginx-values.yaml
   - name: cert-manager
-    version: 1.9.1-1
+    version: 1.9.1-2
     chart: platform-operator/thirdparty/charts/cert-manager
     valuesFiles:
       - platform-operator/helm_config/overrides/cert-manager-values.yaml
@@ -121,7 +121,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/prometheus-pushgateway-values.yaml
   - name: prometheus-node-exporter
-    version: 1.6.1
+    version: 1.6.1-1
     chart: platform-operator/thirdparty/charts/prometheus-community/prometheus-node-exporter
     valuesFiles:
       - platform-operator/helm_config/overrides/prometheus-node-exporter-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -773,7 +773,7 @@
     },
     {
       "name": "prometheus-node-exporter",
-      "version": "1.6.1",
+      "version": "1.6.1-1",
       "subcomponents": [
         {
           "repository": "verrazzano",

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "cert-manager",
-      "version": "1.9.1-1",
+      "version": "1.9.1-2",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -52,30 +52,30 @@
           "images": [
             {
               "image": "cert-manager-controller",
-              "tag": "v1.9.1-20230922085719-ec3b7033",
+              "tag": "v1.9.1-20231108025749-df3d99c0",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "cert-manager-acmesolver",
-              "tag": "v1.9.1-20230922085719-ec3b7033",
+              "tag": "v1.9.1-20231108025749-df3d99c0",
               "helmFullImageKey": "extraArgs[0]"
             },
             {
               "image": "cert-manager-cainjector",
-              "tag": "v1.9.1-20230922085719-ec3b7033",
+              "tag": "v1.9.1-20231108025749-df3d99c0",
               "helmFullImageKey": "cainjector.image.repository",
               "helmTagKey": "cainjector.image.tag"
             },
             {
               "image": "cert-manager-webhook",
-              "tag": "v1.9.1-20230922085719-ec3b7033",
+              "tag": "v1.9.1-20231108025749-df3d99c0",
               "helmFullImageKey": "webhook.image.repository",
               "helmTagKey": "webhook.image.tag"
             },
             {
               "image": "cert-manager-ctl",
-              "tag": "v1.9.1-20230922085719-ec3b7033",
+              "tag": "v1.9.1-20231108025749-df3d99c0",
               "helmFullImageKey": "startupapicheck.image.repository",
               "helmTagKey": "startupapicheck.image.tag"
             }
@@ -781,7 +781,7 @@
           "images": [
             {
               "image": "node-exporter",
-              "tag": "v1.6.1-20230925193620-d2d52786",
+              "tag": "v1.6.1-20231108025039-e17b88f1",
               "helmRegKey": "image.registry",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"


### PR DESCRIPTION
Updates cert-manager and node-exporter images, built with Go v1.20.10