### PR TITLE
VZ-11614: Refresh nginx-prometheus-exporter and oam-kubernetes-runtime images in release-1.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -214,7 +214,7 @@ replace (
 	github.com/cespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.2.0
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.18
 	github.com/crossplane/crossplane-runtime => github.com/verrazzano/crossplane-runtime v0.17.0-1
-	github.com/crossplane/oam-kubernetes-runtime => github.com/verrazzano/oam-kubernetes-runtime v0.3.3-4
+	github.com/crossplane/oam-kubernetes-runtime => github.com/verrazzano/oam-kubernetes-runtime v0.3.3-5
 	github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/docker/distribution => github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/docker => github.com/docker/docker v20.10.24+incompatible

--- a/go.sum
+++ b/go.sum
@@ -850,8 +850,8 @@ github.com/verrazzano/crossplane-runtime v0.17.0-1 h1:juTCAYMWDWITX9vFTdNnF97+Sl
 github.com/verrazzano/crossplane-runtime v0.17.0-1/go.mod h1:fA8Dp1vT5JjpBCE3KlellJ0Z/Xo1aekngOXmuDsryz0=
 github.com/verrazzano/fluent-operator/v2 v2.2.0 h1:rsKzccy5Di5SdbIJW31AdbWqET7cHRW+p0XY10+XXZ0=
 github.com/verrazzano/fluent-operator/v2 v2.2.0/go.mod h1:v/q0zLEOWP6MKHP7xvrhtASZTwlrk4LcCne/kgPQ7J0=
-github.com/verrazzano/oam-kubernetes-runtime v0.3.3-4 h1:32vLP4nf/Z4A3yto7O9O+439leZDB5128EMYecoVuhs=
-github.com/verrazzano/oam-kubernetes-runtime v0.3.3-4/go.mod h1:1p/NurfVWx9Xi5uLuXF9Ojx+XUmIF+z9TPkljcZcd5E=
+github.com/verrazzano/oam-kubernetes-runtime v0.3.3-5 h1:L3Nqu21o8Fp+xi8RcsLmByXTtTbW0f6tmSPb7Il0ToI=
+github.com/verrazzano/oam-kubernetes-runtime v0.3.3-5/go.mod h1:3PfDc3fH2VoVSEaK5nQlrGTZftAh7fsGij+uxR+bYzA=
 github.com/verrazzano/pkg v0.0.2 h1:Q80lpGaAswNPXkZZL/0THIa9PXvewi+c6xSSzWQyhG8=
 github.com/verrazzano/pkg v0.0.2/go.mod h1:l9utTv9KBQZlJI/HYnw2NQwisYTeHeHl82XOlCiZygM=
 github.com/verrazzano/verrazzano-modules v0.0.0-20230915154150-1fe7062cbccd h1:+YEpt1F5UUr20PSeyvy4knsEO//a3SnmjJj1AvAxRqk=

--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -49,7 +49,7 @@ modules:
     version: VERRAZZANO_VERSION
     chart: platform-operator/helm_config/charts/verrazzano-monitoring-operator
   - name: oam-kubernetes-runtime
-    version: 0.3.3-2
+    version: 0.3.3-4
     chart: platform-operator/thirdparty/charts/oam-kubernetes-runtime
     valuesFiles:
       - platform-operator/helm_config/overrides/oam-kubernetes-runtime-values.yaml

--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -49,7 +49,7 @@ modules:
     version: VERRAZZANO_VERSION
     chart: platform-operator/helm_config/charts/verrazzano-monitoring-operator
   - name: oam-kubernetes-runtime
-    version: 0.3.3-4
+    version: 0.3.3-3
     chart: platform-operator/thirdparty/charts/oam-kubernetes-runtime
     valuesFiles:
       - platform-operator/helm_config/overrides/oam-kubernetes-runtime-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -289,7 +289,7 @@
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "v0.11.0-20231201054409-85f8a297",
+              "tag": "v0.11.0-20231222064638-0b419280",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }
@@ -398,7 +398,7 @@
     },
     {
       "name": "oam-kubernetes-runtime",
-      "version": "0.3.3-2",
+      "version": "0.3.3-3",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -406,7 +406,7 @@
           "images": [
             {
               "image": "oam-kubernetes-runtime",
-              "tag": "v0.3.3-20231107030837-d2005b2",
+              "tag": "v0.3.3-20231221101608-f2b743d",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Refreshes nginx-prometheus-exporter and oam-kubernetes-runtime images built with Go 1.20.12, in release-1.7