### PR TITLE
VZ-11528: Update nginx-prometheus-exporter v0.10.0 image in release-1.6

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -277,7 +277,7 @@
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "v0.10.0-20230922082301-7cf62c11",
+              "tag": "v0.10.0-20231201054329-b30259fe",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }


### PR DESCRIPTION
Updates nginx-prometheus-exporter image built using Go 1.20.10