### PR TITLE
VZ-11894 cert renewal fix for release-1.6

### DIFF
--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -175,6 +175,11 @@ func (r *VerrazzanoSecretsReconciler) renewClusterIssuerCertificates(req ctrl.Re
 	// Renew each certificate that was issued by the Verrazzano ClusterIssuer
 	for i, cert := range certList.Items {
 		if cert.Spec.IssuerRef.Name == vzconst.VerrazzanoClusterIssuerName {
+			// Only renew the cert if the renewal time is in the past
+			if time.Now().Before(cert.Status.RenewalTime.Time) {
+				continue
+			}
+
 			r.log.Infof("Renewing certificate %s/%s", cert.Namespace, cert.Name)
 			if err := issuer.RenewCertificate(context.TODO(), cmClient, r.log, &certList.Items[i]); err != nil {
 				return newRequeueWithDelay(), err

--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -176,7 +176,7 @@ func (r *VerrazzanoSecretsReconciler) renewClusterIssuerCertificates(req ctrl.Re
 	for i, cert := range certList.Items {
 		if cert.Spec.IssuerRef.Name == vzconst.VerrazzanoClusterIssuerName {
 			// Only renew the cert if the renewal time is in the past
-			if time.Now().Before(cert.Status.RenewalTime.Time) {
+			if cert.Status.RenewalTime == nil || time.Now().Before(cert.Status.RenewalTime.Time) {
 				continue
 			}
 

--- a/platform-operator/controllers/secrets/secrets_controller.go
+++ b/platform-operator/controllers/secrets/secrets_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package secrets

--- a/platform-operator/controllers/secrets/secrets_controller_test.go
+++ b/platform-operator/controllers/secrets/secrets_controller_test.go
@@ -596,6 +596,12 @@ func newCertificateWithSecret(issuerName string, commonName string, certName str
 			},
 			SecretName: secret.Name,
 		},
+		Status: certv1.CertificateStatus{
+			RenewalTime: &metav1.Time{
+				// yesterday
+				Time: time.Now().AddDate(0, 0, -1),
+			},
+		},
 	}
 
 	return secret, certificate, nil

--- a/platform-operator/controllers/secrets/secrets_controller_test.go
+++ b/platform-operator/controllers/secrets/secrets_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package secrets

--- a/platform-operator/controllers/secrets/verrazzano_tls_secret.go
+++ b/platform-operator/controllers/secrets/verrazzano_tls_secret.go
@@ -153,7 +153,7 @@ func (r *VerrazzanoSecretsReconciler) updateSecret(namespace string, name string
 		return controllerutil.OperationResultNone, err
 	}
 
-	r.log.Infof("Created or updated secret %s/%s (result: %v)", name, namespace, result)
+	r.log.Debugf("Created or updated secret %s/%s (result: %v)", name, namespace, result)
 	return result, nil
 }
 

--- a/platform-operator/controllers/secrets/verrazzano_tls_secret.go
+++ b/platform-operator/controllers/secrets/verrazzano_tls_secret.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package secrets


### PR DESCRIPTION
Fix a bug where the cert was being renewed every day or so. This caused the OpenSearch Dashboard console to require a new login. The fix changes the code so that it only renews the cert if the current time is later than the renewal time. In reality when that happens cert-manager operator will automatically renew the cert, but just in case it doesn't the VPO will do it. So the cert only gets renewed every few months now.