### PR TITLE
VZ-11656: Analysis tool - ensure all redacted values have a unique hash

### DIFF
--- a/tools/vz/pkg/helpers/vzsanitize.go
+++ b/tools/vz/pkg/helpers/vzsanitize.go
@@ -41,9 +41,14 @@ func SanitizeString(l string) string {
 	}
 	knownHostNamesMutex.Unlock()
 	for _, eachRegex := range regexToReplacementList {
-		l = regexp.MustCompile(eachRegex).ReplaceAllString(l, getSha256Hash(l))
+		l = regexp.MustCompile(eachRegex).ReplaceAllStringFunc(l, redact)
 	}
 	return l
+}
+
+// redact outputs a string, representing a piece of redacted text
+func redact(s string) string {
+	return "REDACTED-" + getSha256Hash(s)
 }
 
 // getSha256Hash generates the one way hash for the input string

--- a/tools/vz/pkg/helpers/vzsanitize.go
+++ b/tools/vz/pkg/helpers/vzsanitize.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helpers


### PR DESCRIPTION
There was a analysis tool bug where every redacted value within a single file would be assigned the same hash value. This fixes that bug.

Also adds a "REDACTED-" prefix to every redacted value.