### PR TITLE
Fix Backend pipeline

### DIFF
--- a/ci/tools/derive_upgrade_version.go
+++ b/ci/tools/derive_upgrade_version.go
@@ -56,7 +56,7 @@ func main() {
 		}
 		fmt.Println(tagsAfter)
 	case VersionsLT:
-		tagsBefore, err := getTagsLT(releaseTags, excludeReleaseTags[0])
+		tagsBefore, err := getTagsLT(releaseTags, developmentVersion)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This PR fixes derive versions logic to include development version of the branch. So that the logic will only consider versions less than the development version of the branch. 