### PR TITLE
First pass of adding version of CLI output to commands

### DIFF
--- a/tools/vz/cmd/analyze/analyze.go
+++ b/tools/vz/cmd/analyze/analyze.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package analyze

--- a/tools/vz/cmd/analyze/analyze.go
+++ b/tools/vz/cmd/analyze/analyze.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package analyze

--- a/tools/vz/cmd/analyze/analyze.go
+++ b/tools/vz/cmd/analyze/analyze.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package analyze
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
-	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/analysis"
 	vzbugreport "github.com/verrazzano/verrazzano/tools/vz/pkg/bugreport"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
@@ -94,7 +93,6 @@ func analyzeLiveCluster(cmd *cobra.Command, vzHelper helpers.VZHelper, directory
 }
 
 func RunCmdAnalyze(cmd *cobra.Command, vzHelper helpers.VZHelper, printReportToConsole bool) error {
-	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	directoryFlag := cmd.PersistentFlags().Lookup(constants.DirectoryFlagName)
 	if err := setVzK8sVersion(directoryFlag, vzHelper, cmd); err == nil {
 		fmt.Fprintf(vzHelper.GetOutputStream(), helpers.GetVersionOut())

--- a/tools/vz/cmd/analyze/analyze.go
+++ b/tools/vz/cmd/analyze/analyze.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/analysis"
 	vzbugreport "github.com/verrazzano/verrazzano/tools/vz/pkg/bugreport"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
@@ -93,6 +94,7 @@ func analyzeLiveCluster(cmd *cobra.Command, vzHelper helpers.VZHelper, directory
 }
 
 func RunCmdAnalyze(cmd *cobra.Command, vzHelper helpers.VZHelper, printReportToConsole bool) error {
+	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	directoryFlag := cmd.PersistentFlags().Lookup(constants.DirectoryFlagName)
 	if err := setVzK8sVersion(directoryFlag, vzHelper, cmd); err == nil {
 		fmt.Fprintf(vzHelper.GetOutputStream(), helpers.GetVersionOut())

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package bugreport
@@ -6,7 +6,6 @@ package bugreport
 import (
 	"errors"
 	"fmt"
-	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"io/fs"
 	"os"
 	"strings"
@@ -80,7 +79,6 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	newCmd := analyze.NewCmdAnalyze(vzHelper)
 	err := setUpFlags(cmd, newCmd)
 	if err != nil {
-		fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 		return fmt.Errorf(flagErrorStr, err.Error())
 	}
 	analyzeErr := analyze.RunCmdAnalyze(newCmd, vzHelper, false)

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -6,6 +6,7 @@ package bugreport
 import (
 	"errors"
 	"fmt"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"io/fs"
 	"os"
 	"strings"
@@ -79,6 +80,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	newCmd := analyze.NewCmdAnalyze(vzHelper)
 	err := setUpFlags(cmd, newCmd)
 	if err != nil {
+		fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 		return fmt.Errorf(flagErrorStr, err.Error())
 	}
 	analyzeErr := analyze.RunCmdAnalyze(newCmd, vzHelper, false)

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package bugreport

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package bugreport

--- a/tools/vz/cmd/export/oam/oam.go
+++ b/tools/vz/cmd/export/oam/oam.go
@@ -6,6 +6,7 @@ package oam
 import (
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -97,6 +98,7 @@ func NewCmdExportOAM(vzHelper helpers.VZHelper) *cobra.Command {
 
 func RunCmdExportOAM(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 	// Get the OAM application name
+	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	appName, err := cmd.PersistentFlags().GetString(constants.AppNameFlag)
 	if err != nil {
 		return fmt.Errorf(flagErrorStr, err.Error())

--- a/tools/vz/cmd/export/oam/oam.go
+++ b/tools/vz/cmd/export/oam/oam.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oam

--- a/tools/vz/cmd/export/oam/oam.go
+++ b/tools/vz/cmd/export/oam/oam.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, Oracle and/or its affiliates.
+// Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oam

--- a/tools/vz/cmd/export/oam/oam.go
+++ b/tools/vz/cmd/export/oam/oam.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package oam
@@ -6,7 +6,6 @@ package oam
 import (
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -98,7 +97,6 @@ func NewCmdExportOAM(vzHelper helpers.VZHelper) *cobra.Command {
 
 func RunCmdExportOAM(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
 	// Get the OAM application name
-	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	appName, err := cmd.PersistentFlags().GetString(constants.AppNameFlag)
 	if err != nil {
 		return fmt.Errorf(flagErrorStr, err.Error())

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -120,6 +120,7 @@ func NewCmdInstall(vzHelper helpers.VZHelper) *cobra.Command {
 
 func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) error {
 	// Get the controller runtime client
+	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	client, err := vzHelper.GetClient(cmd)
 	if err != nil {
 		return err

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package install
@@ -120,7 +120,6 @@ func NewCmdInstall(vzHelper helpers.VZHelper) *cobra.Command {
 
 func runCmdInstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) error {
 	// Get the controller runtime client
-	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	client, err := vzHelper.GetClient(cmd)
 	if err != nil {
 		return err

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package install

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package install

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package status

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package status
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
-	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"reflect"
 	"strings"
 
@@ -85,7 +84,6 @@ func NewCmdStatus(vzHelper helpers.VZHelper) *cobra.Command {
 
 // runCmdStatus - run the "vz status" command
 func runCmdStatus(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
-	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	client, err := vzHelper.GetClient(cmd)
 	if err != nil {
 		return err

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"reflect"
 	"strings"
 
@@ -84,6 +85,7 @@ func NewCmdStatus(vzHelper helpers.VZHelper) *cobra.Command {
 
 // runCmdStatus - run the "vz status" command
 func runCmdStatus(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
+	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	client, err := vzHelper.GetClient(cmd)
 	if err != nil {
 		return err

--- a/tools/vz/cmd/status/status.go
+++ b/tools/vz/cmd/status/status.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package status

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"io"
 	"os"
 	"regexp"
@@ -97,6 +98,7 @@ func NewCmdUninstall(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) error {
+	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	// Get the controller runtime client.
 	client, err := vzHelper.GetClient(cmd)
 	if err != nil {

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package uninstall
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"io"
 	"os"
 	"regexp"
@@ -98,7 +97,6 @@ func NewCmdUninstall(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdUninstall(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper) error {
-	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	// Get the controller runtime client.
 	client, err := vzHelper.GetClient(cmd)
 	if err != nil {

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package uninstall

--- a/tools/vz/cmd/uninstall/uninstall.go
+++ b/tools/vz/cmd/uninstall/uninstall.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package uninstall

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package upgrade

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package upgrade

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -76,6 +76,7 @@ func NewCmdUpgrade(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
+	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	if err := validateCmd(cmd); err != nil {
 		return fmt.Errorf("Command validation failed: %s", err.Error())
 	}

--- a/tools/vz/cmd/upgrade/upgrade.go
+++ b/tools/vz/cmd/upgrade/upgrade.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package upgrade
@@ -76,7 +76,6 @@ func NewCmdUpgrade(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdUpgrade(cmd *cobra.Command, vzHelper helpers.VZHelper) error {
-	fmt.Fprintf(vzHelper.GetOutputStream(), version.GetVZCLIVersionMessageString())
 	if err := validateCmd(cmd); err != nil {
 		return fmt.Errorf("Command validation failed: %s", err.Error())
 	}

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -5,7 +5,6 @@ package version
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
@@ -46,7 +45,7 @@ func NewCmdVersion(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdVersion(vzHelper helpers.VZHelper) error {
-
+	fmt.Fprintf(vzHelper.GetOutputStream(), GetVZCLIVersionMessageString())
 	templateValues := map[string]string{
 		"cli_version": cliVersion,
 		"build_date":  buildDate,
@@ -73,4 +72,8 @@ func GetEffectiveDocsVersion() string {
 
 func GetCLIVersion() string {
 	return cliVersion
+}
+
+func GetVZCLIVersionMessageString() string {
+	return "This command was run with VZ CLI Version " + GetCLIVersion() + "\n"
 }

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -74,5 +74,5 @@ func GetCLIVersion() string {
 }
 
 func GetVZCLIVersionMessageString() string {
-	return "This command was run with vz CLI Version " + GetCLIVersion() + "\n"
+	return "\nThis command was run with vz CLI Version " + GetCLIVersion() + "\n"
 }

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -45,7 +45,6 @@ func NewCmdVersion(vzHelper helpers.VZHelper) *cobra.Command {
 }
 
 func runCmdVersion(vzHelper helpers.VZHelper) error {
-	fmt.Fprintf(vzHelper.GetOutputStream(), GetVZCLIVersionMessageString())
 	templateValues := map[string]string{
 		"cli_version": cliVersion,
 		"build_date":  buildDate,

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package version

--- a/tools/vz/cmd/version/version.go
+++ b/tools/vz/cmd/version/version.go
@@ -74,5 +74,5 @@ func GetCLIVersion() string {
 }
 
 func GetVZCLIVersionMessageString() string {
-	return "This command was run with VZ CLI Version " + GetCLIVersion() + "\n"
+	return "This command was run with vz CLI Version " + GetCLIVersion() + "\n"
 }

--- a/tools/vz/pkg/analysis/internal/util/report/report.go
+++ b/tools/vz/pkg/analysis/internal/util/report/report.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 // Package report handles reporting
@@ -7,6 +7,7 @@ package report
 import (
 	"errors"
 	"fmt"
+	"github.com/verrazzano/verrazzano/tools/vz/cmd/version"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
 	"go.uber.org/zap"
@@ -213,9 +214,9 @@ func GenerateHumanReport(log *zap.SugaredLogger, vzHelper helpers.VZHelper, repo
 	// printReport std outs reports to console
 	printReport := func() {
 		if reportCtx.ReportFormat == constants.DetailedReport {
-			fmt.Fprintf(vzHelper.GetOutputStream(), sepOut+writeOut)
+			fmt.Fprintf(vzHelper.GetOutputStream(), sepOut+writeOut+version.GetVZCLIVersionMessageString())
 		} else if reportCtx.ReportFormat == constants.SummaryReport {
-			fmt.Fprintf(vzHelper.GetOutputStream(), sepOut+writeSummaryOut)
+			fmt.Fprintf(vzHelper.GetOutputStream(), sepOut+writeSummaryOut+version.GetVZCLIVersionMessageString())
 		}
 	}
 
@@ -241,7 +242,7 @@ func GenerateHumanReport(log *zap.SugaredLogger, vzHelper helpers.VZHelper, repo
 			return err
 		}
 		// writes vz & k8s version, a separator and detected issues to report file
-		_, err = repFile.Write([]byte(helpers.GetVersionOut() + sepOut + writeOut))
+		_, err = repFile.Write([]byte(helpers.GetVersionOut() + sepOut + writeOut + version.GetVZCLIVersionMessageString()))
 		if reportCtx.PrintReportToConsole {
 			printReport()
 		}
@@ -263,6 +264,7 @@ func GenerateHumanReport(log *zap.SugaredLogger, vzHelper helpers.VZHelper, repo
 					writeOut += fmt.Sprintf("Verrazzano analysis CLI did not detect any issue in %s\n", source)
 				}
 			}
+			writeOut += version.GetVZCLIVersionMessageString()
 			fmt.Fprintf(vzHelper.GetOutputStream(), writeOut)
 		}
 	}

--- a/tools/vz/pkg/analysis/internal/util/report/report.go
+++ b/tools/vz/pkg/analysis/internal/util/report/report.go
@@ -258,7 +258,7 @@ func GenerateHumanReport(log *zap.SugaredLogger, vzHelper helpers.VZHelper, repo
 			if len(sourcesWithoutIssues) == 1 {
 				// This is a workaround to avoid printing the source when analyzing the live cluster, although it impacts the
 				// regular use case with a directory containing a single cluster snapshot
-				writeOut += "Verrazzano analysis CLI did not detect any issue in the cluster\n"
+				writeOut += version.GetVZCLIVersionMessageString()
 			} else {
 				for _, source := range sourcesWithoutIssues {
 					writeOut += fmt.Sprintf("Verrazzano analysis CLI did not detect any issue in %s\n", source)


### PR DESCRIPTION
This commit adds the CLI version as first output to all of the commands in the cmd folder, except for the version command.
