### PR TITLE
vz-11649 --include-logs flag grab pod logs without needing --include-namespaces 

### DIFF
--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -45,7 +45,10 @@ vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include
 
 The values specified for the flag --include-namespaces are case-sensitive.
 
-# Use the --include-logs flag to collect the logs from the pods in one or more namespaces, by specifying the --include-namespaces flag.
+# Use the --include-logs flag to capture logs from all the containers in running pods, from the default namespaces being captured
+vz bug-report --report-file bugreport.tgz --include-logs
+
+# Use the --include-logs flag in combination with the --include-namespaces flag to extend the default namespaces being captured and capture additional logs from all containers in running pods of the specified namespaces being captured
 vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-logs
 
 # The flag --duration collects logs for a specific period. The default value is 0, which collects the complete pod log. It supports seconds, minutes, and hours.

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -33,6 +33,9 @@ When --report-file is not provided, the command creates bug-report.tar.gz in the
 # Create a bug report file, bugreport.tar.gz, including the additional namespace ns1 from the cluster:
 vz bug-report --report-file bugreport.tgz --include-namespaces ns1
 
+# Use the --include-logs flag to collect logs from Verrazzano that are already being captured
+vz bug-report --report-file bugreport.tgz --include-logs
+
 # The flag --include-namespaces accepts comma-separated values and can be specified multiple times. For example, the following commands create a bug report by including additional namespaces ns1, ns2, and ns3:
    a. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2,ns3
    b. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-namespaces ns3

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -33,7 +33,7 @@ When --report-file is not provided, the command creates bug-report.tar.gz in the
 # Create a bug report file, bugreport.tar.gz, including the additional namespace ns1 from the cluster:
 vz bug-report --report-file bugreport.tgz --include-namespaces ns1
 
-# Use the --include-logs flag to collect logs from Verrazzano that are already being captured
+# Use the --include-logs flag to collect logs from Verrazzano namespaces that are already being captured
 vz bug-report --report-file bugreport.tgz --include-logs
 
 # The flag --include-namespaces accepts comma-separated values and can be specified multiple times. For example, the following commands create a bug report by including additional namespaces ns1, ns2, and ns3:

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -33,12 +33,6 @@ When --report-file is not provided, the command creates bug-report.tar.gz in the
 # Create a bug report file, bugreport.tar.gz, including the additional namespace ns1 from the cluster:
 vz bug-report --report-file bugreport.tgz --include-namespaces ns1
 
-# Use the --include-logs flag to capture logs from all the containers in running pods, from the default namespaces being captured
-vz bug-report --report-file bugreport.tgz --include-logs
-
-# Use the --include-logs flag in combination with the --include-namespaces flag to extend the default namespaces being captured and capture additional logs from all containers in running pods of the specified namespaces being captured
-vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-logs
-
 # The flag --include-namespaces accepts comma-separated values and can be specified multiple times. For example, the following commands create a bug report by including additional namespaces ns1, ns2, and ns3:
    a. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2,ns3
    b. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-namespaces ns3

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -36,7 +36,7 @@ vz bug-report --report-file bugreport.tgz --include-namespaces ns1
 # Use the --include-logs flag to capture logs from all the containers in running pods, from the default namespaces being captured
 vz bug-report --report-file bugreport.tgz --include-logs
 
-# Use the --include-logs flag in combination with the --include-namespaces flag to extend the namespaces being captured and capture additional logs from all containers in running pods of the namespaces being captured
+# Use the --include-logs flag in combination with the --include-namespaces flag to extend the default namespaces being captured and capture additional logs from all containers in running pods of the specified namespaces being captured
 vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-logs
 
 # The flag --include-namespaces accepts comma-separated values and can be specified multiple times. For example, the following commands create a bug report by including additional namespaces ns1, ns2, and ns3:

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -33,8 +33,11 @@ When --report-file is not provided, the command creates bug-report.tar.gz in the
 # Create a bug report file, bugreport.tar.gz, including the additional namespace ns1 from the cluster:
 vz bug-report --report-file bugreport.tgz --include-namespaces ns1
 
-# Use the --include-logs flag to collect logs from Verrazzano namespaces that are already being captured
+# Use the --include-logs flag to capture logs from all the containers in running pods, from the default namespaces being captured
 vz bug-report --report-file bugreport.tgz --include-logs
+
+# Use the --include-logs flag in combination with the --include-namespaces flag to extend the namespaces being captured and capture additional logs from all containers in running pods of the namespaces being captured
+vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2 --include-logs
 
 # The flag --include-namespaces accepts comma-separated values and can be specified multiple times. For example, the following commands create a bug report by including additional namespaces ns1, ns2, and ns3:
    a. vz bug-report --report-file bugreport.tgz --include-namespaces ns1,ns2,ns3

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package bugreport

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -6,6 +6,9 @@ package bugreport
 import (
 	"context"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
@@ -19,10 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	dynfake "k8s.io/client-go/dynamic/fake"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 const (
@@ -62,7 +63,7 @@ func TestBugReportHelp(t *testing.T) {
 // WHEN I call cmd.Execute for bug-report
 // THEN expect an error
 func TestBugReportExistingReportFile(t *testing.T) {
-	cmd := setUpAndVerifyResources(t, make([]string, 0))
+	cmd := setUpAndVerifyResources(t)
 
 	tmpDir, _ := os.MkdirTemp("", "bug-report")
 	defer cleanupTempDir(t, tmpDir)
@@ -88,7 +89,7 @@ func TestBugReportExistingReportFile(t *testing.T) {
 // WHEN I call cmd.Execute for bug-report
 // THEN expect an error
 func TestBugReportExistingDir(t *testing.T) {
-	cmd := setUpAndVerifyResources(t, make([]string, 0))
+	cmd := setUpAndVerifyResources(t)
 
 	tmpDir, _ := os.MkdirTemp("", "bug-report")
 	defer cleanupTempDir(t, tmpDir)
@@ -111,7 +112,7 @@ func TestBugReportExistingDir(t *testing.T) {
 // WHEN I call cmd.Execute for bug-report
 // THEN expect an error
 func TestBugReportNonExistingFileDir(t *testing.T) {
-	cmd := setUpAndVerifyResources(t, make([]string, 0))
+	cmd := setUpAndVerifyResources(t)
 
 	tmpDir, _ := os.MkdirTemp("", "bug-report")
 	defer cleanupTempDir(t, tmpDir)
@@ -132,7 +133,7 @@ func TestBugReportNonExistingFileDir(t *testing.T) {
 // WHEN I call cmd.Execute for bug-report
 // THEN expect an error
 func TestBugReportFileNoPermission(t *testing.T) {
-	cmd := setUpAndVerifyResources(t, make([]string, 0))
+	cmd := setUpAndVerifyResources(t)
 
 	tmpDir, _ := os.MkdirTemp("", "bug-report")
 	defer cleanupTempDir(t, tmpDir)
@@ -156,7 +157,7 @@ func TestBugReportFileNoPermission(t *testing.T) {
 // WHEN I call cmd.Execute
 // THEN expect the command to show the resources captured in the standard output and create the bug report file
 func TestBugReportSuccess(t *testing.T) {
-	cmd := setUpAndVerifyResources(t, make([]string, 0))
+	cmd := setUpAndVerifyResources(t)
 
 	tmpDir, _ := os.MkdirTemp("", "bug-report")
 	defer cleanupTempDir(t, tmpDir)
@@ -359,106 +360,6 @@ func getClientWithWatch() client.WithWatch {
 func getClientWithVZWatch() client.WithWatch {
 	return fake.NewClientBuilder().WithScheme(pkghelper.NewScheme()).WithObjects(getVpoObjects()...).Build()
 }
-func getClientWithVZEnabledComponents() client.WithWatch {
-	return fake.NewClientBuilder().WithScheme(pkghelper.NewScheme()).WithObjects(getVpoWithEnabledComps()...).Build()
-}
-
-func getVpoWithEnabledComps() []client.Object {
-	return []client.Object{
-		&v1beta1.Verrazzano{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "verrazzano",
-			},
-			Spec: v1beta1.VerrazzanoSpec{
-				Profile: v1beta1.Dev,
-			},
-			Status: v1beta1.VerrazzanoStatus{
-				Components: v1beta1.ComponentStatusMap{
-					vzconstants.CertManager: &v1beta1.ComponentStatusDetails{
-						Name:  vzconstants.CertManager,
-						State: v1beta1.CompStateReady,
-					},
-					vzconstants.Grafana: &v1beta1.ComponentStatusDetails{
-						Name:  vzconstants.Grafana,
-						State: v1beta1.CompStateReady,
-					},
-					vzconstants.Istio: &v1beta1.ComponentStatusDetails{
-						Name:  vzconstants.Istio,
-						State: v1beta1.CompStateReady,
-					},
-				},
-			},
-		},
-		&corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: vzconstants.VerrazzanoInstallNamespace,
-				Name:      constants.VerrazzanoPlatformOperator,
-				Labels: map[string]string{
-					"app":               constants.VerrazzanoPlatformOperator,
-					"pod-template-hash": "45f78ffddd",
-				},
-			},
-		},
-		&corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: vzconstants.IstioSystemNamespace,
-				Name:      vzconstants.Istio,
-				Labels: map[string]string{
-					"app":                                 vzconstants.Istio,
-					vzconstants.VerrazzanoManagedLabelKey: "true",
-				},
-			},
-			Spec: corev1.PodSpec{},
-		},
-		&corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: vzconstants.VerrazzanoSystemNamespace,
-				Name:      vzconstants.Grafana,
-				Labels: map[string]string{
-					"app":                                 vzconstants.Grafana,
-					vzconstants.VerrazzanoManagedLabelKey: "true",
-				},
-			},
-			Spec: corev1.PodSpec{},
-		},
-		&corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: vzconstants.VerrazzanoSystemNamespace,
-				Name:      vzconstants.CertManager,
-				Labels: map[string]string{
-					"app":                                 vzconstants.CertManager,
-					vzconstants.VerrazzanoManagedLabelKey: "true",
-				},
-			},
-			Spec: corev1.PodSpec{},
-		},
-		&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: vzconstants.VerrazzanoInstallNamespace,
-				Name:      constants.VerrazzanoPlatformOperator,
-			},
-			Spec: appsv1.DeploymentSpec{
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app": constants.VerrazzanoPlatformOperator},
-				},
-			},
-			Status: appsv1.DeploymentStatus{
-				AvailableReplicas: 1,
-				UpdatedReplicas:   1,
-			},
-		},
-		&appsv1.ReplicaSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: vzconstants.VerrazzanoInstallNamespace,
-				Name:      fmt.Sprintf("%s-45f78ffddd", constants.VerrazzanoPlatformOperator),
-				Annotations: map[string]string{
-					"deployment.kubernetes.io/revision": "1",
-				},
-			},
-		},
-	}
-}
 
 func getVpoObjects() []client.Object {
 	return []client.Object{
@@ -567,7 +468,7 @@ func createStdTempFiles(t *testing.T) (*os.File, *os.File) {
 // WHEN I call cmd.Execute with include logs of  additional namespace and duration
 // THEN expect the command to show the resources captured in the standard output and create the bug report file
 func TestBugReportSuccessWithDuration(t *testing.T) {
-	cmd := setUpAndVerifyResources(t, make([]string, 0))
+	cmd := setUpAndVerifyResources(t)
 
 	tmpDir, _ := os.MkdirTemp("", "bug-report")
 	defer cleanupTempDir(t, tmpDir)
@@ -595,66 +496,14 @@ func TestBugReportSuccessWithDuration(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestBugReportLogsFromVzManagedNamespaces
-// GIVEN a CLI bug-report command
-// WHEN I call cmd.Execute with include logs, I should get the logs of all resources across all namespaces
-// THEN expect the command to show the resources captured in the standard output and create the bug report file
-func TestBugReportLogsFromVzManagedNamespaces(t *testing.T) {
-	tests := []struct {
-		name              string
-		logsFlag          bool
-		namespaceFlag     bool
-		enabledComponents []string
-		success           bool
-	}{
-		{"VZ bug-report, --include-logs=true", true, false, []string{"cert-manager", "istio", "grafana"}, true},
-		{"VZ bug-report --include-logs=false, default bug-report", false, false, []string{"cert-manager", "istio", "grafana"}, true},
-		{"VZ bug-report --include-logs=true, --include-namespace=true", true, true, []string{"cert-manager", "istio", "grafana"}, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cmd := setUpAndVerifyResources(t, tt.enabledComponents)
-
-			tmpDir, _ := os.MkdirTemp("", "bug-report")
-			defer cleanupTempDir(t, tmpDir)
-
-			bugRepFile := tmpDir + string(os.PathSeparator) + "bug-report.tgz"
-			setUpGlobalFlags(cmd)
-			err := cmd.PersistentFlags().Set(constants.BugReportFileFlagName, bugRepFile)
-			assert.NoError(t, err)
-
-			if tt.logsFlag {
-				err := cmd.PersistentFlags().Set(constants.BugReportLogFlagName, "true")
-				assert.NoError(t, err)
-			}
-			if tt.namespaceFlag {
-				err := cmd.PersistentFlags().Set(constants.BugReportIncludeNSFlagName, "dummy,verrazzano-install,default")
-				assert.NoError(t, err)
-			}
-
-			err = cmd.PersistentFlags().Set(constants.VerboseFlag, "true")
-			assert.NoError(t, err)
-			err = cmd.Execute()
-			if !tt.success {
-				assert.Error(t, err)
-			}
-			assert.NoError(t, err)
-		})
-	}
-}
-
 func setUpGlobalFlags(cmd *cobra.Command) {
 	tempKubeConfigPath, _ := os.CreateTemp(os.TempDir(), testKubeConfig)
 	cmd.Flags().String(constants.GlobalFlagKubeConfig, tempKubeConfigPath.Name(), "")
 	cmd.Flags().String(constants.GlobalFlagContext, testK8sContext, "")
 }
 
-func setUpAndVerifyResources(t *testing.T, readyStatusComponents []string) *cobra.Command {
+func setUpAndVerifyResources(t *testing.T) *cobra.Command {
 	c := getClientWithVZWatch()
-
-	if len(readyStatusComponents) >= 1 {
-		c = getClientWithVZEnabledComponents()
-	}
 
 	// Verify the vz resource is as expected
 	vz := v1beta1.Verrazzano{}

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -595,7 +595,7 @@ func TestBugReportSuccessWithDuration(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestBugReportLogsFromAllNamespaces
+// TestBugReportLogsFromVzManagedNamespaces
 // GIVEN a CLI bug-report command
 // WHEN I call cmd.Execute with include logs, I should get the logs of all resources across all namespaces
 // THEN expect the command to show the resources captured in the standard output and create the bug report file

--- a/tools/vz/cmd/install/install.go
+++ b/tools/vz/cmd/install/install.go
@@ -378,7 +378,7 @@ func validateCmd(cmd *cobra.Command, client clipkg.Client) error {
 	return nil
 }
 
-// validateCR - validates a Custom Resource before proceeding with an install
+// ValidateCR  - validates a Custom Resource before proceeding with an install
 func ValidateCR(cmd *cobra.Command, obj *unstructured.Unstructured, vzHelper helpers.VZHelper) []error {
 	discoveryClient, err := vzHelper.GetDiscoveryClient(cmd)
 	if err != nil {

--- a/tools/vz/pkg/bugreport/reportgen.go
+++ b/tools/vz/pkg/bugreport/reportgen.go
@@ -99,9 +99,7 @@ func CaptureClusterSnapshot(kubeClient kubernetes.Interface, dynamicClient dynam
 
 	// Append any additional namespaces from the --include-namespace flag, to the list of namespaces already being captured
 	if len(additionalNS) > 0 {
-		for _, ns := range additionalNS {
-			nsList = append(nsList, ns)
-		}
+		nsList = append(nsList, additionalNS...)
 	}
 
 	// Capture logs from resources when the --include-logs flag is enabled

--- a/tools/vz/pkg/bugreport/reportgen.go
+++ b/tools/vz/pkg/bugreport/reportgen.go
@@ -97,11 +97,6 @@ func CaptureClusterSnapshot(kubeClient kubernetes.Interface, dynamicClient dynam
 		pkghelpers.LogError(fmt.Sprintf("There is an error with capturing the Verrazzano resources: %s", err.Error()))
 	}
 
-	// Append any additional namespaces from the --include-namespace flag, to the list of namespaces already being captured
-	if len(additionalNS) > 0 {
-		nsList = append(nsList, additionalNS...)
-	}
-
 	// Capture logs from resources when the --include-logs flag is enabled
 	captureAdditionalResources(client, kubeClient, dynamicClient, vzHelper, clusterSnapshotCtx.BugReportDir, nsList, podLogs)
 

--- a/tools/vz/pkg/bugreport/reportgen.go
+++ b/tools/vz/pkg/bugreport/reportgen.go
@@ -92,15 +92,20 @@ func CaptureClusterSnapshot(kubeClient kubernetes.Interface, dynamicClient dynam
 		fmt.Fprintf(vzHelper.GetOutputStream(), "\n"+msgPrefix+"resources from the cluster ...\n")
 	}
 	// Capture list of resources from verrazzano-install and verrazzano-system namespaces
-	err = captureResources(client, kubeClient, dynamicClient, clusterSnapshotCtx.BugReportDir, vz, vzHelper, nsList, podLogs)
+	err = captureResources(client, kubeClient, dynamicClient, clusterSnapshotCtx.BugReportDir, vz, vzHelper, nsList)
 	if err != nil {
 		pkghelpers.LogError(fmt.Sprintf("There is an error with capturing the Verrazzano resources: %s", err.Error()))
 	}
 
-	// Capture OAM resources from the namespaces specified using --include-namespaces
+	// Append any additional namespaces from the --include-namespace flag, to the list of namespaces already being captured
 	if len(additionalNS) > 0 {
-		captureAdditionalResources(client, kubeClient, dynamicClient, vzHelper, clusterSnapshotCtx.BugReportDir, additionalNS, podLogs)
+		for _, ns := range additionalNS {
+			nsList = append(nsList, ns)
+		}
 	}
+
+	// Capture logs from resources when the --include-logs flag is enabled
+	captureAdditionalResources(client, kubeClient, dynamicClient, vzHelper, clusterSnapshotCtx.BugReportDir, nsList, podLogs)
 
 	// Capture Verrazzano Projects and VerrazzanoManagedCluster
 	if err = captureMultiClusterResources(dynamicClient, clusterSnapshotCtx.BugReportDir, vzHelper); err != nil {
@@ -119,7 +124,7 @@ func CaptureClusterSnapshot(kubeClient kubernetes.Interface, dynamicClient dynam
 	return nil
 }
 
-func captureResources(client clipkg.Client, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface, bugReportDir string, vz *v1beta1.Verrazzano, vzHelper pkghelpers.VZHelper, namespaces []string, podLogs PodLogs) error {
+func captureResources(client clipkg.Client, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface, bugReportDir string, vz *v1beta1.Verrazzano, vzHelper pkghelpers.VZHelper, namespaces []string) error {
 	// List of pods to collect the logs
 	vpoPod, _ := pkghelpers.GetPodList(client, constants.AppLabel, constants.VerrazzanoPlatformOperator, vzconstants.VerrazzanoInstallNamespace)
 	vaoPod, _ := pkghelpers.GetPodList(client, constants.AppLabel, constants.VerrazzanoApplicationOperator, vzconstants.VerrazzanoSystemNamespace)
@@ -154,9 +159,6 @@ func captureResources(client clipkg.Client, kubeClient kubernetes.Interface, dyn
 	for _, ns := range namespaces {
 		go captureK8SResources(wg, ecr, client, kubeClient, dynamicClient, ns, bugReportDir, vzHelper)
 	}
-
-	// captures pod logs of vz component namespaces if --include-logs flag is enabled
-	captureAdditionalResources(client, kubeClient, dynamicClient, vzHelper, bugReportDir, namespaces, podLogs)
 
 	wg.Wait()
 	close(ecl)

--- a/tools/vz/pkg/bugreport/reportgen.go
+++ b/tools/vz/pkg/bugreport/reportgen.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package bugreport

--- a/tools/vz/pkg/bugreport/reportgen.go
+++ b/tools/vz/pkg/bugreport/reportgen.go
@@ -77,7 +77,7 @@ func CaptureClusterSnapshot(kubeClient kubernetes.Interface, dynamicClient dynam
 	}
 
 	// Get the list of namespaces based on the failed components and value specified by flag --include-namespaces
-	nsList, additionalNS, err := collectNamespaces(kubeClient, dynamicClient, clusterSnapshotCtx.MoreNS, vz, vzHelper)
+	nsList, _, err := collectNamespaces(kubeClient, dynamicClient, clusterSnapshotCtx.MoreNS, vz, vzHelper)
 	if err != nil {
 		return err
 	}

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package constants

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -210,7 +210,7 @@ const (
 	// Flag for capture pods logs( both additional and system namespaces)
 	BugReportLogFlagName         = "include-logs"
 	BugReportLogFlagNameShort    = "l"
-	BugReportLogFlagNameUsage    = "Include logs from the pods in one or more namespaces; this is specified along with the --include-namespaces flag."
+	BugReportLogFlagNameUsage    = "Include logs from pods of the namespaces being captured."
 	BugReportTimeFlagName        = "duration"
 	BugReportTimeFlagNameShort   = "d"
 	BugReportTimeFlagDefaultTime = 0

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -210,7 +210,7 @@ const (
 	// Flag for capture pods logs( both additional and system namespaces)
 	BugReportLogFlagName         = "include-logs"
 	BugReportLogFlagNameShort    = "l"
-	BugReportLogFlagNameUsage    = "Include logs from pods of the namespaces being captured."
+	BugReportLogFlagNameUsage    = "Include logs from all containers in running pods of the namespaces being captured."
 	BugReportTimeFlagName        = "duration"
 	BugReportTimeFlagNameShort   = "d"
 	BugReportTimeFlagDefaultTime = 0


### PR DESCRIPTION
Get pod logs from namespaces being captured with the --include-logs flag