### PR TITLE
VZ-11772: Fix TestBugReportGetPreviousLogs unit test

### DIFF
--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -205,15 +205,23 @@ func TestBugReportGetPreviousLogs(t *testing.T) {
 	istioSystemPath := filepath.Join("cluster-snapshot", "istio-system")
 	previousLogTxt := "previous-logs.txt"
 	istioPodPath := filepath.Join(tmpDir, istioSystemPath, "istio", previousLogTxt)
+	secondIstioPodPath := filepath.Join(tmpDir, istioSystemPath, "second-istio-pod", previousLogTxt)
 	thirdIstioPodPath := filepath.Join(tmpDir, istioSystemPath, "third-istio-pod", previousLogTxt)
 
 	pkghelper.UntarArchive(tmpDir, file)
+
+	// The first and third istio pods have problems and should be flagged
 	stat, err := os.Stat(istioPodPath)
 	assert.NoError(t, err)
 	assert.NotNil(t, stat.Name())
 	stat, err = os.Stat(thirdIstioPodPath)
 	assert.NoError(t, err)
 	assert.NotNil(t, stat.Name())
+
+	// The second istio pod is running as expected and should not be flagged
+	stat, err = os.Stat(secondIstioPodPath)
+	assert.Error(t, err)
+	assert.Nil(t, stat)
 }
 
 // TestDefaultBugReportSuccess

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -560,6 +560,12 @@ func kubeClientObjets() []runtime.Object {
 			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{{Name: vzconstants.Istio}, {Name: "This-should-not-be-here"}},

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -33,6 +33,8 @@ import (
 const (
 	testKubeConfig = "kubeconfig"
 	testK8sContext = "testcontext"
+	secondIstioPodName = "second-istio-pod"
+	thirdIstioPodName = "third-istio-pod"
 
 	// captureResourceErrMsg   = "Capturing resources from the cluster"
 	// sensitiveDataErrMsg     = "WARNING: Please examine the contents of the bug report for any sensitive data"
@@ -202,11 +204,10 @@ func TestBugReportGetPreviousLogs(t *testing.T) {
 	file, _ := os.Open(bugRepFile)
 	defer file.Close()
 
-	istioSystemPath := filepath.Join("cluster-snapshot", "istio-system")
-	previousLogTxt := "previous-logs.txt"
-	istioPodPath := filepath.Join(tmpDir, istioSystemPath, "istio", previousLogTxt)
-	secondIstioPodPath := filepath.Join(tmpDir, istioSystemPath, "second-istio-pod", previousLogTxt)
-	thirdIstioPodPath := filepath.Join(tmpDir, istioSystemPath, "third-istio-pod", previousLogTxt)
+	istioSystemPath := filepath.Join("cluster-snapshot", vzconstants.IstioSystemNamespace)
+	istioPodPath := filepath.Join(tmpDir, istioSystemPath, vzconstants.Istio, constants.PreviousLogFile)
+	secondIstioPodPath := filepath.Join(tmpDir, istioSystemPath, secondIstioPodName, constants.PreviousLogFile)
+	thirdIstioPodPath := filepath.Join(tmpDir, istioSystemPath, thirdIstioPodName, constants.PreviousLogFile)
 
 	pkghelper.UntarArchive(tmpDir, file)
 
@@ -512,10 +513,10 @@ func getClientWithMissingSidecar() client.WithWatch {
 
 // getKubeClient returns a kubeClient containing runtime objects: namespace and a pod
 func getKubeClient() *k8sfake.Clientset {
-	return k8sfake.NewSimpleClientset(kubeClientObjets()...)
+	return k8sfake.NewSimpleClientset(kubeClientObjects()...)
 }
 
-func kubeClientObjets() []runtime.Object {
+func kubeClientObjects() []runtime.Object {
 	return []runtime.Object{
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -561,7 +562,7 @@ func kubeClientObjets() []runtime.Object {
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: vzconstants.IstioSystemNamespace,
-				Name:      "second-istio-pod",
+				Name:      secondIstioPodName,
 				Labels: map[string]string{
 					"app": vzconstants.Istio,
 				},
@@ -582,7 +583,7 @@ func kubeClientObjets() []runtime.Object {
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: vzconstants.IstioSystemNamespace,
-				Name:      "third-istio-pod",
+				Name:      thirdIstioPodName,
 				Labels: map[string]string{
 					"app": vzconstants.Istio,
 				},
@@ -659,7 +660,7 @@ func getVpoObjects() []client.Object {
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: vzconstants.IstioSystemNamespace,
-				Name:      "second-istio-pod",
+				Name:      secondIstioPodName,
 				Labels: map[string]string{
 					"app": vzconstants.Istio,
 				},
@@ -674,7 +675,7 @@ func getVpoObjects() []client.Object {
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: vzconstants.IstioSystemNamespace,
-				Name:      "third-istio-pod",
+				Name:      thirdIstioPodName,
 				Labels: map[string]string{
 					"app": vzconstants.Istio,
 				},

--- a/tools/vz/cmd/bugreport/bugreport_test.go
+++ b/tools/vz/cmd/bugreport/bugreport_test.go
@@ -31,10 +31,10 @@ import (
 )
 
 const (
-	testKubeConfig = "kubeconfig"
-	testK8sContext = "testcontext"
+	testKubeConfig     = "kubeconfig"
+	testK8sContext     = "testcontext"
 	secondIstioPodName = "second-istio-pod"
-	thirdIstioPodName = "third-istio-pod"
+	thirdIstioPodName  = "third-istio-pod"
 
 	// captureResourceErrMsg   = "Capturing resources from the cluster"
 	// sensitiveDataErrMsg     = "WARNING: Please examine the contents of the bug report for any sensitive data"

--- a/tools/vz/pkg/internal/util/log/log.go
+++ b/tools/vz/pkg/internal/util/log/log.go
@@ -63,7 +63,7 @@ func GetDebugEnabledLogger() *zap.SugaredLogger {
 	return logger.Sugar()
 }
 
-// DebugfNotNil executes log.Debugf(s, args) if log is not nil. If log is nil, then this function is a no-op.
+// DebugfIfNotNil executes log.Debugf(s, args) if log is not nil. If log is nil, then this function is a no-op.
 func DebugfIfNotNil(log *zap.SugaredLogger, s string, args ...interface{}) {
 	if log == nil {
 		return


### PR DESCRIPTION
The `TestBugReportGetPreviousLogs` unit test had a problem with flagging a pod as problematic when it shouldn't have been.

This PR
- fixes the above problem by adding a condition to the Pod named `second-istio-pod` in the fake cluster
- adds a check for the problem in the unit test
- cleans up code (i.e. define constants, fix typos)