### PR TITLE
VZ-11670: --redacted-values-file flag for vz bug-report

### DIFF
--- a/tools/vz/cmd/analyze/analyze.go
+++ b/tools/vz/cmd/analyze/analyze.go
@@ -5,20 +5,20 @@ package analyze
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 	cmdhelpers "github.com/verrazzano/verrazzano/tools/vz/cmd/helpers"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/analysis"
 	vzbugreport "github.com/verrazzano/verrazzano/tools/vz/pkg/bugreport"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/helpers"
-	"os"
-	"path/filepath"
 )
 
 const (
 	CommandName      = "analyze"
 	helpShort        = "Analyze cluster"
-	flagErrorMessage = "an error occurred while reading value for the flag %s: %s"
 	helpLong         = `Analyze cluster for identifying issues and providing advice`
 	helpExample      = `
 # Run analysis tool on captured directory
@@ -141,18 +141,18 @@ func RunCmdAnalyze(cmd *cobra.Command, vzHelper helpers.VZHelper, printReportToC
 func parseFlags(cmd *cobra.Command, vzHelper helpers.VZHelper, directoryFlagValue string, tarFlagValue string, reportFileFlagValue string, verboseFlagValue string) (*directoryAndTarValidationStruct, error) {
 	directory, err := cmd.PersistentFlags().GetString(directoryFlagValue)
 	if err != nil {
-		return nil, fmt.Errorf(flagErrorMessage, constants.DirectoryFlagName, err.Error())
+		return nil, fmt.Errorf(constants.FlagErrorMessage, constants.DirectoryFlagName, err.Error())
 	}
 	tarFileString, err := cmd.PersistentFlags().GetString(tarFlagValue)
 	if err != nil {
-		return nil, fmt.Errorf(flagErrorMessage, constants.TarFileFlagName, err.Error())
+		return nil, fmt.Errorf(constants.FlagErrorMessage, constants.TarFileFlagName, err.Error())
 	}
 	if directory != "" && tarFileString != "" {
 		return nil, fmt.Errorf("a directory and a tar file cannot be both specified")
 	}
 	isVerbose, err := cmd.PersistentFlags().GetBool(verboseFlagValue)
 	if err != nil {
-		return nil, fmt.Errorf(flagErrorMessage, constants.VerboseFlag, err.Error())
+		return nil, fmt.Errorf(constants.FlagErrorMessage, constants.VerboseFlag, err.Error())
 	}
 	if err := setVzK8sVersion(tarFileString, directory, vzHelper, cmd); err == nil {
 		fmt.Fprintf(vzHelper.GetOutputStream(), helpers.GetVersionOut())

--- a/tools/vz/cmd/analyze/analyze.go
+++ b/tools/vz/cmd/analyze/analyze.go
@@ -17,10 +17,10 @@ import (
 )
 
 const (
-	CommandName      = "analyze"
-	helpShort        = "Analyze cluster"
-	helpLong         = `Analyze cluster for identifying issues and providing advice`
-	helpExample      = `
+	CommandName = "analyze"
+	helpShort   = "Analyze cluster"
+	helpLong    = `Analyze cluster for identifying issues and providing advice`
+	helpExample = `
 # Run analysis tool on captured directory
 vz analyze --capture-dir <path>
 

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	flagErrorMessage = "an error occurred while reading value for the flag %s: %s"
 	CommandName  = "bug-report"
 	helpShort    = "Collect information from the cluster to report an issue"
 	helpLong     = `Verrazzano command line utility to collect data from the cluster, to report an issue`
@@ -94,7 +93,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	// determines the bug report file
 	bugReportFile, err := cmd.PersistentFlags().GetString(constants.BugReportFileFlagName)
 	if err != nil {
-		return fmt.Errorf(flagErrorMessage, constants.BugReportFileFlagName, err.Error())
+		return fmt.Errorf(constants.FlagErrorMessage, constants.BugReportFileFlagName, err.Error())
 	}
 	if bugReportFile == "" {
 		bugReportFile = constants.BugReportFileDefaultValue
@@ -139,18 +138,18 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	// Read the additional namespaces provided using flag --include-namespaces
 	moreNS, err := cmd.PersistentFlags().GetStringSlice(constants.BugReportIncludeNSFlagName)
 	if err != nil {
-		return fmt.Errorf(flagErrorMessage, constants.BugReportIncludeNSFlagName, err.Error())
+		return fmt.Errorf(constants.FlagErrorMessage, constants.BugReportIncludeNSFlagName, err.Error())
 	}
 	// If additional namespaces pods logs needs to be capture using flag --include-logs
 	isPodLog, err := cmd.PersistentFlags().GetBool(constants.BugReportLogFlagName)
 	if err != nil {
-		return fmt.Errorf(flagErrorMessage, constants.BugReportLogFlagName, err.Error())
+		return fmt.Errorf(constants.FlagErrorMessage, constants.BugReportLogFlagName, err.Error())
 	}
 
 	// If additional namespaces pods logs needs to be capture using flag with duration --duration
 	durationString, err := cmd.PersistentFlags().GetDuration(constants.BugReportTimeFlagName)
 	if err != nil {
-		return fmt.Errorf(flagErrorMessage, constants.BugReportTimeFlagName, err.Error())
+		return fmt.Errorf(constants.FlagErrorMessage, constants.BugReportTimeFlagName, err.Error())
 	}
 	durationValue := int64(durationString.Seconds())
 	if err != nil {
@@ -170,7 +169,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	// set the flag to control the display the resources captured
 	isVerbose, err := cmd.PersistentFlags().GetBool(constants.VerboseFlag)
 	if err != nil {
-		return fmt.Errorf(flagErrorMessage, constants.VerboseFlag, err.Error())
+		return fmt.Errorf(constants.FlagErrorMessage, constants.VerboseFlag, err.Error())
 	}
 	helpers.SetVerboseOutput(isVerbose)
 
@@ -192,7 +191,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	// Process the redacted values file flag.
 	redactionFilePath, err := cmd.PersistentFlags().GetString(constants.RedactedValuesFlagName)
 	if err != nil {
-		return fmt.Errorf(flagErrorMessage, constants.RedactedValuesFlagName, err.Error())
+		return fmt.Errorf(constants.FlagErrorMessage, constants.RedactedValuesFlagName, err.Error())
 	}
 	if redactionFilePath != "" {
 		// Create the redaction map file if the user provides a non-empty file path.
@@ -284,11 +283,11 @@ func AutoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) err
 func setUpFlags(cmd *cobra.Command, newCmd *cobra.Command) error {
 	kubeconfigFlag, errFlag := cmd.Flags().GetString(constants.GlobalFlagKubeConfig)
 	if errFlag != nil {
-		return fmt.Errorf(flagErrorMessage, constants.GlobalFlagKubeConfig, errFlag.Error())
+		return fmt.Errorf(constants.FlagErrorMessage, constants.GlobalFlagKubeConfig, errFlag.Error())
 	}
 	contextFlag, errFlag2 := cmd.Flags().GetString(constants.GlobalFlagContext)
 	if errFlag2 != nil {
-		return fmt.Errorf(flagErrorMessage, constants.GlobalFlagContext, errFlag2.Error())
+		return fmt.Errorf(constants.FlagErrorMessage, constants.GlobalFlagContext, errFlag2.Error())
 	}
 	newCmd.Flags().StringVar(&kubeconfigFlagValPointer, constants.GlobalFlagKubeConfig, "", constants.GlobalFlagKubeConfigHelp)
 	newCmd.Flags().StringVar(&contextFlagValPointer, constants.GlobalFlagContext, "", constants.GlobalFlagContextHelp)

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -189,6 +189,18 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 			"Please go through errors (if any), in the standard output.\n")
 	}
 
+	// Create the redaction mapping file.
+	redactionFilePath, err := cmd.PersistentFlags().GetString(constants.RedactedValuesFlagName)
+	if err != nil {
+		return fmt.Errorf("an error occurred while reading value for the flag %s: %s", constants.RedactedValuesFlagName, err.Error())
+	}
+	if redactionFilePath != "" {
+		// Create the redaction map file if the user provides a non-empty file path.
+		if err := helpers.WriteRedactionMapFile(bugReportDir, nil); err != nil {
+			return fmt.Errorf("an error occurred while creating the redacted values map at %s: %s", redactionFilePath, err.Error())
+		}
+	}
+
 	// Generate the bug report
 	err = helpers.CreateReportArchive(bugReportDir, bugRepFile)
 	if err != nil {

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -189,7 +189,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 			"Please go through errors (if any), in the standard output.\n")
 	}
 
-	// Create the redaction mapping file.
+	// Process the redacted values file flag.
 	redactionFilePath, err := cmd.PersistentFlags().GetString(constants.RedactedValuesFlagName)
 	if err != nil {
 		return fmt.Errorf("an error occurred while reading value for the flag %s: %s", constants.RedactedValuesFlagName, err.Error())

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -196,7 +196,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	}
 	if redactionFilePath != "" {
 		// Create the redaction map file if the user provides a non-empty file path.
-		if err := helpers.WriteRedactionMapFile(bugReportDir, nil); err != nil {
+		if err := helpers.WriteRedactionMapFile(redactionFilePath, nil); err != nil {
 			return fmt.Errorf("an error occurred while creating the redacted values map at %s: %s", redactionFilePath, err.Error())
 		}
 	}

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -66,6 +66,7 @@ func NewCmdBugReport(vzHelper helpers.VZHelper) *cobra.Command {
 	}
 
 	cmd.Example = helpExample
+	cmd.PersistentFlags().String(constants.RedactedValuesFlagName, constants.RedactedValuesFlagValue, constants.RedactedValuesFlagUsage)
 	cmd.PersistentFlags().StringP(constants.BugReportFileFlagName, constants.BugReportFileFlagShort, constants.BugReportFileFlagValue, constants.BugReportFileFlagUsage)
 	cmd.PersistentFlags().StringSliceP(constants.BugReportIncludeNSFlagName, constants.BugReportIncludeNSFlagShort, []string{}, constants.BugReportIncludeNSFlagUsage)
 	cmd.PersistentFlags().BoolP(constants.VerboseFlag, constants.VerboseFlagShorthand, constants.VerboseFlagDefault, constants.VerboseFlagUsage)

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	flagErrorStr = "error fetching flag: %s"
+	flagErrorMessage = "an error occurred while reading value for the flag %s: %s"
 	CommandName  = "bug-report"
 	helpShort    = "Collect information from the cluster to report an issue"
 	helpLong     = `Verrazzano command line utility to collect data from the cluster, to report an issue`
@@ -83,7 +83,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	newCmd := analyze.NewCmdAnalyze(vzHelper)
 	err := setUpFlags(cmd, newCmd)
 	if err != nil {
-		return fmt.Errorf(flagErrorStr, err.Error())
+		return err
 	}
 	analyzeErr := analyze.RunCmdAnalyze(newCmd, vzHelper, false)
 	if analyzeErr != nil {
@@ -94,7 +94,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	// determines the bug report file
 	bugReportFile, err := cmd.PersistentFlags().GetString(constants.BugReportFileFlagName)
 	if err != nil {
-		return fmt.Errorf(flagErrorStr, err.Error())
+		return fmt.Errorf(flagErrorMessage, constants.BugReportFileFlagName, err.Error())
 	}
 	if bugReportFile == "" {
 		bugReportFile = constants.BugReportFileDefaultValue
@@ -139,18 +139,18 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	// Read the additional namespaces provided using flag --include-namespaces
 	moreNS, err := cmd.PersistentFlags().GetStringSlice(constants.BugReportIncludeNSFlagName)
 	if err != nil {
-		return fmt.Errorf("an error occurred while reading values for the flag --include-namespaces: %s", err.Error())
+		return fmt.Errorf(flagErrorMessage, constants.BugReportIncludeNSFlagName, err.Error())
 	}
 	// If additional namespaces pods logs needs to be capture using flag --include-logs
 	isPodLog, err := cmd.PersistentFlags().GetBool(constants.BugReportLogFlagName)
 	if err != nil {
-		return fmt.Errorf("an error occurred while reading values for the flag --include-logs: %s", err.Error())
+		return fmt.Errorf(flagErrorMessage, constants.BugReportLogFlagName, err.Error())
 	}
 
 	// If additional namespaces pods logs needs to be capture using flag with duration --duration
 	durationString, err := cmd.PersistentFlags().GetDuration(constants.BugReportTimeFlagName)
 	if err != nil {
-		return fmt.Errorf("an error occurred while reading values for the flag --duration: %s", err.Error())
+		return fmt.Errorf(flagErrorMessage, constants.BugReportTimeFlagName, err.Error())
 	}
 	durationValue := int64(durationString.Seconds())
 	if err != nil {
@@ -170,7 +170,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	// set the flag to control the display the resources captured
 	isVerbose, err := cmd.PersistentFlags().GetBool(constants.VerboseFlag)
 	if err != nil {
-		return fmt.Errorf("an error occurred while reading value for the flag %s: %s", constants.VerboseFlag, err.Error())
+		return fmt.Errorf(flagErrorMessage, constants.VerboseFlag, err.Error())
 	}
 	helpers.SetVerboseOutput(isVerbose)
 
@@ -192,7 +192,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	// Process the redacted values file flag.
 	redactionFilePath, err := cmd.PersistentFlags().GetString(constants.RedactedValuesFlagName)
 	if err != nil {
-		return fmt.Errorf("an error occurred while reading value for the flag %s: %s", constants.RedactedValuesFlagName, err.Error())
+		return fmt.Errorf(flagErrorMessage, constants.RedactedValuesFlagName, err.Error())
 	}
 	if redactionFilePath != "" {
 		// Create the redaction map file if the user provides a non-empty file path.
@@ -284,11 +284,11 @@ func AutoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) err
 func setUpFlags(cmd *cobra.Command, newCmd *cobra.Command) error {
 	kubeconfigFlag, errFlag := cmd.Flags().GetString(constants.GlobalFlagKubeConfig)
 	if errFlag != nil {
-		return fmt.Errorf(flagErrorStr, errFlag.Error())
+		return fmt.Errorf(flagErrorMessage, constants.GlobalFlagKubeConfig, errFlag.Error())
 	}
 	contextFlag, errFlag2 := cmd.Flags().GetString(constants.GlobalFlagContext)
 	if errFlag2 != nil {
-		return fmt.Errorf(flagErrorStr, errFlag2.Error())
+		return fmt.Errorf(flagErrorMessage, constants.GlobalFlagContext, errFlag2.Error())
 	}
 	newCmd.Flags().StringVar(&kubeconfigFlagValPointer, constants.GlobalFlagKubeConfig, "", constants.GlobalFlagKubeConfigHelp)
 	newCmd.Flags().StringVar(&contextFlagValPointer, constants.GlobalFlagContext, "", constants.GlobalFlagContextHelp)

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -20,10 +20,10 @@ import (
 )
 
 const (
-	CommandName  = "bug-report"
-	helpShort    = "Collect information from the cluster to report an issue"
-	helpLong     = `Verrazzano command line utility to collect data from the cluster, to report an issue`
-	helpExample  = `
+	CommandName = "bug-report"
+	helpShort   = "Collect information from the cluster to report an issue"
+	helpLong    = `Verrazzano command line utility to collect data from the cluster, to report an issue`
+	helpExample = `
 # Create a bug report file, bugreport.tar.gz, by collecting data from the cluster:
 vz bug-report --report-file bugreport.tar.gz
 

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -165,7 +165,7 @@ const (
 	// Flag for generating the redacted values mappping file
 	RedactedValuesFlagName  = "redacted-values-file"
 	RedactedValuesFlagValue = ""
-	RedactedValuesFlagUsage = "Creates a CSV file at the file path provided, containing a mapping between values redacted by the VZ sanitation tool and their original values. Do not share this file as it contains sensitive data."
+	RedactedValuesFlagUsage = "Creates a CSV file at the file path provided, containing a mapping between values redacted by the VZ analysis tool and their original values. Do not share this file as it contains sensitive data."
 
 	BugReportDir = "bug-report"
 

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -162,6 +162,11 @@ const (
 	BugReportIncludeNSFlagShort = "i"
 	BugReportIncludeNSFlagUsage = "A comma-separated list of namespaces, in addition to the ones collected by default (system namespaces), for collecting cluster information. This flag can be specified multiple times, such as --include-namespaces ns1 --include-namespaces ns..."
 
+	// Flag for generating the redacted values mappping file
+	RedactedValuesFlagName = "redacted-values-file"
+	RedactedValuesFlagValue = ""
+	RedactedValuesFlagUsage = "Creates a CSV file at the file path provided, containing a mapping between values redacted by the VZ sanitation tool and their original values. Do not share this file as it contains sensitive data."
+
 	BugReportDir = "bug-report"
 
 	// File name for the log captured from the pod

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -241,4 +241,4 @@ const RefreshRate = time.Second * 10
 const TotalWidth = 50
 
 // Error message for failing to parse a flag
-const FlagErrorMessage = "an error occurred while reading value for the flag %s: %s"
+const FlagErrorMessage = "an error occurred while reading value for the flag --%s: %s"

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -239,3 +239,6 @@ const (
 const ProgressShorthand = "p"
 const RefreshRate = time.Second * 10
 const TotalWidth = 50
+
+// Error message for failing to parse a flag
+const FlagErrorMessage = "an error occurred while reading value for the flag %s: %s"

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -163,7 +163,7 @@ const (
 	BugReportIncludeNSFlagUsage = "A comma-separated list of namespaces, in addition to the ones collected by default (system namespaces), for collecting cluster information. This flag can be specified multiple times, such as --include-namespaces ns1 --include-namespaces ns..."
 
 	// Flag for generating the redacted values mappping file
-	RedactedValuesFlagName = "redacted-values-file"
+	RedactedValuesFlagName  = "redacted-values-file"
 	RedactedValuesFlagValue = ""
 	RedactedValuesFlagUsage = "Creates a CSV file at the file path provided, containing a mapping between values redacted by the VZ sanitation tool and their original values. Do not share this file as it contains sensitive data."
 

--- a/tools/vz/pkg/helpers/vzsanitize.go
+++ b/tools/vz/pkg/helpers/vzsanitize.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -78,13 +77,12 @@ func SanitizeString(l string, redactedValuesOverride map[string]string) string {
 	return l
 }
 
-// WriteRedactionMapFile creates a CSV file to document all the values this tool has
+// WriteRedactionMapFile creates a CSV file at the provided outputFilePath to document all the values this tool has
 // redacted so far, stored in the redactedValues (or redactedValuesOverride) map.
-func WriteRedactionMapFile(captureDir string, redactedValuesOverride map[string]string) error {
-	fileName := filepath.Join(captureDir, constants.RedactionMap)
-	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+func WriteRedactionMapFile(outputFilePath string, redactedValuesOverride map[string]string) error {
+	f, err := os.OpenFile(outputFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
-		return fmt.Errorf(createFileError, fileName, err.Error())
+		return fmt.Errorf(createFileError, outputFilePath, err.Error())
 	}
 	defer f.Close()
 
@@ -93,7 +91,7 @@ func WriteRedactionMapFile(captureDir string, redactedValuesOverride map[string]
 	csvWriter := csv.NewWriter(f)
 	for s, r := range redactedValues {
 		if err = csvWriter.Write([]string{r, s}); err != nil {
-			LogError(fmt.Sprintf("An error occurred while writing the file %s: %s\n", fileName, err.Error()))
+			LogError(fmt.Sprintf("An error occurred while writing the file %s: %s\n", outputFilePath, err.Error()))
 			return err
 		}
 	}

--- a/tools/vz/pkg/helpers/vzsanitize_test.go
+++ b/tools/vz/pkg/helpers/vzsanitize_test.go
@@ -6,6 +6,7 @@ package helpers
 import (
 	"encoding/csv"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -41,7 +42,6 @@ var (
 
 	// Specifies the location and name of the CSV file written to by WriteRedactionMapFile for these tests.
 	redactMapFileLocation = os.TempDir()
-	redactMapFilePath     = redactMapFileLocation + "/" + constants.RedactionMap
 )
 
 // TestSanitizeALine tests the SanitizeString function.
@@ -80,12 +80,23 @@ func TestSanitizeALine(t *testing.T) {
 func TestWriteRedactionMapFileEmpty(t *testing.T) {
 	a := assert.New(t)
 	testRedactedValues := make(map[string]string)
-	err := WriteRedactionMapFile(redactMapFileLocation, testRedactedValues)
+	redactMapFilePath := filepath.Join(redactMapFileLocation, "empty-redaction-map.csv")
+
+	// Should create the CSV file
+	err := WriteRedactionMapFile(redactMapFilePath, testRedactedValues)
 	a.Nil(err)
-	_, err = os.Stat(redactMapFilePath)
-	a.Nil(err, "redaction file %s does not exist", redactMapFilePath)
-	err = os.Remove(redactMapFilePath)
+
+	// Open the file
+	f, err := os.Open(redactMapFilePath)
 	a.Nil(err)
+	defer f.Close()
+	defer os.Remove(f.Name())
+
+	// Check the file is empty
+	reader := csv.NewReader(f)
+	data, err := reader.ReadAll()
+	a.Nil(err)
+	a.Zero(len(data))
 }
 
 // TestWriteRedactionMapFile tests that WriteRedactionMapFile correctly writes redacted string mapping to a CSV file.
@@ -95,6 +106,8 @@ func TestWriteRedactionMapFileEmpty(t *testing.T) {
 func TestWriteRedactionMapFile(t *testing.T) {
 	a := assert.New(t)
 	testRedactedValues := make(map[string]string)
+	redactMapFilePath := filepath.Join(redactMapFileLocation, "test-redaction-map.csv")
+
 	// redact a variety of inputs, as well as inputting a value more than once.
 	testInputs := []string{testIP, testOCID, testSSH, testUserData, testOPCID, testIP}
 	for _, input := range testInputs {
@@ -104,7 +117,7 @@ func TestWriteRedactionMapFile(t *testing.T) {
 	a.Len(testRedactedValues, numUniqueInputs)
 
 	// write the redacted values to the CSV file
-	err := WriteRedactionMapFile(redactMapFileLocation, testRedactedValues)
+	err := WriteRedactionMapFile(redactMapFilePath, testRedactedValues)
 	a.Nil(err)
 
 	// open the file


### PR DESCRIPTION
Introduces the `--redacted-values-file` flag to the VZ bug report CLI command.

If users provide the flag, the redaction mapping CSV file will be created using the code provided by https://github.com/verrazzano/verrazzano/pull/7678.