### PR TITLE
OLCNE-6488: Disable ACME Staging Tests In Pipeline

### DIFF
--- a/ci/JenkinsfilePeriodicTests
+++ b/ci/JenkinsfilePeriodicTests
@@ -414,7 +414,7 @@ pipeline {
                         }
                     }
                 }
-                stage('OCI DNS/ACME-Staging Tests') {
+                stage('OCI DNS/ACME-Production Tests') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
@@ -422,7 +422,7 @@ pipeline {
                                     parameters: [
                                         string(name: 'GIT_COMMIT_TO_USE', value: env.GIT_COMMIT),
                                         string(name: 'CERT_ISSUER', value: "acme"),
-                                        string(name: 'ACME_ENVIRONMENT', value: "staging"),
+                                        string(name: 'ACME_ENVIRONMENT', value: "production"),
                                         booleanParam(name: 'CREATE_CLUSTER_USE_CALICO', value: false),
                                         string(name: 'TAGGED_TESTS', value: params.TAGGED_TESTS),
                                         string(name: 'INCLUDED_TESTS', value: params.INCLUDED_TESTS),

--- a/ci/a-la-carte/JenkensfileALaCarteTriggered
+++ b/ci/a-la-carte/JenkensfileALaCarteTriggered
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, Oracle and/or its affiliates.
+// Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 pipeline {
@@ -135,7 +135,7 @@ pipeline {
                         }
                     }
                 }
-                stage('OCIDNS, LetEncypt staging, Cert-Manager default clusterResourceNamespace') {
+                stage('OCIDNS, LetsEncrypt Production, Cert-Manager default clusterResourceNamespace') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {
@@ -189,7 +189,7 @@ pipeline {
                         }
                     }
                 }
-                stage('OCIDNS, LetEncypt staging, Cert-Manager custom clusterResourceNamespace') {
+                stage('OCIDNS, LetsEncrypt Production, Cert-Manager custom clusterResourceNamespace') {
                     steps {
                         retry(count: JOB_PROMOTION_RETRIES) {
                             script {

--- a/ci/a-la-carte/Jenkinsfile
+++ b/ci/a-la-carte/Jenkinsfile
@@ -199,6 +199,8 @@ pipeline {
                         oci --region us-phoenix-1 os object get --namespace ${OCI_OS_NAMESPACE} -bn ${OCI_OS_COMMIT_BUCKET} --name ephemeral/${env.BRANCH_NAME}/${SHORT_COMMIT_HASH}/${VZ_CLI_TARGZ} --file ${VZ_CLI_TARGZ}
                         tar xzf ${VZ_CLI_TARGZ} -C ${GO_REPO_PATH}
                         ${GO_REPO_PATH}/vz version
+                        echo "update CA certs"
+                        sudo update-ca-trust
                     """
                 }
             }

--- a/ci/oke-ocidns/Jenkinsfile
+++ b/ci/oke-ocidns/Jenkinsfile
@@ -249,6 +249,8 @@ pipeline {
                         mkdir -p ${GO_REPO_PATH}
                         tar xzf ${VZ_CLI_TARGZ} -C ${GO_REPO_PATH}
                         ${GO_REPO_PATH}/vz version
+                        echo "update CA certs"
+                        sudo update-ca-trust
                     """
                 }
             }

--- a/pkg/certs/letsencrypt.go
+++ b/pkg/certs/letsencrypt.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	intR10PEM = "https://letsencrypt.org/certs/2024/r10.pem"
-	intE5PEM  = "https://letsencrypt.org/certs/2024/e5-cross.pem"
+	intR3PEM  = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r3.pem"
+	intE1PEM  = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e1.pem"
 	rootX1PEM = "https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem"
 )
 
@@ -48,10 +48,10 @@ func (c *certBuilder) appendCertWithHTTP(uri string) error {
 // Verrazzano uses the LetsEncrypt staging certificate chain for Rancher ingress on ACME staging environments.
 // See https://letsencrypt.org/docs/staging-environment/ for more information.
 func (c *certBuilder) buildLetsEncryptStagingChain() error {
-	if err := c.appendCertWithHTTP(intR10PEM); err != nil {
+	if err := c.appendCertWithHTTP(intR3PEM); err != nil {
 		return err
 	}
-	if err := c.appendCertWithHTTP(intE5PEM); err != nil {
+	if err := c.appendCertWithHTTP(intE1PEM); err != nil {
 		return err
 	}
 	if err := c.appendCertWithHTTP(rootX1PEM); err != nil {

--- a/pkg/certs/letsencrypt.go
+++ b/pkg/certs/letsencrypt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package certs

--- a/pkg/certs/letsencrypt.go
+++ b/pkg/certs/letsencrypt.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	intR10PEM = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r10.pem"
-	intE5PEM  = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e5.pem"
+	intR10PEM = "https://letsencrypt.org/certs/2024/r10.pem"
+	intE5PEM  = "https://letsencrypt.org/certs/2024/e5-cross.pem"
 	rootX1PEM = "https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem"
 )
 

--- a/pkg/certs/letsencrypt.go
+++ b/pkg/certs/letsencrypt.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	intR3PEM  = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r3.pem"
-	intE1PEM  = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e1.pem"
+	intR10PEM = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r10.pem"
+	intE5PEM  = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e5.pem"
 	rootX1PEM = "https://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem"
 )
 
@@ -48,10 +48,10 @@ func (c *certBuilder) appendCertWithHTTP(uri string) error {
 // Verrazzano uses the LetsEncrypt staging certificate chain for Rancher ingress on ACME staging environments.
 // See https://letsencrypt.org/docs/staging-environment/ for more information.
 func (c *certBuilder) buildLetsEncryptStagingChain() error {
-	if err := c.appendCertWithHTTP(intR3PEM); err != nil {
+	if err := c.appendCertWithHTTP(intR10PEM); err != nil {
 		return err
 	}
-	if err := c.appendCertWithHTTP(intE1PEM); err != nil {
+	if err := c.appendCertWithHTTP(intE5PEM); err != nil {
 		return err
 	}
 	if err := c.appendCertWithHTTP(rootX1PEM); err != nil {

--- a/pkg/certs/letsencrypt_test.go
+++ b/pkg/certs/letsencrypt_test.go
@@ -104,7 +104,7 @@ func TestCreateLetsEncryptStagingBundle(t *testing.T) {
 			func(hc *http.Client, req *http.Request) (*http.Response, error) {
 				bundleData := ""
 				switch req.URL.Path[len(req.URL.Path)-15:] {
-				case "-stg-int-r10.pem":
+				case "stg-int-r10.pem":
 					bundleData = "intR10PEM\n"
 				case "-stg-int-e5.pem":
 					bundleData = "intE5PEM\n"

--- a/pkg/certs/letsencrypt_test.go
+++ b/pkg/certs/letsencrypt_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package certs

--- a/pkg/certs/letsencrypt_test.go
+++ b/pkg/certs/letsencrypt_test.go
@@ -103,19 +103,20 @@ func TestCreateLetsEncryptStagingBundle(t *testing.T) {
 			"should be able to download staging bundles",
 			func(hc *http.Client, req *http.Request) (*http.Response, error) {
 				bundleData := ""
-				if strings.Contains(req.URL.Path, "stg-root-x1.pem") {
+				switch req.URL.Path[len(req.URL.Path)-15:] {
+				case "-stg-int-r3.pem":
+					bundleData = "intR3PEM\n"
+				case "-stg-int-e1.pem":
+					bundleData = "intE1PEM\n"
+				case "stg-root-x1.pem":
 					bundleData = "rootX1PEM\n"
-				} else if strings.Contains(req.URL.Path, "r10.pem") {
-					bundleData = "intR10PEM\n"
-				} else if strings.Contains(req.URL.Path, "e5-cross.pem") {
-					bundleData = "intE5PEM\n"
 				}
 				return &http.Response{
 					Body:       io.NopCloser(strings.NewReader(bundleData)),
 					StatusCode: http.StatusOK,
 				}, nil
 			},
-			[]byte("intR10PEM\nintE5PEM\nrootX1PEM"),
+			[]byte("intR3PEM\nintE1PEM\nrootX1PEM"),
 			false,
 		},
 		{

--- a/pkg/certs/letsencrypt_test.go
+++ b/pkg/certs/letsencrypt_test.go
@@ -104,10 +104,10 @@ func TestCreateLetsEncryptStagingBundle(t *testing.T) {
 			func(hc *http.Client, req *http.Request) (*http.Response, error) {
 				bundleData := ""
 				switch req.URL.Path[len(req.URL.Path)-15:] {
-				case "-stg-int-r3.pem":
-					bundleData = "intR3PEM\n"
-				case "-stg-int-e1.pem":
-					bundleData = "intE1PEM\n"
+				case "-stg-int-r10.pem":
+					bundleData = "intR10PEM\n"
+				case "-stg-int-e5.pem":
+					bundleData = "intE5PEM\n"
 				case "stg-root-x1.pem":
 					bundleData = "rootX1PEM\n"
 				}
@@ -116,7 +116,7 @@ func TestCreateLetsEncryptStagingBundle(t *testing.T) {
 					StatusCode: http.StatusOK,
 				}, nil
 			},
-			[]byte("intR3PEM\nintE1PEM\nrootX1PEM"),
+			[]byte("intR10PEM\nintE5PEM\nrootX1PEM"),
 			false,
 		},
 		{

--- a/pkg/certs/letsencrypt_test.go
+++ b/pkg/certs/letsencrypt_test.go
@@ -103,13 +103,12 @@ func TestCreateLetsEncryptStagingBundle(t *testing.T) {
 			"should be able to download staging bundles",
 			func(hc *http.Client, req *http.Request) (*http.Response, error) {
 				bundleData := ""
-				switch req.URL.Path[len(req.URL.Path)-15:] {
-				case "stg-int-r10.pem":
-					bundleData = "intR10PEM\n"
-				case "-stg-int-e5.pem":
-					bundleData = "intE5PEM\n"
-				case "stg-root-x1.pem":
+				if strings.Contains(req.URL.Path, "stg-root-x1.pem") {
 					bundleData = "rootX1PEM\n"
+				} else if strings.Contains(req.URL.Path, "r10.pem") {
+					bundleData = "intR10PEM\n"
+				} else if strings.Contains(req.URL.Path, "e5-cross.pem") {
+					bundleData = "intE5PEM\n"
 				}
 				return &http.Response{
 					Body:       io.NopCloser(strings.NewReader(bundleData)),

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, Oracle and/or its affiliates.
+// Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package issuer

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer.go
@@ -795,7 +795,6 @@ func getPrivateBundleData(log vzlog.VerrazzanoLogger, c crtclient.Client, cluste
 	} else if isLetsEncryptStagingEnv {
 		log.Infof("Getting Let's Encrypt Staging CA bundle for Rancher")
 		if bundleData, err = getLetsEncryptStagingBundleFunc(); err != nil {
-			fmt.Println(err.Error())
 			return []byte{}, err
 		}
 	}

--- a/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer.go
+++ b/platform-operator/controllers/verrazzano/component/certmanager/issuer/cluster_issuer.go
@@ -795,6 +795,7 @@ func getPrivateBundleData(log vzlog.VerrazzanoLogger, c crtclient.Client, cluste
 	} else if isLetsEncryptStagingEnv {
 		log.Infof("Getting Let's Encrypt Staging CA bundle for Rancher")
 		if bundleData, err = getLetsEncryptStagingBundleFunc(); err != nil {
+			fmt.Println(err.Error())
 			return []byte{}, err
 		}
 	}

--- a/tests/e2e/pkg/acme_ca_certs.go
+++ b/tests/e2e/pkg/acme_ca_certs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 package pkg
 

--- a/tests/e2e/pkg/acme_ca_certs.go
+++ b/tests/e2e/pkg/acme_ca_certs.go
@@ -7,13 +7,13 @@ import (
 	"net/http"
 )
 
-const letsEncryptStagingIntR10 = "https://letsencrypt.org/certs/2024/r10.pem"
-const letsEncryptStagingIntE5 = "https://letsencrypt.org/certs/2024/e5-cross.pem"
+const letsEncryptStagingIntR3 = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r3.pem"
+const letsEncryptStagingIntE1 = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e1.pem"
 
 func getACMEStagingCAs() [][]byte {
-	letsEncryptStagingIntE5CA := loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntE5, "E5")
-	letsEncryptStagingIntR10CA := loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntR10, "R10")
-	return [][]byte{letsEncryptStagingIntE5CA, letsEncryptStagingIntR10CA}
+	letsEncryptStagingIntE1CA := loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntE1, "E1")
+	letsEncryptStagingIntR3CA := loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntR3, "R3")
+	return [][]byte{letsEncryptStagingIntE1CA, letsEncryptStagingIntR3CA}
 }
 
 func newSimpleHTTPClient() *http.Client {

--- a/tests/e2e/pkg/acme_ca_certs.go
+++ b/tests/e2e/pkg/acme_ca_certs.go
@@ -7,13 +7,13 @@ import (
 	"net/http"
 )
 
-const letsEncryptStagingIntR3 = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r3.pem"
-const letsEncryptStagingIntE1 = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e1.pem"
+const letsEncryptStagingIntR10 = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r10.pem"
+const letsEncryptStagingIntE5 = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e5.pem"
 
 func getACMEStagingCAs() [][]byte {
-	letsEncryptStagingIntE1CA := loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntE1, "E1")
-	letsEncryptStagingIntR3CA := loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntR3, "R3")
-	return [][]byte{letsEncryptStagingIntE1CA, letsEncryptStagingIntR3CA}
+	letsEncryptStagingIntE5CA := loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntE5, "E5")
+	letsEncryptStagingIntR10CA := loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntR10, "R10")
+	return [][]byte{letsEncryptStagingIntE5CA, letsEncryptStagingIntR10CA}
 }
 
 func newSimpleHTTPClient() *http.Client {

--- a/tests/e2e/pkg/acme_ca_certs.go
+++ b/tests/e2e/pkg/acme_ca_certs.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 )
 
-const letsEncryptStagingIntR10 = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-r10.pem"
-const letsEncryptStagingIntE5 = "https://letsencrypt.org/certs/staging/letsencrypt-stg-int-e5.pem"
+const letsEncryptStagingIntR10 = "https://letsencrypt.org/certs/2024/r10.pem"
+const letsEncryptStagingIntE5 = "https://letsencrypt.org/certs/2024/e5-cross.pem"
 
 func getACMEStagingCAs() [][]byte {
 	letsEncryptStagingIntE5CA := loadStagingCA(newSimpleHTTPClient(), letsEncryptStagingIntE5, "E5")

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -338,7 +338,7 @@ func getHTTPClientWithCABundle(caData []byte, kubeconfigPath string) (*http.Clie
 
 // getVerrazzanoCACert returns the Verrazzano CA cert in the specified cluster
 func getVerrazzanoCACert(kubeconfigPath string) ([]byte, error) {
-	cacert, err := GetCACertFromSecret("verrazzano-tls", "verrazzano-system", "tls.crt", kubeconfigPath)
+	cacert, err := GetCACertFromSecret("verrazzano-tls", "verrazzano-system", "ca.crt", kubeconfigPath)
 	if err != nil {
 		envName, err := GetEnvName(kubeconfigPath)
 		if err != nil {

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -338,7 +338,7 @@ func getHTTPClientWithCABundle(caData []byte, kubeconfigPath string) (*http.Clie
 
 // getVerrazzanoCACert returns the Verrazzano CA cert in the specified cluster
 func getVerrazzanoCACert(kubeconfigPath string) ([]byte, error) {
-	cacert, err := GetCACertFromSecret("verrazzano-tls", "verrazzano-system", "ca.crt", kubeconfigPath)
+	cacert, err := GetCACertFromSecret("verrazzano-tls", "verrazzano-system", "tls.crt", kubeconfigPath)
 	if err != nil {
 		envName, err := GetEnvName(kubeconfigPath)
 		if err != nil {

--- a/tests/e2e/pkg/web.go
+++ b/tests/e2e/pkg/web.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package pkg

--- a/tests/e2e/update/a-la-carte/a_la_carte_test.go
+++ b/tests/e2e/update/a-la-carte/a_la_carte_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, Oracle and/or its affiliates.
+// Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package alacarte
@@ -111,7 +111,7 @@ func (m appStackModifier) ModifyCR(cr *vzapi.Verrazzano) {
 	if certificateType == letsEncryptType {
 		clusterIssuer.LetsEncrypt = &vzapi.LetsEncryptACMEIssuer{
 			EmailAddress: "jane.doe@mycompany.com",
-			Environment:  "staging",
+			Environment:  "production",
 		}
 	}
 	cr.Spec.Components.ClusterIssuer = clusterIssuer


### PR DESCRIPTION
In this PR, I disable the ACME staging tests in the oci-dns tests and in the a-la-carte tests. 
