### PR TITLE
VZ-11614: Refresh nginx-prometheus-exporter and oam-kubernetes-runtime images in release-1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -170,7 +170,7 @@ require (
 replace (
 	github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 => github.com/coreos/go-json v0.0.0-20220325222439-31b2177291ae
 	github.com/crossplane/crossplane-runtime => github.com/verrazzano/crossplane-runtime v0.17.0-1
-	github.com/crossplane/oam-kubernetes-runtime => github.com/verrazzano/oam-kubernetes-runtime v0.3.3-4
+	github.com/crossplane/oam-kubernetes-runtime => github.com/verrazzano/oam-kubernetes-runtime v0.3.3-5
 	github.com/docker/docker => github.com/docker/docker v20.10.24+incompatible
 	github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.16.0+incompatible
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -1182,8 +1182,8 @@ github.com/verrazzano/crossplane-runtime v0.17.0-1 h1:juTCAYMWDWITX9vFTdNnF97+Sl
 github.com/verrazzano/crossplane-runtime v0.17.0-1/go.mod h1:fA8Dp1vT5JjpBCE3KlellJ0Z/Xo1aekngOXmuDsryz0=
 github.com/verrazzano/kind v0.0.0-20221129215948-885481909133 h1:B4UOVPaicKuN8xUnNNGVTHzKck6EMLZ0jvvsfa6LYpA=
 github.com/verrazzano/kind v0.0.0-20221129215948-885481909133/go.mod h1:t5GndzzvtTW702bHZ/6dpkbd/eC4SaTenEmivLVnBKA=
-github.com/verrazzano/oam-kubernetes-runtime v0.3.3-4 h1:32vLP4nf/Z4A3yto7O9O+439leZDB5128EMYecoVuhs=
-github.com/verrazzano/oam-kubernetes-runtime v0.3.3-4/go.mod h1:1p/NurfVWx9Xi5uLuXF9Ojx+XUmIF+z9TPkljcZcd5E=
+github.com/verrazzano/oam-kubernetes-runtime v0.3.3-5 h1:L3Nqu21o8Fp+xi8RcsLmByXTtTbW0f6tmSPb7Il0ToI=
+github.com/verrazzano/oam-kubernetes-runtime v0.3.3-5/go.mod h1:3PfDc3fH2VoVSEaK5nQlrGTZftAh7fsGij+uxR+bYzA=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.31-0.20230201202534-ac5ebe880e95 h1:+kHIXVr+itVlN7lT0166/LgcaoupkE8tEq/VbXxZio4=
 github.com/verrazzano/verrazzano-monitoring-operator v0.0.31-0.20230201202534-ac5ebe880e95/go.mod h1:UIDEHkYPJt9SzdobI1z/p4oGfeW8cpPimDcqZu1YBlk=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -205,7 +205,7 @@
             },
             {
               "image": "nginx-prometheus-exporter",
-              "tag": "v0.10.0-20231201054329-b30259fe",
+              "tag": "v0.10.0-20231222111532-2f605a9b",
               "helmFullImageKey": "api.metricsImageName",
               "helmTagKey": "api.metricsImageVersion"
             }
@@ -287,7 +287,7 @@
           "images": [
             {
               "image": "oam-kubernetes-runtime",
-              "tag": "v0.3.3-20231107030837-d2005b2",
+              "tag": "v0.3.3-20231221101608-f2b743d",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Refreshes nginx-prometheus-exporter and oam-kubernetes-runtime images in release-1.5, built using Go 1.20.12
