### PR TITLE
VZ-11504: Pick up rancher images built with golang 1.20 version of dapper

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -30,7 +30,7 @@ modules:
   - name: istio
     version: 1.19.3
   - name: rancher
-    version: 2.7.8-4
+    version: 2.7.8-6
     chart: platform-operator/thirdparty/charts/rancher
     valuesFiles:
       - platform-operator/helm_config/overrides/rancher-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -146,7 +146,7 @@
     },
     {
       "name": "rancher",
-      "version": "2.7.8-4",
+      "version": "2.7.8-6",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -158,13 +158,13 @@
               "rancherUI": "v2.7.2-17/release-2.7.2",
               "ocneDriverVersion": "v0.26.0",
               "ocneDriverChecksum": "687ab81766302e84351364f3df1151478117e454553d64dc2a58a0a630ece0a2",
-              "tag": "v2.7.8-20231201191200-0cee4e72a",
+              "tag": "v2.7.8-20231204165452-c72b17b77",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.8-20231201191200-0cee4e72a"
+              "tag": "v2.7.8-20231204165452-c72b17b77"
             }
           ]
         },
@@ -174,27 +174,27 @@
           "images": [
             {
               "image": "rancher-shell",
-              "tag": "v0.1.20-20231121214943-e141521"
+              "tag": "v0.1.20-20231204184619-874fbbf"
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.3.6-20231128145611-faab8c4"
+              "tag": "v0.3.6-20231204194426-f5a2cc2"
             },
             {
               "image": "rancher-fleet-agent",
-              "tag": "v0.7.1-20231127113723-ac1e6d47"
+              "tag": "v0.7.1-20231204203332-146b3ff4"
             },
             {
               "image": "rancher-fleet",
-              "tag": "v0.7.1-20231127113723-ac1e6d47"
+              "tag": "v0.7.1-20231204203332-146b3ff4"
             },
             {
               "image": "rancher-gitjob",
-              "tag": "v0.1.32-20231127180810-1d71079"
+              "tag": "v0.1.32-20231205020907-52b92ba"
             },
             {
               "image": "rancher-cleanup",
-              "tag": "v1.0.0-20231115164124-83ffd98"
+              "tag": "v1.0.0-20231205022606-4bdef1c"
             }
           ]
         }


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
