### PR TITLE
VZ-11615: Update jaeger images built with golang 1.20.12

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -126,7 +126,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/prometheus-node-exporter-values.yaml
   - name: jaeger-operator
-    version: 1.42.0-2
+    version: 1.42.0-3
     chart: platform-operator/thirdparty/charts/jaegertracing/jaeger-operator
     valuesFiles:
       - platform-operator/helm_config/overrides/jaeger-operator-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -792,7 +792,7 @@
     },
     {
       "name": "jaeger-operator",
-      "version": "1.42.0-2",
+      "version": "1.42.0-3",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -800,7 +800,7 @@
           "images": [
             {
               "image": "jaeger-operator",
-              "tag": "1.42.0-20231113173501-e3e86fb8",
+              "tag": "1.42.0-20231220150148-2c0a703c",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }
@@ -812,7 +812,7 @@
           "images": [
             {
               "image": "jaeger-agent",
-              "tag": "1.42.0-20231113164841-192e39df",
+              "tag": "1.42.0-20231220153435-1a09f940",
               "helmFullImageKey": "jaegerAgentImage"
             }
           ]
@@ -823,7 +823,7 @@
           "images": [
             {
               "image": "jaeger-collector",
-              "tag": "1.42.0-20231113164841-192e39df",
+              "tag": "1.42.0-20231220153435-1a09f940",
               "helmFullImageKey": "jaegerCollectorImage"
             }
           ]
@@ -834,7 +834,7 @@
           "images": [
             {
               "image": "jaeger-query",
-              "tag": "1.42.0-20231113164841-192e39df",
+              "tag": "1.42.0-20231220153435-1a09f940",
               "helmFullImageKey": "jaegerQueryImage"
             }
           ]
@@ -845,7 +845,7 @@
           "images": [
             {
               "image": "jaeger-ingester",
-              "tag": "1.42.0-20231113164841-192e39df",
+              "tag": "1.42.0-20231220153435-1a09f940",
               "helmFullImageKey": "jaegerIngesterImage"
             }
           ]
@@ -856,7 +856,7 @@
           "images": [
             {
               "image": "jaeger-es-index-cleaner",
-              "tag": "1.42.0-20231113164841-192e39df",
+              "tag": "1.42.0-20231220153435-1a09f940",
               "helmFullImageKey": "jaegerESIndexCleanerImage"
             }
           ]
@@ -867,7 +867,7 @@
           "images": [
             {
               "image": "jaeger-es-rollover",
-              "tag": "1.42.0-20231113164841-192e39df",
+              "tag": "1.42.0-20231220153435-1a09f940",
               "helmFullImageKey": "jaegerESRolloverImage"
             }
           ]
@@ -878,7 +878,7 @@
           "images": [
             {
               "image": "jaeger-all-in-one",
-              "tag": "1.42.0-20231113164841-192e39df",
+              "tag": "1.42.0-20231220153435-1a09f940",
               "helmFullImageKey": "jaegerAllInOneImage"
             }
           ]


### PR DESCRIPTION
Update jaeger images built with golang 1.20.12