### PR TITLE
VZ-11528: Update nginx-prometheus-exporter image

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -289,7 +289,7 @@
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "v0.11.0-20230925134800-53d30b7f",
+              "tag": "v0.11.0-20231201054409-85f8a297",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }


### PR DESCRIPTION
Updates nginx-prometheus-exporter image built using Go 1.20.10