### PR TITLE
VZ-11614: Update component images built with Go 1.20.12, in release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -52,24 +52,24 @@
           "images": [
             {
               "image": "cert-manager-controller",
-              "tag": "v1.9.1-20231108025749-df3d99c0",
+              "tag": "v1.9.1-20231219115213-4c06aea1",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             },
             {
               "image": "cert-manager-acmesolver",
-              "tag": "v1.9.1-20231108025749-df3d99c0",
+              "tag": "v1.9.1-20231219115213-4c06aea1",
               "helmFullImageKey": "extraArgs[0]"
             },
             {
               "image": "cert-manager-cainjector",
-              "tag": "v1.9.1-20231108025749-df3d99c0",
+              "tag": "v1.9.1-20231219115213-4c06aea1",
               "helmFullImageKey": "cainjector.image.repository",
               "helmTagKey": "cainjector.image.tag"
             },
             {
               "image": "cert-manager-webhook",
-              "tag": "v1.9.1-20231108025749-df3d99c0",
+              "tag": "v1.9.1-20231219115213-4c06aea1",
               "helmFullImageKey": "webhook.image.repository",
               "helmTagKey": "webhook.image.tag"
             }
@@ -87,7 +87,7 @@
           "images": [
             {
               "image": "external-dns",
-              "tag": "v0.12.2-20231107025450-8480e5c7",
+              "tag": "v0.12.2-20231219112424-52012475",
               "helmFullImageKey": "image.repository",
               "helmRegKey": "image.registry",
               "helmTagKey": "image.tag"
@@ -553,7 +553,7 @@
           "images": [
             {
               "image": "kube-state-metrics",
-              "tag": "v2.6.0-20231116043210-021e9a28",
+              "tag": "v2.6.0-20231220052747-021e9a28",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -587,7 +587,7 @@
           "images": [
             {
               "image": "node-exporter",
-              "tag": "v1.3.1-20231116134013-92516a9d",
+              "tag": "v1.3.1-20231220064005-f480b991",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updates component images built with Go 1.20.12, in release-1.5