### PR TITLE
VZ-11614: Update ArgoCD image, built with Go 1.20.12

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -142,7 +142,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/rancher-backup-override-static-values.yaml
   - name: argocd
-    version: 2.8.3-1
+    version: 2.8.3-2
     chart: platform-operator/thirdparty/charts/argo-cd
     valuesFiles:
       - platform-operator/helm_config/overrides/argocd-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -964,8 +964,8 @@
           "name": "argocd",
           "images": [
             {
-              "image": "argocd-jenkins",
-              "tag": "v2.8.3-20240109135649-eb571521",
+              "image": "argocd",
+              "tag": "v2.8.3-20240110063556-01439f10",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -957,15 +957,15 @@
     },
     {
       "name": "argocd",
-      "version": "2.8.3-1",
+      "version": "2.8.3-2",
       "subcomponents": [
         {
           "repository": "verrazzano",
           "name": "argocd",
           "images": [
             {
-              "image": "argocd",
-              "tag": "v2.8.3-20231206060849-c0637ae9",
+              "image": "argocd-jenkins",
+              "tag": "v2.8.3-20240109135649-eb571521",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updates ArgoCD v2.8.3 image, built with Go 1.20.12