### PR TITLE
VZ-11675: Include the redaction map file with auto bug report

### DIFF
--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -282,7 +282,7 @@ func AutoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) err
 		//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from either installVerrazzano() or waitForInstallToComplete()
 		var bugReportFileName string
 		bugReportFileName, err = CallVzBugReport(cmd, vzHelper, err)
-		redactionFileName := generateRedactionFileNameFromBugReportName(bugReportFileName)
+		redactionFileName := helpers.GenerateRedactionFileNameFromBugReportName(bugReportFileName)
 		if redactErr := helpers.WriteRedactionMapFile(redactionFileName, nil); redactErr != nil {
 			return fmt.Errorf(constants.RedactionMapCreationError, redactionFileName, redactErr.Error())
 		}
@@ -304,12 +304,4 @@ func setUpFlags(cmd *cobra.Command, newCmd *cobra.Command) error {
 	newCmd.Flags().Set(constants.GlobalFlagKubeConfig, kubeconfigFlag)
 	newCmd.Flags().Set(constants.GlobalFlagContext, contextFlag)
 	return nil
-}
-
-// generateRedactionFileNameFromBugReportName returns a name for the redacted values file
-// to match the bugReportFileName.
-// For example, for a bugReportFileName of vz-bug-report-datetime-xxxx.tar.gz,
-// this function returns vz-bug-report-datetime-xxxx-sensitive-do-not-share-redaction-map.csv.
-func generateRedactionFileNameFromBugReportName(bugReportFileName string) string {
-	return strings.TrimSuffix(bugReportFileName, ".tar.gz") + constants.RedactionFileSuffix
 }

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -196,7 +196,7 @@ func runCmdBugReport(cmd *cobra.Command, args []string, vzHelper helpers.VZHelpe
 	if redactionFilePath != "" {
 		// Create the redaction map file if the user provides a non-empty file path.
 		if err := helpers.WriteRedactionMapFile(redactionFilePath, nil); err != nil {
-			return fmt.Errorf("an error occurred while creating the redacted values map at %s: %s", redactionFilePath, err.Error())
+			return fmt.Errorf(constants.RedactionMapCreationError, redactionFilePath, err.Error())
 		}
 	}
 

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -280,13 +280,11 @@ func AutoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) err
 	}
 	if autoBugReportFlag {
 		//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from either installVerrazzano() or waitForInstallToComplete()
-		bugReportFileName, err := CallVzBugReport(cmd, vzHelper, err)
-		redactionFileName, redactErr := generateRedactionFileNameFromBugReportName(bugReportFileName)
-		if redactErr != nil {
-			return fmt.Errorf("That's a whole lot of hoopla") // FIXME: make a good error message
-		}
+		var bugReportFileName string
+		bugReportFileName, err = CallVzBugReport(cmd, vzHelper, err)
+		redactionFileName := generateRedactionFileNameFromBugReportName(bugReportFileName)
 		if redactErr := helpers.WriteRedactionMapFile(redactionFileName, nil); redactErr != nil {
-			return fmt.Errorf(constants.RedactionMapCreationError, redactionFileName, err.Error())
+			return fmt.Errorf(constants.RedactionMapCreationError, redactionFileName, redactErr.Error())
 		}
 	}
 	return err
@@ -310,7 +308,6 @@ func setUpFlags(cmd *cobra.Command, newCmd *cobra.Command) error {
 
 // generateRedactionFileNameFromBugReportName returns a name for the redacted values file such that it matches the
 // filled-in values of the bugReportFileName, which should have a format of vz-bug-report-datetime-xxxx.tar.gz
-func generateRedactionFileNameFromBugReportName(bugReportFileName string) (string, error) {
-	// TODO: actually implement this
-	return "HOOPLA" + bugReportFileName, nil
+func generateRedactionFileNameFromBugReportName(bugReportFileName string) string {
+	return strings.TrimSuffix(bugReportFileName, ".tar.gz") + "-sensitive-do-not-share-redaction-map.csv"
 }

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -306,8 +306,10 @@ func setUpFlags(cmd *cobra.Command, newCmd *cobra.Command) error {
 	return nil
 }
 
-// generateRedactionFileNameFromBugReportName returns a name for the redacted values file such that it matches the
-// filled-in values of the bugReportFileName, which should have a format of vz-bug-report-datetime-xxxx.tar.gz
+// generateRedactionFileNameFromBugReportName returns a name for the redacted values file
+// to match the bugReportFileName.
+// For example, for a bugReportFileName of vz-bug-report-datetime-xxxx.tar.gz,
+// this function returns vz-bug-report-datetime-xxxx-sensitive-do-not-share-redaction-map.csv.
 func generateRedactionFileNameFromBugReportName(bugReportFileName string) string {
-	return strings.TrimSuffix(bugReportFileName, ".tar.gz") + "-sensitive-do-not-share-redaction-map.csv"
+	return strings.TrimSuffix(bugReportFileName, ".tar.gz") + constants.RedactionFileSuffix
 }

--- a/tools/vz/cmd/bugreport/bugreport.go
+++ b/tools/vz/cmd/bugreport/bugreport.go
@@ -282,9 +282,13 @@ func AutoBugReport(cmd *cobra.Command, vzHelper helpers.VZHelper, err error) err
 		//err returned from CallVzBugReport is the same error that's passed in, the error that was returned from either installVerrazzano() or waitForInstallToComplete()
 		var bugReportFileName string
 		bugReportFileName, err = CallVzBugReport(cmd, vzHelper, err)
-		redactionFileName := helpers.GenerateRedactionFileNameFromBugReportName(bugReportFileName)
-		if redactErr := helpers.WriteRedactionMapFile(redactionFileName, nil); redactErr != nil {
-			return fmt.Errorf(constants.RedactionMapCreationError, redactionFileName, redactErr.Error())
+
+		// Create the redacted values file
+		if bugReportFileName != "" {
+			redactionFileName := helpers.GenerateRedactionFileNameFromBugReportName(bugReportFileName)
+			if redactErr := helpers.WriteRedactionMapFile(redactionFileName, nil); redactErr != nil {
+				return fmt.Errorf(constants.RedactionMapCreationError, redactionFileName, redactErr.Error())
+			}
 		}
 	}
 	return err

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -7,10 +7,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/validators"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/validators"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -102,7 +103,7 @@ func TestInstallCmdDefaultTimeoutBugReport(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "Error: Timeout 2ms exceeded waiting for install to complete\n", errBuf.String())
 	assert.Contains(t, buf.String(), "Installing Verrazzano version v1.3.1")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -138,7 +139,7 @@ func TestInstallCmdDefaultTimeoutNoBugReport(t *testing.T) {
 	assert.Equal(t, "Error: Timeout 2ms exceeded waiting for install to complete\n", errBuf.String())
 	assert.Contains(t, buf.String(), "Installing Verrazzano version v1.3.1")
 	// Bug report must not exist
-	if helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal("found bug report file in current directory")
 	}
 }
@@ -163,7 +164,7 @@ func TestInstallCmdDefaultNoVPO(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Waiting for verrazzano-platform-operator pod in namespace verrazzano-install")
 	assert.Contains(t, errBuf.String(), "Error: Waiting for verrazzano-platform-operator pod in namespace verrazzano-install")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -194,7 +195,7 @@ func TestInstallCmdDefaultMultipleVPO(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Waiting for verrazzano-platform-operator, more than one verrazzano-platform-operator pod was found in namespace verrazzano-install")
 	assert.Contains(t, errBuf.String(), "Error: Waiting for verrazzano-platform-operator, more than one verrazzano-platform-operator pod was found in namespace verrazzano-install")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -249,7 +250,7 @@ func TestInstallCmdMultipleGroupVersions(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot merge objects with different group versions")
-	if helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -504,7 +505,7 @@ func TestInstallValidations(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("--%s and --%s cannot both be specified", constants.VersionFlag, constants.ManifestsFlag))
-	if helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 
@@ -707,7 +708,7 @@ func TestInstallCmdAlreadyInstalled(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Only one install of Verrazzano is allowed")
-	if helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -745,7 +746,7 @@ func TestInstallCmdDifferentVersion(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Unable to install version v1.3.1, install of version v1.3.2 is in progress")
-	if helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }

--- a/tools/vz/cmd/install/install_test.go
+++ b/tools/vz/cmd/install/install_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package install

--- a/tools/vz/cmd/sanitize/sanitize.go
+++ b/tools/vz/cmd/sanitize/sanitize.go
@@ -95,7 +95,7 @@ func runCmdSanitize(cmd *cobra.Command, args []string, vzHelper helpers.VZHelper
 	if redactionFilePath != "" {
 		// Create the redaction map file if the user provides a non-empty file path.
 		if err := helpers.WriteRedactionMapFile(redactionFilePath, nil); err != nil {
-			return fmt.Errorf("an error occurred while creating the redacted values map at %s: %s", redactionFilePath, err.Error())
+			return fmt.Errorf(constants.RedactionMapCreationError, redactionFilePath, err.Error())
 		}
 	}
 	return nil

--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -167,7 +167,7 @@ func TestUninstallCmdDefaultTimeout(t *testing.T) {
 	// since the Verrazzano resource gets deleted almost instantaneously
 	assert.Equal(t, "Error: Timeout 2ms exceeded waiting for uninstall to complete\n", errBuf.String())
 	ensureResourcesNotDeleted(t, c)
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -209,7 +209,7 @@ func TestUninstallCmdDefaultTimeoutNoBugReport(t *testing.T) {
 	assert.Equal(t, "Error: Timeout 2ms exceeded waiting for uninstall to complete\n", errBuf.String())
 	ensureResourcesNotDeleted(t, c)
 	// Bug Report must not exist
-	if helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal("found bug report file in current directory")
 	}
 }
@@ -311,7 +311,7 @@ func TestUninstallCmdDefaultNoVPO(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, VzVpoFailureError)
 	assert.Contains(t, errBuf.String(), VzVpoFailureError)
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -351,7 +351,7 @@ func TestUninstallCmdDefaultNoUninstallJob(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, PodNotFoundError)
 	assert.Contains(t, errBuf.String(), PodNotFoundError)
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }
@@ -384,7 +384,7 @@ func TestUninstallCmdDefaultNoVzResource(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Verrazzano is not installed: Failed to find any Verrazzano resources")
 	assert.Contains(t, errBuf.String(), "Verrazzano is not installed: Failed to find any Verrazzano resources")
-	if helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal(BugReportNotExist)
 	}
 }

--- a/tools/vz/cmd/uninstall/uninstall_test.go
+++ b/tools/vz/cmd/uninstall/uninstall_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package uninstall

--- a/tools/vz/cmd/upgrade/upgrade_test.go
+++ b/tools/vz/cmd/upgrade/upgrade_test.go
@@ -104,7 +104,7 @@ func TestUpgradeCmdDefaultTimeoutBugReport(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "Error: Timeout 2ms exceeded waiting for upgrade to complete\n", errBuf.String())
 	assert.Contains(t, buf.String(), "Upgrading Verrazzano to version v1.4.0")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal("cannot find bug report file in current directory")
 	}
 }
@@ -144,7 +144,7 @@ func TestUpgradeCmdDefaultTimeoutNoBugReport(t *testing.T) {
 	assert.Equal(t, "Error: Timeout 2ms exceeded waiting for upgrade to complete\n", errBuf.String())
 	assert.Contains(t, buf.String(), "Upgrading Verrazzano to version v1.4.0")
 	// Bug report must not exist
-	if helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal("found bug report file in current directory")
 	}
 }
@@ -176,7 +176,7 @@ func TestUpgradeCmdDefaultNoVPO(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Waiting for verrazzano-platform-operator pod in namespace verrazzano-install")
 	assert.Contains(t, errBuf.String(), "Error: Waiting for verrazzano-platform-operator pod in namespace verrazzano-install")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal("found bug report file in current directory")
 	}
 }
@@ -214,7 +214,7 @@ func TestUpgradeCmdDefaultMultipleVPO(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Waiting for verrazzano-platform-operator, more than one verrazzano-platform-operator pod was found in namespace verrazzano-install")
 	assert.Contains(t, errBuf.String(), "Error: Waiting for verrazzano-platform-operator, more than one verrazzano-platform-operator pod was found in namespace verrazzano-install")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal("found bug report file in current directory")
 	}
 }

--- a/tools/vz/cmd/upgrade/upgrade_test.go
+++ b/tools/vz/cmd/upgrade/upgrade_test.go
@@ -104,7 +104,7 @@ func TestUpgradeCmdDefaultTimeoutBugReport(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "Error: Timeout 2ms exceeded waiting for upgrade to complete\n", errBuf.String())
 	assert.Contains(t, buf.String(), "Upgrading Verrazzano to version v1.4.0")
-	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
 		t.Fatal("cannot find bug report file in current directory")
 	}
 }

--- a/tools/vz/cmd/upgrade/upgrade_test.go
+++ b/tools/vz/cmd/upgrade/upgrade_test.go
@@ -104,7 +104,7 @@ func TestUpgradeCmdDefaultTimeoutBugReport(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "Error: Timeout 2ms exceeded waiting for upgrade to complete\n", errBuf.String())
 	assert.Contains(t, buf.String(), "Upgrading Verrazzano to version v1.4.0")
-	if !helpers.CheckAndRemoveBugReportExistsInDir("") {
+	if !helpers.CheckAndRemoveBugReportAndRedactionFileExistsInDir("") {
 		t.Fatal("cannot find bug report file in current directory")
 	}
 }

--- a/tools/vz/cmd/upgrade/upgrade_test.go
+++ b/tools/vz/cmd/upgrade/upgrade_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package upgrade

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -207,7 +207,6 @@ const (
 
 	// File containing a map from redacted values to their original values
 	RedactionPrefix = "REDACTED-"
-	RedactionMap    = "sensitive-do-not-share-redaction-map.csv"
 
 	// File names for the various resources
 	VzResource        = "verrazzano-resources.json"

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -268,6 +268,6 @@ const TotalWidth = 50
 
 // Common error strings
 const (
-	FlagErrorMessage = "an error occurred while reading value for the flag --%s: %s"
+	FlagErrorMessage          = "an error occurred while reading value for the flag --%s: %s"
 	RedactionMapCreationError = "an error occurred while creating the redacted values map at %s: %s"
 )

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -206,7 +206,8 @@ const (
 	BugReportWarning = "WARNING: Please examine the contents of the bug report for any sensitive data"
 
 	// File containing a map from redacted values to their original values
-	RedactionPrefix = "REDACTED-"
+	RedactionPrefix     = "REDACTED-"
+	RedactionFileSuffix = "-sensitive-do-not-share-redaction-map.csv"
 
 	// File names for the various resources
 	VzResource        = "verrazzano-resources.json"

--- a/tools/vz/pkg/constants/constants.go
+++ b/tools/vz/pkg/constants/constants.go
@@ -267,5 +267,8 @@ const ProgressShorthand = "p"
 const RefreshRate = time.Second * 10
 const TotalWidth = 50
 
-// Error message for failing to parse a flag
-const FlagErrorMessage = "an error occurred while reading value for the flag --%s: %s"
+// Common error strings
+const (
+	FlagErrorMessage = "an error occurred while reading value for the flag --%s: %s"
+	RedactionMapCreationError = "an error occurred while creating the redacted values map at %s: %s"
+)

--- a/tools/vz/pkg/helpers/vzhelper.go
+++ b/tools/vz/pkg/helpers/vzhelper.go
@@ -367,19 +367,9 @@ func VerifyVzInstallNamespaceExists(kubeClient kubernetes.Interface) bool {
 	return false
 }
 
-// CheckAndRemoveBugReportExistsInDir checks vz bug report exists in dir or not
+// CheckAndRemoveBugReportExistsInDir checks that the bug-report file and the redacted values file
+// exist in the directory dir. Returns true if both exists and have matching names.
 func CheckAndRemoveBugReportExistsInDir(dir string) bool {
-	bugReportFilePattern := strings.Replace(vzconstants.BugReportFileDefaultValue, "-dt", "", 1)
-	if fileMatched, _ := filepath.Glob(dir + bugReportFilePattern); len(fileMatched) == 1 {
-		os.Remove(fileMatched[0])
-		return true
-	}
-	return false
-}
-
-// CheckAndRemoveBugReportAndRedactionFileExistsInDir checks that both a vz bug-report file and
-// a redacted values file exists in dir, with matching names
-func CheckAndRemoveBugReportAndRedactionFileExistsInDir(dir string) bool {
 	// Check for the bug report file
 	bugReportFilePattern := strings.Replace(vzconstants.BugReportFileDefaultValue, "-dt", "", 1)
 	var bugReportFilesMatched []string

--- a/tools/vz/pkg/helpers/vzhelper.go
+++ b/tools/vz/pkg/helpers/vzhelper.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package helpers

--- a/tools/vz/pkg/helpers/vzhelper.go
+++ b/tools/vz/pkg/helpers/vzhelper.go
@@ -21,7 +21,6 @@ import (
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	vpoconstants "github.com/verrazzano/verrazzano/platform-operator/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/registry"
-	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	vzconstants "github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/github"
 	istioclient "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -387,7 +386,7 @@ func CheckAndRemoveBugReportAndRedactionFileExistsInDir(dir string) bool {
 		return false
 	}
 	existingBugReportFileName := bugReportFilesMatched[0]
-	defer os.Remove(existingBugReportFileName )
+	defer os.Remove(existingBugReportFileName)
 
 	// Check the redacted values file exists with the expected name
 	expectedRedactionFileName := GenerateRedactionFileNameFromBugReportName(existingBugReportFileName)
@@ -403,5 +402,5 @@ func CheckAndRemoveBugReportAndRedactionFileExistsInDir(dir string) bool {
 // For example, for a bugReportFileName of vz-bug-report-datetime-xxxx.tar.gz,
 // this function returns vz-bug-report-datetime-xxxx-sensitive-do-not-share-redaction-map.csv.
 func GenerateRedactionFileNameFromBugReportName(bugReportFileName string) string {
-	return strings.TrimSuffix(bugReportFileName, ".tar.gz") + constants.RedactionFileSuffix
+	return strings.TrimSuffix(bugReportFileName, ".tar.gz") + vzconstants.RedactionFileSuffix
 }

--- a/tools/vz/pkg/helpers/vzhelper.go
+++ b/tools/vz/pkg/helpers/vzhelper.go
@@ -367,9 +367,19 @@ func VerifyVzInstallNamespaceExists(kubeClient kubernetes.Interface) bool {
 	return false
 }
 
-// CheckAndRemoveBugReportExistsInDir checks that the bug-report file and the redacted values file
-// exist in the directory dir. Returns true if both exists and have matching names.
+// CheckAndRemoveBugReportExistsInDir checks vz bug report exists in dir or not
 func CheckAndRemoveBugReportExistsInDir(dir string) bool {
+	bugReportFilePattern := strings.Replace(vzconstants.BugReportFileDefaultValue, "-dt", "", 1)
+	if fileMatched, _ := filepath.Glob(dir + bugReportFilePattern); len(fileMatched) == 1 {
+		os.Remove(fileMatched[0])
+		return true
+	}
+	return false
+}
+
+// CheckAndRemoveBugReportAndRedactionFileExistsInDir checks that both a vz bug-report file and
+// a redacted values file exists in dir, with matching names
+func CheckAndRemoveBugReportAndRedactionFileExistsInDir(dir string) bool {
 	// Check for the bug report file
 	bugReportFilePattern := strings.Replace(vzconstants.BugReportFileDefaultValue, "-dt", "", 1)
 	var bugReportFilesMatched []string


### PR DESCRIPTION
Upon failed `vz` CLI commands, an automatic bug report is created by the `AutoBugReport` function.

The PR creates a redacted values file along with every automatic bug report. If a bug report has the name `vz-bug-report-datetime-xxxx.tar.gz`, the redacted values file is created as `vz-bug-report-datetime-xxxx-sensitive-do-not-share-redaction-map.csv`.

Also updates unit tests to check for the existence of the redacted values file.