### PR TITLE
VZ-11614: Update NGINX and ArgoCD images built with Go 1.20.12, in release-1.5

### DIFF
--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -28,13 +28,13 @@
           "images": [
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20231117052541-9e99d0c4b",
+              "tag": "v1.3.1-20240110065333-0df494800",
               "helmFullImageKey": "controller.image.repository",
               "helmTagKey": "controller.image.tag"
             },
             {
               "image": "nginx-ingress-default-backend",
-              "tag": "v1.3.1-20231117052541-9e99d0c4b",
+              "tag": "v1.3.1-20240110065333-0df494800",
               "helmFullImageKey": "defaultBackend.image.repository",
               "helmTagKey": "defaultBackend.image.tag"
             }
@@ -199,7 +199,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20231117052541-9e99d0c4b",
+              "tag": "v1.3.1-20240110065333-0df494800",
               "helmFullImageKey": "api.imageName",
               "helmTagKey": "api.imageVersion"
             },
@@ -254,7 +254,7 @@
             },
             {
               "image": "nginx-ingress-controller",
-              "tag": "v1.3.1-20231117052541-9e99d0c4b",
+              "tag": "v1.3.1-20240110065333-0df494800",
               "helmFullImageKey": "monitoringOperator.oidcProxyImage"
             }
           ]
@@ -483,7 +483,7 @@
             },
             {
               "image": "kube-webhook-certgen",
-              "tag": "v1.3.1-20231117052541-9e99d0c4b",
+              "tag": "v1.3.1-20240110065333-0df494800",
               "helmFullImageKey": "prometheusOperator.admissionWebhooks.patch.image.repository",
               "helmTagKey": "prometheusOperator.admissionWebhooks.patch.image.tag"
             }
@@ -758,7 +758,7 @@
           "images": [
             {
               "image": "argocd",
-              "tag": "v2.7.2-20231207123510-b47fb278",
+              "tag": "v2.7.2-20240110145351-e6d8ee06",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updates NGINX v1.3.1 and ArgoCD images built with Go 1.20.12, in release-1.5
