### PR TITLE
VZ-11457 - Switch the Verrazzano cluster operator image to use the ol8-static image as its base image

### DIFF
--- a/cluster-operator/Dockerfile
+++ b/cluster-operator/Dockerfile
@@ -2,6 +2,8 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 ARG BASE_IMAGE=ghcr.io/oracle/oraclelinux:8-slim
+ARG FINAL_IMAGE=ghcr.io/verrazzano/ol8-static:v0.0.1-20231102152128-e7afc807
+
 FROM $BASE_IMAGE AS build_base
 
 # Need to use specific WORKDIR to match verrazzano-cluster-operator's source packages
@@ -11,20 +13,21 @@ COPY . .
 COPY out/linux_amd64/verrazzano-cluster-operator /usr/local/bin/verrazzano-cluster-operator
 
 RUN chmod 500 /usr/local/bin/verrazzano-cluster-operator \
-    && chmod 500 /root/go/src/github.com/verrazzano/cluster-operator/scripts/wait4webhook.sh
-
-# Create the verrazzano-cluster-operator image
-FROM $BASE_IMAGE AS final
-
-RUN rm -rf /var/cache/yum /var/lib/rpm/* \
     && groupadd -r verrazzano  \
     && useradd --no-log-init -r -g verrazzano -u 1000 verrazzano \
     && mkdir /home/verrazzano \
     && chown -R 1000:verrazzano /home/verrazzano
 
+# Create the verrazzano-cluster-operator image
+FROM $FINAL_IMAGE AS final
+
+# Copy users, groups and /home
+COPY --from=build_base /etc/passwd /etc/passwd
+COPY --from=build_base /etc/group /etc/group
+COPY --from=build_base --chown=verrazzano:verrazzano /home/ /home/
+
 # Copy the operator binary
 COPY --from=build_base --chown=verrazzano:verrazzano /usr/local/bin/verrazzano-cluster-operator /usr/local/bin/verrazzano-cluster-operator
-COPY --from=build_base --chown=verrazzano:verrazzano /root/go/src/github.com/verrazzano/cluster-operator/scripts/wait4webhook.sh /usr/local/bin/wait4webhook.sh
 
 COPY --from=build_base /root/go/src/github.com/verrazzano/cluster-operator/THIRD_PARTY_LICENSES.txt /licenses/
 

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/templates/deployment.yaml
@@ -24,8 +24,8 @@ spec:
       initContainers:
         - name: webhookswait
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          image: {{ .Values.image }}
-          command: [ 'sh', '-c', "/usr/local/bin/wait4webhook.sh" ]
+          image: {{ .Values.webhookWaitImage }}
+          command: [ 'sh', '-c', "curl -4 -k --retry 25 --retry-max-time 120 --retry-delay 5 --retry-connrefused --fail https://verrazzano-cluster-operator-webhook:443/validate-clusters-verrazzano-io-v1alpha1-verrazzanomanagedcluster -H 'Content-Type: application/json'" ]
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml
+++ b/platform-operator/helm_config/charts/verrazzano-cluster-operator/values.yaml
@@ -14,3 +14,6 @@ syncClusters:
 
 # TTL in minutes
 argoCDClusterTokenTTL: 240
+
+# Image to use for the webhookswait init container
+webhookWaitImage: ghcr.io/oracle/oraclelinux:8-slim

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -426,6 +426,12 @@
               "image": "VERRAZZANO_CLUSTER_OPERATOR_IMAGE",
               "tag": "VERRAZZANO_CLUSTER_OPERATOR_TAG",
               "helmFullImageKey": "image"
+            },
+            {
+              "repository": "oracle",
+              "image": "oraclelinux",
+              "tag": "8-slim",
+              "helmFullImageKey": "webhookWaitImage"
             }
           ]
         }


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
