### PR TITLE
VZ-11451: Update node-exporter image built using Go 1.20.10 in release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -587,7 +587,7 @@
           "images": [
             {
               "image": "node-exporter",
-              "tag": "v1.3.1-20230925070337-b7f69924",
+              "tag": "v1.3.1-20231116134013-92516a9d",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updates node-exporter image built using Go 1.20.10 in release-1.5
