### PR TITLE
VZ-11673: Uptake Redis 7.0.15 (release-1.6)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### 1.6.11
+Component version updates:
+
+- Redis v7.0.15
+
 ### 1.6.10
 
 Fixes:

--- a/platform-operator/verrazzano-bom.json
+++ b/platform-operator/verrazzano-bom.json
@@ -896,7 +896,7 @@
           "images": [
             {
               "image": "redis",
-              "tag": "v7.0.12-20230921093854-848a7e94",
+              "tag": "v7.0.15-20240207150632-c98c652f",
               "helmFullImageKey": "image.repository",
               "helmTagKey": "image.tag"
             }


### PR DESCRIPTION
Backport of Redis 7.0.15 to release-1.6 branch. See https://github.com/verrazzano/verrazzano/pull/7739.