### PR TITLE
use JAO labels BP 1.7

### DIFF
--- a/ci/oke-ocidns/JenknsfileDnsKind
+++ b/ci/oke-ocidns/JenknsfileDnsKind
@@ -16,7 +16,7 @@ def testEnvironments = env.JOB_NAME.contains('oci-dns-acceptance')
                        : ["kind_oci_dns", "magicdns_oke", "ocidns_oke"]
 def acmeEnvironments = [ "staging", "production" ]
 def certIssuers = [ "self-signed", "acme" ]
-def agentLabel = env.JOB_NAME.contains('oci-dns-kind-tests') ? "phx-large" : "large"
+def agentLabel = env.JOB_NAME.contains('oci-dns-kind-tests') ? "2.0-large-phx" : "2.0-large"
 
 // pulling "ap-*" from the test regions given discovery of image pull issues
 def availableRegions = [  "us-ashburn-1", "ca-montreal-1", "ca-toronto-1", "eu-amsterdam-1", "eu-frankfurt-1", "eu-zurich-1", "me-jeddah-1",


### PR DESCRIPTION
Backport the fix to have the DNS kind sweep tests use the JAO label to 1.7 (older releases are already ok)
