### PR TITLE
vz-11649 Have --include-logs flag grab pod logs without needing --include-namespaces

### DIFF
--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -33,6 +33,9 @@ When --report-file is not provided, the command creates bug-report.tar.gz in the
 # Create a bug report file, bugreport.tar.gz, including the additional namespace ns1 from the cluster:
 vz bug-report --report-file bugreport.tgz --include-namespaces ns1
 
+# Use the --include-logs flag to collect logs from Verrazzano that are already being captured
+vz bug-report --report-file bugreport.tgz --include-logs
+
 # The flag --include-namespaces accepts comma-separated values and can be specified multiple times. For example, the following commands create a bug report by including additional namespaces ns1, ns2, and ns3:
    a. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2,ns3
    b. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-namespaces ns3

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -33,7 +33,7 @@ When --report-file is not provided, the command creates bug-report.tar.gz in the
 # Create a bug report file, bugreport.tar.gz, including the additional namespace ns1 from the cluster:
 vz bug-report --report-file bugreport.tgz --include-namespaces ns1
 
-# Use the --include-logs flag to collect logs from Verrazzano that are already being captured
+# Use the --include-logs flag to collect logs from Verrazzano namespaces that are already being captured
 vz bug-report --report-file bugreport.tgz --include-logs
 
 # The flag --include-namespaces accepts comma-separated values and can be specified multiple times. For example, the following commands create a bug report by including additional namespaces ns1, ns2, and ns3:

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -36,7 +36,7 @@ vz bug-report --report-file bugreport.tgz --include-namespaces ns1
 # Use the --include-logs flag to capture logs from all the containers in running pods, from the default namespaces being captured
 vz bug-report --report-file bugreport.tgz --include-logs
 
-# Use the --include-logs flag in combination with the --include-namespaces flag to extend the namespaces being captured and capture additional logs from all containers in running pods of the namespaces being captured
+# Use the --include-logs flag in combination with the --include-namespaces flag to extend the default namespaces being captured and capture additional logs from all containers in running pods of the specified namespaces being captured
 vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-logs
 
 # The flag --include-namespaces accepts comma-separated values and can be specified multiple times. For example, the following commands create a bug report by including additional namespaces ns1, ns2, and ns3:

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -33,8 +33,11 @@ When --report-file is not provided, the command creates bug-report.tar.gz in the
 # Create a bug report file, bugreport.tar.gz, including the additional namespace ns1 from the cluster:
 vz bug-report --report-file bugreport.tgz --include-namespaces ns1
 
-# Use the --include-logs flag to collect logs from Verrazzano namespaces that are already being captured
+# Use the --include-logs flag to capture logs from all the containers in running pods, from the default namespaces being captured
 vz bug-report --report-file bugreport.tgz --include-logs
+
+# Use the --include-logs flag in combination with the --include-namespaces flag to extend the namespaces being captured and capture additional logs from all containers in running pods of the namespaces being captured
+vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-logs
 
 # The flag --include-namespaces accepts comma-separated values and can be specified multiple times. For example, the following commands create a bug report by including additional namespaces ns1, ns2, and ns3:
    a. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2,ns3

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package bugreport

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -595,7 +595,7 @@ func TestBugReportSuccessWithDuration(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestBugReportLogsFromAllNamespaces
+// TestBugReportLogsFromVzManagedNamespaces
 // GIVEN a CLI bug-report command
 // WHEN I call cmd.Execute with include logs, I should get the logs of all resources across all namespaces
 // THEN expect the command to show the resources captured in the standard output and create the bug report file

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -378,7 +378,7 @@ func validateCmd(cmd *cobra.Command, client clipkg.Client) error {
 	return nil
 }
 
-// validateCR - validates a Custom Resource before proceeding with an install
+// ValidateCR  - validates a Custom Resource before proceeding with an install
 func ValidateCR(cmd *cobra.Command, obj *unstructured.Unstructured, vzHelper helpers.VZHelper) []error {
 	discoveryClient, err := vzHelper.GetDiscoveryClient(cmd)
 	if err != nil {

--- a/tools/vz/pkg/bugreport/reportgen.go
+++ b/tools/vz/pkg/bugreport/reportgen.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package bugreport

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -210,7 +210,7 @@ const (
 	// Flag for capture pods logs( both additional and system namespaces)
 	BugReportLogFlagName         = "include-logs"
 	BugReportLogFlagNameShort    = "l"
-	BugReportLogFlagNameUsage    = "Include logs from the pods in one or more namespaces; this is specified along with the --include-namespaces flag."
+	BugReportLogFlagNameUsage    = "Include logs from pods of the namespaces being captured."
 	BugReportTimeFlagName        = "duration"
 	BugReportTimeFlagNameShort   = "d"
 	BugReportTimeFlagDefaultTime = 0

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -210,7 +210,7 @@ const (
 	// Flag for capture pods logs( both additional and system namespaces)
 	BugReportLogFlagName         = "include-logs"
 	BugReportLogFlagNameShort    = "l"
-	BugReportLogFlagNameUsage    = "Include logs from pods of the namespaces being captured."
+	BugReportLogFlagNameUsage    = "Include logs from all containers in running pods of the namespaces being captured."
 	BugReportTimeFlagName        = "duration"
 	BugReportTimeFlagNameShort   = "d"
 	BugReportTimeFlagDefaultTime = 0


### PR DESCRIPTION
Changes grab pod logs as expected with --include-logs flag without the need of explicitly using --include-namespaces for individual namespaces