### PR TITLE
Cleanup cluster creation key usages

### DIFF
--- a/ci/backup/JenkinsfileAlllBackupOKETest
+++ b/ci/backup/JenkinsfileAlllBackupOKETest
@@ -99,7 +99,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = ""
+        TF_VAR_ssh_public_key_path = "${WORKSPACE}/ephemeral-key.pub"
 
         TEST_CONFIG_FILE = "${HOME}/testConfigOke.yaml"
         OCI_CLI_TENANCY = credentials('oci-tenancy')
@@ -260,7 +260,7 @@ pipeline {
                     ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
                     ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
                 """
-                sh "TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
+                sh "TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 

--- a/ci/backup/JenkinsfileAlllBackupOKETest
+++ b/ci/backup/JenkinsfileAlllBackupOKETest
@@ -99,6 +99,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
+        TF_VAR_ssh_public_key_path = ""
 
         TEST_CONFIG_FILE = "${HOME}/testConfigOke.yaml"
         OCI_CLI_TENANCY = credentials('oci-tenancy')
@@ -253,7 +254,13 @@ pipeline {
 
         stage("Create OKE Cluster") {
             steps {
-                sh "TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
+                sh """
+                    ssh-keygen -t rsa -b 4096 -q -N "" -f ${WORKSPACE}/ephemeral-key
+                    chmod 600 ${WORKSPACE}/ephemeral-key
+                    ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
+                    ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
+                """
+                sh "${WORKSPACE}/ephemeral-key.pub TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 

--- a/ci/backup/JenkinsfileAlllBackupOKETest
+++ b/ci/backup/JenkinsfileAlllBackupOKETest
@@ -99,7 +99,6 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
 
         TEST_CONFIG_FILE = "${HOME}/testConfigOke.yaml"
         OCI_CLI_TENANCY = credentials('oci-tenancy')

--- a/ci/backup/JenkinsfileAlllBackupOKETest
+++ b/ci/backup/JenkinsfileAlllBackupOKETest
@@ -260,7 +260,7 @@ pipeline {
                     ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
                     ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
                 """
-                sh "${WORKSPACE}/ephemeral-key.pub TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
+                sh "TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 

--- a/ci/clusterAPI/JenkinsfileCAPI
+++ b/ci/clusterAPI/JenkinsfileCAPI
@@ -169,7 +169,6 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
 
         // CAPI variables
         OCI_USER_ID = credentials('oci-user-ocid')
@@ -186,7 +185,6 @@ pipeline {
         CLUSTER_SUFFIX_ID = "${clusterSuffix}"
         CLUSTER_NAMESPACE = "ocnecapikluster-${CLUSTER_SUFFIX_ID}"
         CLUSTER_NAME = "ocnecapikluster-${CLUSTER_SUFFIX_ID}"
-        CAPI_NODE_SSH_KEY_PATH = credentials('oci-tf-pub-ssh-key')
         CAPI_OCI_PRIVATE_KEY_PATH = credentials('oci-api-key')
         ORACLE_LINUX_NAME = "${params.ORACLE_LINUX_NAME}"
         OPERATING_SYSTEM = "${params.OPERATING_SYSTEM}"

--- a/ci/clusterAPI/JenkinsfileCAPIQC
+++ b/ci/clusterAPI/JenkinsfileCAPIQC
@@ -130,7 +130,6 @@ pipeline {
         OCI_TENANCY_ID = credentials('oci-tenancy')
         OCI_REGION = "${params.CAPI_CLUSTER_REGION}"
         OCI_COMPARTMENT_ID = credentials('oci-tiburon-dev-compartment-ocid')
-        CAPI_NODE_SSH_KEY_PATH = credentials('oci-tf-pub-ssh-key')
         CAPI_OCI_PRIVATE_KEY_PATH = credentials('oci-api-key')
         CNI_TYPE = "${params.OKE_CNI_TYPE}"
     }

--- a/ci/ha/JenkinsfileRollingUpgrade
+++ b/ci/ha/JenkinsfileRollingUpgrade
@@ -90,7 +90,6 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')

--- a/ci/multicluster/Jenkinsfile
+++ b/ci/multicluster/Jenkinsfile
@@ -136,7 +136,6 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')

--- a/ci/multiplatform/Jenkinsfile
+++ b/ci/multiplatform/Jenkinsfile
@@ -91,7 +91,6 @@ pipeline {
         TF_VAR_nodepool_config = "${params.OKE_NODE_POOL}"
         TF_VAR_api_fingerprint = credentials('oci-api-key-fingerprint')
         TF_VAR_api_private_key_path = credentials('oci-api-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
         TF_VAR_compartment_id = credentials('oci-tiburon-dev-compartment-ocid')
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -106,7 +106,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
+        TF_VAR_ssh_public_key_path = ""
         TF_VAR_compartment_id = credentials('oci-tiburon-dev-compartment-ocid')
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -276,7 +276,7 @@ pipeline {
                                         ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
                                         ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
                                         # set the ssh public key value for terraform
-                                        export TF_VAR_ssh_public_key_path=/tmp/opc_ssh.pub
+                                        export TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub
                                         export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
                                         # call create_oke_cluster with cluster access private
                                         ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true false

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -106,7 +106,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = ""
+        TF_VAR_ssh_public_key_path = "${WORKSPACE}/ephemeral-key.pub"
         TF_VAR_compartment_id = credentials('oci-tiburon-dev-compartment-ocid')
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
@@ -275,8 +275,6 @@ pipeline {
                                         export OPC_USER_KEY_FILE=${WORKSPACE}/ephemeral-key
                                         ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
                                         ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
-                                        # set the ssh public key value for terraform
-                                        export TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub
                                         export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
                                         # call create_oke_cluster with cluster access private
                                         ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true false

--- a/ci/oci-integration/Jenkinsfile
+++ b/ci/oci-integration/Jenkinsfile
@@ -269,19 +269,18 @@ pipeline {
                             }
                             steps {
                                 script {
-                                    withCredentials([sshUserPrivateKey(credentialsId: '5fcc03de-31ce-4566-b11f-9de38e5d98fd', keyFileVariable: 'OPC_USER_KEY_FILE', passphraseVariable: 'OPC_USER_PASSPHRASE', usernameVariable: 'OPC_USERNAME')]) {
-                                        sh """
-                                            # get the ssh public key
-                                            ssh-keygen -y -e -f ${OPC_USER_KEY_FILE} > /tmp/opc_ssh2.pub
-                                            # convert SSH2 public key into an OpenSSH format
-                                            ssh-keygen -i -f /tmp/opc_ssh2.pub > /tmp/opc_ssh.pub
-                                            # set the ssh public key value for terraform
-                                            export TF_VAR_ssh_public_key_path=/tmp/opc_ssh.pub
-                                            export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
-                                            # call create_oke_cluster with cluster access private
-                                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true false
-                                        """
-                                    }
+                                    sh """
+                                        ssh-keygen -t rsa -b 4096 -q -N "" -f ${WORKSPACE}/ephemeral-key
+                                        chmod 600 ${WORKSPACE}/ephemeral-key
+                                        export OPC_USER_KEY_FILE=${WORKSPACE}/ephemeral-key
+                                        ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
+                                        ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
+                                        # set the ssh public key value for terraform
+                                        export TF_VAR_ssh_public_key_path=/tmp/opc_ssh.pub
+                                        export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
+                                        # call create_oke_cluster with cluster access private
+                                        ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true false
+                                    """
                                 }
                             }
                             post {

--- a/ci/ocne-cluster-driver/Jenkinsfile
+++ b/ci/ocne-cluster-driver/Jenkinsfile
@@ -241,7 +241,6 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')
@@ -560,7 +559,6 @@ def setUpEnvVarsForOCNEClusterCreation() {
     env.OCI_TENANCY_ID="${env.TF_VAR_tenancy_id}"
     env.OCI_CREDENTIALS_FINGERPRINT="${env.TF_VAR_api_fingerprint}"
     env.OCI_PRIVATE_KEY_PATH="${TF_VAR_api_private_key_path}"
-    env.NODE_PUBLIC_KEY_PATH="${TF_VAR_ssh_public_key_path}"
     env.OCI_COMPARTMENT_ID="${env.TF_VAR_compartment_id}"
     env.WORKER_NODE_SUBNET="${env.SUBNET_ID}"
     env.CONTROL_PLANE_SUBNET="${env.SUBNET_ID}"

--- a/ci/ocne-cluster-driver/Jenkinsfile
+++ b/ci/ocne-cluster-driver/Jenkinsfile
@@ -241,7 +241,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = ""
+        TF_VAR_ssh_public_key_path = "${WORKSPACE}/ephemeral-key.pub"
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')
@@ -384,7 +384,7 @@ pipeline {
                     ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
                     ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
                 """
-                sh "TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=ocne-driver-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
+                sh "TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=ocne-driver-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 
@@ -566,6 +566,7 @@ def setUpEnvVarsForOCNEClusterCreation() {
     env.OCI_TENANCY_ID="${env.TF_VAR_tenancy_id}"
     env.OCI_CREDENTIALS_FINGERPRINT="${env.TF_VAR_api_fingerprint}"
     env.OCI_PRIVATE_KEY_PATH="${TF_VAR_api_private_key_path}"
+    env.NODE_PUBLIC_KEY_PATH="${TF_VAR_ssh_public_key_path}"
     env.OCI_COMPARTMENT_ID="${env.TF_VAR_compartment_id}"
     env.WORKER_NODE_SUBNET="${env.SUBNET_ID}"
     env.CONTROL_PLANE_SUBNET="${env.SUBNET_ID}"

--- a/ci/ocne-cluster-driver/Jenkinsfile
+++ b/ci/ocne-cluster-driver/Jenkinsfile
@@ -241,6 +241,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
+        TF_VAR_ssh_public_key_path = ""
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')
@@ -377,7 +378,13 @@ pipeline {
 
         stage("Create OKE Cluster") {
             steps {
-                sh "TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=ocne-driver-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
+                sh """
+                    ssh-keygen -t rsa -b 4096 -q -N "" -f ${WORKSPACE}/ephemeral-key
+                    chmod 600 ${WORKSPACE}/ephemeral-key
+                    ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
+                    ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
+                """
+                sh "TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=ocne-driver-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 

--- a/ci/oke-capi-cluster-driver/Jenkinsfile
+++ b/ci/oke-capi-cluster-driver/Jenkinsfile
@@ -157,6 +157,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
+        TF_VAR_ssh_public_key_path = ""
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')

--- a/ci/oke-capi-cluster-driver/Jenkinsfile
+++ b/ci/oke-capi-cluster-driver/Jenkinsfile
@@ -157,7 +157,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = ""
+        TF_VAR_ssh_public_key_path = "${WORKSPACE}/ephemeral-key.pub"
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')
@@ -301,7 +301,7 @@ pipeline {
                     ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
                     ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
                 """
-                sh "TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=oke-capi-driver-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
+                sh "TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=oke-capi-driver-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 
@@ -484,6 +484,7 @@ def setUpEnvVarsForOKECAPIClusterCreation() {
     env.OCI_TENANCY_ID="${env.TF_VAR_tenancy_id}"
     env.OCI_CREDENTIALS_FINGERPRINT="${env.TF_VAR_api_fingerprint}"
     env.OCI_PRIVATE_KEY_PATH="${TF_VAR_api_private_key_path}"
+    env.NODE_PUBLIC_KEY_PATH="${TF_VAR_ssh_public_key_path}"
     env.OCI_COMPARTMENT_ID="${env.TF_VAR_compartment_id}"
     env.WORKER_NODE_SUBNET="${env.SUBNET_ID}"
     env.CONTROL_PLANE_SUBNET="${env.SUBNET_ID}"

--- a/ci/oke-capi-cluster-driver/Jenkinsfile
+++ b/ci/oke-capi-cluster-driver/Jenkinsfile
@@ -157,7 +157,6 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')
@@ -478,7 +477,6 @@ def setUpEnvVarsForOKECAPIClusterCreation() {
     env.OCI_TENANCY_ID="${env.TF_VAR_tenancy_id}"
     env.OCI_CREDENTIALS_FINGERPRINT="${env.TF_VAR_api_fingerprint}"
     env.OCI_PRIVATE_KEY_PATH="${TF_VAR_api_private_key_path}"
-    env.NODE_PUBLIC_KEY_PATH="${TF_VAR_ssh_public_key_path}"
     env.OCI_COMPARTMENT_ID="${env.TF_VAR_compartment_id}"
     env.WORKER_NODE_SUBNET="${env.SUBNET_ID}"
     env.CONTROL_PLANE_SUBNET="${env.SUBNET_ID}"

--- a/ci/oke-capi-cluster-driver/Jenkinsfile
+++ b/ci/oke-capi-cluster-driver/Jenkinsfile
@@ -294,7 +294,13 @@ pipeline {
 
         stage("Create OKE Cluster") {
             steps {
-                sh "TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=oke-capi-driver-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
+                sh """
+                    ssh-keygen -t rsa -b 4096 -q -N "" -f ${WORKSPACE}/ephemeral-key
+                    chmod 600 ${WORKSPACE}/ephemeral-key
+                    ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
+                    ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
+                """
+                sh "TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=oke-capi-driver-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
+        TF_VAR_ssh_public_key_path = ""
         TF_VAR_compartment_id = credentials('oci-tiburon-dev-compartment-ocid')
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -276,7 +276,7 @@ pipeline {
                         ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
                         ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
                         # set the ssh public key value for terraform
-                        export TF_VAR_ssh_public_key_path=/tmp/opc_ssh.pub
+                        export TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub
                         export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
                         # call create_oke_cluster with cluster access private
                         ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${params.CREATE_CLUSTER_USE_CALICO}

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -261,27 +261,26 @@ pipeline {
             }
             steps {
                 script {
-                    withCredentials([sshUserPrivateKey(credentialsId: '5fcc03de-31ce-4566-b11f-9de38e5d98fd', keyFileVariable: 'OPC_USER_KEY_FILE', passphraseVariable: 'OPC_USER_PASSPHRASE', usernameVariable: 'OPC_USERNAME')]) {
                     def RUNNER_REGION = sh(returnStdout: true, script: "curl -s -H \"Authorization: Bearer Oracle\" http://169.254.169.254/opc/v2/instance/canonicalRegionName").trim()
                     env.TF_VAR_region = "${params.DNS_SCOPE == 'PRIVATE' ? RUNNER_REGION : params.OKE_CLUSTER_REGION}"
                     env.OCI_CLI_REGION = "${params.DNS_SCOPE == 'PRIVATE' ? RUNNER_REGION : params.OKE_CLUSTER_REGION}"
                     if (params.NGINX_LB_SCOPE == "PRIVATE" || params.ISTIO_LB_SCOPE == "PRIVATE")  {
                         env.TF_VAR_region = RUNNER_REGION
                         env.OCI_CLI_REGION = RUNNER_REGION
-                   }
-                    println("runner region is ${RUNNER_REGION}, tf var region is ${env.TF_VAR_REGION}")
-                        sh """
-                            # get the ssh public key
-                            ssh-keygen -y -e -f ${OPC_USER_KEY_FILE} > /tmp/opc_ssh2.pub
-                            # convert SSH2 public key into an OpenSSH format
-                            ssh-keygen -i -f /tmp/opc_ssh2.pub > /tmp/opc_ssh.pub
-                            # set the ssh public key value for terraform
-                            export TF_VAR_ssh_public_key_path=/tmp/opc_ssh.pub
-                            export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
-                            # call create_oke_cluster with cluster access private
-                            ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${params.CREATE_CLUSTER_USE_CALICO}
-                        """
                     }
+                    println("runner region is ${RUNNER_REGION}, tf var region is ${env.TF_VAR_REGION}")
+                    sh """
+                        ssh-keygen -t rsa -b 4096 -q -N "" -f ${WORKSPACE}/ephemeral-key
+                        chmod 600 ${WORKSPACE}/ephemeral-key
+                        export OPC_USER_KEY_FILE=${WORKSPACE}/ephemeral-key
+                        ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
+                        ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
+                        # set the ssh public key value for terraform
+                        export TF_VAR_ssh_public_key_path=/tmp/opc_ssh.pub
+                        export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
+                        # call create_oke_cluster with cluster access private
+                        ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${params.CREATE_CLUSTER_USE_CALICO}
+                    """
                 }
             }
             post {

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = ""
+        TF_VAR_ssh_public_key_path = "${WORKSPACE}/ephemeral-key.pub"
         TF_VAR_compartment_id = credentials('oci-tiburon-dev-compartment-ocid')
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
@@ -275,8 +275,6 @@ pipeline {
                         export OPC_USER_KEY_FILE=${WORKSPACE}/ephemeral-key
                         ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
                         ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
-                        # set the ssh public key value for terraform
-                        export TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub
                         export TF_VAR_state_name=${env.BUILD_NUMBER}-${env.TIMESTAMP}-${env.BRANCH_NAME}
                         # call create_oke_cluster with cluster access private
                         ${WORKSPACE}/tests/e2e/config/scripts/create_oke_cluster.sh true ${params.CREATE_CLUSTER_USE_CALICO}

--- a/ci/olcne/Jenkinsfile
+++ b/ci/olcne/Jenkinsfile
@@ -283,7 +283,7 @@ pipeline {
 
                     // Install terraform and generate ssh keys
                     sh """
-                        sudo yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer/x86_64
+                        sudo yum-config-manager --add-repo https://yum.oracle.com/repo/OracleLinux/OL7/developer/archive/x86_64/
                         sudo yum install -y terraform
                         mkdir -p $OCNE_DUMP_DIR
                         ssh-keygen -t rsa -b 4096 -q -N "" -f $TF_VAR_ssh_private_key_path

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -92,7 +92,6 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
 
         TEST_CONFIG_FILE = "${HOME}/testConfigOke.yaml"
         OCI_CLI_TENANCY = credentials('oci-tenancy')

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = ""
+        TF_VAR_ssh_public_key_path = "${WORKSPACE}/ephemeral-key.pub"
 
         TEST_CONFIG_FILE = "${HOME}/testConfigOke.yaml"
         OCI_CLI_TENANCY = credentials('oci-tenancy')
@@ -232,7 +232,7 @@ pipeline {
                     ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
                     ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
                 """
-                sh "TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
+                sh "TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 

--- a/ci/uninstall/Jenkinsfile
+++ b/ci/uninstall/Jenkinsfile
@@ -92,6 +92,7 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
+        TF_VAR_ssh_public_key_path = ""
 
         TEST_CONFIG_FILE = "${HOME}/testConfigOke.yaml"
         OCI_CLI_TENANCY = credentials('oci-tenancy')
@@ -225,7 +226,13 @@ pipeline {
 
         stage("Create Cluster") {
             steps {
-                sh "TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
+                sh """
+                    ssh-keygen -t rsa -b 4096 -q -N "" -f ${WORKSPACE}/ephemeral-key
+                    chmod 600 ${WORKSPACE}/ephemeral-key
+                    ssh-keygen -y -e -f ${WORKSPACE}/ephemeral-key > ${WORKSPACE}/ephemeral-key.pub-1
+                    ssh-keygen -i -f ${WORKSPACE}/ephemeral-key.pub-1 > ${WORKSPACE}/ephemeral-key.pub
+                """
+                sh "TF_VAR_ssh_public_key_path=${WORKSPACE}/ephemeral-key.pub TF_VAR_label_prefix=${OKE_CLUSTER_PREFIX} TF_VAR_state_name=uninstall-${env.BUILD_NUMBER}-${env.BRANCH_NAME}/${env.TIMESTAMP} ${GO_REPO_PATH}/verrazzano/tests/e2e/config/scripts/create_oke_cluster.sh"
             }
         }
 

--- a/ci/upgrade-paths/Jenkinsfile
+++ b/ci/upgrade-paths/Jenkinsfile
@@ -161,7 +161,6 @@ pipeline {
         TF_VAR_api_private_key_path = credentials('oci-api-key')
         TF_VAR_s3_bucket_access_key = credentials('oci-s3-bucket-access-key')
         TF_VAR_s3_bucket_secret_key = credentials('oci-s3-bucket-secret-key')
-        TF_VAR_ssh_public_key_path = credentials('oci-tf-pub-ssh-key')
 
         OCI_CLI_TENANCY = credentials('oci-tenancy')
         OCI_CLI_USER = credentials('oci-user-ocid')


### PR DESCRIPTION
- Cleanup SSH key usages, switch the ones that setup tunnels to use ephemeral keys.
- Unrelated to ssh keys, the OL7 yum repo removed terraform, so get it from an archive repo for now