### PR TITLE
VZ-11451: Update NGINX images, built from oracle/release/1.7.1 branch

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -3,7 +3,7 @@
 
 modules:
   - name: ingress-controller
-    version: 1.7.1-2
+    version: 1.7.1-3
     chart: platform-operator/thirdparty/charts/ingress-nginx
     valuesFiles:
       - platform-operator/helm_config/overrides/ingress-nginx-values.yaml

--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -101,7 +101,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/keycloak-values.yaml
   - name: prometheus-operator
-    version: 0.64.1-3
+    version: 0.64.1-4
     chart: platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack
     valuesFiles:
       - platform-operator/helm_config/overrides/prometheus-operator-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "ingress-controller",
-      "version": "1.7.1-2",
+      "version": "1.7.1-3",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -28,13 +28,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20231113191341-3732e6c9e",
+              "tag": "20231116165343-c17d0e0a2",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "v1.7.1-20231113191341-3732e6c9e",
+              "tag": "20231116165343-c17d0e0a2",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -283,7 +283,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20231113191341-3732e6c9e",
+              "tag": "20231116165343-c17d0e0a2",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
@@ -373,7 +373,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20231113191341-3732e6c9e",
+              "tag": "20231116165343-c17d0e0a2",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]
@@ -680,7 +680,7 @@
             },
             {
               "image": "kube-webhook-certgen",
-              "tag": "v1.7.1-20231107025443-ae3a45db1",
+              "tag": "20231116165343-c17d0e0a2",
               "helmRegKey": "prometheusOperator.admissionWebhooks.patch.image.registry",
               "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
               "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -665,7 +665,7 @@
     },
     {
       "name": "prometheus-operator",
-      "version": "0.64.1-3",
+      "version": "0.64.1-4",
       "subcomponents": [
         {
           "repository": "verrazzano",

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -28,13 +28,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "20231116165343-c17d0e0a2",
+              "tag": "v1.7.1-20231117052956-63316f57d",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "20231116165343-c17d0e0a2",
+              "tag": "v1.7.1-20231117052956-63316f57d",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -283,7 +283,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "20231116165343-c17d0e0a2",
+              "tag": "v1.7.1-20231117052956-63316f57d",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
@@ -373,7 +373,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "20231116165343-c17d0e0a2",
+              "tag": "v1.7.1-20231117052956-63316f57d",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]
@@ -680,7 +680,7 @@
             },
             {
               "image": "kube-webhook-certgen",
-              "tag": "20231116165343-c17d0e0a2",
+              "tag": "v1.7.1-20231117052956-63316f57d",
               "helmRegKey": "prometheusOperator.admissionWebhooks.patch.image.registry",
               "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
               "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"


### PR DESCRIPTION
Updates latest NGINX images built with the changes from https://github.com/verrazzano/ingress-nginx/pull/16