### PR TITLE
VZ-11599: VZ-11605: Update Velero and Kiali images built with golang 1.20.12  (#7584)

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -81,7 +81,7 @@ modules:
     version: 2.0.11
     chart: platform-operator/helm_config/charts/fluentbit-opensearch-output
   - name: kiali-server
-    version: 1.73.0-2
+    version: 1.73.0-3
     chart: platform-operator/thirdparty/charts/kiali-server
     valuesFiles:
       - platform-operator/helm_config/overrides/kiali-server-values.yaml
@@ -132,7 +132,7 @@ modules:
       - platform-operator/helm_config/overrides/jaeger-operator-values.yaml
       - platform-operator/helm_config/overrides/jaeger-production-strategy-values.yaml
   - name: velero
-    version: 1.9.1-2
+    version: 1.9.1-3
     chart: platform-operator/thirdparty/charts/velero
     valuesFiles:
       - platform-operator/helm_config/overrides/velero-override-static-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -554,7 +554,7 @@
     },
     {
       "name": "kiali-server",
-      "version": "1.73.0-2",
+      "version": "1.73.0-3",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -562,7 +562,7 @@
           "images": [
             {
               "image": "kiali",
-              "tag": "v1.73.0-20231005093008-db373114",
+              "tag": "v1.73.0-20231215145100-8474271b",
               "helmFullImageKey": "deployment.image_name",
               "helmTagKey": "deployment.image_version"
             }
@@ -887,7 +887,7 @@
     },
     {
       "name": "velero",
-      "version": "1.9.1-2",
+      "version": "1.9.1-3",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -895,18 +895,18 @@
           "images": [
             {
               "image": "velero",
-              "tag": "v1.9.1-20231121201509-a233e1dd",
+              "tag": "v1.9.1-20231214220002-52c8f1fc",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "velero-plugin-for-aws",
-              "tag": "v1.5.0-20231121190640-0a60cf3a",
+              "tag": "v1.5.0-20231215143502-6f82d913",
               "helmFullImageKey": "initContainers[0].image"
             },
             {
               "image": "velero-restic-restore-helper",
-              "tag": "v1.9.1-20231121201509-a233e1dd",
+              "tag": "v1.9.1-20231214220002-52c8f1fc",
               "helmFullImageKey": "configMaps.restic-restore-action-config.data.image"
             }
           ]


### PR DESCRIPTION
Backport #7584 