### PR TITLE
VZ-11448: Pick up Jaeger images built using golang 1.20.10

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -126,7 +126,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/prometheus-node-exporter-values.yaml
   - name: jaeger-operator
-    version: 1.42.0-1
+    version: 1.42.0-2
     chart: platform-operator/thirdparty/charts/jaegertracing/jaeger-operator
     valuesFiles:
       - platform-operator/helm_config/overrides/jaeger-operator-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -792,15 +792,15 @@
     },
     {
       "name": "jaeger-operator",
-      "version": "1.42.0-1",
+      "version": "1.42.0-2",
       "subcomponents": [
         {
           "repository": "verrazzano",
           "name": "jaeger-operator",
           "images": [
             {
-              "image": "jaeger-operator",
-              "tag": "1.42.0-20230922084214-9970d003",
+              "image": "jaeger-operator-jenkins",
+              "tag": "1.42.0-20231109143706-75b530ba",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -811,8 +811,8 @@
           "name": "jaeger-agent",
           "images": [
             {
-              "image": "jaeger-agent",
-              "tag": "1.42.0-20230925061552-cd357656",
+              "image": "jaeger-agent-jenkins",
+              "tag": "1.42.0-20231109150800-11d0a5de",
               "helmFullImageKey": "jaegerAgentImage"
             }
           ]
@@ -822,8 +822,8 @@
           "name": "jaeger-collector",
           "images": [
             {
-              "image": "jaeger-collector",
-              "tag": "1.42.0-20230925061552-cd357656",
+              "image": "jaeger-collector-jenkins",
+              "tag": "1.42.0-20231109150800-11d0a5de",
               "helmFullImageKey": "jaegerCollectorImage"
             }
           ]
@@ -833,8 +833,8 @@
           "name": "jaeger-query",
           "images": [
             {
-              "image": "jaeger-query",
-              "tag": "1.42.0-20230925061552-cd357656",
+              "image": "jaeger-query-jenkins",
+              "tag": "1.42.0-20231109150800-11d0a5de",
               "helmFullImageKey": "jaegerQueryImage"
             }
           ]
@@ -844,8 +844,8 @@
           "name": "jaeger-ingester",
           "images": [
             {
-              "image": "jaeger-ingester",
-              "tag": "1.42.0-20230925061552-cd357656",
+              "image": "jaeger-ingester-jenkins",
+              "tag": "1.42.0-20231109150800-11d0a5de",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -855,8 +855,8 @@
           "name": "jaeger-es-index-cleaner",
           "images": [
             {
-              "image": "jaeger-es-index-cleaner",
-              "tag": "1.42.0-20230925061552-cd357656",
+              "image": "jaeger-es-index-cleaner-jenkins",
+              "tag": "1.42.0-20231109150800-11d0a5de",
               "helmFullImageKey": "jaegerESIndexCleanerImage"
             }
           ]
@@ -866,8 +866,8 @@
           "name": "jaeger-es-rollover",
           "images": [
             {
-              "image": "jaeger-es-rollover",
-              "tag": "1.42.0-20230925061552-cd357656",
+              "image": "jaeger-es-rollover-jenkins",
+              "tag": "1.42.0-20231109150800-11d0a5de",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]
@@ -877,8 +877,8 @@
           "name": "jaeger-all-in-one",
           "images": [
             {
-              "image": "jaeger-all-in-one",
-              "tag": "1.42.0-20230925061552-cd357656",
+              "image": "jaeger-all-in-one-jenkins",
+              "tag": "1.42.0-20231109150800-11d0a5de",
               "helmFullImageKey": "jaegerAllInOneImage"
             }
           ]

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -805,8 +805,8 @@
           "name": "jaeger-operator",
           "images": [
             {
-              "image": "jaeger-operator-jenkins",
-              "tag": "1.42.0-20231109143706-75b530ba",
+              "image": "jaeger-operator",
+              "tag": "1.42.0-20231113173501-e3e86fb8",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -817,8 +817,8 @@
           "name": "jaeger-agent",
           "images": [
             {
-              "image": "jaeger-agent-jenkins",
-              "tag": "1.42.0-20231109150800-11d0a5de",
+              "image": "jaeger-agent",
+              "tag": "1.42.0-20231113164841-192e39df",
               "helmFullImageKey": "jaegerAgentImage"
             }
           ]
@@ -828,8 +828,8 @@
           "name": "jaeger-collector",
           "images": [
             {
-              "image": "jaeger-collector-jenkins",
-              "tag": "1.42.0-20231109150800-11d0a5de",
+              "image": "jaeger-collector",
+              "tag": "1.42.0-20231113164841-192e39df",
               "helmFullImageKey": "jaegerCollectorImage"
             }
           ]
@@ -839,8 +839,8 @@
           "name": "jaeger-query",
           "images": [
             {
-              "image": "jaeger-query-jenkins",
-              "tag": "1.42.0-20231109150800-11d0a5de",
+              "image": "jaeger-query",
+              "tag": "1.42.0-20231113164841-192e39df",
               "helmFullImageKey": "jaegerQueryImage"
             }
           ]
@@ -850,8 +850,8 @@
           "name": "jaeger-ingester",
           "images": [
             {
-              "image": "jaeger-ingester-jenkins",
-              "tag": "1.42.0-20231109150800-11d0a5de",
+              "image": "jaeger-ingester",
+              "tag": "1.42.0-20231113164841-192e39df",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -861,8 +861,8 @@
           "name": "jaeger-es-index-cleaner",
           "images": [
             {
-              "image": "jaeger-es-index-cleaner-jenkins",
-              "tag": "1.42.0-20231109150800-11d0a5de",
+              "image": "jaeger-es-index-cleaner",
+              "tag": "1.42.0-20231113164841-192e39df",
               "helmFullImageKey": "jaegerESIndexCleanerImage"
             }
           ]
@@ -872,8 +872,8 @@
           "name": "jaeger-es-rollover",
           "images": [
             {
-              "image": "jaeger-es-rollover-jenkins",
-              "tag": "1.42.0-20231109150800-11d0a5de",
+              "image": "jaeger-es-rollover",
+              "tag": "1.42.0-20231113164841-192e39df",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]
@@ -883,8 +883,8 @@
           "name": "jaeger-all-in-one",
           "images": [
             {
-              "image": "jaeger-all-in-one-jenkins",
-              "tag": "1.42.0-20231109150800-11d0a5de",
+              "image": "jaeger-all-in-one",
+              "tag": "1.42.0-20231113164841-192e39df",
               "helmFullImageKey": "jaegerAllInOneImage"
             }
           ]


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
