### PR TITLE
VZ-11451: Update kube-state-metrics v2.6.0 built with Go 1.20.10, in release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -553,7 +553,7 @@
           "images": [
             {
               "image": "kube-state-metrics",
-              "tag": "v2.6.0-20230927044643-27d76120",
+              "tag": "v2.6.0-20231116043210-021e9a28",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updates kube-state-metrics v2.6.0 built with Go 1.20.10, in release-1.5