### PR TITLE
VZ-11673: Uptake Redis 7.0.15 (release-1.7)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,12 @@
 
 Component version updates:
 
-- Coherence Operator 3.3.2
-- Rancher 2.7.8
+- Coherence Operator v3.3.2
+- Rancher v2.7.8
 - WebLogic Kubernetes Operator v4.1.4
 - WebLogic Monitoring Exporter v2.1.8
-- Istio 1.19.3
+- Istio v1.19.3
+- Redis v7.0.15
 
 Features:
 

--- a/platform-operator/manifests/catalog/catalog.yaml
+++ b/platform-operator/manifests/catalog/catalog.yaml
@@ -142,7 +142,7 @@ modules:
     valuesFiles:
       - platform-operator/helm_config/overrides/rancher-backup-override-static-values.yaml
   - name: argocd
-    version: 2.8.3-2
+    version: 2.8.3-3
     chart: platform-operator/thirdparty/charts/argo-cd
     valuesFiles:
       - platform-operator/helm_config/overrides/argocd-values.yaml

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -945,7 +945,7 @@
     },
     {
       "name": "argocd",
-      "version": "2.8.3-2",
+      "version": "2.8.3-3",
       "subcomponents": [
         {
           "repository": "verrazzano",
@@ -965,7 +965,7 @@
           "images": [
             {
               "image": "redis",
-              "tag": "v7.0.12-20230921093854-848a7e94",
+              "tag": "v7.0.15-20240207150632-c98c652f",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Backport of Redis 7.0.15 to release-1.7 branch. See #7739.