### PR TITLE
VZ-11673: Uptake Redis 7.0.15

### DIFF
--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -142,7 +142,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/rancher-backup-override-static-values.yaml
   - name: argocd
-    version: 2.8.3-2
+    version: 2.8.3-3
     chart: platform-operator/thirdparty/charts/argo-cd
     valuesFiles:
       - platform-operator/helm_config/overrides/argocd-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -977,7 +977,7 @@
           "images": [
             {
               "image": "redis",
-              "tag": "v7.0.15-20240206175908-c98c652f",
+              "tag": "v7.0.15-20240207150632-c98c652f",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -957,7 +957,7 @@
     },
     {
       "name": "argocd",
-      "version": "2.8.3-2",
+      "version": "2.8.3-3",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -977,7 +977,7 @@
           "images": [
             {
               "image": "redis",
-              "tag": "v7.0.12-20230921093854-848a7e94",
+              "tag": "v7.0.15-20240206175908-c98c652f",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
This PR upgrades Redis from 7.0.12 to 7.0.15. Redis is a component of ArgoCD.

Note there are no Helm chart updates required for this patch release upgrade.
