### PR TITLE
VZ-11482 uptake CAPI OCNE image with golang 1.20

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -35,7 +35,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/rancher-values.yaml
   - name: cluster-api
-    version: 1.5.3-1
+    version: 1.5.3-2
   - name: verrazzano
     version: VERRAZZANO_VERSION
     chart: platform-operator/helm_config/charts/verrazzano

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -242,11 +242,11 @@
           "images": [
             {
               "image": "cluster-api-ocne-bootstrap-controller",
-              "tag": "v1.7.0-20230815141941-9a36ded"
+              "tag": "v1.7.0-20231115223310-76c6881"
             },
             {
               "image": "cluster-api-ocne-control-plane-controller",
-              "tag": "v1.7.0-20230815141941-9a36ded"
+              "tag": "v1.7.0-20231115223310-76c6881"
             }
           ]
         }


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
