### PR TITLE
Tvlatas/dump tweaks

### DIFF
--- a/tools/scripts/k8s-dump-cluster.sh
+++ b/tools/scripts/k8s-dump-cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2021, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)


### PR DESCRIPTION
This adds the ability to limit the capture to a single namespace rather than a full cluster dump.

This can be useful at times if we need to have someone gather more information than what the vz capture/bug-report provides, but we only need the details from a specific namespace. 

 -n single-namespace 
