### PR TITLE
vz-11752 followup task to create testBugReportFailedPods scenario

### DIFF
--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -182,7 +182,7 @@ func TestBugReportSuccess(t *testing.T) {
 // TestBugReportGetPreviousLogs
 // GIVEN a CLI bug-report command with no flags, but failed pods on the cluster
 // WHEN I call cmd.Execute
-// THEN expect the command to try and capture previous pod logs if possible and write them out to 'previous-logs.txt'
+// THEN expect the command to try and capture previous pod logs create the file 'previous-logs.txt'
 func TestBugReportGetPreviousLogs(t *testing.T) {
 	cmd := setUpAndVerifyResources(t)
 
@@ -200,13 +200,16 @@ func TestBugReportGetPreviousLogs(t *testing.T) {
 	file, _ := os.Open(bugRepFile)
 	defer file.Close()
 
-	istioSystemPath := "/cluster-snapshot/istio-system/"
+	istioSystemPath := "cluster-snapshot/istio-system"
 	previousLogTxt := "previous-logs.txt"
+	istioPodPath := filepath.Join(tmpDir, istioSystemPath, "istio", previousLogTxt)
+	thirdIstioPodPath := filepath.Join(tmpDir, istioSystemPath, "third-istio-pod", previousLogTxt)
+
 	pkghelper.UntarArchive(tmpDir, file)
-	stat, err := os.Stat(tmpDir + istioSystemPath + "istio/" + previousLogTxt)
+	stat, err := os.Stat(istioPodPath)
 	assert.NoError(t, err)
 	assert.NotNil(t, stat.Name())
-	stat, err = os.Stat(tmpDir + istioSystemPath + "third-istio-pod/" + previousLogTxt)
+	stat, err = os.Stat(thirdIstioPodPath)
 	assert.NoError(t, err)
 	assert.NotNil(t, stat.Name())
 }

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -187,6 +187,8 @@ func TestBugReportGetPreviousLogs(t *testing.T) {
 	cmd := setUpAndVerifyResources(t)
 
 	tmpDir, _ := os.MkdirTemp("", "bug-report")
+	defer cleanupTempDir(t, tmpDir)
+
 	bugRepFile := tmpDir + string(os.PathSeparator) + "bug-report.tgz"
 	setUpGlobalFlags(cmd)
 	err := cmd.PersistentFlags().Set(constants.BugReportFileFlagName, bugRepFile)
@@ -196,6 +198,7 @@ func TestBugReportGetPreviousLogs(t *testing.T) {
 	err = cmd.Execute()
 	assert.NoError(t, err)
 	file, err := os.Open(bugRepFile)
+	defer file.Close()
 
 	istioSystemPath := "/cluster-snapshot/istio-system/"
 	previousLogTxt := "previous-logs.txt"
@@ -206,9 +209,6 @@ func TestBugReportGetPreviousLogs(t *testing.T) {
 	stat, err = os.Stat(tmpDir + istioSystemPath + "third-istio-pod/" + previousLogTxt)
 	assert.NoError(t, err)
 	assert.NotNil(t, stat.Name())
-
-	defer file.Close()
-	defer cleanupTempDir(t, tmpDir)
 }
 
 // TestDefaultBugReportSuccess

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -197,7 +197,7 @@ func TestBugReportGetPreviousLogs(t *testing.T) {
 	assert.NoError(t, err)
 	err = cmd.Execute()
 	assert.NoError(t, err)
-	file, err := os.Open(bugRepFile)
+	file, _ := os.Open(bugRepFile)
 	defer file.Close()
 
 	istioSystemPath := "/cluster-snapshot/istio-system/"


### PR DESCRIPTION
Expands unit test to check if file created while capturing previous pod logs is actually captured