### PR TITLE
VZ-11614: Update Dex image built using Go 1.20.12

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -18,7 +18,7 @@ modules:
   - name: cluster-issuer
     version: VERRAZZANO_VERSION
   - name: dex
-    version: 2.37.0-2
+    version: 2.37.0-3
     chart: platform-operator/thirdparty/charts/dex
     valuesFiles:
       - platform-operator/helm_config/overrides/dex-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -1013,8 +1013,8 @@
           "name": "dex",
           "images": [
             {
-              "image": "dex-jenkins",
-              "tag": "20240111060937-adb513d2",
+              "image": "dex",
+              "tag": "v2.37.0-20240111092116-096a4329",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -1006,15 +1006,15 @@
     },
     {
       "name": "dex",
-      "version": "2.37.0-2",
+      "version": "2.37.0-3",
       "subcomponents": [
         {
           "repository": "verrazzano",
           "name": "dex",
           "images": [
             {
-              "image": "dex",
-              "tag": "v2.37.0-20231205102912-49e7dd3e",
+              "image": "dex-jenkins",
+              "tag": "20240111060937-adb513d2",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updates Dex image built using Go 1.20.12