### PR TITLE
VZ-11604: Update coherence-operator to 3.3.2 on release-1.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### v1.6.9
 Component version updates:
 
+- Coherence Operator 3.3.2
 - WebLogic Kubernetes Operator v4.1.4
 - WebLogic Monitoring Exporter v2.1.8
 - Istio v1.19.3

--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -18,7 +18,7 @@ spec:
             app: robert-coh
             version: v1
           replicas: 2
-          image: container-registry.oracle.com/verrazzano/example-roberts-coherence:1.0.0-1-20210728181814-eb1e622
+          image: container-registry.oracle.com/verrazzano/example-roberts-coherence:1.0.0-1-20230830170835-ad1de21
           imagePullPolicy: IfNotPresent
           imagePullSecrets:
             - name: bobs-books-repo-credentials
@@ -67,13 +67,15 @@ spec:
         podSpec:
           containers:
             - name: robert-helidon-stock-application
-              image: container-registry.oracle.com/verrazzano/example-roberts-helidon-stock-application:1.0.0-1-20210728181814-eb1e622
+              image: container-registry.oracle.com/verrazzano/example-roberts-helidon-stock-application:1.0.0-1-20230830170835-ad1de21
               imagePullPolicy: IfNotPresent
               ports:
                 - name: http
                   containerPort: 8080
               env:
                 - name: COH_CLUSTER
+                  value: roberts-coherence
+                - name: COHERENCE_CLUSTER
                   value: roberts-coherence
                 - name: COH_CACHE_CONFIG
                   value: coherence-cache-config.xml
@@ -99,7 +101,7 @@ spec:
             app: bobbys-coh
             version: v1
           replicas: 1
-          image: container-registry.oracle.com/verrazzano/example-bobbys-coherence:1.0.0-1-20210728181814-eb1e622
+          image: container-registry.oracle.com/verrazzano/example-bobbys-coherence:1.0.0-1-20230830170835-ad1de21
           imagePullPolicy: IfNotPresent
           imagePullSecrets:
             - name: bobs-books-repo-credentials
@@ -144,7 +146,7 @@ spec:
         podSpec:
           containers:
             - name: bobbys-helidon-stock-application
-              image: container-registry.oracle.com/verrazzano/example-bobbys-helidon-stock-application:1.0.0-1-20210728181814-eb1e622
+              image: container-registry.oracle.com/verrazzano/example-bobbys-helidon-stock-application:1.0.0-1-20230830170835-ad1de21
               imagePullPolicy: IfNotPresent
               ports:
                 - containerPort: 8080
@@ -155,6 +157,8 @@ spec:
                 - name: BACKEND_HOSTNAME
                   value: bobs-bookstore-cluster-cluster-1
                 - name: COH_CLUSTER
+                  value: bobbys-coherence
+                - name: COHERENCE_CLUSTER
                   value: bobbys-coherence
                 - name: COH_CACHE_CONFIG
                   value: coherence-cache-config.xml

--- a/platform-operator/helm_config/overrides/coherence-values.yaml
+++ b/platform-operator/helm_config/overrides/coherence-values.yaml
@@ -3,9 +3,12 @@
 
 # The coherence-operator image now comes from the bill of materials file (verrazzano-bom.json).
 # This file only specifies the defaultCoherenceImage
-defaultCoherenceImage: ghcr.io/oracle/coherence-ce:22.06.1
+defaultCoherenceImage: ghcr.io/oracle/coherence-ce:22.06.6
 
 replicas: 1
+
+labels:
+  sidecar.istio.io/inject: 'false'
 
 securityContext:
   seccompProfile:

--- a/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/Chart.yaml
@@ -5,8 +5,8 @@
 name: coherence-operator
 description: A Kubernetes Operator for Coherence
 apiVersion: v1
-version: 3.2.10
-appVersion: 3.2.10
+version: 3.3.2
+appVersion: 3.3.2
 home: https://github.com/oracle/coherence-operator
 sources:
 - https://github.com/oracle/coherence-operator

--- a/platform-operator/thirdparty/charts/coherence-operator/README.md
+++ b/platform-operator/thirdparty/charts/coherence-operator/README.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020, Oracle Corporation and/or its affiliates.
+  Copyright 2020, 2023, Oracle Corporation and/or its affiliates.
   Licensed under the Universal Permissive License v 1.0 as shown at
   http://oss.oracle.com/licenses/upl.
 -->
@@ -14,7 +14,7 @@ This chart install a coherence-operator deployment on a
 package manager.
 
 ## Prerequisites
-* Kubernetes 1.13 or above
+* Kubernetes 1.19 or above
 * Helm 3 or above
 
 ## Installing the Chart
@@ -35,6 +35,3 @@ To uninstall the `sample-coherence-operator` deployment:
 $ helm delete sample-coherence-operator
 ```
 
-### Modifications by the Verrazzano team
-
-1. The deployment pod template in deployment.yaml has been changed to add a new label, `sidecar.istio.io/inject: "false"`.

--- a/platform-operator/thirdparty/charts/coherence-operator/templates/deployment.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/templates/deployment.yaml
@@ -16,7 +16,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.10"
+    app.kubernetes.io/version: "3.3.2"
     app.kubernetes.io/component: webhook
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -28,7 +28,7 @@ spec:
   selector:
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.10"
+    app.kubernetes.io/version: "3.3.2"
     app.kubernetes.io/component: manager
 ---
 apiVersion: v1
@@ -40,7 +40,7 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-rest
-    app.kubernetes.io/version: "3.2.10"
+    app.kubernetes.io/version: "3.3.2"
     app.kubernetes.io/component: rest
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
@@ -52,7 +52,7 @@ spec:
   selector:
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.10"
+    app.kubernetes.io/version: "3.3.2"
     app.kubernetes.io/component: manager
 ---
 apiVersion: apps/v1
@@ -64,11 +64,18 @@ metadata:
     control-plane: coherence
     app.kubernetes.io/name: coherence-operator
     app.kubernetes.io/instance: coherence-operator-manager
-    app.kubernetes.io/version: "3.2.10"
+    app.kubernetes.io/version: "3.3.2"
     app.kubernetes.io/component: manager
     app.kubernetes.io/part-of: coherence-operator
     app.kubernetes.io/managed-by: helm
     app.kubernetes.io/created-by: controller-manager
+{{- if .Values.deploymentLabels }}
+{{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- end }}
+{{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ default 3 .Values.replicas }}
   selector:
@@ -77,15 +84,21 @@ spec:
   template:
     metadata:
       labels:
-        sidecar.istio.io/inject: 'false'
         control-plane: coherence
         app.kubernetes.io/name: coherence-operator
         app.kubernetes.io/instance: coherence-operator-manager
-        app.kubernetes.io/version: "3.2.10"
+        app.kubernetes.io/version: "3.3.2"
         app.kubernetes.io/component: manager
         app.kubernetes.io/part-of: coherence-operator
         app.kubernetes.io/managed-by: helm
         app.kubernetes.io/created-by: controller-manager
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 8 }}
+{{- end }}
+{{- if .Values.annotations }}
+      annotations:
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ default "coherence-operator" .Values.serviceAccountName }}
 {{- if .Values.podSecurityContext }}
@@ -125,13 +138,21 @@ spec:
         - name: CERT_TYPE
           value: {{ default "self-signed" .Values.webhookCertType | quote }}
         - name: COHERENCE_IMAGE
+{{- if kindIs "string" .Values.defaultCoherenceImage }}
           value: {{ .Values.defaultCoherenceImage | quote }}
+{{- else }}
+          value: {{ printf "%s/%s:%s" .Values.defaultCoherenceImage.registry .Values.defaultCoherenceImage.name .Values.defaultCoherenceImage.tag | quote }}
+{{- end }}
         - name: RACK_LABEL
           value: {{ .Values.rackLabel | quote }}
         - name: SITE_LABEL
           value: {{ .Values.siteLabel | quote }}
         - name: OPERATOR_IMAGE
-          value: {{ .Values.defaultCoherenceUtilsImage | quote }}
+{{- if kindIs "string" .Values.image }}
+          value: {{ .Values.image | quote }}
+{{- else }}
+          value: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.name .Values.image.tag | quote }}
+{{- end }}
         - name: WATCH_NAMESPACE
 {{- if .Values.onlySameNamespace }}
           value: {{ .Release.Namespace | quote }}
@@ -142,7 +163,11 @@ spec:
           value: {{ .Release.Namespace | quote }}
 {{-   end }}
 {{- end }}
-        image: {{ .Values.image }}
+{{- if kindIs "string" .Values.image }}
+        image: {{ .Values.image | quote }}
+{{- else }}
+        image: {{ printf "%s/%s:%s" .Values.image.registry .Values.image.name .Values.image.tag | quote }}
+{{- end }}
         ports:
         - containerPort: 8000
           name: operator
@@ -209,7 +234,7 @@ spec:
                     control-plane: coherence
                     app.kubernetes.io/name: coherence-operator
                     app.kubernetes.io/instance: coherence-operator-manager
-                    app.kubernetes.io/version: "3.2.10"
+                    app.kubernetes.io/version: "3.3.2"
               weight: 50
             - podAffinityTerm:
                 topologyKey: "oci.oraclecloud.com/fault-domain"
@@ -218,7 +243,7 @@ spec:
                     control-plane: coherence
                     app.kubernetes.io/name: coherence-operator
                     app.kubernetes.io/instance: coherence-operator-manager
-                    app.kubernetes.io/version: "3.2.10"
+                    app.kubernetes.io/version: "3.3.2"
               weight: 10
             - podAffinityTerm:
                 topologyKey: "kubernetes.io/hostname"
@@ -227,7 +252,7 @@ spec:
                     control-plane: coherence
                     app.kubernetes.io/name: coherence-operator
                     app.kubernetes.io/instance: coherence-operator-manager
-                    app.kubernetes.io/version: "3.2.10"
+                    app.kubernetes.io/version: "3.3.2"
               weight: 1
 {{- end }}
       volumes:

--- a/platform-operator/thirdparty/charts/coherence-operator/templates/rbac.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/templates/rbac.yaml
@@ -173,6 +173,9 @@ rules:
   - coherence
   - coherence/finalizers
   - coherence/status
+  - coherencejob
+  - coherencejob/finalizers
+  - coherencejob/status
   verbs:
   - create
   - delete

--- a/platform-operator/thirdparty/charts/coherence-operator/values.yaml
+++ b/platform-operator/thirdparty/charts/coherence-operator/values.yaml
@@ -3,15 +3,17 @@
 # http://oss.oracle.com/licenses/upl.
 
 # image is the Coherence Operator image
-image: "ghcr.io/oracle/coherence-operator:3.2.10"
+image:
+  registry: "ghcr.io/oracle"
+  name: "coherence-operator"
+  tag: "3.3.2"
 
 # defaultCoherenceImage is the default application image that will be used if a Coherence
 # resource does not specify an image name.
-defaultCoherenceImage: "ghcr.io/oracle/coherence-ce:22.06.3"
-
-# defaultCoherenceUtilsImage is the Coherence Operator image that will be used when running
-# Coherence Pods. This image version should typically match the Operator version.
-defaultCoherenceUtilsImage: "ghcr.io/oracle/coherence-operator:3.2.10"
+defaultCoherenceImage:
+  registry: "ghcr.io/oracle"
+  name: "coherence-ce"
+  tag: "22.06.6"
 
 # watchNamespaces is the comma delimited list of namespaces that the operator should
 # manage Coherence resources in. The default is to manage all namespaces.
@@ -41,6 +43,22 @@ replicas: 3
 #   - name: "foo"
 #   - name: "bar"
 imagePullSecrets:
+
+# ---------------------------------------------------------------------------
+# Additional labels that are added to the Operator Pods.
+labels:
+
+# ---------------------------------------------------------------------------
+# Additional annotations that are added to the Operator Pods.
+annotations:
+
+# ---------------------------------------------------------------------------
+# Additional labels that are added to the Operator Deployment.
+deploymentLabels:
+
+# ---------------------------------------------------------------------------
+# Additional annotations that are added to the Operator Deployment.
+deploymentAnnotations:
 
 # ---------------------------------------------------------------------------
 # Operator Pod securityContext

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -442,7 +442,7 @@
     },
     {
       "name": "coherence-operator",
-      "version": "3.2.10",
+      "version": "3.3.2",
       "subcomponents": [
         {
           "repository": "oracle",
@@ -450,7 +450,7 @@
           "images": [
             {
               "image": "coherence-operator",
-              "tag": "3.2.10",
+              "tag": "3.3.2",
               "helmFullImageKey": "image"
             }
           ]


### PR DESCRIPTION
Provide a summary of the change and which issue (i.e. ticket) is fixed.
If there are any dependencies, for example on a PR in another repository, list those.
