### PR TITLE
VZ-8679: unit tests for capture VZProjects and VMCs

### DIFF
--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -367,7 +367,6 @@ func TestCaptureVerrazzanoProjects(t *testing.T) {
 				bytesToUnmarshall, err := returnBytesFromAFile(expectedFilePath)
 				assert.NoError(t, err)
 				assert.NoError(t, json.Unmarshal(bytesToUnmarshall, vzProjectList))
-				assert.NoError(t, err)
 				assert.Len(t, vzProjectList.Items, len(tt.vzProjects),
 					"the file %s did not have the expected number of VerrazzanoProject resources listed", expectedFilePath)
 			}
@@ -451,7 +450,6 @@ func TestCaptureVerrazzanoManagedCluster(t *testing.T) {
 				bytesToUnmarshall, err := returnBytesFromAFile(expectedFilePath)
 				assert.NoError(t, err)
 				assert.NoError(t, json.Unmarshal(bytesToUnmarshall, vmcList))
-				assert.NoError(t, err)
 				assert.Len(t, vmcList.Items, len(tt.vmcs),
 					"the file %s did not have the expected number of VerrazzanoManagedCluster resources listed", expectedFilePath)
 			}

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -289,8 +289,6 @@ func TestCaptureVZResource(t *testing.T) {
 	assert.True(t, GetIsLiveCluster())
 }
 
-// TODO: test captureMultiClusterResources in regportgen.go
-
 // TestCaptureVerrazzanoProjects tests the CaptureVerrazzanoProjects function
 // GIVEN a dynamic client possibly containing a VerrazzanoProject resource
 // WHEN I call CaptureVerrazzanoProjects

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -395,7 +395,7 @@ func TestCaptureVerrazzanoManagedCluster(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
+		name string
 		vmcs []runtime.Object
 	}{
 		{

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -290,9 +290,9 @@ func TestCaptureVZResource(t *testing.T) {
 }
 
 // TestCaptureVerrazzanoProjects tests the CaptureVerrazzanoProjects function
-// GIVEN a dynamic client possibly containing a VerrazzanoProject resource
+// GIVEN a dynamic client possibly containing VerrazzanoProject resources
 // WHEN I call CaptureVerrazzanoProjects
-// THEN expect it to detect the VerrazzanoProject and appropriately create a JSON file
+// THEN expect it to detect the VerrazzanoProjects and appropriately create a JSON file
 func TestCaptureVerrazzanoProjects(t *testing.T) {
 	scheme := k8scheme.Scheme
 	_ = appclusterv1alpha1.AddToScheme(scheme)
@@ -373,9 +373,9 @@ func TestCaptureVerrazzanoProjects(t *testing.T) {
 }
 
 // TestCaptureVerrazzanoManagedCluster tests the CaptureVerrazzanoManagedCluster function
-// GIVEN a dynamic client possibly containing a VMC resource
+// GIVEN a dynamic client possibly containing VMC resources
 // WHEN I call CaptureVerrazzanoManagedCluster
-// THEN expect it to detect the VMC and appropriately create a JSON file
+// THEN expect it to detect the VMCs and appropriately create a JSON file
 func TestCaptureVerrazzanoManagedCluster(t *testing.T) {
 	scheme := k8scheme.Scheme
 	_ = clusterv1alpha1.AddToScheme(scheme)

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -8,9 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -30,6 +27,9 @@ import (
 	testhelpers "github.com/verrazzano/verrazzano/tools/vz/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -139,11 +139,11 @@ func TestCaptureK8SResources(t *testing.T) {
 	isError = false
 }
 
-// TestCaptureMultiClusterResources tests the functionality to capture the multi cluster related resources
+// TestCaptureMultiClusterOAMResources tests the functionality to capture the multi cluster related resources
 //
-//	WHEN I call functions to capture Verrazzano multi cluster resources
+//	WHEN I call functions to capture Verrazzano OAM resources in a multi cluster environment
 //	THEN expect it to not throw any error
-func TestCaptureMultiClusterResources(t *testing.T) {
+func TestCaptureMultiClusterOAMResources(t *testing.T) {
 	scheme := k8scheme.Scheme
 	_ = v1beta1.AddToScheme(scheme)
 	_ = clusterv1alpha1.AddToScheme(scheme)

--- a/tools/vz/pkg/helpers/vzcapture_test.go
+++ b/tools/vz/pkg/helpers/vzcapture_test.go
@@ -21,6 +21,7 @@ import (
 	appclusterv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/clusters/v1alpha1"
 	appoamv1alpha1 "github.com/verrazzano/verrazzano/application-operator/apis/oam/v1alpha1"
 	clusterv1alpha1 "github.com/verrazzano/verrazzano/cluster-operator/apis/clusters/v1alpha1"
+	vzconstants "github.com/verrazzano/verrazzano/pkg/constants"
 	"github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1beta1"
 	"github.com/verrazzano/verrazzano/platform-operator/controllers/verrazzano/component/common"
 	"github.com/verrazzano/verrazzano/tools/vz/pkg/constants"
@@ -286,6 +287,58 @@ func TestCaptureVZResource(t *testing.T) {
 	assert.NotNil(t, GetMultiWriterOut())
 	assert.NotNil(t, GetMultiWriterErr())
 	assert.True(t, GetIsLiveCluster())
+}
+
+// TODO: test captureMultiClusterResources in regportgen.go
+
+// TODO: write description
+func TestCaptureVerrazzanoProjects(t *testing.T) {
+	vzProject := &appclusterv1alpha1.VerrazzanoProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: vzconstants.VerrazzanoMultiClusterNamespace,
+			Name:      "myvzproject",
+		},
+		Spec: appclusterv1alpha1.VerrazzanoProjectSpec{
+			Template: appclusterv1alpha1.ProjectTemplate{
+				Namespaces: []appclusterv1alpha1.NamespaceTemplate{
+					{
+						Metadata: metav1.ObjectMeta{
+							Name: "application-ns",
+						},
+					},
+				},
+			},
+		},
+	}
+	_ = vzProject // FIXME: remove
+
+	scheme := k8scheme.Scheme
+	// FIXME: figure out minimal scheme
+	// _ = v1beta1.AddToScheme(scheme)
+	// _ = clusterv1alpha1.AddToScheme(scheme)
+	_ = appclusterv1alpha1.AddToScheme(scheme)
+	// _ = appv1alpha1.AddToScheme(scheme)
+	// _ = appoamv1alpha1.AddToScheme(scheme)
+	// _ = core.AddToScheme(scheme)
+
+	dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme, vzProject)
+	captureDir, err := os.MkdirTemp("", "testcapture")
+	defer cleanupTempDir(t, captureDir)
+	assert.NoError(t, err)
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	tempFile, _ := os.CreateTemp("", "testfile")
+	defer cleanupFile(t, tempFile)
+	SetMultiWriterOut(buf, tempFile)
+	SetMultiWriterErr(errBuf, tempFile)
+	rc := testhelpers.NewFakeRootCmdContext(genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: errBuf})
+	assert.NoError(t, CaptureVerrazzanoProjects(dynamicClient, captureDir, rc))
+}
+
+// TestCaptureVerrazzanoManagedCluster tests the CaptureVerrazzanoManagedCluster function
+// GIVEN TODO: write description
+func TestCaptureVerrazzanoManagedCluster(t *testing.T) {
+	assert.True(t, true) // FIXME: replace with actual testing
 }
 
 // TestDoesNamespaceExist tests the functionality to check if a given namespace exists.


### PR DESCRIPTION
Introduces unit tests that validate the analysis tool's ability to capture `VerrazzanoProjects` and `VerrazzanoManagedClusters`.

Also renames the following unit test: `TestCaptureMultiClusterResources` -> `TestCaptureMultiClusterOAMResources`
