### PR TITLE
VZ-11614: Update Dex image built using Go 1.20.12, in release-1.7

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -18,7 +18,7 @@ modules:
   - name: cluster-issuer
     version: VERRAZZANO_VERSION
   - name: dex
-    version: 2.37.0-1
+    version: 2.37.0-2
     chart: platform-operator/thirdparty/charts/dex
     valuesFiles:
       - platform-operator/helm_config/overrides/dex-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -994,7 +994,7 @@
     },
     {
       "name": "dex",
-      "version": "2.37.0-1",
+      "version": "2.37.0-2",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -1002,7 +1002,7 @@
           "images": [
             {
               "image": "dex",
-              "tag": "v2.37.0-20231205102912-49e7dd3e",
+              "tag": "v2.37.0-20240111092116-096a4329",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Updates Dex image built using Go 1.20.12, in release-1.7