### PR TITLE
VZ-11454: Uptake distroless-based VMO image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -341,8 +341,8 @@
           "name": "verrazzano-monitoring-operator",
           "images": [
             {
-              "image": "verrazzano-monitoring-operator-jenkins",
-              "tag": "v2.0.0-20231109160049-7e37f4b",
+              "image": "verrazzano-monitoring-operator",
+              "tag": "v2.0.0-20231109190054-44bb613",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -341,8 +341,8 @@
           "name": "verrazzano-monitoring-operator",
           "images": [
             {
-              "image": "verrazzano-monitoring-operator",
-              "tag": "v2.0.0-20230913103358-6033fa2",
+              "image": "verrazzano-monitoring-operator-jenkins",
+              "tag": "v2.0.0-20231109160049-7e37f4b",
               "helmFullImageKey": "monitoringOperator.imageName",
               "helmTagKey": "monitoringOperator.imageVersion"
             },


### PR DESCRIPTION
This uptakes the new VMO image that is based on the distroless static image.