### PR TITLE
VZ-11451: Update kube-state-metrics v2.10.0 built with Go 1.20.10

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -111,7 +111,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/prometheus-adapter-values.yaml
   - name: kube-state-metrics
-    version: 2.10.0
+    version: 2.10.0-1
     chart: platform-operator/thirdparty/charts/prometheus-community/kube-state-metrics
     valuesFiles:
       - platform-operator/helm_config/overrides/kube-state-metrics-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -748,7 +748,7 @@
     },
     {
       "name": "kube-state-metrics",
-      "version": "2.10.0",
+      "version": "2.10.0-1",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -756,7 +756,7 @@
           "images": [
             {
               "image": "kube-state-metrics",
-              "tag": "v2.10.0-20230925145429-85dfe41a",
+              "tag": "v2.10.0-20231110043525-74ed1d97",
               "helmRegKey": "image.registry",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"


### PR DESCRIPTION
Updates kube-state-metrics v2.10.0 built with Go 1.20.10
