### PR TITLE
VZ-11565: Uptake Rancher images and components built with golang 1.20.12 to release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -147,7 +147,7 @@
           "images": [
             {
               "image": "rancher-shell",
-              "tag": "v0.1.18-20231204185524-88224c8"
+              "tag": "v0.1.18-20231213174651-0bd21f0"
             },
             {
               "image": "rancher-webhook",

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -131,13 +131,13 @@
             {
               "image": "rancher",
               "dashboard": "v2.7.2-20230509143745-870a44e17",
-              "tag": "v2.7.3-release-1.5-20231204172500-23715c978",
+              "tag": "20231215135151-74556a79c",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "v2.7.3-release-1.5-20231204172500-23715c978"
+              "tag": "20231215135151-74556a79c"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -131,13 +131,13 @@
             {
               "image": "rancher",
               "dashboard": "v2.7.2-20230509143745-870a44e17",
-              "tag": "20231215135151-74556a79c",
+              "tag": "v2.7.3-release-1.5-20231215142704-305a3a2af",
               "helmFullImageKey": "rancherImage",
               "helmTagKey": "rancherImageTag"
             },
             {
               "image": "rancher-agent",
-              "tag": "20231215135151-74556a79c"
+              "tag": "v2.7.3-release-1.5-20231215142704-305a3a2af"
             }
           ]
         },

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -151,7 +151,7 @@
             },
             {
               "image": "rancher-webhook",
-              "tag": "v0.3.3-20231204201907-11799e9"
+              "tag": "v0.3.3-20231213131455-391e4b1"
             },
             {
               "image": "rancher-fleet-agent",

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -155,11 +155,11 @@
             },
             {
               "image": "rancher-fleet-agent",
-              "tag": "v0.6.0-20231205015732-a1e3576"
+              "tag": "v0.6.0-20231213140012-f873921"
             },
             {
               "image": "rancher-fleet",
-              "tag": "v0.6.0-20231205015732-a1e3576"
+              "tag": "v0.6.0-20231213140012-f873921"
             },
             {
               "image": "rancher-gitjob",

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -163,7 +163,7 @@
             },
             {
               "image": "rancher-gitjob",
-              "tag": "v0.1.30-20231205021809-f29918c"
+              "tag": "v0.1.30-20231213145641-fa8cdfa"
             },
             {
               "image": "rancher-cleanup",


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
