### PR TITLE
microservices url is dead now, archived today. Ignore for now

### DIFF
--- a/tools/url_linter/ignore_urls.txt
+++ b/tools/url_linter/ignore_urls.txt
@@ -76,3 +76,6 @@ https://oracle.github.io/coherence-operator/charts
 
 # Until we have the advice versioned, ignore new advice not in all releases
 https://verrazzano.io/latest/docs/troubleshooting/diagnostictools/analysisadvice/ingressinvalidshape
+
+# This got archived 5-dec-2023, ignore for now
+https://microservices-demo.github.io/


### PR DESCRIPTION
microservices url is dead now, archived today. Ignore for now