### PR TITLE
Workaround to resolve issue with daily scan job for release branches

### DIFF
--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     triggers { cron("@daily") }
 
     environment {
-        CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
+        CLEAN_BRANCH_NAME = "release-1.7"
 
         OCI_CLI_TENANCY = credentials('oci-dev-tenancy')
         OCI_CLI_USER = credentials('oci-dev-user-ocid')

--- a/ci/scan-results/Jenkinsfile
+++ b/ci/scan-results/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     triggers { cron("@daily") }
 
     environment {
-        CLEAN_BRANCH_NAME = "release-1.7"
+        CLEAN_BRANCH_NAME = "${env.BRANCH_NAME.replace("/", "%2F")}"
 
         OCI_CLI_TENANCY = credentials('oci-dev-tenancy')
         OCI_CLI_USER = credentials('oci-dev-user-ocid')

--- a/ci/scripts/get_branch_scan_results.sh
+++ b/ci/scripts/get_branch_scan_results.sh
@@ -208,6 +208,7 @@ if [[ "${CLEAN_BRANCH_NAME}" == release-* ]]; then
     GIT_COMMIT=$(git rev-list -n 1 ${VERSION})
     echo "Fetching BOM for ${VERSION}"
 
+    ls -ltr ${BOM_DIR}
     export SCAN_BOM_FILE=${BOM_DIR}/${VERSION}-bom.json
     get_bom_from_release ${VERSION} ${SCAN_BOM_FILE}
 
@@ -215,11 +216,12 @@ if [[ "${CLEAN_BRANCH_NAME}" == release-* ]]; then
     mkdir -p ${SCAN_RESULTS_DIR}
 
     echo "Fetching scan results for BOM: ${SCAN_BOM_FILE}"
-    ${RELEASE_SCRIPT_DIR}/scan_bom_images.sh  -b ${SCAN_BOM_FILE} -o ${SCAN_RESULTS_DIR} -r ${OCIR_SCAN_REGISTRY} -x ${OCIR_REPOSITORY_BASE}
-    ${RELEASE_SCRIPT_DIR}/get_ocir_scan_results.sh ${SCAN_BOM_FILE}
-    ${RELEASE_SCRIPT_DIR}/generate_vulnerability_report.sh ${SCAN_RESULTS_DIR} ${GIT_COMMIT} ${CLEAN_BRANCH_NAME} ${VERSION} ${SCAN_DATETIME} ${BUILD_NUMBER}
-    ${RELEASE_SCRIPT_DIR}/generate_upload_file.sh ${SCAN_RESULTS_DIR}/consolidated.csv "${VERSION}" > ${SCAN_RESULTS_DIR}/consolidated-upload.json
-    publish_results ${VERSION} ${SCAN_BOM_FILE} ${SCAN_RESULTS_DIR}
+
+    #${RELEASE_SCRIPT_DIR}/scan_bom_images.sh  -b ${SCAN_BOM_FILE} -o ${SCAN_RESULTS_DIR} -r ${OCIR_SCAN_REGISTRY} -x ${OCIR_REPOSITORY_BASE}
+    #${RELEASE_SCRIPT_DIR}/get_ocir_scan_results.sh ${SCAN_BOM_FILE}
+    #${RELEASE_SCRIPT_DIR}/generate_vulnerability_report.sh ${SCAN_RESULTS_DIR} ${GIT_COMMIT} ${CLEAN_BRANCH_NAME} ${VERSION} ${SCAN_DATETIME} ${BUILD_NUMBER}
+    #${RELEASE_SCRIPT_DIR}/generate_upload_file.sh ${SCAN_RESULTS_DIR}/consolidated.csv "${VERSION}" > ${SCAN_RESULTS_DIR}/consolidated-upload.json
+    #publish_results ${VERSION} ${SCAN_BOM_FILE} ${SCAN_RESULTS_DIR}
   else
     echo "There are no released versions for v${MAJOR_MINOR_VERSION} yet"
   fi

--- a/ci/scripts/get_branch_scan_results.sh
+++ b/ci/scripts/get_branch_scan_results.sh
@@ -207,6 +207,7 @@ if [[ "${CLEAN_BRANCH_NAME}" == release-* ]]; then
 
     GIT_COMMIT=$(git rev-list -n 1 ${VERSION})
     echo "Fetching BOM for ${VERSION}"
+
     export SCAN_BOM_FILE=${BOM_DIR}/${VERSION}-bom.json
     get_bom_from_release ${VERSION} ${SCAN_BOM_FILE}
 
@@ -214,8 +215,8 @@ if [[ "${CLEAN_BRANCH_NAME}" == release-* ]]; then
     mkdir -p ${SCAN_RESULTS_DIR}
 
     echo "Fetching scan results for BOM: ${SCAN_BOM_FILE}"
-    ${RELEASE_SCRIPT_DIR}/scan_bom_images.sh  -b ${SCAN_BOM_FILE} -o ${SCAN_RESULTS_DIR} -r ${OCIR_SCAN_REGISTRY} -x ${OCIR_REPOSITORY_BASE} || exit 1
-    ${RELEASE_SCRIPT_DIR}/get_ocir_scan_results.sh ${SCAN_BOM_FILE} || exit 1
+    ${RELEASE_SCRIPT_DIR}/scan_bom_images.sh  -b ${SCAN_BOM_FILE} -o ${SCAN_RESULTS_DIR} -r ${OCIR_SCAN_REGISTRY} -x ${OCIR_REPOSITORY_BASE}
+    ${RELEASE_SCRIPT_DIR}/get_ocir_scan_results.sh ${SCAN_BOM_FILE}
     ${RELEASE_SCRIPT_DIR}/generate_vulnerability_report.sh ${SCAN_RESULTS_DIR} ${GIT_COMMIT} ${CLEAN_BRANCH_NAME} ${VERSION} ${SCAN_DATETIME} ${BUILD_NUMBER}
     ${RELEASE_SCRIPT_DIR}/generate_upload_file.sh ${SCAN_RESULTS_DIR}/consolidated.csv "${VERSION}" > ${SCAN_RESULTS_DIR}/consolidated-upload.json
     publish_results ${VERSION} ${SCAN_BOM_FILE} ${SCAN_RESULTS_DIR}

--- a/ci/scripts/get_branch_scan_results.sh
+++ b/ci/scripts/get_branch_scan_results.sh
@@ -208,20 +208,21 @@ if [[ "${CLEAN_BRANCH_NAME}" == release-* ]]; then
     GIT_COMMIT=$(git rev-list -n 1 ${VERSION})
     echo "Fetching BOM for ${VERSION}"
 
-    ls -ltr ${BOM_DIR}
     export SCAN_BOM_FILE=${BOM_DIR}/${VERSION}-bom.json
     get_bom_from_release ${VERSION} ${SCAN_BOM_FILE}
+
+    ls -ltr ${BOM_DIR}
 
     export SCAN_RESULTS_DIR=${SCAN_RESULTS_BASE_DIR}/${VERSION}
     mkdir -p ${SCAN_RESULTS_DIR}
 
     echo "Fetching scan results for BOM: ${SCAN_BOM_FILE}"
 
-    #${RELEASE_SCRIPT_DIR}/scan_bom_images.sh  -b ${SCAN_BOM_FILE} -o ${SCAN_RESULTS_DIR} -r ${OCIR_SCAN_REGISTRY} -x ${OCIR_REPOSITORY_BASE}
-    #${RELEASE_SCRIPT_DIR}/get_ocir_scan_results.sh ${SCAN_BOM_FILE}
-    #${RELEASE_SCRIPT_DIR}/generate_vulnerability_report.sh ${SCAN_RESULTS_DIR} ${GIT_COMMIT} ${CLEAN_BRANCH_NAME} ${VERSION} ${SCAN_DATETIME} ${BUILD_NUMBER}
-    #${RELEASE_SCRIPT_DIR}/generate_upload_file.sh ${SCAN_RESULTS_DIR}/consolidated.csv "${VERSION}" > ${SCAN_RESULTS_DIR}/consolidated-upload.json
-    #publish_results ${VERSION} ${SCAN_BOM_FILE} ${SCAN_RESULTS_DIR}
+    ${RELEASE_SCRIPT_DIR}/scan_bom_images.sh  -b ${SCAN_BOM_FILE} -o ${SCAN_RESULTS_DIR} -r ${OCIR_SCAN_REGISTRY} -x ${OCIR_REPOSITORY_BASE}
+    ${RELEASE_SCRIPT_DIR}/get_ocir_scan_results.sh ${SCAN_BOM_FILE}
+    ${RELEASE_SCRIPT_DIR}/generate_vulnerability_report.sh ${SCAN_RESULTS_DIR} ${GIT_COMMIT} ${CLEAN_BRANCH_NAME} ${VERSION} ${SCAN_DATETIME} ${BUILD_NUMBER}
+    ${RELEASE_SCRIPT_DIR}/generate_upload_file.sh ${SCAN_RESULTS_DIR}/consolidated.csv "${VERSION}" > ${SCAN_RESULTS_DIR}/consolidated-upload.json
+    publish_results ${VERSION} ${SCAN_BOM_FILE} ${SCAN_RESULTS_DIR}
   else
     echo "There are no released versions for v${MAJOR_MINOR_VERSION} yet"
   fi

--- a/ci/scripts/get_branch_scan_results.sh
+++ b/ci/scripts/get_branch_scan_results.sh
@@ -207,17 +207,12 @@ if [[ "${CLEAN_BRANCH_NAME}" == release-* ]]; then
 
     GIT_COMMIT=$(git rev-list -n 1 ${VERSION})
     echo "Fetching BOM for ${VERSION}"
-
     export SCAN_BOM_FILE=${BOM_DIR}/${VERSION}-bom.json
     get_bom_from_release ${VERSION} ${SCAN_BOM_FILE}
-
-    ls -ltr ${BOM_DIR}
-
     export SCAN_RESULTS_DIR=${SCAN_RESULTS_BASE_DIR}/${VERSION}
     mkdir -p ${SCAN_RESULTS_DIR}
 
     echo "Fetching scan results for BOM: ${SCAN_BOM_FILE}"
-
     ${RELEASE_SCRIPT_DIR}/scan_bom_images.sh  -b ${SCAN_BOM_FILE} -o ${SCAN_RESULTS_DIR} -r ${OCIR_SCAN_REGISTRY} -x ${OCIR_REPOSITORY_BASE}
     ${RELEASE_SCRIPT_DIR}/get_ocir_scan_results.sh ${SCAN_BOM_FILE}
     ${RELEASE_SCRIPT_DIR}/generate_vulnerability_report.sh ${SCAN_RESULTS_DIR} ${GIT_COMMIT} ${CLEAN_BRANCH_NAME} ${VERSION} ${SCAN_DATETIME} ${BUILD_NUMBER}


### PR DESCRIPTION
There is some issue with the logic which attempts to scan matching releases for a given release branch. This change allows the build to succeed when the job fails to download the BOM file for all the releases, as as workaround for now.