### PR TITLE
VZ-11465 backport new OCI CAPI controller

### DIFF
--- a/platform-operator/capi/infrastructure-oci/v0.13.0/infrastructure-components.yaml
+++ b/platform-operator/capi/infrastructure-oci/v0.13.0/infrastructure-components.yaml
@@ -5061,6 +5061,219 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-oci
     cluster.x-k8s.io/v1beta1: v1beta1
+  name: ocimachinepoolmachines.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: capoci-webhook-service
+          namespace: cluster-api-provider-oci-system
+          path: /convert
+      conversionReviewVersions:
+        - v1
+        - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: OCIMachinePoolMachine
+    listKind: OCIMachinePoolMachineList
+    plural: ocimachinepoolmachines
+    singular: ocimachinepoolmachine
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OCIMachinePoolMachineSpec defines the desired state of OCIMachinePoolMachine
+              properties:
+                instanceName:
+                  description: InstanceName is the name of the instance.
+                  type: string
+                machineType:
+                  description: MachineType is the type of the machine.
+                  type: string
+                ocid:
+                  description: OCID is the OCID of the associated instance.
+                  type: string
+                providerID:
+                  description: ProviderID is the Oracle Cloud Identifier of the associated
+                    instance.
+                  type: string
+              type: object
+            status:
+              description: OCIMachinePoolMachineStatus defines the observed state of
+                OCIMachinePoolMachine
+              properties:
+                conditions:
+                  description: Conditions defines current service state of the OCIMachinePool.
+                  items:
+                    description: Condition defines an observation of a Cluster API resource
+                      operational state.
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status
+                          to another. This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field
+                          changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about
+                          the transition. This field may be empty.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition
+                          in CamelCase. The specific API may choose whether or not this
+                          field is considered a guaranteed API. This field may not be
+                          empty.
+                        type: string
+                      severity:
+                        description: Severity provides an explicit classification of
+                          Reason code, so the users or machines can immediately understand
+                          the current situation and act accordingly. The Severity field
+                          MUST be set only when Status=False.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                          Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                ready:
+                  description: Flag set to true when machine is ready.
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - name: v1beta2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OCIMachinePoolMachineSpec defines the desired state of OCIMachinePoolMachine
+              properties:
+                instanceName:
+                  description: InstanceName is the name of the instance.
+                  type: string
+                machineType:
+                  description: MachineType is the type of the machine.
+                  type: string
+                ocid:
+                  description: OCID is the OCID of the associated instance.
+                  type: string
+                providerID:
+                  description: ProviderID is Oracle Cloud Identifier of the associated
+                    instance.
+                  type: string
+              type: object
+            status:
+              description: OCIMachinePoolMachineStatus defines the observed state of
+                OCIMachinePoolMachine
+              properties:
+                conditions:
+                  description: Conditions defines current service state of the OCIMachinePool.
+                  items:
+                    description: Condition defines an observation of a Cluster API resource
+                      operational state.
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status
+                          to another. This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field
+                          changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about
+                          the transition. This field may be empty.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition
+                          in CamelCase. The specific API may choose whether or not this
+                          field is considered a guaranteed API. This field may not be
+                          empty.
+                        type: string
+                      severity:
+                        description: Severity provides an explicit classification of
+                          Reason code, so the users or machines can immediately understand
+                          the current situation and act accordingly. The Severity field
+                          MUST be set only when Status=False.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                          Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                ready:
+                  description: Flag set to true when machine is ready.
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: cluster-api-provider-oci-system/capoci-serving-cert
+    controller-gen.kubebuilder.io/version: v0.10.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-oci
+    cluster.x-k8s.io/v1beta1: v1beta1
   name: ocimachinepools.infrastructure.cluster.x-k8s.io
 spec:
   conversion:
@@ -5786,6 +5999,10 @@ spec:
                   description: MachineStatusError defines errors states for Machine
                     objects.
                   type: string
+                infrastructureMachineKind:
+                  description: InfrastructureMachineKind is the kind of the infrastructure
+                    resources behind MachinePool Machines.
+                  type: string
                 ready:
                   description: Ready is true when the provider resource is ready.
                   type: boolean
@@ -6502,6 +6719,10 @@ spec:
                   description: MachineStatusError defines errors states for Machine
                     objects.
                   type: string
+                infrastructureMachineKind:
+                  description: InfrastructureMachineKind is the kind of the infrastructure
+                    resources behind MachinePool Machines.
+                  type: string
                 ready:
                   description: Ready is true when the provider resource is ready.
                   type: boolean
@@ -6669,6 +6890,11 @@ spec:
                 compartmentId:
                   description: Compartment to launch the instance in.
                   type: string
+                computeClusterId:
+                  description: ComputeClusterId refers to OCID of the compute cluster
+                    that the instance will be created in. Please refer https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm
+                    for more details
+                  type: string
                 dedicatedVmHostId:
                   description: DedicatedVmHostId defines the OCID of the dedicated VM
                     host.
@@ -6725,6 +6951,8 @@ spec:
                       type: string
                   type: object
                 ipxeScript:
+                  description: IpxeScript is the  custom iPXE script that will run when
+                    the instance boots.
                   type: string
                 isPvEncryptionInTransitEnabled:
                   description: Is in transit encryption of volumes required.
@@ -7430,6 +7658,11 @@ spec:
                 compartmentId:
                   description: Compartment to launch the instance in.
                   type: string
+                computeClusterId:
+                  description: ComputeClusterId refers to OCID of the compute cluster
+                    that the instance will be created in. Please refer https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm
+                    for more details
+                  type: string
                 dedicatedVmHostId:
                   description: DedicatedVmHostId defines the OCID of the dedicated VM
                     host.
@@ -7486,6 +7719,8 @@ spec:
                       type: string
                   type: object
                 ipxeScript:
+                  description: IpxeScript is the  custom iPXE script that will run when
+                    the instance boots.
                   type: string
                 isPvEncryptionInTransitEnabled:
                   description: Is in transit encryption of volumes required.
@@ -8220,6 +8455,12 @@ spec:
                         compartmentId:
                           description: Compartment to launch the instance in.
                           type: string
+                        computeClusterId:
+                          description: ComputeClusterId refers to OCID of the compute
+                            cluster that the instance will be created in. Please refer
+                            https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm
+                            for more details
+                          type: string
                         dedicatedVmHostId:
                           description: DedicatedVmHostId defines the OCID of the dedicated
                             VM host.
@@ -8280,6 +8521,8 @@ spec:
                               type: string
                           type: object
                         ipxeScript:
+                          description: IpxeScript is the  custom iPXE script that will
+                            run when the instance boots.
                           type: string
                         isPvEncryptionInTransitEnabled:
                           description: Is in transit encryption of volumes required.
@@ -8960,6 +9203,12 @@ spec:
                         compartmentId:
                           description: Compartment to launch the instance in.
                           type: string
+                        computeClusterId:
+                          description: ComputeClusterId refers to OCID of the compute
+                            cluster that the instance will be created in. Please refer
+                            https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm
+                            for more details
+                          type: string
                         dedicatedVmHostId:
                           description: DedicatedVmHostId defines the OCID of the dedicated
                             VM host.
@@ -9020,6 +9269,8 @@ spec:
                               type: string
                           type: object
                         ipxeScript:
+                          description: IpxeScript is the  custom iPXE script that will
+                            run when the instance boots.
                           type: string
                         isPvEncryptionInTransitEnabled:
                           description: Is in transit encryption of volumes required.
@@ -15300,6 +15551,10 @@ spec:
                   description: MachineStatusError defines errors states for Machine
                     objects.
                   type: string
+                infrastructureMachineKind:
+                  description: InfrastructureMachineKind is the kind of the infrastructure
+                    resources behind MachinePool Machines.
+                  type: string
                 ready:
                   type: boolean
                 replicas:
@@ -15583,6 +15838,10 @@ spec:
                 failureReason:
                   description: MachineStatusError defines errors states for Machine
                     objects.
+                  type: string
+                infrastructureMachineKind:
+                  description: InfrastructureMachineKind is the kind of the infrastructure
+                    resources behind MachinePool Machines.
                   type: string
                 ready:
                   type: boolean
@@ -16281,6 +16540,10 @@ spec:
                   description: FailureReason will contains the CAPI MachinePoolStatusFailure
                     if the virtual machine pool has hit an error condition.
                   type: string
+                infrastructureMachineKind:
+                  description: InfrastructureMachineKind is the kind of the infrastructure
+                    resources behind MachinePool Machines.
+                  type: string
                 ready:
                   type: boolean
                 replicas:
@@ -16467,6 +16730,10 @@ spec:
                   description: FailureReason will contains the CAPI MachinePoolStatusFailure
                     if the virtual machine pool has hit an error condition.
                   type: string
+                infrastructureMachineKind:
+                  description: InfrastructureMachineKind is the kind of the infrastructure
+                    resources behind MachinePool Machines.
+                  type: string
                 ready:
                   type: boolean
                 replicas:
@@ -16645,6 +16912,7 @@ rules:
       - get
       - list
       - watch
+      - delete
   - apiGroups:
       - cluster.x-k8s.io
     resources:
@@ -16783,6 +17051,26 @@ rules:
       - infrastructure.cluster.x-k8s.io
     resources:
       - ocivirtualmachinepools/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - infrastructure.cluster.x-k8s.io
+    resources:
+      - ocimachinepoolmachines
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - infrastructure.cluster.x-k8s.io
+    resources:
+      - ocimachinepoolmachines/status
     verbs:
       - get
       - patch
@@ -16975,12 +17263,13 @@ spec:
             - --metrics-bind-address=127.0.0.1:8080
             - --logging-format=${LOG_FORMAT:=text}
             - --init-oci-clients-on-startup=${INIT_OCI_CLIENTS_ON_STARTUP:=true}
+            - --enable-instance-metadata-service-lookup=${ENABLE_INSTANCE_METADATA_SERVICE_LOOKUP:=false}
           command:
             - /manager
           env:
             - name: AUTH_CONFIG_DIR
               value: /etc/oci
-          image: ghcr.io/oracle/cluster-api-oci-controller:v0.12.1
+          image: ghcr.io/oracle/cluster-api-oci-controller:v0.13.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/platform-operator/capi/infrastructure-oci/v0.13.0/metadata.yaml
+++ b/platform-operator/capi/infrastructure-oci/v0.13.0/metadata.yaml
@@ -44,3 +44,6 @@ releaseSeries:
   - major: 0
     minor: 12
     contract: v1beta1
+  - major: 0
+    minor: 13
+    contract: v1beta1

--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -35,7 +35,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/rancher-values.yaml
   - name: cluster-api
-    version: 1.5.3
+    version: 1.5.3-1
   - name: verrazzano
     version: VERRAZZANO_VERSION
     chart: platform-operator/helm_config/charts/verrazzano

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -218,7 +218,7 @@
     },
     {
       "name": "capi-oci",
-      "version": "v0.12.1",
+      "version": "v0.13.0",
       "subcomponents": [
         {
           "repository": "oracle",
@@ -226,7 +226,7 @@
           "images": [
             {
               "image": "cluster-api-oci-controller",
-              "tag": "v0.12.1"
+              "tag": "v0.13.0"
             }
           ]
         }


### PR DESCRIPTION
cherry pick e89f48c

* VZ-11465: New OCI drivers
* VZ-11465 : Increment CAPI pre-release version

Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
