### PR TITLE
VZ-11528: Update nginx-prometheus-exporter image in release-1.7

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -289,7 +289,7 @@
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "v0.11.0-20230925134800-53d30b7f",
+              "tag": "v0.11.0-20231201054409-85f8a297",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }


### PR DESCRIPTION
Backports https://github.com/verrazzano/verrazzano/pull/7521 to release-1.7