### PR TITLE
VZ-11614: Update NGINX and ArgoCD images built with Go 1.20.12 in release-1.7

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -3,7 +3,7 @@
 
 modules:
   - name: ingress-controller
-    version: 1.7.1-2
+    version: 1.7.1-3
     chart: platform-operator/thirdparty/charts/ingress-nginx
     valuesFiles:
       - platform-operator/helm_config/overrides/ingress-nginx-values.yaml
@@ -101,7 +101,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/keycloak-values.yaml
   - name: prometheus-operator
-    version: 0.64.1-5
+    version: 0.64.1-6
     chart: platform-operator/thirdparty/charts/prometheus-community/kube-prometheus-stack
     valuesFiles:
       - platform-operator/helm_config/overrides/prometheus-operator-values.yaml
@@ -142,7 +142,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/rancher-backup-override-static-values.yaml
   - name: argocd
-    version: 2.8.3-1
+    version: 2.8.3-2
     chart: platform-operator/thirdparty/charts/argo-cd
     valuesFiles:
       - platform-operator/helm_config/overrides/argocd-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "ingress-controller",
-      "version": "1.7.1-2",
+      "version": "1.7.1-3",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -28,13 +28,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20231117052956-63316f57d",
+              "tag": "v1.7.1-20240109112845-33c273be0",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "v1.7.1-20231117052956-63316f57d",
+              "tag": "v1.7.1-20240109112845-33c273be0",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -283,7 +283,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20231117052956-63316f57d",
+              "tag": "v1.7.1-20240109112845-33c273be0",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
@@ -373,7 +373,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.7.1-20231117052956-63316f57d",
+              "tag": "v1.7.1-20240109112845-33c273be0",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]
@@ -653,7 +653,7 @@
     },
     {
       "name": "prometheus-operator",
-      "version": "0.64.1-5",
+      "version": "0.64.1-6",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -668,7 +668,7 @@
             },
             {
               "image": "kube-webhook-certgen",
-              "tag": "v1.7.1-20231117052956-63316f57d",
+              "tag": "v1.7.1-20240109112845-33c273be0",
               "helmRegKey": "prometheusOperator.admissionWebhooks.patch.image.registry",
               "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
               "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"
@@ -945,7 +945,7 @@
     },
     {
       "name": "argocd",
-      "version": "2.8.3-1",
+      "version": "2.8.3-2",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -953,7 +953,7 @@
           "images": [
             {
               "image": "argocd",
-              "tag": "v2.8.3-20231206060849-c0637ae9",
+              "tag": "v2.8.3-20240110063556-01439f10",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updates NGINX v1.7.1 and ArgoCD images, built with Go 1.20.12 in release-1.7
