### PR TITLE
Revert "Always pull the weblogic:12.2.1.4 image rather than getting it from t…"

### DIFF
--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2

--- a/examples/bobs-books/bobs-books-comp.yaml
+++ b/examples/bobs-books/bobs-books-comp.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2
@@ -189,7 +189,6 @@ spec:
           domainUID: bobbys-front-end
           domainHome: /u01/oracle/user_projects/domains/bobbys-front-end
           image: container-registry.oracle.com/middleware/weblogic:12.2.1.4
-          imagePullPolicy: Always
           imagePullSecrets:
             - name: bobs-books-repo-credentials
           domainHomeSourceType: "FromModel"
@@ -454,7 +453,6 @@ spec:
           domainHome: /u01/oracle/user_projects/domains/bobs-bookstore
           domainHomeSourceType: FromModel
           image: container-registry.oracle.com/middleware/weblogic:12.2.1.4
-          imagePullPolicy: Always
           includeServerOutInPodLog: true
           replicas: 1
           webLogicCredentialsSecret:

--- a/examples/multicluster/todo-list/todo-list-components.yaml
+++ b/examples/multicluster/todo-list/todo-list-components.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2
@@ -22,7 +22,6 @@ spec:
           domainUID: tododomain
           domainHome: /u01/domains/tododomain
           image: container-registry.oracle.com/middleware/weblogic:12.2.1.4
-          imagePullPolicy: Always
           imagePullSecrets:
             - name: tododomain-repo-credentials
           domainHomeSourceType: "FromModel"

--- a/examples/multicluster/todo-list/todo-list-components.yaml
+++ b/examples/multicluster/todo-list/todo-list-components.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2

--- a/examples/todo-list/todo-list-components.yaml
+++ b/examples/todo-list/todo-list-components.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2024, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2
@@ -20,7 +20,6 @@ spec:
           domainUID: tododomain
           domainHome: /u01/domains/tododomain
           image: container-registry.oracle.com/middleware/weblogic:12.2.1.4
-          imagePullPolicy: Always
           imagePullSecrets:
             - name: tododomain-repo-credentials
           domainHomeSourceType: "FromModel"

--- a/examples/todo-list/todo-list-components.yaml
+++ b/examples/todo-list/todo-list-components.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 apiVersion: core.oam.dev/v1alpha2


### PR DESCRIPTION
Reverts verrazzano/verrazzano#7847

This change was not needed and causes problems in the private registry and air-gap testing.